### PR TITLE
Fix process cleanup when closing terminal sessions

### DIFF
--- a/AgentHubDemo/AgentHubDemo/AgentHubDemoApp.swift
+++ b/AgentHubDemo/AgentHubDemo/AgentHubDemoApp.swift
@@ -8,27 +8,49 @@
 import SwiftUI
 import AgentHub
 
+// MARK: - App Delegate
+
+/// Handles app lifecycle events for process cleanup
+@MainActor
+class AppDelegate: NSObject, NSApplicationDelegate {
+  /// Shared provider instance - created here so it's available for lifecycle events
+  let provider = AgentHubProvider()
+
+  func applicationDidFinishLaunching(_ notification: Notification) {
+    // Note: We intentionally do NOT clean up orphaned processes here
+    // because we can't distinguish between processes spawned by AgentHub
+    // vs processes the user started directly in Terminal.app
+  }
+
+  func applicationWillTerminate(_ notification: Notification) {
+    // Terminate all active terminal processes on app quit
+    provider.terminateAllTerminals()
+  }
+}
+
+// MARK: - App
+
 @main
 struct AgentHubDemoApp: App {
-  @State private var provider = AgentHubProvider()
+  @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
 
   var body: some Scene {
     WindowGroup {
       AgentHubSessionsView()
-        .agentHub(provider)
+        .agentHub(appDelegate.provider)
     }
     .windowStyle(.hiddenTitleBar)
 
     MenuBarExtra(
       isInserted: Binding(
-        get: { provider.displaySettings.isMenuBarMode },
+        get: { appDelegate.provider.displaySettings.isMenuBarMode },
         set: { _ in }
       )
     ) {
       AgentHubMenuBarContent()
-        .environment(\.agentHub, provider)
+        .environment(\.agentHub, appDelegate.provider)
     } label: {
-      AgentHubMenuBarLabel(provider: provider)
+      AgentHubMenuBarLabel(provider: appDelegate.provider)
     }
     .menuBarExtraStyle(.window)
   }

--- a/Sources/AgentHub/ViewModels/CLISessionsViewModel.swift
+++ b/Sources/AgentHub/ViewModels/CLISessionsViewModel.swift
@@ -175,8 +175,11 @@ public final class CLISessionsViewModel {
     return terminal
   }
 
-  /// Removes the terminal for a given key
+  /// Removes the terminal for a given key and terminates its process
   public func removeTerminal(forKey key: String) {
+    if let terminal = activeTerminals[key] {
+      terminal.terminateProcess()
+    }
     activeTerminals.removeValue(forKey: key)
   }
 
@@ -1121,6 +1124,9 @@ public final class CLISessionsViewModel {
     sessionsWithTerminalView.remove(sessionId)
     monitorStates.removeValue(forKey: sessionId)
     monitoringCancellables.removeValue(forKey: sessionId)
+
+    // Remove and terminate the terminal process
+    removeTerminal(forKey: sessionId)
 
     persistMonitoredSessions()
     persistSessionsWithTerminalView()


### PR DESCRIPTION
- Add terminateProcess() to TerminalContainerView with SIGTERM/SIGKILL fallback
- Track Claude process PIDs asynchronously after terminal startup
- Call removeTerminal() from stopMonitoring() to ensure process cleanup
- Add app lifecycle methods to AgentHubProvider for cleanup on quit
- Wire up AppDelegate in AgentHubDemo to terminate processes on app exit

This prevents orphaned Claude CLI processes when users close sessions in the Hub.