### PR TITLE
Fix days active calculation and add sessions approximate indicator

### DIFF
--- a/Sources/AgentHub/Services/GlobalStatsService.swift
+++ b/Sources/AgentHub/Services/GlobalStatsService.swift
@@ -73,14 +73,9 @@ public final class GlobalStatsService: @unchecked Sendable {
     return stats.dailyActivity.first { $0.date == today }
   }
 
-  /// Days since first session
+  /// Number of days with at least one session
   public var daysActive: Int {
-    guard let firstDate = stats.firstSessionDate,
-          let date = parseISO8601Date(firstDate) else {
-      return 0
-    }
-    let days = Calendar.current.dateComponents([.day], from: date, to: Date()).day ?? 0
-    return max(0, days)
+    stats.dailyActivity.count
   }
 
   /// First session date formatted

--- a/Sources/AgentHub/UI/GlobalStatsMenuView.swift
+++ b/Sources/AgentHub/UI/GlobalStatsMenuView.swift
@@ -100,7 +100,7 @@ public struct GlobalStatsMenuView: View {
 
       StatRow(
         label: "Sessions",
-        value: "\(service.stats.totalSessions)",
+        value: "~\(service.stats.totalSessions)",
         icon: "terminal.fill"
       )
 


### PR DESCRIPTION
## Summary
- Fix `daysActive` to return count of days with activity (matches official CLI's "Active days: 69/74") instead of calendar span since first session
- Add `~` prefix to sessions count to indicate cached/approximate value

## Test plan
- [ ] Verify Days Active shows 69 (not 72)
- [ ] Verify Sessions shows ~958 format
- [ ] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)