### PR TITLE
Add global stats menu bar extra

### DIFF
--- a/AgentHubDemo/AgentHubDemo.xcodeproj/project.pbxproj
+++ b/AgentHubDemo/AgentHubDemo.xcodeproj/project.pbxproj
@@ -582,9 +582,9 @@
 /* End XCConfigurationList section */
 
 /* Begin XCLocalSwiftPackageReference section */
-		7B03D9402F14D66700C36AA3 /* XCLocalSwiftPackageReference "../../AgentHub" */ = {
+		7B03D9402F14D66700C36AA3 /* XCLocalSwiftPackageReference ".." */ = {
 			isa = XCLocalSwiftPackageReference;
-			relativePath = ../../AgentHub;
+			relativePath = ..;
 		};
 /* End XCLocalSwiftPackageReference section */
 

--- a/AgentHubDemo/AgentHubDemo/AgentHubDemoApp.swift
+++ b/AgentHubDemo/AgentHubDemo/AgentHubDemoApp.swift
@@ -6,12 +6,25 @@
 //
 
 import SwiftUI
+import AgentHub
 
 @main
 struct AgentHubDemoApp: App {
-    var body: some Scene {
-        WindowGroup {
-            ContentView()
-        }
+  @State private var statsService = GlobalStatsService()
+
+  var body: some Scene {
+    WindowGroup {
+      ContentView()
     }
+
+    MenuBarExtra {
+      GlobalStatsMenuView(service: statsService)
+    } label: {
+      HStack(spacing: 4) {
+        Image(systemName: "sparkle")
+        Text(statsService.formattedTotalTokens)
+      }
+    }
+    .menuBarExtraStyle(.window)
+  }
 }

--- a/Sources/AgentHub/Models/GlobalStatsCache.swift
+++ b/Sources/AgentHub/Models/GlobalStatsCache.swift
@@ -1,0 +1,127 @@
+import Foundation
+
+// MARK: - GlobalStatsCache
+
+/// Represents the global stats from ~/.claude/stats-cache.json
+public struct GlobalStatsCache: Decodable, Sendable {
+  public let version: Int
+  public let lastComputedDate: String
+  public let dailyActivity: [DailyActivity]
+  public let dailyModelTokens: [DailyModelTokens]?
+  public let modelUsage: [String: ModelUsage]
+  public let totalSessions: Int
+  public let totalMessages: Int
+  public let longestSession: LongestSession?
+  public let firstSessionDate: String?
+  public let hourCounts: [String: Int]?
+
+  public init(
+    version: Int = 1,
+    lastComputedDate: String = "",
+    dailyActivity: [DailyActivity] = [],
+    dailyModelTokens: [DailyModelTokens]? = nil,
+    modelUsage: [String: ModelUsage] = [:],
+    totalSessions: Int = 0,
+    totalMessages: Int = 0,
+    longestSession: LongestSession? = nil,
+    firstSessionDate: String? = nil,
+    hourCounts: [String: Int]? = nil
+  ) {
+    self.version = version
+    self.lastComputedDate = lastComputedDate
+    self.dailyActivity = dailyActivity
+    self.dailyModelTokens = dailyModelTokens
+    self.modelUsage = modelUsage
+    self.totalSessions = totalSessions
+    self.totalMessages = totalMessages
+    self.longestSession = longestSession
+    self.firstSessionDate = firstSessionDate
+    self.hourCounts = hourCounts
+  }
+}
+
+// MARK: - ModelUsage
+
+public struct ModelUsage: Decodable, Sendable {
+  public let inputTokens: Int
+  public let outputTokens: Int
+  public let cacheReadInputTokens: Int
+  public let cacheCreationInputTokens: Int
+  public let webSearchRequests: Int?
+  public let costUSD: Double?
+
+  public init(
+    inputTokens: Int = 0,
+    outputTokens: Int = 0,
+    cacheReadInputTokens: Int = 0,
+    cacheCreationInputTokens: Int = 0,
+    webSearchRequests: Int? = nil,
+    costUSD: Double? = nil
+  ) {
+    self.inputTokens = inputTokens
+    self.outputTokens = outputTokens
+    self.cacheReadInputTokens = cacheReadInputTokens
+    self.cacheCreationInputTokens = cacheCreationInputTokens
+    self.webSearchRequests = webSearchRequests
+    self.costUSD = costUSD
+  }
+
+  /// Total tokens for this model
+  public var totalTokens: Int {
+    inputTokens + outputTokens + cacheReadInputTokens + cacheCreationInputTokens
+  }
+}
+
+// MARK: - DailyActivity
+
+public struct DailyActivity: Decodable, Sendable {
+  public let date: String
+  public let messageCount: Int
+  public let sessionCount: Int
+  public let toolCallCount: Int
+
+  public init(
+    date: String,
+    messageCount: Int,
+    sessionCount: Int,
+    toolCallCount: Int
+  ) {
+    self.date = date
+    self.messageCount = messageCount
+    self.sessionCount = sessionCount
+    self.toolCallCount = toolCallCount
+  }
+}
+
+// MARK: - DailyModelTokens
+
+public struct DailyModelTokens: Decodable, Sendable {
+  public let date: String
+  public let tokensByModel: [String: Int]
+
+  public init(date: String, tokensByModel: [String: Int]) {
+    self.date = date
+    self.tokensByModel = tokensByModel
+  }
+}
+
+// MARK: - LongestSession
+
+public struct LongestSession: Decodable, Sendable {
+  public let sessionId: String
+  public let duration: Int
+  public let messageCount: Int
+  public let timestamp: String
+
+  public init(
+    sessionId: String,
+    duration: Int,
+    messageCount: Int,
+    timestamp: String
+  ) {
+    self.sessionId = sessionId
+    self.duration = duration
+    self.messageCount = messageCount
+    self.timestamp = timestamp
+  }
+}

--- a/Sources/AgentHub/Services/GlobalStatsService.swift
+++ b/Sources/AgentHub/Services/GlobalStatsService.swift
@@ -1,0 +1,235 @@
+//
+//  GlobalStatsService.swift
+//  AgentHub
+//
+//  Created by Assistant on 1/13/26.
+//
+
+import Foundation
+import Observation
+
+// MARK: - GlobalStatsService
+
+/// Service that monitors and provides global Claude Code usage statistics
+@Observable
+public final class GlobalStatsService: @unchecked Sendable {
+
+  // MARK: - Properties
+
+  /// The parsed global stats cache
+  public private(set) var stats: GlobalStatsCache = GlobalStatsCache()
+
+  /// Whether the stats file exists
+  public private(set) var isAvailable: Bool = false
+
+  /// Last time stats were updated
+  public private(set) var lastUpdated: Date?
+
+  private let statsFilePath: String
+  private var fileWatcher: DispatchSourceFileSystemObject?
+  private var fileDescriptor: Int32 = -1
+
+  // MARK: - Computed Properties
+
+  /// Total tokens across all models (input + output only, excludes cache)
+  public var totalTokens: Int {
+    stats.modelUsage.values.reduce(0) { $0 + $1.inputTokens + $1.outputTokens }
+  }
+
+  /// Formatted total tokens (e.g., "10.5M", "150K")
+  public var formattedTotalTokens: String {
+    formatTokenCount(totalTokens)
+  }
+
+  /// Estimated total cost using CostCalculator pricing
+  public var estimatedCost: Decimal {
+    var totalCost: Decimal = 0
+    for (modelName, usage) in stats.modelUsage {
+      let breakdown = CostCalculator.calculate(
+        model: modelName,
+        inputTokens: usage.inputTokens,
+        outputTokens: usage.outputTokens,
+        cacheReadTokens: usage.cacheReadInputTokens,
+        cacheCreationTokens: usage.cacheCreationInputTokens
+      )
+      totalCost += breakdown.totalCost
+    }
+    return totalCost
+  }
+
+  /// Formatted cost string (e.g., "$127.45")
+  public var formattedCost: String {
+    let formatter = NumberFormatter()
+    formatter.numberStyle = .currency
+    formatter.currencyCode = "USD"
+    formatter.maximumFractionDigits = 2
+    return formatter.string(from: estimatedCost as NSDecimalNumber) ?? "$0.00"
+  }
+
+  /// Today's activity stats
+  public var todayActivity: DailyActivity? {
+    let today = formatDateForComparison(Date())
+    return stats.dailyActivity.first { $0.date == today }
+  }
+
+  /// Days since first session
+  public var daysActive: Int {
+    guard let firstDate = stats.firstSessionDate,
+          let date = parseISO8601Date(firstDate) else {
+      return 0
+    }
+    let days = Calendar.current.dateComponents([.day], from: date, to: Date()).day ?? 0
+    return max(0, days)
+  }
+
+  /// First session date formatted
+  public var firstSessionFormatted: String? {
+    guard let firstDate = stats.firstSessionDate,
+          let date = parseISO8601Date(firstDate) else {
+      return nil
+    }
+    let formatter = DateFormatter()
+    formatter.dateStyle = .medium
+    return formatter.string(from: date)
+  }
+
+  /// Model-specific stats
+  public var modelStats: [(name: String, usage: ModelUsage, cost: Decimal)] {
+    stats.modelUsage.map { (modelName, usage) in
+      let breakdown = CostCalculator.calculate(
+        model: modelName,
+        inputTokens: usage.inputTokens,
+        outputTokens: usage.outputTokens,
+        cacheReadTokens: usage.cacheReadInputTokens,
+        cacheCreationTokens: usage.cacheCreationInputTokens
+      )
+      return (name: formatModelName(modelName), usage: usage, cost: breakdown.totalCost)
+    }.sorted { $0.cost > $1.cost }
+  }
+
+  // MARK: - Initialization
+
+  public init(claudePath: String = "~/.claude") {
+    let expandedPath = NSString(string: claudePath).expandingTildeInPath
+    self.statsFilePath = "\(expandedPath)/stats-cache.json"
+
+    loadStats()
+    startWatching()
+  }
+
+  deinit {
+    stopWatching()
+  }
+
+  // MARK: - Public API
+
+  /// Manually refresh stats
+  public func refresh() {
+    loadStats()
+  }
+
+  // MARK: - Private Methods
+
+  private func loadStats() {
+    guard FileManager.default.fileExists(atPath: statsFilePath) else {
+      isAvailable = false
+      return
+    }
+
+    do {
+      let data = try Data(contentsOf: URL(fileURLWithPath: statsFilePath))
+      stats = try JSONDecoder().decode(GlobalStatsCache.self, from: data)
+      isAvailable = true
+      lastUpdated = Date()
+    } catch {
+      print("[GlobalStatsService] Failed to parse stats: \(error)")
+      isAvailable = false
+    }
+  }
+
+  private func startWatching() {
+    guard FileManager.default.fileExists(atPath: statsFilePath) else {
+      // Try again later when file might exist
+      DispatchQueue.global().asyncAfter(deadline: .now() + 5) { [weak self] in
+        self?.startWatching()
+      }
+      return
+    }
+
+    fileDescriptor = open(statsFilePath, O_EVTONLY)
+    guard fileDescriptor >= 0 else {
+      print("[GlobalStatsService] Could not open file for watching")
+      return
+    }
+
+    let source = DispatchSource.makeFileSystemObjectSource(
+      fileDescriptor: fileDescriptor,
+      eventMask: [.write, .extend, .attrib],
+      queue: DispatchQueue.global(qos: .utility)
+    )
+
+    source.setEventHandler { [weak self] in
+      DispatchQueue.main.async {
+        self?.loadStats()
+      }
+    }
+
+    source.setCancelHandler { [weak self] in
+      if let fd = self?.fileDescriptor, fd >= 0 {
+        close(fd)
+      }
+    }
+
+    source.resume()
+    fileWatcher = source
+  }
+
+  private func stopWatching() {
+    fileWatcher?.cancel()
+    fileWatcher = nil
+  }
+
+  // MARK: - Formatting Helpers
+
+  private func formatTokenCount(_ count: Int) -> String {
+    if count >= 1_000_000_000 {
+      let billions = Double(count) / 1_000_000_000
+      return String(format: "%.1fB", billions)
+    } else if count >= 1_000_000 {
+      let millions = Double(count) / 1_000_000
+      return String(format: "%.1fM", millions)
+    } else if count >= 1_000 {
+      let thousands = Double(count) / 1_000
+      return String(format: "%.1fK", thousands)
+    }
+    return "\(count)"
+  }
+
+  private func formatModelName(_ model: String) -> String {
+    if model.lowercased().contains("opus") {
+      return "Opus"
+    } else if model.lowercased().contains("sonnet") {
+      return "Sonnet"
+    } else if model.lowercased().contains("haiku") {
+      return "Haiku"
+    }
+    return model
+  }
+
+  private func formatDateForComparison(_ date: Date) -> String {
+    let formatter = DateFormatter()
+    formatter.dateFormat = "yyyy-MM-dd"
+    return formatter.string(from: date)
+  }
+
+  private func parseISO8601Date(_ string: String) -> Date? {
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+    if let date = formatter.date(from: string) {
+      return date
+    }
+    // Try without fractional seconds
+    formatter.formatOptions = [.withInternetDateTime]
+    return formatter.date(from: string)
+  }
+}

--- a/Sources/AgentHub/UI/GlobalStatsMenuView.swift
+++ b/Sources/AgentHub/UI/GlobalStatsMenuView.swift
@@ -1,0 +1,258 @@
+//
+//  GlobalStatsMenuView.swift
+//  AgentHub
+//
+//  Created by Assistant on 1/13/26.
+//
+
+import SwiftUI
+
+// MARK: - GlobalStatsMenuView
+
+/// View for displaying global Claude Code stats in a menu bar dropdown
+public struct GlobalStatsMenuView: View {
+  let service: GlobalStatsService
+
+  public init(service: GlobalStatsService) {
+    self.service = service
+  }
+
+  public var body: some View {
+    VStack(alignment: .leading, spacing: 0) {
+      if service.isAvailable {
+        // Header
+        headerSection
+
+        Divider()
+          .padding(.vertical, 8)
+
+        // Total stats
+        totalStatsSection
+
+        Divider()
+          .padding(.vertical, 8)
+
+        // Today's activity
+        todaySection
+
+        Divider()
+          .padding(.vertical, 8)
+
+        // Model breakdown
+        modelBreakdownSection
+
+        Divider()
+          .padding(.vertical, 8)
+
+        // Footer with refresh
+        footerSection
+      } else {
+        Text("Stats not available")
+          .foregroundColor(.secondary)
+          .padding()
+      }
+    }
+    .padding(12)
+    .frame(width: 280)
+  }
+
+  // MARK: - Header Section
+
+  private var headerSection: some View {
+    HStack {
+      Image(systemName: "chart.bar.fill")
+        .foregroundColor(.brandPrimary)
+      Text("Claude Code Stats")
+        .font(.headline)
+      Spacer()
+    }
+  }
+
+  // MARK: - Total Stats Section
+
+  private var totalStatsSection: some View {
+    VStack(alignment: .leading, spacing: 6) {
+      StatRow(
+        label: "Total Tokens",
+        value: service.formattedTotalTokens,
+        icon: "number.circle.fill"
+      )
+
+      StatRow(
+        label: "Estimated Cost",
+        value: service.formattedCost,
+        icon: "dollarsign.circle.fill"
+      )
+
+      StatRow(
+        label: "Sessions",
+        value: "\(service.stats.totalSessions)",
+        icon: "terminal.fill"
+      )
+
+      StatRow(
+        label: "Messages",
+        value: formatNumber(service.stats.totalMessages),
+        icon: "message.fill"
+      )
+
+      if service.daysActive > 0 {
+        StatRow(
+          label: "Days Active",
+          value: "\(service.daysActive)",
+          icon: "calendar"
+        )
+      }
+    }
+  }
+
+  // MARK: - Today Section
+
+  private var todaySection: some View {
+    VStack(alignment: .leading, spacing: 6) {
+      Text("Today")
+        .font(.subheadline)
+        .fontWeight(.semibold)
+        .foregroundColor(.secondary)
+
+      if let today = service.todayActivity {
+        HStack(spacing: 16) {
+          MiniStat(value: "\(today.messageCount)", label: "msgs")
+          MiniStat(value: "\(today.sessionCount)", label: "sessions")
+          MiniStat(value: "\(today.toolCallCount)", label: "tools")
+        }
+      } else {
+        Text("No activity yet")
+          .font(.caption)
+          .foregroundColor(.secondary)
+      }
+    }
+  }
+
+  // MARK: - Model Breakdown Section
+
+  private var modelBreakdownSection: some View {
+    VStack(alignment: .leading, spacing: 6) {
+      Text("By Model")
+        .font(.subheadline)
+        .fontWeight(.semibold)
+        .foregroundColor(.secondary)
+
+      ForEach(service.modelStats, id: \.name) { model in
+        HStack {
+          Text(model.name)
+            .font(.caption)
+          Spacer()
+          Text(formatTokenCount(model.usage.inputTokens + model.usage.outputTokens))
+            .font(.caption)
+            .foregroundColor(.secondary)
+          Text(formatCost(model.cost))
+            .font(.caption)
+            .fontWeight(.medium)
+        }
+      }
+    }
+  }
+
+  // MARK: - Footer Section
+
+  private var footerSection: some View {
+    HStack {
+      if let lastUpdated = service.lastUpdated {
+        Text("Updated \(lastUpdated, style: .relative) ago")
+          .font(.caption2)
+          .foregroundColor(.secondary)
+      }
+
+      Spacer()
+
+      Button(action: { service.refresh() }) {
+        Image(systemName: "arrow.clockwise")
+          .font(.caption)
+      }
+      .buttonStyle(.plain)
+      .help("Refresh stats")
+
+      Button("Quit") {
+        NSApplication.shared.terminate(nil)
+      }
+      .buttonStyle(.plain)
+      .font(.caption)
+    }
+  }
+
+  // MARK: - Helpers
+
+  private func formatNumber(_ num: Int) -> String {
+    let formatter = NumberFormatter()
+    formatter.numberStyle = .decimal
+    return formatter.string(from: NSNumber(value: num)) ?? "\(num)"
+  }
+
+  private func formatTokenCount(_ count: Int) -> String {
+    if count >= 1_000_000_000 {
+      return String(format: "%.1fB", Double(count) / 1_000_000_000)
+    } else if count >= 1_000_000 {
+      return String(format: "%.1fM", Double(count) / 1_000_000)
+    } else if count >= 1_000 {
+      return String(format: "%.0fK", Double(count) / 1_000)
+    }
+    return "\(count)"
+  }
+
+  private func formatCost(_ cost: Decimal) -> String {
+    let formatter = NumberFormatter()
+    formatter.numberStyle = .currency
+    formatter.currencyCode = "USD"
+    formatter.maximumFractionDigits = 2
+    return formatter.string(from: cost as NSDecimalNumber) ?? "$0"
+  }
+}
+
+// MARK: - StatRow
+
+private struct StatRow: View {
+  let label: String
+  let value: String
+  let icon: String
+
+  var body: some View {
+    HStack {
+      Image(systemName: icon)
+        .foregroundColor(.brandPrimary)
+        .frame(width: 16)
+      Text(label)
+        .font(.caption)
+      Spacer()
+      Text(value)
+        .font(.caption)
+        .fontWeight(.medium)
+    }
+  }
+}
+
+// MARK: - MiniStat
+
+private struct MiniStat: View {
+  let value: String
+  let label: String
+
+  var body: some View {
+    VStack(spacing: 2) {
+      Text(value)
+        .font(.system(.caption, design: .monospaced))
+        .fontWeight(.semibold)
+      Text(label)
+        .font(.caption2)
+        .foregroundColor(.secondary)
+    }
+  }
+}
+
+// MARK: - Preview
+
+#if DEBUG
+#Preview {
+  GlobalStatsMenuView(service: GlobalStatsService())
+}
+#endif


### PR DESCRIPTION
## Summary
- Parse `~/.claude/stats-cache.json` to display Claude Code usage statistics
- Add menu bar extra showing total tokens, estimated cost, and daily activity
- Real-time updates via file watching when stats change
- Per-model breakdown (Opus vs Sonnet) with cost calculation

## Changes
- `GlobalStatsCache.swift` - Models to decode stats-cache.json
- `GlobalStatsService.swift` - Service with file watching and computed stats
- `GlobalStatsMenuView.swift` - SwiftUI view for menu bar dropdown
- `AgentHubDemoApp.swift` - Added MenuBarExtra scene

## Test plan
- [ ] Launch app and verify menu bar icon appears with token count
- [ ] Click menu bar to verify dropdown shows all stats
- [ ] Run a Claude Code session and verify stats update
- [ ] Compare values with `/stats` command output

🤖 Generated with [Claude Code](https://claude.ai/code)