### PR TITLE
Persist monitored sessions across app relaunches

### DIFF
--- a/Sources/AgentHub/Configuration/AgentHubDefaults.swift
+++ b/Sources/AgentHub/Configuration/AgentHubDefaults.swift
@@ -38,6 +38,14 @@ public enum AgentHubDefaults {
   /// Type: Data (JSON-encoded [String])
   public static let selectedRepositories = "\(keyPrefix)sessions.selectedRepositories"
 
+  /// Persisted monitored session IDs (JSON-encoded array of session IDs)
+  /// Type: Data (JSON-encoded [String])
+  public static let monitoredSessionIds = "\(keyPrefix)sessions.monitoredSessionIds"
+
+  /// Persisted session IDs that have terminal view enabled
+  /// Type: Data (JSON-encoded [String])
+  public static let sessionsWithTerminalView = "\(keyPrefix)sessions.sessionsWithTerminalView"
+
   // MARK: - Theme Settings
 
   /// Selected color theme name


### PR DESCRIPTION
## Summary
- Add persistence for monitored session IDs and terminal view state to UserDefaults
- Restore monitored sessions automatically after repositories load on app startup
- Clean up monitored sessions when their repository is removed
- Validate session files still exist before restoring monitoring

## Test plan
- [ ] Build the project with `swift build`
- [ ] Run the app, add a repository, start monitoring a session
- [ ] Quit and relaunch the app
- [ ] Verify the monitored session is restored in the hub
- [ ] Verify terminal view state is also restored if it was enabled
- [ ] Remove a repository and verify its sessions are no longer monitored

🤖 Generated with [Claude Code](https://claude.ai/code)