### PR TITLE
Add inline editor support to GitDiffView

### DIFF
--- a/Sources/AgentHub/UI/MonitoringCardView.swift
+++ b/Sources/AgentHub/UI/MonitoringCardView.swift
@@ -101,7 +101,8 @@ public struct MonitoringCardView: View {
       GitDiffView(
         session: item.session,
         projectPath: item.projectPath,
-        onDismiss: { gitDiffSheetItem = nil }
+        onDismiss: { gitDiffSheetItem = nil },
+        claudeClient: claudeClient
       )
     }
   }


### PR DESCRIPTION
## Summary
- Enable inline editor in git diff UI (was previously only in CodeChangesView)
- Add `claudeClient` parameter to `GitDiffView` for inline editor operations
- Add line click handler to show inline editor overlay with contextual prompts
- Update escape key to dismiss inline editor before closing the view

## Test plan
- [ ] Open a monitored session with git changes
- [ ] Click "Diff" button to open GitDiffView
- [ ] Click on any line in the diff
- [ ] Verify the inline editor appears below the clicked line
- [ ] Type a question and submit
- [ ] Verify Terminal opens with the resumed session and contextual prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)