### PR TITLE
Add AgentHubProvider for centralized dependency injection

### DIFF
--- a/AgentHubDemo/AgentHubDemo/AgentHubDemoApp.swift
+++ b/AgentHubDemo/AgentHubDemo/AgentHubDemoApp.swift
@@ -10,30 +10,25 @@ import AgentHub
 
 @main
 struct AgentHubDemoApp: App {
-  @State private var statsService = GlobalStatsService()
-  @State private var displaySettings = StatsDisplaySettings(.menuBar)
+  @State private var provider = AgentHubProvider()
 
   var body: some Scene {
     WindowGroup {
-      ContentView(
-        statsService: statsService,
-        displaySettings: displaySettings
-      )
+      AgentHubSessionsView()
+        .agentHub(provider)
     }
     .windowStyle(.hiddenTitleBar)
 
     MenuBarExtra(
       isInserted: Binding(
-        get: { displaySettings.isMenuBarMode },
+        get: { provider.displaySettings.isMenuBarMode },
         set: { _ in }
       )
     ) {
-      GlobalStatsMenuView(service: statsService)
+      AgentHubMenuBarContent()
+        .environment(\.agentHub, provider)
     } label: {
-      HStack(spacing: 4) {
-        Image(systemName: "sparkle")
-        Text(statsService.formattedTotalTokens)
-      }
+      AgentHubMenuBarLabel(provider: provider)
     }
     .menuBarExtraStyle(.window)
   }

--- a/AgentHubDemo/AgentHubDemo/ContentView.swift
+++ b/AgentHubDemo/AgentHubDemo/ContentView.swift
@@ -7,103 +7,18 @@
 
 import SwiftUI
 import AgentHub
-import ClaudeCodeSDK
 
-/// The main content view for the AgentHubDemo application.
+/// A simple wrapper view for previewing AgentHubSessionsView.
 ///
-/// This view serves as the root of the application's view hierarchy, initializing
-/// the required services and displaying the CLI sessions list interface.
-///
-/// ## Overview
-/// `ContentView` sets up the dependency graph for the application by:
-/// - Creating a `CLISessionMonitorService` to track active CLI sessions
-/// - Initializing a `ClaudeCodeClient` for AI-powered interactions
-/// - Injecting these dependencies into a `CLISessionsViewModel`
-///
-/// ## Example
-/// ```swift
-/// @main
-/// struct AgentHubDemoApp: App {
-///   var body: some Scene {
-///     WindowGroup {
-///       ContentView()
-///     }
-///   }
-/// }
-/// ```
+/// The main application now uses `AgentHubSessionsView` directly with
+/// `AgentHubProvider` for dependency injection. This ContentView is
+/// kept for preview convenience only.
 struct ContentView: View {
-
-  /// The view model managing CLI session state and business logic.
-  @State private var viewModel: CLISessionsViewModel
-
-  /// Intelligence overlay state
-  @State private var isShowingIntelligenceOverlay = false
-  @State private var intelligenceViewModel: IntelligenceViewModel
-
-  /// Monitor service for tracking CLI sessions
-  private let monitorService: CLISessionMonitorService
-
-  /// Git worktree service for orchestration
-  private let gitService: GitWorktreeService
-
-  /// Optional stats service for popover mode display
-  var statsService: GlobalStatsService?
-
-  /// Optional display settings for controlling stats display mode
-  var displaySettings: StatsDisplaySettings?
-
-  /// Creates a new content view with all required dependencies.
-  init(
-    statsService: GlobalStatsService? = nil,
-    displaySettings: StatsDisplaySettings? = nil
-  ) {
-    let service = CLISessionMonitorService()
-    let git = GitWorktreeService()
-    let claudeClient = try? ClaudeCodeClient(configuration: .default)
-    _viewModel = State(initialValue: CLISessionsViewModel(
-      monitorService: service,
-      claudeClient: claudeClient
-    ))
-    _intelligenceViewModel = State(initialValue: IntelligenceViewModel(
-      gitService: git,
-      monitorService: service
-    ))
-    self.monitorService = service
-    self.gitService = git
-    self.statsService = statsService
-    self.displaySettings = displaySettings
-  }
+  @State private var provider = AgentHubProvider()
 
   var body: some View {
-    ZStack(alignment: .top) {
-      // Main content
-      CLISessionsListView(viewModel: viewModel)
-        .frame(minWidth: 400, minHeight: 600)
-        .toolbar(removing: .title)
-        .toolbar {
-          ToolbarItem(placement: .principal) {
-            HStack {
-              Spacer()
-              // Intelligence button - always visible
-              IntelligencePopoverButton(isShowingOverlay: $isShowingIntelligenceOverlay)
-              if let settings = displaySettings,
-                 settings.isPopoverMode,
-                 let service = statsService {
-                GlobalStatsPopoverButton(service: service)
-              }
-            }
-            .frame(maxWidth: .infinity)
-          }
-        }
-
-      // Intelligence overlay - full screen
-      if isShowingIntelligenceOverlay {
-        IntelligenceOverlayView(
-          viewModel: $intelligenceViewModel,
-          isPresented: $isShowingIntelligenceOverlay
-        )
-      }
-    }
+    AgentHubSessionsView()
+      .agentHub(provider)
   }
 }
 

--- a/Sources/AgentHub/AgentHub.swift
+++ b/Sources/AgentHub/AgentHub.swift
@@ -9,3 +9,59 @@ import Foundation
 
 /// AgentHub version
 public let agentHubVersion = "1.0.0"
+
+// MARK: - Quick Start
+//
+// AgentHub provides a simple API for monitoring Claude Code CLI sessions.
+//
+// ## Basic Usage (Recommended)
+//
+// ```swift
+// import AgentHub
+//
+// @main
+// struct MyApp: App {
+//   @State private var provider = AgentHubProvider()
+//
+//   var body: some Scene {
+//     WindowGroup {
+//       AgentHubSessionsView()
+//         .agentHub(provider)
+//     }
+//     .windowStyle(.hiddenTitleBar)
+//
+//     MenuBarExtra {
+//       AgentHubMenuBarContent()
+//         .environment(\.agentHub, provider)
+//     } label: {
+//       AgentHubMenuBarLabel(provider: provider)
+//     }
+//   }
+// }
+// ```
+//
+// ## Custom Configuration
+//
+// ```swift
+// var config = AgentHubConfiguration.default
+// config.enableDebugLogging = true
+// let provider = AgentHubProvider(configuration: config)
+// ```
+//
+// ## Direct Service Access
+//
+// For advanced usage, access services directly from the provider:
+//
+// ```swift
+// let stats = provider.statsService.formattedTotalTokens
+// let sessions = provider.sessionsViewModel.totalSessionCount
+// ```
+
+// MARK: - Re-exports
+
+// Configuration types are exported via their public declarations in:
+// - Configuration/AgentHubConfiguration.swift
+// - Configuration/AgentHubProvider.swift
+// - Configuration/AgentHubEnvironment.swift
+// - Configuration/AgentHubViews.swift
+// - Configuration/AgentHubDefaults.swift

--- a/Sources/AgentHub/Configuration/AgentHubConfiguration.swift
+++ b/Sources/AgentHub/Configuration/AgentHubConfiguration.swift
@@ -1,0 +1,70 @@
+//
+//  AgentHubConfiguration.swift
+//  AgentHub
+//
+//  Configuration for AgentHub services and providers
+//
+
+import Foundation
+
+/// Configuration for AgentHub services
+///
+/// Use this to customize behavior when initializing `AgentHubProvider`.
+///
+/// ## Example
+/// ```swift
+/// var config = AgentHubConfiguration.default
+/// config.enableDebugLogging = true
+/// let provider = AgentHubProvider(configuration: config)
+/// ```
+public struct AgentHubConfiguration: Sendable {
+
+  /// Path to Claude data directory (default: ~/.claude)
+  public var claudeDataPath: String
+
+  /// Enable debug logging for troubleshooting
+  public var enableDebugLogging: Bool
+
+  /// Additional paths to search for Claude CLI
+  /// These are added to the PATH when launching Claude processes
+  public var additionalCLIPaths: [String]
+
+  /// Display mode for stats (menu bar or popover)
+  public var statsDisplayMode: StatsDisplayMode
+
+  /// Creates a configuration with custom values
+  public init(
+    claudeDataPath: String = "~/.claude",
+    enableDebugLogging: Bool = false,
+    additionalCLIPaths: [String] = [],
+    statsDisplayMode: StatsDisplayMode = .menuBar
+  ) {
+    let expanded = NSString(string: claudeDataPath).expandingTildeInPath
+    self.claudeDataPath = expanded
+    self.enableDebugLogging = enableDebugLogging
+    self.additionalCLIPaths = additionalCLIPaths
+    self.statsDisplayMode = statsDisplayMode
+  }
+
+  /// Default configuration with sensible defaults
+  public static var `default`: AgentHubConfiguration {
+    AgentHubConfiguration()
+  }
+
+  /// Configuration with common development tool paths included
+  public static var withDevPaths: AgentHubConfiguration {
+    let homeDir = NSHomeDirectory()
+    return AgentHubConfiguration(
+      additionalCLIPaths: [
+        "\(homeDir)/.claude/local",
+        "/usr/local/bin",
+        "/opt/homebrew/bin",
+        "/usr/bin",
+        "\(homeDir)/.bun/bin",
+        "\(homeDir)/.deno/bin",
+        "\(homeDir)/.cargo/bin",
+        "\(homeDir)/.local/bin"
+      ]
+    )
+  }
+}

--- a/Sources/AgentHub/Configuration/AgentHubDefaults.swift
+++ b/Sources/AgentHub/Configuration/AgentHubDefaults.swift
@@ -1,0 +1,99 @@
+//
+//  AgentHubDefaults.swift
+//  AgentHub
+//
+//  Centralized UserDefaults keys for AgentHub
+//
+
+import Foundation
+
+/// Centralized UserDefaults keys for AgentHub
+///
+/// All keys are namespaced with `com.agenthub.` prefix to avoid collisions.
+///
+/// ## Usage
+/// ```swift
+/// // Read
+/// let showLast = UserDefaults.standard.bool(forKey: AgentHubDefaults.showLastMessage)
+///
+/// // Write
+/// UserDefaults.standard.set(true, forKey: AgentHubDefaults.showLastMessage)
+/// ```
+public enum AgentHubDefaults {
+
+  /// Prefix for all AgentHub UserDefaults keys
+  public static let keyPrefix = "com.agenthub."
+
+  // MARK: - Session Settings
+
+  /// Whether to show the last message instead of first in session rows
+  /// Type: Bool (default: false)
+  public static let showLastMessage = "\(keyPrefix)sessions.showLastMessage"
+
+  /// Seconds to wait before triggering approval alert sound
+  /// Type: Int (default: 5)
+  public static let approvalTimeout = "\(keyPrefix)sessions.approvalTimeout"
+
+  /// Persisted selected repositories (JSON-encoded array of paths)
+  /// Type: Data (JSON-encoded [String])
+  public static let selectedRepositories = "\(keyPrefix)sessions.selectedRepositories"
+
+  // MARK: - Theme Settings
+
+  /// Selected color theme name
+  /// Type: String (default: "claude")
+  public static let selectedTheme = "\(keyPrefix)theme.selected"
+
+  /// Custom primary color hex value
+  /// Type: String (default: "#7C3AED")
+  public static let customPrimaryHex = "\(keyPrefix)theme.customPrimaryHex"
+
+  /// Custom secondary color hex value
+  /// Type: String (default: "#FFB000")
+  public static let customSecondaryHex = "\(keyPrefix)theme.customSecondaryHex"
+
+  /// Custom tertiary color hex value
+  /// Type: String (default: "#64748B")
+  public static let customTertiaryHex = "\(keyPrefix)theme.customTertiaryHex"
+
+  // MARK: - Migration
+
+  /// Legacy keys mapping for migration
+  private static let legacyKeyMappings: [String: String] = [
+    "CLISessionsShowLastMessage": showLastMessage,
+    "CLISessionsApprovalTimeout": approvalTimeout,
+    "CLISessionsSelectedRepositories": selectedRepositories,
+    "selectedTheme": selectedTheme,
+    "customPrimaryHex": customPrimaryHex,
+    "customSecondaryHex": customSecondaryHex,
+    "customTertiaryHex": customTertiaryHex
+  ]
+
+  /// Migrates legacy UserDefaults keys to namespaced keys
+  ///
+  /// Call this once during app launch to migrate existing settings.
+  /// The migration is idempotent - it only copies values if the new key doesn't exist.
+  ///
+  /// ```swift
+  /// // In your App's init or onAppear
+  /// AgentHubDefaults.migrateIfNeeded()
+  /// ```
+  public static func migrateIfNeeded() {
+    let defaults = UserDefaults.standard
+    let migrationKey = "\(keyPrefix)migration.completed"
+
+    // Skip if already migrated
+    guard !defaults.bool(forKey: migrationKey) else { return }
+
+    for (legacyKey, newKey) in legacyKeyMappings {
+      // Only migrate if legacy key exists and new key doesn't
+      if defaults.object(forKey: legacyKey) != nil && defaults.object(forKey: newKey) == nil {
+        if let value = defaults.object(forKey: legacyKey) {
+          defaults.set(value, forKey: newKey)
+        }
+      }
+    }
+
+    defaults.set(true, forKey: migrationKey)
+  }
+}

--- a/Sources/AgentHub/Configuration/AgentHubEnvironment.swift
+++ b/Sources/AgentHub/Configuration/AgentHubEnvironment.swift
@@ -1,0 +1,97 @@
+//
+//  AgentHubEnvironment.swift
+//  AgentHub
+//
+//  SwiftUI environment integration for AgentHub
+//
+
+import SwiftUI
+
+// MARK: - Environment Key
+
+private struct AgentHubProviderKey: EnvironmentKey {
+  static let defaultValue: AgentHubProvider? = nil
+}
+
+extension EnvironmentValues {
+  /// Access to the AgentHub provider from the environment
+  ///
+  /// Use this to access AgentHub services from any view in the hierarchy.
+  ///
+  /// ## Example
+  /// ```swift
+  /// struct MyView: View {
+  ///   @Environment(\.agentHub) private var agentHub
+  ///
+  ///   var body: some View {
+  ///     if let provider = agentHub {
+  ///       Text("Tokens: \(provider.statsService.formattedTotalTokens)")
+  ///     }
+  ///   }
+  /// }
+  /// ```
+  public var agentHub: AgentHubProvider? {
+    get { self[AgentHubProviderKey.self] }
+    set { self[AgentHubProviderKey.self] = newValue }
+  }
+}
+
+// MARK: - View Modifier
+
+/// View modifier that injects AgentHub provider into the environment
+private struct AgentHubModifier: ViewModifier {
+  let provider: AgentHubProvider
+
+  func body(content: Content) -> some View {
+    content
+      .environment(\.agentHub, provider)
+      .environment(provider.statsService)
+      .environment(provider.displaySettings)
+  }
+}
+
+extension View {
+  /// Configures the view hierarchy with an AgentHub provider
+  ///
+  /// Use this modifier at the root of your view hierarchy to make
+  /// AgentHub services available to all child views.
+  ///
+  /// ## Example
+  /// ```swift
+  /// @State private var provider = AgentHubProvider()
+  ///
+  /// var body: some Scene {
+  ///   WindowGroup {
+  ///     ContentView()
+  ///       .agentHub(provider)
+  ///   }
+  /// }
+  /// ```
+  ///
+  /// - Parameter provider: The AgentHub provider to inject
+  /// - Returns: A view with AgentHub configured in the environment
+  public func agentHub(_ provider: AgentHubProvider) -> some View {
+    modifier(AgentHubModifier(provider: provider))
+  }
+
+  /// Configures the view hierarchy with a default AgentHub provider
+  ///
+  /// Creates a new `AgentHubProvider` with default configuration.
+  /// For most cases, prefer passing an explicit provider to share
+  /// state across windows/scenes.
+  ///
+  /// - Returns: A view with AgentHub configured in the environment
+  public func agentHub() -> some View {
+    modifier(AgentHubModifier(provider: AgentHubProvider()))
+  }
+
+  /// Configures the view hierarchy with a custom AgentHub configuration
+  ///
+  /// Creates a new `AgentHubProvider` with the specified configuration.
+  ///
+  /// - Parameter configuration: Custom configuration for AgentHub
+  /// - Returns: A view with AgentHub configured in the environment
+  public func agentHub(configuration: AgentHubConfiguration) -> some View {
+    modifier(AgentHubModifier(provider: AgentHubProvider(configuration: configuration)))
+  }
+}

--- a/Sources/AgentHub/Configuration/AgentHubViews.swift
+++ b/Sources/AgentHub/Configuration/AgentHubViews.swift
@@ -1,0 +1,159 @@
+//
+//  AgentHubViews.swift
+//  AgentHub
+//
+//  Pre-configured view components for AgentHub
+//
+
+import SwiftUI
+
+// MARK: - RemoveTitleToolbarModifier
+
+/// A view modifier that removes the toolbar title on macOS 15+
+private struct RemoveTitleToolbarModifier: ViewModifier {
+  func body(content: Content) -> some View {
+    if #available(macOS 15.0, *) {
+      content.toolbar(removing: .title)
+    } else {
+      content
+    }
+  }
+}
+
+// MARK: - AgentHubSessionsView
+
+/// Pre-configured sessions view that reads from the environment
+///
+/// This view automatically gets its dependencies from the AgentHub provider
+/// in the environment. Make sure to apply `.agentHub()` modifier to a parent view.
+///
+/// ## Example
+/// ```swift
+/// WindowGroup {
+///   AgentHubSessionsView()
+///     .agentHub(provider)
+/// }
+/// ```
+public struct AgentHubSessionsView: View {
+  @Environment(\.agentHub) private var agentHub
+  @State private var isShowingIntelligenceOverlay = false
+
+  public init() {}
+
+  public var body: some View {
+    if let provider = agentHub {
+      ZStack(alignment: .top) {
+        // Main content
+        sessionsListView(provider: provider)
+
+        // Intelligence overlay
+        if isShowingIntelligenceOverlay {
+          IntelligenceOverlayView(
+            viewModel: Binding(
+              get: { provider.intelligenceViewModel },
+              set: { _ in }
+            ),
+            isPresented: $isShowingIntelligenceOverlay
+          )
+        }
+      }
+    } else {
+      missingProviderView
+    }
+  }
+
+  @ViewBuilder
+  private func sessionsListView(provider: AgentHubProvider) -> some View {
+    CLISessionsListView(viewModel: provider.sessionsViewModel)
+      .frame(minWidth: 400, minHeight: 600)
+      .modifier(RemoveTitleToolbarModifier())
+      .toolbar {
+        ToolbarItem(placement: .principal) {
+          HStack {
+            Spacer()
+            // Intelligence button
+            IntelligencePopoverButton(isShowingOverlay: $isShowingIntelligenceOverlay)
+            // Stats button (popover mode only)
+            if provider.displaySettings.isPopoverMode {
+              GlobalStatsPopoverButton(service: provider.statsService)
+            }
+          }
+          .frame(maxWidth: .infinity)
+        }
+      }
+  }
+
+  private var missingProviderView: some View {
+    VStack(spacing: 12) {
+      Image(systemName: "exclamationmark.triangle")
+        .font(.largeTitle)
+        .foregroundStyle(.secondary)
+      Text("AgentHub provider not found")
+        .font(.headline)
+      Text("Add .agentHub() modifier to a parent view")
+        .font(.caption)
+        .foregroundStyle(.secondary)
+    }
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+  }
+}
+
+// MARK: - AgentHubMenuBarContent
+
+/// Pre-configured menu bar content for MenuBarExtra
+///
+/// Use this as the content of a MenuBarExtra to show global stats.
+///
+/// ## Example
+/// ```swift
+/// MenuBarExtra("Stats", systemImage: "sparkle") {
+///   AgentHubMenuBarContent()
+///     .environment(\.agentHub, provider)
+/// }
+/// ```
+public struct AgentHubMenuBarContent: View {
+  @Environment(\.agentHub) private var agentHub
+
+  public init() {}
+
+  public var body: some View {
+    if let provider = agentHub {
+      GlobalStatsMenuView(service: provider.statsService)
+    } else {
+      Text("AgentHub provider not found")
+        .foregroundStyle(.secondary)
+    }
+  }
+}
+
+// MARK: - AgentHubMenuBarLabel
+
+/// Pre-configured label for MenuBarExtra
+///
+/// Shows an icon with token count in the menu bar.
+///
+/// ## Example
+/// ```swift
+/// @State private var provider = AgentHubProvider()
+///
+/// MenuBarExtra {
+///   AgentHubMenuBarContent()
+///     .environment(\.agentHub, provider)
+/// } label: {
+///   AgentHubMenuBarLabel(provider: provider)
+/// }
+/// ```
+public struct AgentHubMenuBarLabel: View {
+  let provider: AgentHubProvider
+
+  public init(provider: AgentHubProvider) {
+    self.provider = provider
+  }
+
+  public var body: some View {
+    HStack(spacing: 4) {
+      Image(systemName: "sparkle")
+      Text(provider.statsService.formattedTotalTokens)
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add `AgentHubProvider` as central service factory for simplified app setup
- Refactor `CodeChangesView` to accept `claudeClient` as parameter (enables proper DI)
- Simplify demo app from manual service wiring to single provider instance
- Add Configuration/ module with provider, configuration, environment, and view helpers

## New Files
- `AgentHubConfiguration.swift` - Configuration options
- `AgentHubProvider.swift` - Central service factory
- `AgentHubEnvironment.swift` - SwiftUI environment key
- `AgentHubViews.swift` - Convenience views (AgentHubSessionsView, menu bar components)
- `AgentHubDefaults.swift` - UserDefaults keys

## Test plan
- [ ] Build succeeds
- [ ] Demo app launches with `AgentHubProvider`
- [ ] Session monitoring works
- [ ] Inline editor in CodeChangesView works (requires claudeClient pass-through)

🤖 Generated with [Claude Code](https://claude.com/claude-code)