### PR TITLE
Improve UX across monitoring panel and session views

### DIFF
--- a/Sources/AgentHub/UI/ContextWindowBar.swift
+++ b/Sources/AgentHub/UI/ContextWindowBar.swift
@@ -13,6 +13,7 @@ import SwiftUI
 struct ContextWindowBar: View {
   let percentage: Double
   let formattedUsage: String
+  var model: String? = nil
   @State private var showingHelp = false
 
   private var barColor: Color {
@@ -28,6 +29,9 @@ struct ContextWindowBar: View {
           .font(.caption2)
           .foregroundColor(.secondary)
         Spacer()
+        if let model = model {
+          ModelBadge(model: model)
+        }
         Text(formattedUsage)
           .font(.caption2)
           .monospacedDigit()
@@ -76,17 +80,20 @@ struct ContextWindowBar: View {
   VStack(spacing: 20) {
     ContextWindowBar(
       percentage: 0.07,
-      formattedUsage: "~15K / 200K (~7%)"
+      formattedUsage: "~15K / 200K (~7%)",
+      model: "claude-opus-4-20250514"
     )
 
     ContextWindowBar(
       percentage: 0.45,
-      formattedUsage: "~90K / 200K (~45%)"
+      formattedUsage: "~90K / 200K (~45%)",
+      model: "claude-sonnet-4-20250514"
     )
 
     ContextWindowBar(
       percentage: 0.78,
-      formattedUsage: "~156K / 200K (~78%)"
+      formattedUsage: "~156K / 200K (~78%)",
+      model: "claude-haiku-4-20250514"
     )
 
     ContextWindowBar(

--- a/Sources/AgentHub/UI/InlineEditorView.swift
+++ b/Sources/AgentHub/UI/InlineEditorView.swift
@@ -93,13 +93,13 @@ struct InlineEditorView: View {
         .onKeyPress { key in
           handleKeyPress(key)
         }
+        .padding(.top, 8)
 
       if text.isEmpty {
         Text(placeholder)
           .font(.body)
           .foregroundColor(.secondary)
-          .padding(.horizontal, 10)
-          .padding(.vertical, 14)
+          .padding(.leading, 11)
           .allowsHitTesting(false)
       }
     }

--- a/Sources/AgentHub/UI/MonitoringCardView.swift
+++ b/Sources/AgentHub/UI/MonitoringCardView.swift
@@ -116,7 +116,7 @@ public struct MonitoringCardView: View {
     .overlay(alignment: .topTrailing) {
       Button(action: onStopMonitoring) {
         Image(systemName: "xmark.circle.fill")
-          .font(.system(size: 18))
+          .font(.system(size: 16))
           .foregroundColor(.secondary)
           .shadow(color: .black.opacity(0.2), radius: 2, x: 0, y: 1)
       }

--- a/Sources/AgentHub/UI/MonitoringPanelView.swift
+++ b/Sources/AgentHub/UI/MonitoringPanelView.swift
@@ -69,7 +69,7 @@ public struct MonitoringPanelView: View {
 
       // Layout toggle (only show when > 2 sessions total)
       let totalSessions = viewModel.monitoredSessionIds.count + viewModel.pendingHubSessions.count
-      if totalSessions > 2 {
+      if totalSessions >= 2 {
         HStack(spacing: 0) {
           Button(action: { withAnimation(.easeInOut(duration: 0.2)) { useGridLayout = false } }) {
             Image(systemName: "list.bullet")
@@ -121,15 +121,15 @@ public struct MonitoringPanelView: View {
 
   private var emptyState: some View {
     VStack(spacing: 12) {
-      Image(systemName: "eye.slash")
+      Image(systemName: "rectangle.on.rectangle")
         .font(.largeTitle)
         .foregroundColor(.secondary.opacity(0.5))
 
-      Text("No Sessions Monitored")
+      Text("Select a Session")
         .font(.headline)
         .foregroundColor(.secondary)
 
-      Text("Click the monitor button on a session to start tracking its activity in real-time.")
+      Text("Choose a session from the sidebar to get started.")
         .font(.caption)
         .foregroundColor(.secondary)
         .multilineTextAlignment(.center)
@@ -144,7 +144,7 @@ public struct MonitoringPanelView: View {
   private var monitoredSessionsList: some View {
     ScrollView {
       if useGridLayout {
-        LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: 12) {
+        LazyVGrid(columns: [GridItem(.flexible(), alignment: .top), GridItem(.flexible(), alignment: .top)], spacing: 12) {
           monitoredSessionsContent
         }
         .padding(12)
@@ -156,6 +156,13 @@ public struct MonitoringPanelView: View {
       }
     }
     .animation(.easeInOut(duration: 0.2), value: useGridLayout)
+    .onChange(of: viewModel.monitoredSessionIds.count + viewModel.pendingHubSessions.count) { _, newCount in
+      if newCount < 2 && useGridLayout {
+        withAnimation(.easeInOut(duration: 0.2)) {
+          useGridLayout = false
+        }
+      }
+    }
   }
 
   @ViewBuilder

--- a/Sources/AgentHub/UI/SessionMonitorPanel.swift
+++ b/Sources/AgentHub/UI/SessionMonitorPanel.swift
@@ -41,21 +41,21 @@ public struct SessionMonitorPanel: View {
 
   public var body: some View {
     VStack(alignment: .leading, spacing: 12) {
-      // Status indicator and model (only when state exists)
+      // Status indicator (only when state exists and not in terminal mode)
       if let state = state {
-        HStack {
-          StatusBadge(status: state.status)
-          Spacer()
-          if let model = state.model {
-            ModelBadge(model: model)
+        if !showTerminal {
+          HStack {
+            StatusBadge(status: state.status)
+            Spacer()
           }
         }
 
-        // Context window usage bar
+        // Context window usage bar (always visible)
         if state.inputTokens > 0 {
           ContextWindowBar(
             percentage: state.contextWindowUsagePercentage,
-            formattedUsage: state.formattedContextUsage
+            formattedUsage: state.formattedContextUsage,
+            model: state.model
           )
         }
       }


### PR DESCRIPTION
## Summary
- Show grid/list toggle with 2+ sessions (previously required 3+)
- Auto-switch to list view when session count drops below 2
- Add model badge to context window bar
- Fix inline editor placeholder alignment
- Reduce close button size on monitoring cards
- Update empty state messaging for better clarity
- Fix grid alignment for monitoring cards (top alignment)
- Move status badge visibility logic for terminal mode

## Test plan
- [ ] Open 2 sessions - verify grid/list toggle appears
- [ ] Switch to grid view, delete one session - verify auto-switches to list view
- [ ] Verify model badge displays in context window bar
- [ ] Check inline editor placeholder is properly aligned
- [ ] Verify monitoring card close buttons are appropriately sized

🤖 Generated with [Claude Code](https://claude.com/claude-code)