### PR TITLE
Enable full ANSI color support in embedded terminal

### DIFF
--- a/Sources/AgentHub/UI/EmbeddedTerminalView.swift
+++ b/Sources/AgentHub/UI/EmbeddedTerminalView.swift
@@ -124,6 +124,13 @@ public class TerminalContainerView: NSView {
 
     // Build environment with PATH
     var environment = ProcessInfo.processInfo.environment
+
+    // Enable full color support for Claude Code CLI
+    // These tell the CLI that the terminal supports 256 colors and true color (24-bit RGB)
+    environment["TERM"] = "xterm-256color"
+    environment["COLORTERM"] = "truecolor"
+    environment["LANG"] = "en_US.UTF-8"
+
     let paths = (additionalPaths ?? []) + [
       "/usr/local/bin",
       "/opt/homebrew/bin",


### PR DESCRIPTION
## Summary
- Add `TERM=xterm-256color` environment variable to signal 256-color support
- Add `COLORTERM=truecolor` to enable 24-bit RGB colors
- Add `LANG=en_US.UTF-8` for proper Unicode/ASCII art rendering

This fixes the issue where Claude Code CLI's colored ASCII art, menu highlights, and syntax highlighting weren't displaying in the embedded terminal. The CLI auto-detects terminal capabilities via these environment variables.

## Test plan
- [ ] Build and run the app
- [ ] Open an embedded terminal session with Claude Code
- [ ] Verify colored ASCII art logo displays
- [ ] Navigate menus with ↑/↓ and verify selection highlights appear
- [ ] Check syntax highlighting in code blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)