### PR TITLE
Add session naming feature with SQL storage

### DIFF
--- a/app/AgentHub.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/app/AgentHub.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "0902c7a92d5daddf48b1355b43dd3d941d9c296fc8885595c4e2aa07c311d27d",
+  "originHash" : "1cad70013da4e4607da47df5033dc5400b17e3de18694a469065b11adad36951",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -17,6 +17,15 @@
       "state" : {
         "revision" : "f626d1d1eab3bf43a1eef2f70b2a493903f7e5e8",
         "version" : "1.2.4"
+      }
+    },
+    {
+      "identity" : "grdb.swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/groue/GRDB.swift",
+      "state" : {
+        "revision" : "2cf6c756e1e5ef6901ebae16576a7e4e4b834622",
+        "version" : "6.29.3"
       }
     },
     {

--- a/app/modules/AgentHubCore/Package.resolved
+++ b/app/modules/AgentHubCore/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "3b3b6c4ee3d60344bb63fe2072eedfb125da6d5433636eb2cf513f74529997de",
+  "originHash" : "8b09c58a291970f3f75281f6d1a1a307215a9e296869ec2033a6e2bdc3331f5c",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -17,6 +17,15 @@
       "state" : {
         "revision" : "f626d1d1eab3bf43a1eef2f70b2a493903f7e5e8",
         "version" : "1.2.4"
+      }
+    },
+    {
+      "identity" : "grdb.swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/groue/GRDB.swift",
+      "state" : {
+        "revision" : "2cf6c756e1e5ef6901ebae16576a7e4e4b834622",
+        "version" : "6.29.3"
       }
     },
     {

--- a/app/modules/AgentHubCore/Package.swift
+++ b/app/modules/AgentHubCore/Package.swift
@@ -18,6 +18,7 @@ let package = Package(
     .package(url: "https://github.com/jamesrochabrun/PierreDiffsSwift", exact: "1.1.4"),
     .package(url: "https://github.com/migueldeicaza/SwiftTerm", from: "1.2.0"),
     .package(url: "https://github.com/gonzalezreal/swift-markdown-ui", from: "2.0.0"),
+    .package(url: "https://github.com/groue/GRDB.swift", from: "6.24.0"),
   ],
   targets: [
     .target(
@@ -27,6 +28,7 @@ let package = Package(
         .product(name: "PierreDiffsSwift", package: "PierreDiffsSwift"),
         .product(name: "SwiftTerm", package: "SwiftTerm"),
         .product(name: "MarkdownUI", package: "swift-markdown-ui"),
+        .product(name: "GRDB", package: "GRDB.swift"),
       ],
       path: "Sources/AgentHub",
       swiftSettings: [

--- a/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubProvider.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubProvider.swift
@@ -61,13 +61,24 @@ public final class AgentHubProvider {
     createClaudeClient()
   }()
 
+  /// Session metadata store for user-provided session names
+  public private(set) lazy var metadataStore: SessionMetadataStore? = {
+    do {
+      return try SessionMetadataStore()
+    } catch {
+      AppLogger.session.error("Failed to create SessionMetadataStore: \(error.localizedDescription)")
+      return nil
+    }
+  }()
+
   // MARK: - View Models
 
   /// Sessions view model - created lazily and cached
   public private(set) lazy var sessionsViewModel: CLISessionsViewModel = {
     CLISessionsViewModel(
       monitorService: monitorService,
-      claudeClient: claudeClient
+      claudeClient: claudeClient,
+      metadataStore: metadataStore
     )
   }()
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/Models/SessionMetadata.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Models/SessionMetadata.swift
@@ -1,0 +1,44 @@
+//
+//  SessionMetadata.swift
+//  AgentHub
+//
+//  User-provided metadata for sessions stored in SQLite
+//
+
+import Foundation
+import GRDB
+
+/// Represents user-provided metadata for a session
+/// Stored in SQLite for persistence across app launches
+public struct SessionMetadata: Codable, Sendable, FetchableRecord, PersistableRecord {
+
+  /// The session UUID (primary key, matches CLISession.id)
+  public var sessionId: String
+
+  /// User-provided name for the session (optional)
+  public var customName: String?
+
+  /// When the metadata was created
+  public var createdAt: Date
+
+  /// When the metadata was last updated
+  public var updatedAt: Date
+
+  // MARK: - GRDB Configuration
+
+  public static var databaseTableName: String { "session_metadata" }
+
+  // MARK: - Initialization
+
+  public init(
+    sessionId: String,
+    customName: String? = nil,
+    createdAt: Date = Date(),
+    updatedAt: Date = Date()
+  ) {
+    self.sessionId = sessionId
+    self.customName = customName
+    self.createdAt = createdAt
+    self.updatedAt = updatedAt
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/SessionMetadataStore.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/SessionMetadataStore.swift
@@ -1,0 +1,118 @@
+//
+//  SessionMetadataStore.swift
+//  AgentHub
+//
+//  Actor-based service for persisting session metadata to SQLite
+//
+
+import Foundation
+import GRDB
+
+/// Actor-based service for persisting session metadata to SQLite
+/// Uses GRDB for database operations with async/await support
+public actor SessionMetadataStore {
+
+  // MARK: - Properties
+
+  private let dbQueue: DatabaseQueue
+
+  // MARK: - Initialization
+
+  /// Creates a new metadata store at the default location
+  /// Database is stored in ~/Library/Application Support/AgentHub/session_metadata.sqlite
+  public init() throws {
+    let appSupportURL = FileManager.default.urls(
+      for: .applicationSupportDirectory,
+      in: .userDomainMask
+    ).first!
+
+    let agentHubDir = appSupportURL.appendingPathComponent("AgentHub", isDirectory: true)
+    try FileManager.default.createDirectory(
+      at: agentHubDir,
+      withIntermediateDirectories: true
+    )
+
+    let dbPath = agentHubDir.appendingPathComponent("session_metadata.sqlite")
+    dbQueue = try DatabaseQueue(path: dbPath.path)
+
+    try migrator.migrate(dbQueue)
+  }
+
+  /// Creates a store with a custom database path (for testing)
+  public init(path: String) throws {
+    dbQueue = try DatabaseQueue(path: path)
+    try migrator.migrate(dbQueue)
+  }
+
+  // MARK: - Migrations
+
+  private nonisolated var migrator: DatabaseMigrator {
+    var migrator = DatabaseMigrator()
+
+    migrator.registerMigration("v1_create_session_metadata") { db in
+      try db.create(table: "session_metadata") { t in
+        t.column("sessionId", .text).primaryKey()
+        t.column("customName", .text)
+        t.column("createdAt", .datetime).notNull()
+        t.column("updatedAt", .datetime).notNull()
+      }
+    }
+
+    return migrator
+  }
+
+  // MARK: - Public API
+
+  /// Gets the custom name for a session, if one exists
+  public func getCustomName(for sessionId: String) throws -> String? {
+    try dbQueue.read { db in
+      try SessionMetadata
+        .filter(Column("sessionId") == sessionId)
+        .fetchOne(db)?
+        .customName
+    }
+  }
+
+  /// Sets the custom name for a session
+  /// Creates new record if none exists, updates if it does
+  public func setCustomName(_ name: String?, for sessionId: String) throws {
+    try dbQueue.write { db in
+      if var existing = try SessionMetadata.fetchOne(db, key: sessionId) {
+        existing.customName = name
+        existing.updatedAt = Date()
+        try existing.update(db)
+      } else if let name = name, !name.isEmpty {
+        let metadata = SessionMetadata(
+          sessionId: sessionId,
+          customName: name
+        )
+        try metadata.insert(db)
+      }
+    }
+  }
+
+  /// Gets all metadata for multiple sessions at once (batch fetch)
+  public func getMetadata(for sessionIds: [String]) throws -> [String: SessionMetadata] {
+    try dbQueue.read { db in
+      let records = try SessionMetadata
+        .filter(sessionIds.contains(Column("sessionId")))
+        .fetchAll(db)
+
+      return Dictionary(uniqueKeysWithValues: records.map { ($0.sessionId, $0) })
+    }
+  }
+
+  /// Deletes metadata for a session
+  public func deleteMetadata(for sessionId: String) throws {
+    try dbQueue.write { db in
+      _ = try SessionMetadata.deleteOne(db, key: sessionId)
+    }
+  }
+
+  /// Clears all metadata (for testing/reset)
+  public func clearAll() throws {
+    try dbQueue.write { db in
+      _ = try SessionMetadata.deleteAll(db)
+    }
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/CLIRepositoryTreeView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/CLIRepositoryTreeView.swift
@@ -24,6 +24,7 @@ public struct CLIRepositoryTreeView: View {
   let onOpenTerminalForWorktree: (WorktreeBranch) -> Void
   let onStartInHubForWorktree: (WorktreeBranch) -> Void
   let onDeleteWorktree: ((WorktreeBranch) -> Void)?
+  let getCustomName: ((String) -> String?)?
   var showLastMessage: Bool = false
   var isDebugMode: Bool = false
   var deletingWorktreePath: String? = nil
@@ -45,6 +46,7 @@ public struct CLIRepositoryTreeView: View {
     onOpenTerminalForWorktree: @escaping (WorktreeBranch) -> Void,
     onStartInHubForWorktree: @escaping (WorktreeBranch) -> Void,
     onDeleteWorktree: ((WorktreeBranch) -> Void)? = nil,
+    getCustomName: ((String) -> String?)? = nil,
     showLastMessage: Bool = false,
     isDebugMode: Bool = false,
     deletingWorktreePath: String? = nil
@@ -62,6 +64,7 @@ public struct CLIRepositoryTreeView: View {
     self.onOpenTerminalForWorktree = onOpenTerminalForWorktree
     self.onStartInHubForWorktree = onStartInHubForWorktree
     self.onDeleteWorktree = onDeleteWorktree
+    self.getCustomName = getCustomName
     self.showLastMessage = showLastMessage
     self.isDebugMode = isDebugMode
     self.deletingWorktreePath = deletingWorktreePath
@@ -95,6 +98,7 @@ public struct CLIRepositoryTreeView: View {
             onOpenSessionFile: onOpenSessionFile,
             isSessionMonitored: isSessionMonitored,
             onToggleMonitoring: onToggleMonitoring,
+            getCustomName: getCustomName,
             showLastMessage: showLastMessage,
             isDebugMode: isDebugMode,
             isDeleting: worktree.path == deletingWorktreePath

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/CLISessionRow.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/CLISessionRow.swift
@@ -13,6 +13,7 @@ import SwiftUI
 /// Individual row for displaying a CLI session with connect action
 public struct CLISessionRow: View {
   let session: CLISession
+  let customName: String?
   let isMonitoring: Bool
   let onConnect: () -> Void
   let onCopyId: () -> Void
@@ -24,6 +25,7 @@ public struct CLISessionRow: View {
 
   public init(
     session: CLISession,
+    customName: String? = nil,
     isMonitoring: Bool,
     onConnect: @escaping () -> Void,
     onCopyId: @escaping () -> Void,
@@ -32,6 +34,7 @@ public struct CLISessionRow: View {
     showLastMessage: Bool = false
   ) {
     self.session = session
+    self.customName = customName
     self.isMonitoring = isMonitoring
     self.onConnect = onConnect
     self.onCopyId = onCopyId
@@ -92,7 +95,13 @@ public struct CLISessionRow: View {
         .fill(statusColor)
         .frame(width: 8, height: 8)
 
-      if let slug = session.slug {
+      if let customName = customName {
+        // Show user-provided custom name
+        Text(customName)
+          .font(.system(.subheadline, weight: .semibold))
+          .foregroundColor(.primary)
+          .lineLimit(1)
+      } else if let slug = session.slug {
         // Show slug and short ID (no "Session:" label)
         Text(slug)
           .font(.system(.subheadline, design: .monospaced, weight: .semibold))

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/CLISessionsListView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/CLISessionsListView.swift
@@ -529,6 +529,9 @@ public struct CLISessionsListView: View {
                 await viewModel.deleteWorktree(worktree)
               }
             },
+            getCustomName: { sessionId in
+              viewModel.sessionCustomNames[sessionId]
+            },
             showLastMessage: viewModel.showLastMessage,
             isDebugMode: true,  // Enable debug mode for now
             deletingWorktreePath: viewModel.deletingWorktreePath

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/CLIWorktreeBranchRow.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/CLIWorktreeBranchRow.swift
@@ -23,6 +23,7 @@ public struct CLIWorktreeBranchRow: View {
   let onOpenSessionFile: (CLISession) -> Void
   let isSessionMonitored: (String) -> Bool
   let onToggleMonitoring: (CLISession) -> Void
+  let getCustomName: ((String) -> String?)?
   var showLastMessage: Bool = false
   var isDebugMode: Bool = false
   var isDeleting: Bool = false
@@ -73,6 +74,7 @@ public struct CLIWorktreeBranchRow: View {
     onOpenSessionFile: @escaping (CLISession) -> Void,
     isSessionMonitored: @escaping (String) -> Bool,
     onToggleMonitoring: @escaping (CLISession) -> Void,
+    getCustomName: ((String) -> String?)? = nil,
     showLastMessage: Bool = false,
     isDebugMode: Bool = false,
     isDeleting: Bool = false
@@ -88,6 +90,7 @@ public struct CLIWorktreeBranchRow: View {
     self.onOpenSessionFile = onOpenSessionFile
     self.isSessionMonitored = isSessionMonitored
     self.onToggleMonitoring = onToggleMonitoring
+    self.getCustomName = getCustomName
     self.showLastMessage = showLastMessage
     self.isDebugMode = isDebugMode
     self.isDeleting = isDeleting
@@ -224,6 +227,7 @@ public struct CLIWorktreeBranchRow: View {
               ForEach(visibleSessions) { session in
                 CLISessionRow(
                   session: session,
+                  customName: getCustomName?(session.id),
                   isMonitoring: isSessionMonitored(session.id),
                   onConnect: { onConnectSession(session) },
                   onCopyId: { onCopySessionId(session) },

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/NameSessionSheet.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/NameSessionSheet.swift
@@ -1,0 +1,69 @@
+//
+//  NameSessionSheet.swift
+//  AgentHub
+//
+//  Sheet for editing a session's custom name
+//
+
+import SwiftUI
+
+/// Sheet for editing a session's custom name
+struct NameSessionSheet: View {
+  let session: CLISession
+  let currentName: String?
+  let onSave: (String?) -> Void
+  let onDismiss: () -> Void
+
+  @State private var nameText: String = ""
+  @FocusState private var isTextFieldFocused: Bool
+
+  var body: some View {
+    VStack(spacing: 16) {
+      Text("Name Session")
+        .font(.headline)
+
+      TextField("Enter a name...", text: $nameText)
+        .textFieldStyle(.roundedBorder)
+        .focused($isTextFieldFocused)
+        .onSubmit { save() }
+
+      Text("Session ID: \(session.shortId)")
+        .font(.caption)
+        .foregroundColor(.secondary)
+
+      HStack(spacing: 12) {
+        Button("Cancel") {
+          onDismiss()
+        }
+        .keyboardShortcut(.escape)
+
+        if currentName != nil {
+          Button("Clear") {
+            onSave(nil)
+            onDismiss()
+          }
+          .foregroundColor(.red)
+        }
+
+        Button("Save") {
+          save()
+        }
+        .keyboardShortcut(.return)
+        .buttonStyle(.borderedProminent)
+        .disabled(nameText.isEmpty && currentName == nil)
+      }
+    }
+    .padding(20)
+    .frame(width: 300)
+    .onAppear {
+      nameText = currentName ?? ""
+      isTextFieldFocused = true
+    }
+  }
+
+  private func save() {
+    let trimmed = nameText.trimmingCharacters(in: .whitespacesAndNewlines)
+    onSave(trimmed.isEmpty ? nil : trimmed)
+    onDismiss()
+  }
+}


### PR DESCRIPTION
## Summary

- Add ability to name sessions with custom hints/labels that persist across app restarts
- Store session metadata in SQLite database using GRDB.swift
- Display custom names in both monitoring card header and sidebar session rows
- Show maximize button in both monitor and terminal modes

## Changes

- **New files:**
  - `SessionMetadata.swift` - GRDB record model
  - `SessionMetadataStore.swift` - Actor-based SQLite service
  - `NameSessionSheet.swift` - SwiftUI sheet for name input

- **Modified files:**
  - `Package.swift` - Add GRDB.swift dependency
  - `AgentHubProvider.swift` - Add metadata store
  - `CLISessionsViewModel.swift` - Add naming logic and cache
  - `MonitoringCardView.swift` - Add "Name Session" button and custom name display
  - `CLISessionRow.swift`, `CLIWorktreeBranchRow.swift`, `CLIRepositoryTreeView.swift`, `CLISessionsListView.swift` - Pass custom names to sidebar rows

## Test plan

- [ ] Launch app, observe a session
- [ ] Click plus button → verify "Name Session" option appears
- [ ] Click "Name Session" → verify sheet opens with text field
- [ ] Enter a name and save → verify header updates to show custom name
- [ ] Verify sidebar session row also shows custom name
- [ ] Close and reopen app → verify custom name persists
- [ ] Clear the name → verify both locations revert to "Session: [shortId]"
- [ ] Verify maximize button visible in both monitor and terminal modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)