### PR TITLE
Adjust worktree row menu width and padding

### DIFF
--- a/Sources/AgentHub/UI/CLIWorktreeBranchRow.swift
+++ b/Sources/AgentHub/UI/CLIWorktreeBranchRow.swift
@@ -204,7 +204,8 @@ public struct CLIWorktreeBranchRow: View {
               .padding(.vertical, 8)
               .contentShape(Rectangle())
             }
-            .frame(width: 160)
+            .padding(.vertical, 8)
+            .frame(width: 180)
           }
         }
         .padding(.vertical, 6)


### PR DESCRIPTION
## Summary
- Increase menu width from 160 to 180
- Add vertical padding for better spacing

🤖 Generated with [Claude Code](https://claude.com/claude-code)