### PR TITLE
Add Git Diff button to view unstaged changes

### DIFF
--- a/Sources/AgentHub/Models/GitDiffState.swift
+++ b/Sources/AgentHub/Models/GitDiffState.swift
@@ -1,0 +1,65 @@
+//
+//  GitDiffState.swift
+//  AgentHub
+//
+//  Created by Assistant on 1/19/26.
+//
+
+import Foundation
+
+// MARK: - GitDiffState
+
+/// Aggregates all unstaged file changes from a git repository
+public struct GitDiffState: Equatable, Sendable {
+  /// List of all files with unstaged changes
+  public let files: [GitDiffFileEntry]
+
+  /// Number of files with changes
+  public var fileCount: Int { files.count }
+
+  /// Empty state with no changes
+  public static let empty = GitDiffState(files: [])
+
+  public init(files: [GitDiffFileEntry]) {
+    self.files = files
+  }
+}
+
+// MARK: - GitDiffFileEntry
+
+/// Individual file with unstaged changes, including path and line statistics
+public struct GitDiffFileEntry: Identifiable, Equatable, Sendable {
+  public let id: UUID
+  /// Full absolute path to the file
+  public let filePath: String
+  /// Path relative to repository root
+  public let relativePath: String
+  /// Number of lines added
+  public let additions: Int
+  /// Number of lines deleted
+  public let deletions: Int
+
+  /// File name extracted from path
+  public var fileName: String {
+    URL(fileURLWithPath: filePath).lastPathComponent
+  }
+
+  /// Directory path relative to repo root (without file name)
+  public var directoryPath: String {
+    URL(fileURLWithPath: relativePath).deletingLastPathComponent().path
+  }
+
+  public init(
+    id: UUID = UUID(),
+    filePath: String,
+    relativePath: String,
+    additions: Int,
+    deletions: Int
+  ) {
+    self.id = id
+    self.filePath = filePath
+    self.relativePath = relativePath
+    self.additions = additions
+    self.deletions = deletions
+  }
+}

--- a/Sources/AgentHub/Services/GitDiffService.swift
+++ b/Sources/AgentHub/Services/GitDiffService.swift
@@ -1,0 +1,265 @@
+//
+//  GitDiffService.swift
+//  AgentHub
+//
+//  Created by Assistant on 1/19/26.
+//
+
+import Foundation
+
+/// Errors that can occur during git diff operations
+public enum GitDiffError: LocalizedError, Sendable {
+  case gitCommandFailed(String)
+  case fileNotFound(String)
+  case notAGitRepository(String)
+  case timeout
+  case binaryFile(String)
+
+  public var errorDescription: String? {
+    switch self {
+    case .gitCommandFailed(let message):
+      return "Git command failed: \(message)"
+    case .fileNotFound(let path):
+      return "File not found: \(path)"
+    case .notAGitRepository(let path):
+      return "Not a git repository: \(path)"
+    case .timeout:
+      return "Git command timed out"
+    case .binaryFile(let path):
+      return "Binary file: \(path)"
+    }
+  }
+}
+
+/// Service for git diff operations
+public actor GitDiffService {
+
+  /// Maximum time to wait for git commands (in seconds)
+  private static let gitCommandTimeout: TimeInterval = 30.0
+
+  public init() {
+    print("[GitDiffService] Initialized")
+  }
+
+  // MARK: - Public API
+
+  /// Gets all unstaged changes for a repository
+  /// - Parameter repoPath: Path to the git repository (or any subdirectory)
+  /// - Returns: GitDiffState containing all files with unstaged changes
+  public func getUnstagedChanges(at repoPath: String) async throws -> GitDiffState {
+    print("[GitDiffService] getUnstagedChanges called for: \(repoPath)")
+
+    // Find git root
+    let gitRoot = try await findGitRoot(at: repoPath)
+    print("[GitDiffService] Using git root: \(gitRoot)")
+
+    // Get unstaged changes with --numstat
+    let output = try await runGitCommand(["diff", "--numstat"], at: gitRoot)
+
+    // Also get untracked files
+    let untrackedOutput = try await runGitCommand(["status", "--porcelain", "-uall"], at: gitRoot)
+
+    var files: [GitDiffFileEntry] = []
+
+    // Parse --numstat output: "77\t7\tpath/to/file.swift"
+    let lines = output.components(separatedBy: "\n").filter { !$0.isEmpty }
+    for line in lines {
+      let parts = line.components(separatedBy: "\t")
+      guard parts.count >= 3 else { continue }
+
+      // Handle binary files (shown as "-" for additions/deletions)
+      let additions = Int(parts[0]) ?? 0
+      let deletions = Int(parts[1]) ?? 0
+      let relativePath = parts[2]
+
+      let fullPath = (gitRoot as NSString).appendingPathComponent(relativePath)
+      files.append(GitDiffFileEntry(
+        filePath: fullPath,
+        relativePath: relativePath,
+        additions: additions,
+        deletions: deletions
+      ))
+    }
+
+    // Parse untracked files from porcelain output
+    let untrackedLines = untrackedOutput.components(separatedBy: "\n").filter { !$0.isEmpty }
+    for line in untrackedLines {
+      // Format: "XY filename" where XY is status code
+      guard line.count > 3 else { continue }
+
+      let statusCode = String(line.prefix(2))
+      let filePath = String(line.dropFirst(3))
+
+      // "??" means untracked file, "A " means staged new file
+      if statusCode == "??" {
+        let fullPath = (gitRoot as NSString).appendingPathComponent(filePath)
+
+        // Check if we already have this file from diff output
+        if !files.contains(where: { $0.relativePath == filePath }) {
+          // Count lines in untracked file
+          let lineCount = await countLinesInFile(at: fullPath)
+
+          files.append(GitDiffFileEntry(
+            filePath: fullPath,
+            relativePath: filePath,
+            additions: lineCount,
+            deletions: 0
+          ))
+        }
+      }
+    }
+
+    print("[GitDiffService] Found \(files.count) files with changes")
+    return GitDiffState(files: files)
+  }
+
+  /// Gets the diff content for a specific file (old content from HEAD, new content from disk)
+  /// - Parameters:
+  ///   - filePath: Absolute path to the file
+  ///   - repoPath: Path to the git repository
+  /// - Returns: Tuple of (oldContent, newContent)
+  public func getFileDiff(filePath: String, at repoPath: String) async throws -> (oldContent: String, newContent: String) {
+    print("[GitDiffService] getFileDiff called for: \(filePath)")
+
+    let gitRoot = try await findGitRoot(at: repoPath)
+
+    // Get relative path from git root
+    let relativePath: String
+    if filePath.hasPrefix(gitRoot) {
+      relativePath = String(filePath.dropFirst(gitRoot.count + 1)) // +1 for trailing slash
+    } else {
+      relativePath = filePath
+    }
+
+    print("[GitDiffService] Relative path: \(relativePath)")
+
+    // Get old content from HEAD
+    var oldContent = ""
+    do {
+      oldContent = try await runGitCommand(["show", "HEAD:\(relativePath)"], at: gitRoot)
+    } catch {
+      // File might be new (untracked), so old content is empty
+      print("[GitDiffService] Could not get HEAD content (file may be new): \(error)")
+    }
+
+    // Get new content from disk
+    var newContent = ""
+    let fileURL = URL(fileURLWithPath: filePath)
+    if FileManager.default.fileExists(atPath: filePath) {
+      do {
+        newContent = try String(contentsOf: fileURL, encoding: .utf8)
+      } catch {
+        print("[GitDiffService] Could not read file from disk: \(error)")
+        throw GitDiffError.fileNotFound(filePath)
+      }
+    } else {
+      // File might have been deleted
+      print("[GitDiffService] File does not exist on disk (may be deleted)")
+    }
+
+    return (oldContent, newContent)
+  }
+
+  // MARK: - Git Root Detection
+
+  /// Finds the git root directory from any path within a repository
+  private func findGitRoot(at path: String) async throws -> String {
+    let output = try await runGitCommand(["rev-parse", "--show-toplevel"], at: path)
+    return output.trimmingCharacters(in: .whitespacesAndNewlines)
+  }
+
+  // MARK: - Helper Methods
+
+  /// Counts lines in a file
+  private func countLinesInFile(at path: String) async -> Int {
+    guard let data = FileManager.default.contents(atPath: path),
+          let content = String(data: data, encoding: .utf8) else {
+      return 0
+    }
+    return content.components(separatedBy: .newlines).count
+  }
+
+  /// Runs a git command and returns the output
+  private func runGitCommand(
+    _ arguments: [String],
+    at path: String,
+    timeout: TimeInterval = gitCommandTimeout
+  ) async throws -> String {
+    print("[GitDiffService] runGitCommand: git \(arguments.joined(separator: " ")) at \(path)")
+
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "/usr/bin/git")
+    process.arguments = arguments
+    process.currentDirectoryURL = URL(fileURLWithPath: path)
+
+    // Prevent git from prompting for credentials/input
+    var environment = ProcessInfo.processInfo.environment
+    environment["GIT_TERMINAL_PROMPT"] = "0"
+    environment["GIT_SSH_COMMAND"] = "ssh -o BatchMode=yes"
+    process.environment = environment
+
+    // Provide empty stdin to prevent waiting for input
+    let inputPipe = Pipe()
+    process.standardInput = inputPipe
+
+    let outputPipe = Pipe()
+    let errorPipe = Pipe()
+    process.standardOutput = outputPipe
+    process.standardError = errorPipe
+
+    do {
+      try process.run()
+      try inputPipe.fileHandleForWriting.close()
+    } catch {
+      print("[GitDiffService] Failed to start process: \(error)")
+      throw GitDiffError.gitCommandFailed("Failed to start git: \(error.localizedDescription)")
+    }
+
+    // Wait for process with timeout
+    let didTimeout = await withTaskGroup(of: Bool.self) { group in
+      group.addTask {
+        await withCheckedContinuation { continuation in
+          DispatchQueue.global().async {
+            process.waitUntilExit()
+            continuation.resume(returning: false)
+          }
+        }
+      }
+
+      group.addTask {
+        do {
+          try await Task.sleep(for: .seconds(timeout))
+          if process.isRunning {
+            print("[GitDiffService] Command timed out after \(timeout)s, terminating")
+            process.terminate()
+          }
+          return true
+        } catch {
+          return false
+        }
+      }
+
+      let result = await group.next() ?? false
+      group.cancelAll()
+      return result
+    }
+
+    let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
+    let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
+
+    let output = String(data: outputData, encoding: .utf8) ?? ""
+    let errorOutput = String(data: errorData, encoding: .utf8) ?? ""
+
+    print("[GitDiffService] Exit status: \(process.terminationStatus)")
+
+    if didTimeout {
+      throw GitDiffError.timeout
+    }
+
+    if process.terminationStatus != 0 {
+      throw GitDiffError.gitCommandFailed(errorOutput.trimmingCharacters(in: .whitespacesAndNewlines))
+    }
+
+    return output
+  }
+}

--- a/Sources/AgentHub/UI/GitDiffView.swift
+++ b/Sources/AgentHub/UI/GitDiffView.swift
@@ -1,0 +1,519 @@
+//
+//  GitDiffView.swift
+//  AgentHub
+//
+//  Created by Assistant on 1/19/26.
+//
+
+import SwiftUI
+import PierreDiffsSwift
+
+// MARK: - GitDiffView
+
+/// Full-screen sheet showing git unstaged diffs for a session
+public struct GitDiffView: View {
+  let session: CLISession
+  let projectPath: String
+  let onDismiss: () -> Void
+
+  @State private var diffState: GitDiffState = .empty
+  @State private var isLoading = true
+  @State private var errorMessage: String?
+  @State private var selectedFileId: UUID?
+  @State private var diffContents: [UUID: (old: String, new: String)] = [:]
+  @State private var loadingStates: [UUID: Bool] = [:]
+  @State private var fileErrorMessages: [UUID: String] = [:]
+  @State private var diffStyle: DiffStyle = .unified
+  @State private var overflowMode: OverflowMode = .wrap
+
+  private let gitDiffService = GitDiffService()
+
+  public init(
+    session: CLISession,
+    projectPath: String,
+    onDismiss: @escaping () -> Void
+  ) {
+    self.session = session
+    self.projectPath = projectPath
+    self.onDismiss = onDismiss
+  }
+
+  public var body: some View {
+    VStack(spacing: 0) {
+      // Header
+      header
+
+      Divider()
+
+      // Content
+      if isLoading {
+        loadingState
+      } else if let error = errorMessage {
+        errorState(error)
+      } else if diffState.files.isEmpty {
+        emptyState
+      } else {
+        HSplitView {
+          // File list sidebar
+          fileListSidebar
+            .frame(minWidth: 200, idealWidth: 250, maxWidth: 300)
+
+          // Diff viewer
+          diffViewer
+        }
+      }
+    }
+    .frame(minWidth: 1200, idealWidth: .infinity, maxWidth: .infinity,
+           minHeight: 800, idealHeight: .infinity, maxHeight: .infinity)
+    .onKeyPress(.escape) {
+      onDismiss()
+      return .handled
+    }
+    .task {
+      await loadUnstagedChanges()
+    }
+  }
+
+  // MARK: - Header
+
+  private var header: some View {
+    HStack {
+      HStack(spacing: 8) {
+        Image(systemName: "arrow.left.arrow.right")
+          .font(.title3)
+          .foregroundColor(.brandPrimary)
+
+        Text("Git Diff")
+          .font(.title3.weight(.semibold))
+
+        Text("(\(diffState.fileCount) files)")
+          .font(.title3)
+          .foregroundColor(.secondary)
+      }
+
+      Spacer()
+
+      // Session info
+      HStack(spacing: 8) {
+        Text(session.shortId)
+          .font(.system(.caption, design: .monospaced))
+          .foregroundColor(.secondary)
+
+        if let branch = session.branchName {
+          Text("[\(branch)]")
+            .font(.caption)
+            .foregroundColor(.secondary)
+        }
+      }
+
+      Spacer()
+
+      Button("Close") {
+        onDismiss()
+      }
+    }
+    .padding()
+    .background(Color.surfaceElevated)
+  }
+
+  // MARK: - Loading State
+
+  private var loadingState: some View {
+    VStack(spacing: 12) {
+      ProgressView()
+      Text("Loading unstaged changes...")
+        .font(.caption)
+        .foregroundColor(.secondary)
+    }
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+  }
+
+  // MARK: - Error State
+
+  private func errorState(_ message: String) -> some View {
+    VStack(spacing: 12) {
+      Image(systemName: "exclamationmark.triangle")
+        .font(.system(size: 48))
+        .foregroundColor(.red.opacity(0.5))
+
+      Text("Failed to Load Git Diff")
+        .font(.headline)
+        .foregroundColor(.secondary)
+
+      Text(message)
+        .font(.caption)
+        .foregroundColor(.secondary)
+        .multilineTextAlignment(.center)
+
+      Button("Retry") {
+        Task { await loadUnstagedChanges() }
+      }
+      .buttonStyle(.borderedProminent)
+    }
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+    .padding()
+  }
+
+  // MARK: - Empty State
+
+  private var emptyState: some View {
+    VStack(spacing: 12) {
+      Image(systemName: "checkmark.circle")
+        .font(.system(size: 48))
+        .foregroundColor(.green.opacity(0.5))
+
+      Text("No Unstaged Changes")
+        .font(.headline)
+        .foregroundColor(.secondary)
+
+      Text("Your working directory is clean.")
+        .font(.caption)
+        .foregroundColor(.secondary)
+        .multilineTextAlignment(.center)
+    }
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+    .padding()
+  }
+
+  // MARK: - File List Sidebar
+
+  private var fileListSidebar: some View {
+    VStack(alignment: .leading, spacing: 0) {
+      // Header
+      HStack {
+        Text("Changes")
+          .font(.headline)
+        Spacer()
+      }
+      .padding()
+
+      Divider()
+
+      // File list
+      ScrollView {
+        LazyVStack(alignment: .leading, spacing: 4) {
+          ForEach(diffState.files) { file in
+            GitDiffFileRow(
+              entry: file,
+              isSelected: selectedFileId == file.id,
+              onSelect: {
+                selectedFileId = file.id
+                loadFileDiff(for: file)
+              }
+            )
+          }
+        }
+        .padding(8)
+      }
+    }
+  }
+
+  // MARK: - Diff Viewer
+
+  @ViewBuilder
+  private var diffViewer: some View {
+    if let selectedId = selectedFileId {
+      if loadingStates[selectedId] == true {
+        // Loading state
+        VStack {
+          ProgressView()
+          Text("Loading diff...")
+            .font(.caption)
+            .foregroundColor(.secondary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+      } else if let error = fileErrorMessages[selectedId] {
+        // Error state
+        VStack(spacing: 12) {
+          Image(systemName: "exclamationmark.triangle")
+            .font(.largeTitle)
+            .foregroundColor(.red)
+          Text(error)
+            .font(.caption)
+            .foregroundColor(.secondary)
+            .multilineTextAlignment(.center)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding()
+      } else if let contents = diffContents[selectedId] {
+        // Find the file entry for the name
+        if let file = diffState.files.first(where: { $0.id == selectedId }) {
+          GitDiffContentView(
+            oldContent: contents.old,
+            newContent: contents.new,
+            fileName: file.fileName,
+            filePath: file.filePath,
+            diffStyle: $diffStyle,
+            overflowMode: $overflowMode
+          )
+          .frame(minHeight: 400)
+          .id(selectedId)
+        }
+      } else {
+        // No diff loaded
+        Text("Select a file to view")
+          .foregroundColor(.secondary)
+          .frame(maxWidth: .infinity, maxHeight: .infinity)
+      }
+    } else {
+      Text("Select a file to view")
+        .foregroundColor(.secondary)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+  }
+
+  // MARK: - Data Loading
+
+  private func loadUnstagedChanges() async {
+    isLoading = true
+    errorMessage = nil
+
+    do {
+      let state = try await gitDiffService.getUnstagedChanges(at: projectPath)
+      await MainActor.run {
+        diffState = state
+        isLoading = false
+
+        // Auto-select first file
+        if selectedFileId == nil, let first = state.files.first {
+          selectedFileId = first.id
+          loadFileDiff(for: first)
+        }
+      }
+    } catch {
+      await MainActor.run {
+        errorMessage = error.localizedDescription
+        isLoading = false
+      }
+    }
+  }
+
+  private func loadFileDiff(for file: GitDiffFileEntry) {
+    // Skip if already loaded
+    if diffContents[file.id] != nil { return }
+
+    loadingStates[file.id] = true
+
+    Task {
+      do {
+        let (oldContent, newContent) = try await gitDiffService.getFileDiff(
+          filePath: file.filePath,
+          at: projectPath
+        )
+        await MainActor.run {
+          diffContents[file.id] = (old: oldContent, new: newContent)
+          loadingStates[file.id] = false
+        }
+      } catch {
+        await MainActor.run {
+          fileErrorMessages[file.id] = error.localizedDescription
+          loadingStates[file.id] = false
+        }
+      }
+    }
+  }
+}
+
+// MARK: - GitDiffFileRow
+
+private struct GitDiffFileRow: View {
+  let entry: GitDiffFileEntry
+  let isSelected: Bool
+  let onSelect: () -> Void
+
+  var body: some View {
+    Button(action: onSelect) {
+      HStack(spacing: 8) {
+        // File icon
+        Image(systemName: "doc.text")
+          .font(.caption)
+          .foregroundColor(.blue)
+          .frame(width: 16)
+
+        VStack(alignment: .leading, spacing: 2) {
+          // File name
+          Text(entry.fileName)
+            .font(.system(.caption, design: .monospaced))
+            .fontWeight(.medium)
+            .lineLimit(1)
+
+          // Directory path
+          if !entry.directoryPath.isEmpty {
+            Text(entry.directoryPath)
+              .font(.caption2)
+              .foregroundColor(.secondary)
+              .lineLimit(1)
+          }
+        }
+
+        Spacer()
+
+        // Change counts: +N / -N
+        HStack(spacing: 2) {
+          Text("+\(entry.additions)")
+            .foregroundColor(.green)
+          Text("/")
+            .foregroundColor(.secondary)
+          Text("-\(entry.deletions)")
+            .foregroundColor(.red)
+        }
+        .font(.caption2.bold())
+      }
+      .padding(.horizontal, 8)
+      .padding(.vertical, 6)
+      .background(
+        RoundedRectangle(cornerRadius: 6)
+          .fill(isSelected ? Color.brandPrimary.opacity(0.15) : Color.clear)
+      )
+      .overlay(
+        RoundedRectangle(cornerRadius: 6)
+          .stroke(isSelected ? Color.brandPrimary.opacity(0.3) : Color.clear, lineWidth: 1)
+      )
+      .contentShape(Rectangle())
+    }
+    .buttonStyle(.plain)
+  }
+}
+
+// MARK: - GitDiffContentView
+
+/// Wrapper that adds header controls to PierreDiffView
+private struct GitDiffContentView: View {
+  let oldContent: String
+  let newContent: String
+  let fileName: String
+  let filePath: String
+
+  @Binding var diffStyle: DiffStyle
+  @Binding var overflowMode: OverflowMode
+
+  @State private var webViewOpacity: Double = 1.0
+  @State private var isWebViewReady = false
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 0) {
+      // Header with file info and controls
+      headerView
+
+      // Diff view
+      GeometryReader { _ in
+        ZStack {
+          PierreDiffView(
+            oldContent: oldContent,
+            newContent: newContent,
+            fileName: fileName,
+            diffStyle: $diffStyle,
+            overflowMode: $overflowMode,
+            onLineClickWithPosition: nil,
+            onReady: {
+              withAnimation(.easeInOut(duration: 0.3)) {
+                isWebViewReady = true
+              }
+            }
+          )
+          .opacity(isWebViewReady ? webViewOpacity : 0)
+
+          if !isWebViewReady {
+            VStack(spacing: 12) {
+              ProgressView()
+                .controlSize(.small)
+              Text("Loading diff...")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .transition(.opacity)
+          }
+        }
+      }
+      .animation(.easeInOut(duration: 0.3), value: isWebViewReady)
+    }
+  }
+
+  private var headerView: some View {
+    VStack(alignment: .leading) {
+      HStack {
+        // File name with icon
+        HStack {
+          Image(systemName: "doc.text.fill")
+            .foregroundStyle(.blue)
+          Text(fileName)
+            .font(.headline)
+        }
+
+        Spacer()
+
+        HStack(spacing: 8) {
+          // Split/Unified toggle button
+          Button {
+            toggleDiffStyle()
+          } label: {
+            Image(systemName: diffStyle == .split ? "rectangle.split.2x1" : "rectangle.stack")
+              .font(.system(size: 14))
+          }
+          .buttonStyle(.plain)
+          .help(diffStyle == .split ? "Switch to unified view" : "Switch to split view")
+
+          // Wrap toggle button
+          Button {
+            toggleOverflowMode()
+          } label: {
+            Image(systemName: overflowMode == .wrap ? "text.alignleft" : "text.aligncenter")
+              .font(.system(size: 14))
+              .foregroundStyle(overflowMode == .wrap ? .primary : .secondary)
+          }
+          .buttonStyle(.plain)
+          .help(overflowMode == .wrap ? "Disable word wrap" : "Enable word wrap")
+        }
+      }
+    }
+    .padding(.horizontal)
+    .padding(.vertical, 12)
+  }
+
+  // MARK: - Toggle Functions
+
+  private func toggleDiffStyle() {
+    Task {
+      withAnimation(.easeOut(duration: 0.15)) {
+        webViewOpacity = 0
+      }
+      try? await Task.sleep(for: .milliseconds(150))
+      diffStyle = diffStyle == .split ? .unified : .split
+      withAnimation(.easeIn(duration: 0.15)) {
+        webViewOpacity = 1
+      }
+    }
+  }
+
+  private func toggleOverflowMode() {
+    Task {
+      withAnimation(.easeOut(duration: 0.15)) {
+        webViewOpacity = 0
+      }
+      try? await Task.sleep(for: .milliseconds(150))
+      overflowMode = overflowMode == .scroll ? .wrap : .scroll
+      withAnimation(.easeIn(duration: 0.15)) {
+        webViewOpacity = 1
+      }
+    }
+  }
+}
+
+// MARK: - Preview
+
+#Preview {
+  GitDiffView(
+    session: CLISession(
+      id: "test-session-id",
+      projectPath: "/Users/test/project",
+      branchName: "main",
+      isWorktree: false,
+      lastActivityAt: Date(),
+      messageCount: 10,
+      isActive: true
+    ),
+    projectPath: "/Users/test/project",
+    onDismiss: {}
+  )
+}

--- a/Sources/AgentHub/UI/MonitoringCardView.swift
+++ b/Sources/AgentHub/UI/MonitoringCardView.swift
@@ -17,6 +17,15 @@ private struct CodeChangesSheetItem: Identifiable {
   let codeChangesState: CodeChangesState
 }
 
+// MARK: - GitDiffSheetItem
+
+/// Identifiable wrapper for git diff sheet - captures session and project path
+private struct GitDiffSheetItem: Identifiable {
+  let id = UUID()
+  let session: CLISession
+  let projectPath: String
+}
+
 // MARK: - MonitoringCardView
 
 /// Card view for displaying a monitored session in the monitoring panel
@@ -31,6 +40,7 @@ public struct MonitoringCardView: View {
   let onOpenSessionFile: () -> Void
 
   @State private var codeChangesSheetItem: CodeChangesSheetItem?
+  @State private var gitDiffSheetItem: GitDiffSheetItem?
 
   public init(
     session: CLISession,
@@ -73,6 +83,13 @@ public struct MonitoringCardView: View {
         codeChangesState: item.codeChangesState,
         onDismiss: { codeChangesSheetItem = nil },
         claudeClient: claudeClient
+      )
+    }
+    .sheet(item: $gitDiffSheetItem) { item in
+      GitDiffView(
+        session: item.session,
+        projectPath: item.projectPath,
+        onDismiss: { gitDiffSheetItem = nil }
       )
     }
   }
@@ -153,6 +170,25 @@ public struct MonitoringCardView: View {
         .buttonStyle(.plain)
         .help("View code changes")
       }
+
+      // Git diff button (trailing)
+      Button(action: {
+        gitDiffSheetItem = GitDiffSheetItem(
+          session: session,
+          projectPath: session.projectPath
+        )
+      }) {
+        HStack(spacing: 4) {
+          Image(systemName: "arrow.left.arrow.right")
+            .font(.caption)
+          Text("Diff")
+            .font(.system(.caption2, design: .rounded))
+        }
+        .foregroundColor(.secondary)
+        .agentHubChip()
+      }
+      .buttonStyle(.plain)
+      .help("View git unstaged changes")
 
       // Connect button (trailing)
       Button(action: onConnect) {


### PR DESCRIPTION
## Summary
- Adds a "Diff" button to MonitoringCardView header for viewing git unstaged changes
- Creates GitDiffService actor to run `git diff --numstat` and fetch file contents
- Displays diffs using existing PierreDiffView infrastructure with split/unified toggle

## Test plan
- [ ] Monitor a session with unstaged changes in its worktree
- [ ] Click the "Diff" button in the session card header
- [ ] Verify file list shows file names, directory paths, and +/- line counts
- [ ] Click a file to view the diff in PierreDiffView
- [ ] Test toggle between split/unified view modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)