### PR TITLE
Add pre-application diff preview for pending code changes

### DIFF
--- a/Sources/AgentHub/Models/SessionMonitorState.swift
+++ b/Sources/AgentHub/Models/SessionMonitorState.swift
@@ -363,17 +363,20 @@ public struct PendingToolUse: Equatable, Sendable {
   public let toolUseId: String
   public let timestamp: Date
   public let input: String?
+  public let codeChangeInput: CodeChangeInput?
 
   public init(
     toolName: String,
     toolUseId: String,
     timestamp: Date,
-    input: String? = nil
+    input: String? = nil,
+    codeChangeInput: CodeChangeInput? = nil
   ) {
     self.toolName = toolName
     self.toolUseId = toolUseId
     self.timestamp = timestamp
     self.input = input
+    self.codeChangeInput = codeChangeInput
   }
 
   /// How long this tool has been pending
@@ -384,6 +387,11 @@ public struct PendingToolUse: Equatable, Sendable {
   /// Whether this is likely awaiting approval (pending > 2 seconds)
   public var isLikelyAwaitingApproval: Bool {
     pendingDuration > 2.0
+  }
+
+  /// Whether this is a code-changing tool (Edit, Write, MultiEdit)
+  public var isCodeChangeTool: Bool {
+    ["Edit", "Write", "MultiEdit"].contains(toolName)
   }
 }
 

--- a/Sources/AgentHub/Services/PendingChangesPreviewService.swift
+++ b/Sources/AgentHub/Services/PendingChangesPreviewService.swift
@@ -1,0 +1,189 @@
+//
+//  PendingChangesPreviewService.swift
+//  AgentHub
+//
+//  Created by Assistant on 1/21/26.
+//
+
+import Foundation
+
+// MARK: - PendingChangesPreviewService
+
+/// Service for generating preview diffs of pending code changes before they are applied
+public struct PendingChangesPreviewService {
+
+  // MARK: - Types
+
+  /// Result of generating a pending changes preview
+  public struct PreviewResult: Sendable {
+    public let filePath: String
+    public let fileName: String
+    public let currentContent: String
+    public let previewContent: String
+    public let toolType: CodeChangeInput.ToolType
+    public let isNewFile: Bool
+
+    public init(
+      filePath: String,
+      fileName: String,
+      currentContent: String,
+      previewContent: String,
+      toolType: CodeChangeInput.ToolType,
+      isNewFile: Bool
+    ) {
+      self.filePath = filePath
+      self.fileName = fileName
+      self.currentContent = currentContent
+      self.previewContent = previewContent
+      self.toolType = toolType
+      self.isNewFile = isNewFile
+    }
+  }
+
+  /// Errors that can occur during preview generation
+  public enum PreviewError: LocalizedError {
+    case fileNotFound(path: String)
+    case oldStringNotFound(oldString: String, filePath: String)
+    case invalidToolInput
+    case fileReadError(underlying: Error)
+
+    public var errorDescription: String? {
+      switch self {
+      case .fileNotFound(let path):
+        return "File not found: \(path)"
+      case .oldStringNotFound(let oldString, let filePath):
+        let preview = String(oldString.prefix(50))
+        let suffix = oldString.count > 50 ? "..." : ""
+        return "Could not find '\(preview)\(suffix)' in \(URL(fileURLWithPath: filePath).lastPathComponent)"
+      case .invalidToolInput:
+        return "Invalid tool input parameters"
+      case .fileReadError(let error):
+        return "Failed to read file: \(error.localizedDescription)"
+      }
+    }
+  }
+
+  // MARK: - Public API
+
+  /// Generates a preview of pending changes
+  /// - Parameter codeChangeInput: The pending tool's input parameters
+  /// - Returns: PreviewResult with current and preview content
+  public static func generatePreview(
+    for codeChangeInput: CodeChangeInput
+  ) async throws -> PreviewResult {
+    let filePath = codeChangeInput.filePath
+    let fileName = URL(fileURLWithPath: filePath).lastPathComponent
+
+    // Read current file content
+    let currentContent: String
+    let isNewFile: Bool
+
+    if FileManager.default.fileExists(atPath: filePath) {
+      do {
+        currentContent = try String(contentsOfFile: filePath, encoding: .utf8)
+        isNewFile = false
+      } catch {
+        throw PreviewError.fileReadError(underlying: error)
+      }
+    } else {
+      // New file case - only valid for Write tool
+      currentContent = ""
+      isNewFile = true
+    }
+
+    // Generate preview content based on tool type
+    let previewContent: String
+
+    switch codeChangeInput.toolType {
+    case .edit:
+      previewContent = try applyEditPreview(
+        currentContent: currentContent,
+        oldString: codeChangeInput.oldString,
+        newString: codeChangeInput.newString,
+        replaceAll: codeChangeInput.replaceAll ?? false,
+        filePath: filePath
+      )
+
+    case .write:
+      // Write replaces entire file
+      previewContent = codeChangeInput.newString ?? ""
+
+    case .multiEdit:
+      previewContent = try applyMultiEditPreview(
+        currentContent: currentContent,
+        edits: codeChangeInput.edits,
+        filePath: filePath
+      )
+    }
+
+    return PreviewResult(
+      filePath: filePath,
+      fileName: fileName,
+      currentContent: currentContent,
+      previewContent: previewContent,
+      toolType: codeChangeInput.toolType,
+      isNewFile: isNewFile
+    )
+  }
+
+  // MARK: - Private Helpers
+
+  private static func applyEditPreview(
+    currentContent: String,
+    oldString: String?,
+    newString: String?,
+    replaceAll: Bool,
+    filePath: String
+  ) throws -> String {
+    guard let oldString = oldString,
+          let newString = newString else {
+      throw PreviewError.invalidToolInput
+    }
+
+    if replaceAll {
+      let result = currentContent.replacingOccurrences(of: oldString, with: newString)
+      // Check if any replacement was made
+      if result == currentContent && !currentContent.contains(oldString) {
+        throw PreviewError.oldStringNotFound(oldString: oldString, filePath: filePath)
+      }
+      return result
+    } else {
+      // Single replacement
+      guard let range = currentContent.range(of: oldString) else {
+        throw PreviewError.oldStringNotFound(oldString: oldString, filePath: filePath)
+      }
+      return currentContent.replacingCharacters(in: range, with: newString)
+    }
+  }
+
+  private static func applyMultiEditPreview(
+    currentContent: String,
+    edits: [[String: String]]?,
+    filePath: String
+  ) throws -> String {
+    guard let edits = edits, !edits.isEmpty else {
+      throw PreviewError.invalidToolInput
+    }
+
+    var result = currentContent
+
+    for edit in edits {
+      guard let oldString = edit["old_string"],
+            let newString = edit["new_string"] else {
+        continue
+      }
+
+      let replaceAll = edit["replace_all"] == "true"
+
+      if replaceAll {
+        result = result.replacingOccurrences(of: oldString, with: newString)
+      } else if let range = result.range(of: oldString) {
+        result = result.replacingCharacters(in: range, with: newString)
+      }
+      // Note: We don't throw if old_string not found in MultiEdit
+      // since some edits may be sequential and depend on previous edits
+    }
+
+    return result
+  }
+}

--- a/Sources/AgentHub/UI/PendingChangesView.swift
+++ b/Sources/AgentHub/UI/PendingChangesView.swift
@@ -1,0 +1,312 @@
+//
+//  PendingChangesView.swift
+//  AgentHub
+//
+//  Created by Assistant on 1/21/26.
+//
+
+import SwiftUI
+import PierreDiffsSwift
+import ClaudeCodeSDK
+
+// MARK: - PendingChangesView
+
+/// Sheet view for displaying pending code changes before they are applied.
+/// Shows a diff preview of what the Edit/Write/MultiEdit tool will do.
+public struct PendingChangesView: View {
+  let session: CLISession
+  let pendingToolUse: PendingToolUse
+  let claudeClient: (any ClaudeCode)?
+  let onDismiss: () -> Void
+
+  @State private var previewResult: PendingChangesPreviewService.PreviewResult?
+  @State private var errorMessage: String?
+  @State private var isLoading = true
+  @State private var diffStyle: DiffStyle = .unified
+  @State private var overflowMode: OverflowMode = .wrap
+  @State private var webViewOpacity: Double = 1.0
+  @State private var isWebViewReady = false
+
+  public init(
+    session: CLISession,
+    pendingToolUse: PendingToolUse,
+    claudeClient: (any ClaudeCode)? = nil,
+    onDismiss: @escaping () -> Void
+  ) {
+    self.session = session
+    self.pendingToolUse = pendingToolUse
+    self.claudeClient = claudeClient
+    self.onDismiss = onDismiss
+  }
+
+  public var body: some View {
+    VStack(spacing: 0) {
+      header
+      Divider()
+      content
+    }
+    .frame(minWidth: 1000, idealWidth: 1200, maxWidth: .infinity,
+           minHeight: 600, idealHeight: 800, maxHeight: .infinity)
+    .onKeyPress(.escape) {
+      onDismiss()
+      return .handled
+    }
+    .task {
+      await loadPreview()
+    }
+  }
+
+  // MARK: - Header
+
+  private var header: some View {
+    HStack {
+      HStack(spacing: 8) {
+        Image(systemName: "eye")
+          .font(.title3)
+          .foregroundColor(.orange)
+
+        Text("Pending Changes")
+          .font(.title3.weight(.semibold))
+
+        // Tool badge
+        Text(pendingToolUse.toolName)
+          .font(.caption)
+          .fontWeight(.medium)
+          .foregroundColor(.orange)
+          .padding(.horizontal, 8)
+          .padding(.vertical, 2)
+          .background(Capsule().fill(Color.orange.opacity(0.15)))
+      }
+
+      Spacer()
+
+      // Session info
+      HStack(spacing: 8) {
+        Text(session.shortId)
+          .font(.system(.caption, design: .monospaced))
+          .foregroundColor(.secondary)
+
+        if let branch = session.branchName {
+          Text("[\(branch)]")
+            .font(.caption)
+            .foregroundColor(.secondary)
+        }
+      }
+
+      Spacer()
+
+      Button("Close") { onDismiss() }
+    }
+    .padding()
+    .background(Color.surfaceElevated)
+  }
+
+  // MARK: - Content
+
+  @ViewBuilder
+  private var content: some View {
+    if isLoading {
+      loadingView
+    } else if let error = errorMessage {
+      errorView(error)
+    } else if let preview = previewResult {
+      diffView(preview)
+    } else {
+      Text("No preview available")
+        .foregroundColor(.secondary)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+  }
+
+  private var loadingView: some View {
+    VStack(spacing: 12) {
+      ProgressView()
+      Text("Generating preview...")
+        .font(.caption)
+        .foregroundColor(.secondary)
+    }
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+  }
+
+  private func errorView(_ message: String) -> some View {
+    VStack(spacing: 12) {
+      Image(systemName: "exclamationmark.triangle")
+        .font(.system(size: 48))
+        .foregroundColor(.orange.opacity(0.5))
+
+      Text("Could Not Generate Preview")
+        .font(.headline)
+        .foregroundColor(.secondary)
+
+      Text(message)
+        .font(.caption)
+        .foregroundColor(.secondary)
+        .multilineTextAlignment(.center)
+        .padding(.horizontal, 40)
+    }
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+    .padding()
+  }
+
+  private func diffView(_ preview: PendingChangesPreviewService.PreviewResult) -> some View {
+    VStack(alignment: .leading, spacing: 0) {
+      // File header with controls
+      fileHeader(preview)
+
+      // Diff view
+      GeometryReader { geometry in
+        ZStack {
+          PierreDiffView(
+            oldContent: preview.currentContent,
+            newContent: preview.previewContent,
+            fileName: preview.fileName,
+            diffStyle: $diffStyle,
+            overflowMode: $overflowMode,
+            onReady: {
+              withAnimation(.easeInOut(duration: 0.3)) {
+                isWebViewReady = true
+              }
+            }
+          )
+          .opacity(isWebViewReady ? webViewOpacity : 0)
+
+          if !isWebViewReady {
+            VStack(spacing: 12) {
+              ProgressView()
+                .controlSize(.small)
+              Text("Loading diff...")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .transition(.opacity)
+          }
+        }
+      }
+      .animation(.easeInOut(duration: 0.3), value: isWebViewReady)
+    }
+  }
+
+  private func fileHeader(_ preview: PendingChangesPreviewService.PreviewResult) -> some View {
+    HStack {
+      // File name with icon
+      HStack(spacing: 4) {
+        Image(systemName: preview.isNewFile ? "doc.badge.plus" : "doc.text.fill")
+          .foregroundStyle(preview.isNewFile ? .green : .blue)
+        Text(preview.fileName)
+          .font(.headline)
+        if preview.isNewFile {
+          Text("(New File)")
+            .font(.caption)
+            .foregroundColor(.green)
+        }
+      }
+
+      Spacer()
+
+      // Diff style toggles
+      HStack(spacing: 8) {
+        // Split/Unified toggle button
+        Button {
+          toggleDiffStyle()
+        } label: {
+          Image(systemName: diffStyle == .split ? "rectangle.split.2x1" : "rectangle.stack")
+            .font(.system(size: 14))
+        }
+        .buttonStyle(.plain)
+        .help(diffStyle == .split ? "Switch to unified view" : "Switch to split view")
+
+        // Wrap toggle button
+        Button {
+          toggleOverflowMode()
+        } label: {
+          Image(systemName: overflowMode == .wrap ? "text.alignleft" : "text.aligncenter")
+            .font(.system(size: 14))
+            .foregroundStyle(overflowMode == .wrap ? .primary : .secondary)
+        }
+        .buttonStyle(.plain)
+        .help(overflowMode == .wrap ? "Disable word wrap" : "Enable word wrap")
+      }
+    }
+    .padding(.horizontal)
+    .padding(.vertical, 12)
+  }
+
+  // MARK: - Actions
+
+  private func loadPreview() async {
+    isLoading = true
+    errorMessage = nil
+
+    guard let codeChangeInput = pendingToolUse.codeChangeInput else {
+      errorMessage = "No code change details available"
+      isLoading = false
+      return
+    }
+
+    do {
+      previewResult = try await PendingChangesPreviewService.generatePreview(
+        for: codeChangeInput
+      )
+    } catch {
+      errorMessage = error.localizedDescription
+    }
+
+    isLoading = false
+  }
+
+  private func toggleDiffStyle() {
+    Task {
+      withAnimation(.easeOut(duration: 0.15)) {
+        webViewOpacity = 0
+      }
+      try? await Task.sleep(for: .milliseconds(150))
+      diffStyle = diffStyle == .split ? .unified : .split
+      withAnimation(.easeIn(duration: 0.15)) {
+        webViewOpacity = 1
+      }
+    }
+  }
+
+  private func toggleOverflowMode() {
+    Task {
+      withAnimation(.easeOut(duration: 0.15)) {
+        webViewOpacity = 0
+      }
+      try? await Task.sleep(for: .milliseconds(150))
+      overflowMode = overflowMode == .scroll ? .wrap : .scroll
+      withAnimation(.easeIn(duration: 0.15)) {
+        webViewOpacity = 1
+      }
+    }
+  }
+}
+
+// MARK: - Preview
+
+#Preview {
+  PendingChangesView(
+    session: CLISession(
+      id: "test-session-id",
+      projectPath: "/Users/test/project",
+      branchName: "main",
+      isWorktree: false,
+      lastActivityAt: Date(),
+      messageCount: 10,
+      isActive: true
+    ),
+    pendingToolUse: PendingToolUse(
+      toolName: "Edit",
+      toolUseId: "test-tool-id",
+      timestamp: Date(),
+      input: "main.swift",
+      codeChangeInput: CodeChangeInput(
+        toolType: .edit,
+        filePath: "/Users/test/project/src/main.swift",
+        oldString: "let x = 1",
+        newString: "let x = 2"
+      )
+    ),
+    onDismiss: {}
+  )
+}


### PR DESCRIPTION
## Summary

- Add ability to preview diff changes **before** they are applied when a code-changing tool (Edit, Write, MultiEdit) is awaiting approval
- When a session has a pending code change awaiting approval (5+ seconds), an orange "Preview" button appears in the monitoring card
- Clicking Preview opens a diff view showing current file content vs. proposed changes

## Changes

- **SessionMonitorState.swift**: Add `codeChangeInput: CodeChangeInput?` and `isCodeChangeTool` computed property to `PendingToolUse` struct
- **PendingChangesPreviewService.swift** (new): Service that reads current file and simulates the proposed change to generate preview diff
- **PendingChangesView.swift** (new): SwiftUI sheet view displaying the pending diff using PierreDiffView
- **MonitoringCardView.swift**: Add Preview button and sheet presentation

## How It Works

1. When a Claude Code session has an Edit/Write/MultiEdit tool pending approval, the monitoring card shows an orange "Preview" button
2. Clicking the button opens a sheet showing:
   - Header with "Pending Changes" title and tool type badge
   - File name (with "New File" indicator for Write tool creating new files)
   - Full diff view (current file content → proposed content after change)
   - Split/Unified toggle and word wrap controls

## Test plan

- [ ] Start a Claude Code session and trigger an Edit tool call
- [ ] Wait for approval prompt (5+ seconds)
- [ ] Verify "Preview" button appears in the monitoring card
- [ ] Click Preview and verify diff shows correctly
- [ ] Test with Write tool (full file replacement)
- [ ] Test with MultiEdit tool (multiple edits)
- [ ] Test edge cases: new file creation, old_string not found

🤖 Generated with [Claude Code](https://claude.com/claude-code)