### PR TITLE
Add inline edit prompt support with Enter key fix

### DIFF
--- a/Sources/AgentHub/UI/MonitoringCardView.swift
+++ b/Sources/AgentHub/UI/MonitoringCardView.swift
@@ -35,11 +35,14 @@ public struct MonitoringCardView: View {
   let codeChangesState: CodeChangesState?
   let claudeClient: (any ClaudeCode)?
   let showTerminal: Bool
+  let initialPrompt: String?
   let onToggleTerminal: (Bool) -> Void
   let onStopMonitoring: () -> Void
   let onConnect: () -> Void
   let onCopySessionId: () -> Void
   let onOpenSessionFile: () -> Void
+  let onInlineRequestSubmit: ((String, CLISession) -> Void)?
+  let onPromptConsumed: (() -> Void)?
 
   @State private var codeChangesSheetItem: CodeChangesSheetItem?
   @State private var gitDiffSheetItem: GitDiffSheetItem?
@@ -50,22 +53,28 @@ public struct MonitoringCardView: View {
     codeChangesState: CodeChangesState? = nil,
     claudeClient: (any ClaudeCode)? = nil,
     showTerminal: Bool = false,
+    initialPrompt: String? = nil,
     onToggleTerminal: @escaping (Bool) -> Void,
     onStopMonitoring: @escaping () -> Void,
     onConnect: @escaping () -> Void,
     onCopySessionId: @escaping () -> Void,
-    onOpenSessionFile: @escaping () -> Void
+    onOpenSessionFile: @escaping () -> Void,
+    onInlineRequestSubmit: ((String, CLISession) -> Void)? = nil,
+    onPromptConsumed: (() -> Void)? = nil
   ) {
     self.session = session
     self.state = state
     self.codeChangesState = codeChangesState
     self.claudeClient = claudeClient
     self.showTerminal = showTerminal
+    self.initialPrompt = initialPrompt
     self.onToggleTerminal = onToggleTerminal
     self.onStopMonitoring = onStopMonitoring
     self.onConnect = onConnect
     self.onCopySessionId = onCopySessionId
     self.onOpenSessionFile = onOpenSessionFile
+    self.onInlineRequestSubmit = onInlineRequestSubmit
+    self.onPromptConsumed = onPromptConsumed
   }
 
   public var body: some View {
@@ -84,7 +93,9 @@ public struct MonitoringCardView: View {
         showTerminal: showTerminal,
         sessionId: session.id,
         projectPath: session.projectPath,
-        claudeClient: claudeClient
+        claudeClient: claudeClient,
+        initialPrompt: initialPrompt,
+        onPromptConsumed: onPromptConsumed
       )
     }
     .padding(12)
@@ -102,7 +113,8 @@ public struct MonitoringCardView: View {
         session: item.session,
         projectPath: item.projectPath,
         onDismiss: { gitDiffSheetItem = nil },
-        claudeClient: claudeClient
+        claudeClient: claudeClient,
+        onInlineRequestSubmit: onInlineRequestSubmit
       )
     }
   }

--- a/Sources/AgentHub/UI/MonitoringPanelView.swift
+++ b/Sources/AgentHub/UI/MonitoringPanelView.swift
@@ -182,6 +182,8 @@ public struct MonitoringPanelView: View {
       let codeChangesState = item.state.map {
         CodeChangesState.from(activities: $0.recentActivities)
       }
+      // Read pending prompt (read-only, safe during view body)
+      let initialPrompt = viewModel.pendingPrompt(for: item.session.id)
 
       MonitoringCardView(
         session: item.session,
@@ -189,6 +191,7 @@ public struct MonitoringPanelView: View {
         codeChangesState: codeChangesState,
         claudeClient: claudeClient,
         showTerminal: viewModel.sessionsWithTerminalView.contains(item.session.id),
+        initialPrompt: initialPrompt,
         onToggleTerminal: { show in
           viewModel.setTerminalView(for: item.session.id, show: show)
         },
@@ -205,6 +208,12 @@ public struct MonitoringPanelView: View {
         },
         onOpenSessionFile: {
           openSessionFile(for: item.session)
+        },
+        onInlineRequestSubmit: { prompt, session in
+          viewModel.showTerminalWithPrompt(for: session, prompt: prompt)
+        },
+        onPromptConsumed: {
+          viewModel.clearPendingPrompt(for: item.session.id)
         }
       )
     }

--- a/Sources/AgentHub/UI/SessionMonitorPanel.swift
+++ b/Sources/AgentHub/UI/SessionMonitorPanel.swift
@@ -18,19 +18,25 @@ public struct SessionMonitorPanel: View {
   let sessionId: String?
   let projectPath: String?
   let claudeClient: (any ClaudeCode)?
+  let initialPrompt: String?
+  let onPromptConsumed: (() -> Void)?
 
   public init(
     state: SessionMonitorState?,
     showTerminal: Bool = false,
     sessionId: String? = nil,
     projectPath: String? = nil,
-    claudeClient: (any ClaudeCode)? = nil
+    claudeClient: (any ClaudeCode)? = nil,
+    initialPrompt: String? = nil,
+    onPromptConsumed: (() -> Void)? = nil
   ) {
     self.state = state
     self.showTerminal = showTerminal
     self.sessionId = sessionId
     self.projectPath = projectPath
     self.claudeClient = claudeClient
+    self.initialPrompt = initialPrompt
+    self.onPromptConsumed = onPromptConsumed
   }
 
   public var body: some View {
@@ -81,12 +87,19 @@ public struct SessionMonitorPanel: View {
         EmbeddedTerminalView(
           sessionId: sessionId,
           projectPath: projectPath ?? "",
-          claudeClient: claudeClient
+          claudeClient: claudeClient,
+          initialPrompt: initialPrompt
         )
         .frame(minHeight: showTerminal ? 300 : 0, maxHeight: showTerminal ? .infinity : 0)
         .clipped()
         .cornerRadius(6)
         .opacity(showTerminal ? 1 : 0)
+        .onAppear {
+          // Clear the pending prompt after terminal starts
+          if initialPrompt != nil {
+            onPromptConsumed?()
+          }
+        }
       }
     }
     .frame(maxWidth: .infinity, alignment: .leading)


### PR DESCRIPTION
## Summary
- Add `initialPrompt` parameter to `EmbeddedTerminalView` for inline edit requests from GitDiffView
- Implement `sendPromptIfNeeded` to programmatically send prompt text to the terminal
- Fix Enter key by sending carriage return (ASCII 13) with a small delay to ensure the terminal's input buffer processes the text first
- Use modern Swift concurrency (`Task`/`async`) instead of `DispatchQueue`

## Test plan
- [ ] Build the app: `swift build`
- [ ] Monitor a session with terminal view
- [ ] Open git diff view, click a line, submit an inline edit request
- [ ] Verify: prompt is typed AND submitted (Enter pressed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)