### PR TITLE
Sort Hub sessions by timestamp and add auto-prompt support

### DIFF
--- a/Sources/AgentHub/Models/PendingHubSession.swift
+++ b/Sources/AgentHub/Models/PendingHubSession.swift
@@ -13,11 +13,13 @@ public struct PendingHubSession: Identifiable {
   public let id: UUID
   public let worktree: WorktreeBranch
   public let startedAt: Date
+  public let initialPrompt: String?
 
-  public init(worktree: WorktreeBranch) {
+  public init(worktree: WorktreeBranch, initialPrompt: String? = "Hello!") {
     self.id = UUID()
     self.worktree = worktree
     self.startedAt = Date()
+    self.initialPrompt = initialPrompt
   }
 
   /// Creates a placeholder CLISession for use with MonitoringCardView

--- a/Sources/AgentHub/UI/EmbeddedTerminalView.swift
+++ b/Sources/AgentHub/UI/EmbeddedTerminalView.swift
@@ -273,7 +273,13 @@ public class TerminalContainerView: NSView {
       }
     } else {
       // Start NEW session (no -r flag)
-      shellCommand = "cd '\(escapedPath)' && '\(escapedClaudePath)'"
+      // Include initial prompt if provided (triggers immediate session file creation)
+      if let prompt = initialPrompt, !prompt.isEmpty {
+        let escapedPrompt = prompt.replacingOccurrences(of: "'", with: "'\\''")
+        shellCommand = "cd '\(escapedPath)' && '\(escapedClaudePath)' '\(escapedPrompt)'"
+      } else {
+        shellCommand = "cd '\(escapedPath)' && '\(escapedClaudePath)'"
+      }
     }
 
     // Start bash with the command


### PR DESCRIPTION
## Summary
- Sort sessions within each module section by timestamp (newest first) so new sessions appear at the top
- Add initial prompt support to start sessions with "Hello!" automatically, triggering faster session file creation
- Reduce session detection timeout from 60s to 15s since auto-prompt creates sessions faster

## Test plan
- [ ] Build the app
- [ ] Add multiple sessions to the Hub
- [ ] Verify sessions within each module section are ordered by timestamp (newest at top)
- [ ] Start a new session via "Start in Hub" - it should appear at the top of its section

🤖 Generated with [Claude Code](https://claude.com/claude-code)