### PR TITLE
Move session file fallback inside retry loop for new worktrees

### DIFF
--- a/Sources/AgentHub/UI/EmbeddedTerminalView.swift
+++ b/Sources/AgentHub/UI/EmbeddedTerminalView.swift
@@ -195,6 +195,12 @@ public class TerminalContainerView: NSView {
     let workingDirectory = projectPath.isEmpty ? NSHomeDirectory() : projectPath
     let escapedPath = workingDirectory.replacingOccurrences(of: "'", with: "'\\''")
     let escapedClaudePath = executablePath.replacingOccurrences(of: "'", with: "'\\''")
+#if DEBUG
+    let homeEnv = environment["HOME"] ?? "<nil>"
+    AppLogger.session.debug(
+      "[ClaudeProcess] workingDirectory=\(workingDirectory, privacy: .public) homeEnv=\(homeEnv, privacy: .public) command=\(command, privacy: .public)"
+    )
+#endif
 
     // Build command: resume existing session (-r) or start new session
     let shellCommand: String


### PR DESCRIPTION
## Summary
- Move session file detection inside the retry loop instead of after all 25 retries fail
- Add `findRecentSessionFile` helper to detect existing session files created around pending session start time
- Add debug logging throughout session watcher flow for easier troubleshooting
- Add TODO comment noting the fallback only triggers for worktrees with zero sessions

## Test plan
- [ ] Create a new worktree and start a session from Hub
- [ ] Verify session appears (may require first message for worktrees with existing sessions)
- [ ] Check debug logs show the watcher flow correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)