### PR TITLE
Add drag-and-drop file support and UX improvements

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/EmbeddedTerminalView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/EmbeddedTerminalView.swift
@@ -192,6 +192,13 @@ public class TerminalContainerView: NSView, ManagedLocalProcessTerminalViewDeleg
     }
   }
 
+  /// Types text into the terminal WITHOUT pressing Enter.
+  /// Used for drag-and-drop file paths where user adds context before submitting.
+  public func typeText(_ text: String) {
+    guard let terminal = terminalView else { return }
+    terminal.send(txt: text)
+  }
+
   private func configureTerminalAppearance(_ terminal: TerminalView) {
     // Use a monospace font that looks good in terminals
     let fontSize: CGFloat = 12

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringCardView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringCardView.swift
@@ -7,6 +7,7 @@
 
 import ClaudeCodeSDK
 import SwiftUI
+import UniformTypeIdentifiers
 
 // MARK: - CodeChangesSheetItem
 
@@ -72,6 +73,7 @@ public struct MonitoringCardView: View {
   @State private var gitDiffSheetItem: GitDiffSheetItem?
   @State private var planSheetItem: PlanSheetItem?
   @State private var pendingChangesSheetItem: PendingChangesSheetItem?
+  @State private var isDragging = false
   @Environment(\.colorScheme) private var colorScheme
 
   public init(
@@ -151,6 +153,20 @@ public struct MonitoringCardView: View {
         .padding(.vertical, 8)
     }
     .background(colorScheme == .dark ? Color(white: 0.07) : Color(white: 0.92))
+    .clipShape(RoundedRectangle(cornerRadius: 8))
+    .shadow(
+      color: Color.blue.opacity(isDragging ? 0.875 : 0),
+      radius: isDragging ? 12 : 0
+    )
+    .animation(.easeInOut(duration: 0.2), value: isDragging)
+    .onDrop(
+      of: [.fileURL, .png, .tiff, .image, .pdf],
+      isTargeted: showTerminal ? $isDragging : .constant(false)
+    ) { providers in
+      guard showTerminal else { return false }
+      handleDroppedFiles(providers)
+      return true
+    }
     .sheet(item: $codeChangesSheetItem) { item in
       CodeChangesView(
         session: item.session,
@@ -192,6 +208,100 @@ public struct MonitoringCardView: View {
       return true
     default:
       return false
+    }
+  }
+
+  // MARK: - Drag and Drop
+
+  /// Handles dropped file providers by extracting paths and typing them into terminal
+  private func handleDroppedFiles(_ providers: [NSItemProvider]) {
+    guard showTerminal, let key = terminalKey, let viewModel = viewModel else { return }
+
+    for provider in providers {
+      // Handle file URLs (files dragged from Finder)
+      if provider.hasItemConformingToTypeIdentifier(UTType.fileURL.identifier) {
+        _ = provider.loadObject(ofClass: URL.self) { url, error in
+          guard let url = url, error == nil else { return }
+
+          Task { @MainActor in
+            let path = url.path
+            let quotedPath = path.contains(" ") ? "\"\(path)\"" : path
+            viewModel.typeToTerminal(forKey: key, text: quotedPath + " ")
+          }
+        }
+      }
+      // Handle PNG data (screenshots)
+      else if provider.hasItemConformingToTypeIdentifier(UTType.png.identifier) {
+        _ = provider.loadDataRepresentation(for: .png) { data, error in
+          guard let data = data, error == nil else { return }
+
+          Task { @MainActor in
+            let tempURL = FileManager.default.temporaryDirectory
+              .appendingPathComponent("screenshot_\(UUID().uuidString).png")
+            do {
+              try data.write(to: tempURL)
+              let quotedPath = tempURL.path.contains(" ") ? "\"\(tempURL.path)\"" : tempURL.path
+              viewModel.typeToTerminal(forKey: key, text: quotedPath + " ")
+            } catch {
+              print("Failed to save dropped screenshot: \(error)")
+            }
+          }
+        }
+      }
+      // Handle TIFF data (another screenshot format)
+      else if provider.hasItemConformingToTypeIdentifier(UTType.tiff.identifier) {
+        _ = provider.loadDataRepresentation(for: .tiff) { data, error in
+          guard let data = data, error == nil else { return }
+
+          Task { @MainActor in
+            let tempURL = FileManager.default.temporaryDirectory
+              .appendingPathComponent("screenshot_\(UUID().uuidString).tiff")
+            do {
+              try data.write(to: tempURL)
+              let quotedPath = tempURL.path.contains(" ") ? "\"\(tempURL.path)\"" : tempURL.path
+              viewModel.typeToTerminal(forKey: key, text: quotedPath + " ")
+            } catch {
+              print("Failed to save dropped screenshot: \(error)")
+            }
+          }
+        }
+      }
+      // Handle generic image data
+      else if provider.hasItemConformingToTypeIdentifier(UTType.image.identifier) {
+        _ = provider.loadDataRepresentation(for: .image) { data, error in
+          guard let data = data, error == nil else { return }
+
+          Task { @MainActor in
+            let tempURL = FileManager.default.temporaryDirectory
+              .appendingPathComponent("dropped_image_\(UUID().uuidString).png")
+            do {
+              try data.write(to: tempURL)
+              let quotedPath = tempURL.path.contains(" ") ? "\"\(tempURL.path)\"" : tempURL.path
+              viewModel.typeToTerminal(forKey: key, text: quotedPath + " ")
+            } catch {
+              print("Failed to save dropped image: \(error)")
+            }
+          }
+        }
+      }
+      // Handle PDF data (documents dragged from Preview or other apps)
+      else if provider.hasItemConformingToTypeIdentifier(UTType.pdf.identifier) {
+        _ = provider.loadDataRepresentation(for: .pdf) { data, error in
+          guard let data = data, error == nil else { return }
+
+          Task { @MainActor in
+            let tempURL = FileManager.default.temporaryDirectory
+              .appendingPathComponent("dropped_document_\(UUID().uuidString).pdf")
+            do {
+              try data.write(to: tempURL)
+              let quotedPath = tempURL.path.contains(" ") ? "\"\(tempURL.path)\"" : tempURL.path
+              viewModel.typeToTerminal(forKey: key, text: quotedPath + " ")
+            } catch {
+              print("Failed to save dropped PDF: \(error)")
+            }
+          }
+        }
+      }
     }
   }
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/CLISessionsViewModel.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/CLISessionsViewModel.swift
@@ -205,6 +205,13 @@ public final class CLISessionsViewModel {
     terminal.restart(sessionId: sessionId, projectPath: projectPath, claudeClient: claudeClient)
   }
 
+  /// Types text into the terminal for a given key without pressing Enter.
+  /// Used for drag-and-drop file paths where user adds context before submitting.
+  public func typeToTerminal(forKey key: String, text: String) {
+    guard let terminal = activeTerminals[key] else { return }
+    terminal.typeText(text)
+  }
+
   /// Sessions being started in Hub's embedded terminal (no session ID yet)
   public var pendingHubSessions: [PendingHubSession] = []
 


### PR DESCRIPTION
## Summary
- Add drag-and-drop support for files, screenshots, and PDFs onto monitoring card terminal
- Blue shadow glow visual feedback when dragging files over the card
- Hide dismiss button when monitoring card is maximized

## Test plan
- [ ] Open a monitoring card with terminal visible
- [ ] Drag a file from Finder → blue shadow appears, drop → path typed in terminal
- [ ] Drag a screenshot → saved to temp, path typed in terminal
- [ ] Drag a PDF → path typed in terminal
- [ ] Maximize card → dismiss button should be hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)