### PR TITLE
Fix embedded terminal cleanup

### DIFF
--- a/Sources/AgentHub/Services/TerminalProcessRegistry.swift
+++ b/Sources/AgentHub/Services/TerminalProcessRegistry.swift
@@ -1,0 +1,141 @@
+//
+//  TerminalProcessRegistry.swift
+//  AgentHub
+//
+//  Tracks embedded-terminal PIDs so only app-spawned sessions are terminated.
+//
+
+import Darwin
+import Foundation
+
+final class TerminalProcessRegistry {
+  static let shared = TerminalProcessRegistry()
+
+  private let lock = NSLock()
+  private let storageKey = "AgentHub.TerminalProcessRegistry"
+  private var entries: [Int32: TimeInterval] = [:]
+
+  private init() {
+    load()
+  }
+
+  func register(pid: pid_t) {
+    guard pid > 0 else { return }
+    lock.lock()
+    entries[pid] = Date().timeIntervalSince1970
+    pruneTerminatedLocked()
+    persistLocked()
+    lock.unlock()
+  }
+
+  func unregister(pid: pid_t) {
+    guard pid > 0 else { return }
+    lock.lock()
+    entries.removeValue(forKey: pid)
+    persistLocked()
+    lock.unlock()
+  }
+
+  /// Kills only processes previously spawned by the app.
+  func cleanupRegisteredProcesses() {
+    let snapshot = snapshotEntries()
+    guard !snapshot.isEmpty else { return }
+
+    for (pid, _) in snapshot {
+      guard pid > 0 else {
+        unregister(pid: pid)
+        continue
+      }
+
+      guard isProcessAlive(pid) else {
+        unregister(pid: pid)
+        continue
+      }
+
+      if let command = processCommandLine(pid),
+         !command.localizedCaseInsensitiveContains("claude") {
+        // PID reused or not a Claude process; avoid killing.
+        unregister(pid: pid)
+        continue
+      }
+
+      terminateProcessGroup(pid)
+
+      if !isProcessAlive(pid) {
+        unregister(pid: pid)
+      } else {
+        AppLogger.session.warning("Failed to terminate registered Claude process PID=\(pid)")
+      }
+    }
+  }
+
+  // MARK: - Private
+
+  private func snapshotEntries() -> [Int32: TimeInterval] {
+    lock.lock()
+    let copy = entries
+    lock.unlock()
+    return copy
+  }
+
+  private func load() {
+    guard let dict = UserDefaults.standard.dictionary(forKey: storageKey) as? [String: Double] else {
+      return
+    }
+
+    for (key, value) in dict {
+      if let pid = Int32(key) {
+        entries[pid] = value
+      }
+    }
+  }
+
+  private func persistLocked() {
+    var dict: [String: Double] = [:]
+    for (pid, value) in entries {
+      dict[String(pid)] = value
+    }
+    UserDefaults.standard.set(dict, forKey: storageKey)
+  }
+
+  private func pruneTerminatedLocked() {
+    for pid in Array(entries.keys) {
+      if !isProcessAlive(pid) {
+        entries.removeValue(forKey: pid)
+      }
+    }
+  }
+
+  private func isProcessAlive(_ pid: pid_t) -> Bool {
+    kill(pid, 0) == 0
+  }
+
+  private func processCommandLine(_ pid: pid_t) -> String? {
+    let task = Process()
+    task.executableURL = URL(fileURLWithPath: "/bin/ps")
+    task.arguments = ["-p", "\(pid)", "-o", "command="]
+
+    let pipe = Pipe()
+    task.standardOutput = pipe
+    task.standardError = Pipe()
+
+    do {
+      try task.run()
+      task.waitUntilExit()
+      let data = pipe.fileHandleForReading.readDataToEndOfFile()
+      return String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines)
+    } catch {
+      return nil
+    }
+  }
+
+  private func terminateProcessGroup(_ pid: pid_t) {
+    if killpg(pid, SIGTERM) != 0 {
+      _ = kill(pid, SIGTERM)
+    }
+    usleep(150_000) // 150ms
+    if isProcessAlive(pid) {
+      _ = killpg(pid, SIGKILL)
+    }
+  }
+}

--- a/Sources/AgentHub/UI/ManagedLocalProcessTerminalView.swift
+++ b/Sources/AgentHub/UI/ManagedLocalProcessTerminalView.swift
@@ -1,0 +1,137 @@
+//
+//  ManagedLocalProcessTerminalView.swift
+//  AgentHub
+//
+//  LocalProcessTerminalView-equivalent with explicit process lifecycle control.
+//
+
+import AppKit
+import Darwin
+import SwiftTerm
+
+/// Delegate for ManagedLocalProcessTerminalView process events.
+public protocol ManagedLocalProcessTerminalViewDelegate: AnyObject {
+  func sizeChanged(source: ManagedLocalProcessTerminalView, newCols: Int, newRows: Int)
+  func setTerminalTitle(source: ManagedLocalProcessTerminalView, title: String)
+  func hostCurrentDirectoryUpdate(source: TerminalView, directory: String?)
+  func processTerminated(source: TerminalView, exitCode: Int32?)
+}
+
+/// Local-process terminal view with explicit process control.
+open class ManagedLocalProcessTerminalView: TerminalView, TerminalViewDelegate, LocalProcessDelegate {
+  private var process: LocalProcess!
+
+  /// Delegate for process-related events.
+  public weak var processDelegate: ManagedLocalProcessTerminalViewDelegate?
+
+  public override init(frame: CGRect) {
+    super.init(frame: frame)
+    setup()
+  }
+
+  public required init?(coder: NSCoder) {
+    super.init(coder: coder)
+    setup()
+  }
+
+  private func setup() {
+    terminalDelegate = self
+    process = LocalProcess(delegate: self)
+  }
+
+  /// PID of the running child process, if any.
+  public var currentProcessId: pid_t? {
+    process.running ? process.shellPid : nil
+  }
+
+  // MARK: - TerminalViewDelegate
+
+  public func sizeChanged(source: TerminalView, newCols: Int, newRows: Int) {
+    guard process.running else { return }
+    var size = getWindowSize()
+    let _ = PseudoTerminalHelpers.setWinSize(masterPtyDescriptor: process.childfd, windowSize: &size)
+    processDelegate?.sizeChanged(source: self, newCols: newCols, newRows: newRows)
+  }
+
+  public func clipboardCopy(source: TerminalView, content: Data) {
+    if let str = String(bytes: content, encoding: .utf8) {
+      let pasteBoard = NSPasteboard.general
+      pasteBoard.clearContents()
+      pasteBoard.writeObjects([str as NSString])
+    }
+  }
+
+  public func setTerminalTitle(source: TerminalView, title: String) {
+    processDelegate?.setTerminalTitle(source: self, title: title)
+  }
+
+  public func hostCurrentDirectoryUpdate(source: TerminalView, directory: String?) {
+    processDelegate?.hostCurrentDirectoryUpdate(source: source, directory: directory)
+  }
+
+  open func send(source: TerminalView, data: ArraySlice<UInt8>) {
+    process.send(data: data)
+  }
+
+  public func setHostLogging(directory: String?) {
+    process.setHostLogging(directory: directory)
+  }
+
+  open func scrolled(source: TerminalView, position: Double) {}
+
+  open func rangeChanged(source: TerminalView, startY: Int, endY: Int) {}
+
+  // MARK: - Process Control
+
+  public func startProcess(
+    executable: String = "/bin/bash",
+    args: [String] = [],
+    environment: [String]? = nil,
+    execName: String? = nil
+  ) {
+    process.startProcess(
+      executable: executable,
+      args: args,
+      environment: environment,
+      execName: execName
+    )
+  }
+
+  /// Terminates the process group for the running child.
+  public func terminateProcessTree(graceSeconds: TimeInterval = 1.0) {
+    guard process.running else { return }
+    let pid = process.shellPid
+    guard pid > 0 else { return }
+
+    if killpg(pid, SIGTERM) != 0 {
+      _ = kill(pid, SIGTERM)
+    }
+
+    guard graceSeconds > 0 else { return }
+    DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + graceSeconds) { [weak self] in
+      guard let self, self.process.running else { return }
+      AppLogger.session.warning("Process group PID=\(pid) still alive; sending SIGKILL")
+      _ = killpg(pid, SIGKILL)
+    }
+  }
+
+  // MARK: - LocalProcessDelegate
+
+  open func processTerminated(_ source: LocalProcess, exitCode: Int32?) {
+    processDelegate?.processTerminated(source: self, exitCode: exitCode)
+  }
+
+  open func dataReceived(slice: ArraySlice<UInt8>) {
+    feed(byteArray: slice)
+  }
+
+  open func getWindowSize() -> winsize {
+    let f: CGRect = frame
+    return winsize(
+      ws_row: UInt16(terminal.rows),
+      ws_col: UInt16(terminal.cols),
+      ws_xpixel: UInt16(f.width),
+      ws_ypixel: UInt16(f.height)
+    )
+  }
+}


### PR DESCRIPTION
  - Ensure embedded terminals terminate their process group on close
  - Track app‑spawned PIDs to avoid touching external terminals
  - Tighten cleanup for pending sessions and module removal
    Testing: Not run (manual app verification)
