### PR TITLE
Inline editor opens Terminal for session resume

### DIFF
--- a/Sources/AgentHub/UI/InlineEditorOverlay.swift
+++ b/Sources/AgentHub/UI/InlineEditorOverlay.swift
@@ -43,7 +43,7 @@ struct InlineEditorOverlay: View {
           fileName: state.fileName,
           errorMessage: state.errorMessage,
           onSubmit: { message in
-            // Submit will launch Terminal and then dismiss (if successful)
+            // Submit will open Terminal with resumed session
             onSubmit(message, state.lineNumber, state.side, state.fileName)
           },
           onDismiss: {

--- a/Sources/AgentHub/UI/InlineEditorState.swift
+++ b/Sources/AgentHub/UI/InlineEditorState.swift
@@ -35,7 +35,7 @@ final class InlineEditorState {
 
   // MARK: - Error State
 
-  /// Error message if Terminal launch failed
+  /// Error message if request failed
   var errorMessage: String?
 
   /// Shows the editor at the specified position with context

--- a/Sources/AgentHub/UI/InlineEditorView.swift
+++ b/Sources/AgentHub/UI/InlineEditorView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 import AppKit
 
 /// A compact floating text editor for asking questions about specific diff lines.
-/// Appears below clicked lines in the diff view. Submitting opens Terminal with the question.
+/// Appears below clicked lines in the diff view.
 struct InlineEditorView: View {
 
   // MARK: - Properties
@@ -30,20 +30,9 @@ struct InlineEditorView: View {
 
   var body: some View {
     VStack(alignment: .leading, spacing: 0) {
-      // Input row
-      HStack(spacing: 8) {
-        // Dismiss button
-        dismissButton
+      inputView
 
-        // Text input
-        textEditorView
-
-        // Send button (rounded square with arrow)
-        sendButton
-      }
-      .padding(8)
-
-      // Error message (if Terminal launch failed)
+      // Error message
       if let error = errorMessage {
         Divider()
           .padding(.horizontal, 8)
@@ -72,6 +61,22 @@ struct InlineEditorView: View {
     .onAppear {
       isFocused = true
     }
+  }
+
+  // MARK: - Input View
+
+  private var inputView: some View {
+    HStack(spacing: 8) {
+      // Dismiss button
+      dismissButton
+
+      // Text input
+      textEditorView
+
+      // Send button (rounded square with arrow)
+      sendButton
+    }
+    .padding(8)
   }
 
   // MARK: - Text Editor
@@ -189,7 +194,7 @@ struct InlineEditorView: View {
 
 // MARK: - Preview
 
-#Preview("Default") {
+#Preview("Default - Input Mode") {
   InlineEditorView(
     lineNumber: 42,
     side: "right",
@@ -211,7 +216,7 @@ struct InlineEditorView: View {
     lineNumber: 42,
     side: "right",
     fileName: "Example.swift",
-    errorMessage: "Failed to launch Terminal",
+    errorMessage: "Failed to connect to Claude",
     onSubmit: { _ in },
     onDismiss: {}
   )


### PR DESCRIPTION
## Summary
- Add inline editor overlay to diff view for asking questions about specific lines
- When user submits from inline editor, opens new Terminal window with resumed session and contextual prompt
- Dismisses diff view after Terminal opens (session continues in Terminal, diff won't update)
- Pass full file path to inline editor for better context in prompts

## Trade-off
Opens a visible Terminal window instead of running in background. This keeps session history in sync - user manually closes previous terminal to avoid divergence.

## Test plan
- [ ] Open a session with code changes in diff view
- [ ] Click on a line to open inline editor
- [ ] Submit a question about the line
- [ ] Verify Terminal opens with resumed session and prompt
- [ ] Verify diff view dismisses after Terminal opens
- [ ] Close previous terminal manually to avoid session divergence

🤖 Generated with [Claude Code](https://claude.com/claude-code)