### PR TITLE
Improve active session detection using file modification time

### DIFF
--- a/Sources/AgentHub/UI/CLIRepositoryTreeView.swift
+++ b/Sources/AgentHub/UI/CLIRepositoryTreeView.swift
@@ -95,7 +95,7 @@ public struct CLIRepositoryTreeView: View {
       }
     }
     .padding(6)
-    .agentHubCard(isHighlighted: repository.activeSessionCount > 0)
+    .agentHubCard(isHighlighted: false)
     .alert("Delete Worktree?", isPresented: $showDeleteConfirmation) {
       Button("Cancel", role: .cancel) {
         worktreeToDelete = nil
@@ -135,6 +135,13 @@ public struct CLIRepositoryTreeView: View {
             .font(.headline)
             .fontWeight(.semibold)
             .foregroundColor(.primary)
+
+          // Green dot for active sessions
+          if repository.activeSessionCount > 0 {
+            Circle()
+              .fill(Color.green)
+              .frame(width: 8, height: 8)
+          }
         }
         .contentShape(Rectangle())
       }
@@ -144,18 +151,10 @@ public struct CLIRepositoryTreeView: View {
 
       // Session count badge
       if repository.totalSessionCount > 0 {
-        HStack(spacing: 4) {
-          if repository.activeSessionCount > 0 {
-            Circle()
-              .fill(Color.brandPrimary)
-              .frame(width: 6, height: 6)
-          }
-
-          Text("\(repository.totalSessionCount)")
-            .font(.caption)
-            .foregroundColor(repository.activeSessionCount > 0 ? .brandPrimary : .secondary)
-        }
-        .agentHubChip(isActive: repository.activeSessionCount > 0)
+        Text("\(repository.totalSessionCount)")
+          .font(.caption)
+          .foregroundColor(.secondary)
+          .agentHubChip(isActive: false)
       }
 
       // Create worktree button
@@ -180,7 +179,7 @@ public struct CLIRepositoryTreeView: View {
     }
     .padding(.horizontal, 10)
     .padding(.vertical, 8)
-    .agentHubRow(isHighlighted: repository.activeSessionCount > 0)
+    .agentHubRow(isHighlighted: false)
   }
 }
 

--- a/Sources/AgentHub/UI/CLISessionRow.swift
+++ b/Sources/AgentHub/UI/CLISessionRow.swift
@@ -44,7 +44,7 @@ public struct CLISessionRow: View {
     sessionRowContent
       .padding(.vertical, 8)
       .padding(.horizontal, 10)
-      .agentHubRow(isHighlighted: session.isActive)
+      .agentHubRow(isHighlighted: isMonitoring)
   }
 
   // MARK: - Session Row Content
@@ -84,10 +84,10 @@ public struct CLISessionRow: View {
   }
 
   private var statusColor: Color {
-    if isMonitoring {
-      return .brandPrimary
+    if session.isActive {
+      return .green
     }
-    return session.isActive ? .green : .gray.opacity(0.5)
+    return isMonitoring ? .brandPrimary : .gray.opacity(0.5)
   }
 
   // MARK: - Session ID Row

--- a/Sources/AgentHub/UI/CLISessionsListView.swift
+++ b/Sources/AgentHub/UI/CLISessionsListView.swift
@@ -418,25 +418,6 @@ public struct CLISessionsListView: View {
       }
 
       HStack {
-        // Session count
-        if viewModel.activeSessionCount > 0 {
-          HStack(spacing: 6) {
-            Circle()
-              .fill(Color.green)
-              .frame(width: DesignTokens.StatusSize.sm, height: DesignTokens.StatusSize.sm)
-              .shadow(color: .green.opacity(0.4), radius: 2)
-            Text("\(viewModel.activeSessionCount) active")
-              .font(.system(.caption, weight: .medium))
-              .foregroundColor(.green)
-          }
-          .padding(.horizontal, DesignTokens.Spacing.sm)
-          .padding(.vertical, DesignTokens.Spacing.xs)
-          .background(
-            Capsule()
-              .fill(Color.green.opacity(0.1))
-          )
-        }
-
         Text("\(viewModel.selectedRepositories.count) \(viewModel.selectedRepositories.count == 1 ? "module" : "modules") selected · \(viewModel.totalSessionCount) sessions")
           .font(.caption)
           .foregroundColor(.secondary)

--- a/Sources/AgentHub/UI/CLIWorktreeBranchRow.swift
+++ b/Sources/AgentHub/UI/CLIWorktreeBranchRow.swift
@@ -147,12 +147,20 @@ public struct CLIWorktreeBranchRow: View {
             }
           }
 
-          // Session count
+          // Session count with active indicator
           if !worktree.sessions.isEmpty {
-            Text("\(worktree.sessions.count)")
-              .font(.caption)
-              .foregroundColor(worktree.activeSessionCount > 0 ? .brandPrimary : .secondary)
-              .agentHubChip(isActive: worktree.activeSessionCount > 0)
+            HStack(spacing: 4) {
+              Text("\(worktree.sessions.count)")
+                .font(.caption)
+                .foregroundColor(.secondary)
+
+              if worktree.activeSessionCount > 0 {
+                Circle()
+                  .fill(Color.green)
+                  .frame(width: 6, height: 6)
+              }
+            }
+            .agentHubChip(isActive: false)
           }
 
           // Open terminal button


### PR DESCRIPTION
## Summary
- Replace process-based detection (pgrep/lsof) with file modification time check
- A session is marked active if its `.jsonl` file was modified in last 60 seconds
- This accurately identifies the specific active session, not all sessions in a project
- Simplify UI: use green dots instead of highlighted borders/backgrounds

## Changes

### CLISessionMonitorService.swift
- Remove `getRunningClaudeProcesses()` function (no longer needed)
- Check session file modification time to determine active status

### UI Files
- **CLIRepositoryTreeView**: Add green dot next to module name, remove border highlighting
- **CLIWorktreeBranchRow**: Add green dot next to session count
- **CLISessionRow**: Only highlight when monitored (not when active)
- **CLISessionsListView**: Remove "X active" badge from status bar

## Test plan
- [ ] Start a Claude session in terminal
- [ ] Verify only that specific session shows green dot (not all sessions in project)
- [ ] Kill the session and verify green dot disappears after ~60 seconds
- [ ] Verify monitoring highlighting still works independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)