### PR TITLE
Add plan view feature with markdown rendering

### DIFF
--- a/AgentHubDemo/AgentHubDemo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/AgentHubDemo/AgentHubDemo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swift-server/async-http-client.git",
       "state" : {
-        "revision" : "5dd84c7bb48b348751d7bbe7ba94a17bafdcef37",
-        "version" : "1.30.2"
+        "revision" : "4b99975677236d13f0754339864e5360142ff5a1",
+        "version" : "1.30.3"
       }
     },
     {
@@ -17,6 +17,15 @@
       "state" : {
         "revision" : "f626d1d1eab3bf43a1eef2f70b2a493903f7e5e8",
         "version" : "1.2.4"
+      }
+    },
+    {
+      "identity" : "networkimage",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/gonzalezreal/NetworkImage",
+      "state" : {
+        "revision" : "2849f5323265386e200484b0d0f896e73c3411b9",
+        "version" : "6.0.1"
       }
     },
     {
@@ -78,8 +87,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-certificates.git",
       "state" : {
-        "revision" : "133a347911b6ad0fc8fe3bf46ca90c66cff97130",
-        "version" : "1.17.0"
+        "revision" : "7d5f6124c91a2d06fb63a811695a3400d15a100e",
+        "version" : "1.17.1"
+      }
+    },
+    {
+      "identity" : "swift-cmark",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-cmark",
+      "state" : {
+        "revision" : "5d9bdaa4228b381639fff09403e39a04926e2dbe",
+        "version" : "0.7.1"
       }
     },
     {
@@ -132,8 +150,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log.git",
       "state" : {
-        "revision" : "bc386b95f2a16ccd0150a8235e7c69eab2b866ca",
-        "version" : "1.8.0"
+        "revision" : "2778fd4e5a12a8aaa30a3ee8285f4ce54c5f3181",
+        "version" : "1.9.1"
+      }
+    },
+    {
+      "identity" : "swift-markdown-ui",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/gonzalezreal/swift-markdown-ui",
+      "state" : {
+        "revision" : "5f613358148239d0292c0cef674a3c2314737f9e",
+        "version" : "2.4.1"
       }
     },
     {
@@ -141,8 +168,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "e3d5c560e0a6bfa391a00e857aa28ad52a41fe8d",
-        "version" : "2.92.1"
+        "revision" : "233f61bc2cfbb22d0edeb2594da27a20d2ce514e",
+        "version" : "2.93.0"
       }
     },
     {
@@ -150,8 +177,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-extras.git",
       "state" : {
-        "revision" : "1c90641b02b6ab47c6d0db2063a12198b04e83e2",
-        "version" : "1.31.2"
+        "revision" : "cc599775aa85d04340f09b47e5432564f9889ae7",
+        "version" : "1.32.0"
       }
     },
     {
@@ -213,8 +240,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-system.git",
       "state" : {
-        "revision" : "395a77f0aa927f0ff73941d7ac35f2b46d47c9db",
-        "version" : "1.6.3"
+        "revision" : "7c6ad0fc39d0763e0b699210e4124afd5041c5df",
+        "version" : "1.6.4"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "7325082fe5564f9851668d463bc69fcb963a7539270e3cae52039a1385b7f198",
+  "originHash" : "e1e434305ede540759b87d5669e45d07c519e8f9d4d170d33fb03ea7b3c2f0c6",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -17,6 +17,15 @@
       "state" : {
         "revision" : "f626d1d1eab3bf43a1eef2f70b2a493903f7e5e8",
         "version" : "1.2.4"
+      }
+    },
+    {
+      "identity" : "networkimage",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/gonzalezreal/NetworkImage",
+      "state" : {
+        "revision" : "2849f5323265386e200484b0d0f896e73c3411b9",
+        "version" : "6.0.1"
       }
     },
     {
@@ -83,6 +92,15 @@
       }
     },
     {
+      "identity" : "swift-cmark",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-cmark",
+      "state" : {
+        "revision" : "5d9bdaa4228b381639fff09403e39a04926e2dbe",
+        "version" : "0.7.1"
+      }
+    },
+    {
       "identity" : "swift-collections",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
@@ -134,6 +152,15 @@
       "state" : {
         "revision" : "bc386b95f2a16ccd0150a8235e7c69eab2b866ca",
         "version" : "1.8.0"
+      }
+    },
+    {
+      "identity" : "swift-markdown-ui",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/gonzalezreal/swift-markdown-ui",
+      "state" : {
+        "revision" : "5f613358148239d0292c0cef674a3c2314737f9e",
+        "version" : "2.4.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -18,6 +18,7 @@ let package = Package(
     .package(url: "https://github.com/jamesrochabrun/ClaudeCodeSDK", exact: "1.2.4"),
     .package(url: "https://github.com/jamesrochabrun/PierreDiffsSwift", exact: "1.1.4"),
     .package(url: "https://github.com/migueldeicaza/SwiftTerm", from: "1.2.0"),
+    .package(url: "https://github.com/gonzalezreal/swift-markdown-ui", from: "2.0.0"),
   ],
   targets: [
     .target(
@@ -26,6 +27,7 @@ let package = Package(
         .product(name: "ClaudeCodeSDK", package: "ClaudeCodeSDK"),
         .product(name: "PierreDiffsSwift", package: "PierreDiffsSwift"),
         .product(name: "SwiftTerm", package: "SwiftTerm"),
+        .product(name: "MarkdownUI", package: "swift-markdown-ui"),
       ],
       swiftSettings: [
         .swiftLanguageMode(.v5)

--- a/Sources/AgentHub/Models/PlanState.swift
+++ b/Sources/AgentHub/Models/PlanState.swift
@@ -1,0 +1,48 @@
+//
+//  PlanState.swift
+//  AgentHub
+//
+//  Created by Assistant on 1/20/26.
+//
+
+import Foundation
+
+// MARK: - PlanState
+
+/// Represents a detected plan file from a session's activity history
+public struct PlanState: Equatable, Sendable {
+  /// Path to the plan file
+  public let filePath: String
+
+  /// File name computed from path
+  public var fileName: String {
+    URL(fileURLWithPath: filePath).lastPathComponent
+  }
+
+  public init(filePath: String) {
+    self.filePath = filePath
+  }
+
+  /// Create from session monitor state's recent activities
+  /// Scans for Write or Edit tool calls to ~/.claude/plans/*.md
+  public static func from(activities: [ActivityEntry]) -> PlanState? {
+    // Look for Write or Edit tool calls to plan files
+    for activity in activities.reversed() {
+      guard case .toolUse(let name) = activity.type,
+            (name == "Write" || name == "Edit"),
+            let input = activity.toolInput,
+            (input.toolType == .write || input.toolType == .edit) else {
+        continue
+      }
+
+      let filePath = input.filePath
+
+      // Check if this is a plan file: ~/.claude/plans/*.md
+      if filePath.contains("/.claude/plans/") && filePath.hasSuffix(".md") {
+        return PlanState(filePath: filePath)
+      }
+    }
+
+    return nil
+  }
+}

--- a/Sources/AgentHub/UI/MarkdownView.swift
+++ b/Sources/AgentHub/UI/MarkdownView.swift
@@ -1,0 +1,109 @@
+//
+//  MarkdownView.swift
+//  AgentHub
+//
+//  Created by Assistant on 1/20/26.
+//
+
+import MarkdownUI
+import SwiftUI
+
+// MARK: - MarkdownView
+
+/// A SwiftUI view that renders markdown content using MarkdownUI.
+///
+/// Wraps the MarkdownUI library's Markdown view with custom theming
+/// to match the AgentHub design system.
+public struct MarkdownView: View {
+  let content: String
+
+  public init(content: String) {
+    self.content = content
+  }
+
+  public var body: some View {
+    ScrollView {
+      Markdown(content)
+        .markdownTheme(.agentHub)
+        .markdownCodeSyntaxHighlighter(.plainText)
+        .textSelection(.enabled)
+        .padding()
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+    .background(Color.surfaceCanvas)
+  }
+}
+
+// MARK: - AgentHub Markdown Theme
+
+extension MarkdownUI.Theme {
+  /// Custom theme for plan markdown display
+  static let agentHub = Theme()
+    .code {
+      FontFamilyVariant(.monospaced)
+      FontSize(.em(0.9))
+    }
+    .codeBlock { configuration in
+      ScrollView(.horizontal, showsIndicators: true) {
+        configuration.label
+          .markdownTextStyle {
+            FontFamilyVariant(.monospaced)
+            FontSize(.em(0.9))
+          }
+          .padding(DesignTokens.Spacing.md)
+      }
+      .background(Color.surfaceCard)
+      .clipShape(RoundedRectangle(cornerRadius: DesignTokens.Radius.sm))
+    }
+    .blockquote { configuration in
+      HStack(spacing: 0) {
+        Rectangle()
+          .fill(Color.secondary.opacity(0.3))
+          .frame(width: 3)
+        configuration.label
+          .padding(.leading, DesignTokens.Spacing.md)
+      }
+      .padding(.vertical, DesignTokens.Spacing.xs)
+    }
+}
+
+// MARK: - Preview
+
+#Preview {
+  MarkdownView(content: """
+    # Heading 1
+
+    This is a paragraph with **bold**, *italic*, and `inline code`.
+
+    ## Heading 2
+
+    Here's a code block:
+
+    ```swift
+    func hello() {
+      print("Hello, World!")
+    }
+    ```
+
+    ### Lists
+
+    Unordered list:
+    - Item 1
+    - Item 2
+      - Nested item
+    - Item 3
+
+    Ordered list:
+    1. First
+    2. Second
+    3. Third
+
+    > This is a block quote
+    > with multiple lines
+
+    ---
+
+    That's all!
+    """)
+  .frame(width: 600, height: 800)
+}

--- a/Sources/AgentHub/UI/MonitoringPanelView.swift
+++ b/Sources/AgentHub/UI/MonitoringPanelView.swift
@@ -182,6 +182,9 @@ public struct MonitoringPanelView: View {
       let codeChangesState = item.state.map {
         CodeChangesState.from(activities: $0.recentActivities)
       }
+      let planState = item.state.flatMap {
+        PlanState.from(activities: $0.recentActivities)
+      }
       // Read pending prompt (read-only, safe during view body)
       let initialPrompt = viewModel.pendingPrompt(for: item.session.id)
 
@@ -189,6 +192,7 @@ public struct MonitoringPanelView: View {
         session: item.session,
         state: item.state,
         codeChangesState: codeChangesState,
+        planState: planState,
         claudeClient: claudeClient,
         showTerminal: viewModel.sessionsWithTerminalView.contains(item.session.id),
         initialPrompt: initialPrompt,

--- a/Sources/AgentHub/UI/PlanView.swift
+++ b/Sources/AgentHub/UI/PlanView.swift
@@ -1,0 +1,205 @@
+//
+//  PlanView.swift
+//  AgentHub
+//
+//  Created by Assistant on 1/20/26.
+//
+
+import ClaudeCodeSDK
+import SwiftUI
+
+// MARK: - PlanView
+
+/// Sheet view to display plan markdown content from a session's plan file.
+///
+/// Shows a header with file information and session context, followed by
+/// the rendered markdown content. Handles async loading and error states.
+public struct PlanView: View {
+  let session: CLISession
+  let planState: PlanState
+  let onDismiss: () -> Void
+
+  @State private var content: String?
+  @State private var isLoading = true
+  @State private var errorMessage: String?
+
+  public init(
+    session: CLISession,
+    planState: PlanState,
+    onDismiss: @escaping () -> Void
+  ) {
+    self.session = session
+    self.planState = planState
+    self.onDismiss = onDismiss
+  }
+
+  public var body: some View {
+    VStack(spacing: 0) {
+      // Header
+      header
+
+      Divider()
+
+      // Content
+      if isLoading {
+        loadingState
+      } else if let error = errorMessage {
+        errorState(error)
+      } else if let content = content {
+        markdownContent(content)
+      }
+    }
+    .frame(
+      minWidth: 700, idealWidth: 900, maxWidth: .infinity,
+      minHeight: 500, idealHeight: 700, maxHeight: .infinity
+    )
+    .onKeyPress(.escape) {
+      onDismiss()
+      return .handled
+    }
+    .task {
+      await loadPlanContent()
+    }
+  }
+
+  // MARK: - Header
+
+  private var header: some View {
+    HStack {
+      HStack(spacing: 8) {
+        Image(systemName: "list.bullet.clipboard")
+          .font(.title3)
+          .foregroundColor(.brandPrimary)
+
+        Text("Plan")
+          .font(.title3.weight(.semibold))
+
+        Text(planState.fileName)
+          .font(.system(.subheadline, design: .monospaced))
+          .foregroundColor(.secondary)
+      }
+
+      Spacer()
+
+      // Session info
+      HStack(spacing: 8) {
+        Text(session.shortId)
+          .font(.system(.caption, design: .monospaced))
+          .foregroundColor(.secondary)
+
+        if let branch = session.branchName {
+          Text("[\(branch)]")
+            .font(.caption)
+            .foregroundColor(.secondary)
+        }
+      }
+
+      Spacer()
+
+      Button("Close") {
+        onDismiss()
+      }
+    }
+    .padding()
+    .background(Color.surfaceElevated)
+  }
+
+  // MARK: - Loading State
+
+  private var loadingState: some View {
+    VStack(spacing: 12) {
+      ProgressView()
+        .controlSize(.small)
+      Text("Loading plan...")
+        .font(.caption)
+        .foregroundColor(.secondary)
+    }
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+  }
+
+  // MARK: - Error State
+
+  private func errorState(_ message: String) -> some View {
+    VStack(spacing: 12) {
+      Image(systemName: "exclamationmark.triangle")
+        .font(.largeTitle)
+        .foregroundColor(.red)
+
+      Text("Failed to load plan")
+        .font(.headline)
+        .foregroundColor(.secondary)
+
+      Text(message)
+        .font(.caption)
+        .foregroundColor(.secondary)
+        .multilineTextAlignment(.center)
+    }
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+    .padding()
+  }
+
+  // MARK: - Markdown Content
+
+  private func markdownContent(_ text: String) -> some View {
+    MarkdownView(content: text)
+  }
+
+  // MARK: - Load Content
+
+  private func loadPlanContent() async {
+    isLoading = true
+    errorMessage = nil
+
+    do {
+      // Expand tilde in path if present
+      let expandedPath = (planState.filePath as NSString).expandingTildeInPath
+      let fileURL = URL(fileURLWithPath: expandedPath)
+
+      let data = try Data(contentsOf: fileURL)
+      guard let text = String(data: data, encoding: .utf8) else {
+        throw PlanLoadError.invalidEncoding
+      }
+
+      await MainActor.run {
+        self.content = text
+        self.isLoading = false
+      }
+    } catch {
+      await MainActor.run {
+        self.errorMessage = error.localizedDescription
+        self.isLoading = false
+      }
+    }
+  }
+}
+
+// MARK: - PlanLoadError
+
+private enum PlanLoadError: LocalizedError {
+  case invalidEncoding
+
+  var errorDescription: String? {
+    switch self {
+    case .invalidEncoding:
+      return "File content is not valid UTF-8 text"
+    }
+  }
+}
+
+// MARK: - Preview
+
+#Preview {
+  PlanView(
+    session: CLISession(
+      id: "test-session-id",
+      projectPath: "/Users/test/project",
+      branchName: "main",
+      isWorktree: false,
+      lastActivityAt: Date(),
+      messageCount: 10,
+      isActive: true
+    ),
+    planState: PlanState(filePath: "~/.claude/plans/test-plan.md"),
+    onDismiss: {}
+  )
+}


### PR DESCRIPTION
## Summary
- Add PlanState model to detect Write/Edit operations on `~/.claude/plans/*.md` files
- Add PlanView sheet to display plan markdown content from CLI sessions
- Add MarkdownView using swift-markdown-ui for rich markdown rendering
- Add Plan button in MonitoringCardView (shown alongside Diff button when plan detected)
- Temporarily disable code changes button until ready for production

## Test plan
- [ ] Monitor a CLI session that enters plan mode
- [ ] Verify Plan button appears in the monitoring card
- [ ] Click Plan button and verify the sheet opens with rendered markdown
- [ ] Verify code blocks, headers, lists, and inline formatting render correctly
- [ ] Verify Diff button remains visible alongside Plan button

🤖 Generated with [Claude Code](https://claude.com/claude-code)