### PR TITLE
Add orphaned process UI to menu bar

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubViews.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubViews.swift
@@ -119,7 +119,10 @@ public struct AgentHubMenuBarContent: View {
 
   public var body: some View {
     if let provider = agentHub {
-      GlobalStatsMenuView(service: provider.statsService)
+      GlobalStatsMenuView(
+        service: provider.statsService,
+        sessionsViewModel: provider.sessionsViewModel
+      )
     } else {
       Text("AgentHub provider not found")
         .foregroundStyle(.secondary)

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/EmbeddedTerminalView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/EmbeddedTerminalView.swift
@@ -116,6 +116,11 @@ public class TerminalContainerView: NSView, ManagedLocalProcessTerminalViewDeleg
   private var hasDeliveredInitialPrompt = false
   private var terminalPidMap: [ObjectIdentifier: pid_t] = [:]
 
+  /// The PID of the current terminal process, if running
+  public var currentProcessPID: Int32? {
+    terminalView?.currentProcessId
+  }
+
   // MARK: - Lifecycle
 
   /// Terminate process on deallocation (safety net)

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/GlobalStatsMenuView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/GlobalStatsMenuView.swift
@@ -12,10 +12,16 @@ import SwiftUI
 /// View for displaying global Claude Code stats in a menu bar dropdown
 public struct GlobalStatsMenuView: View {
   let service: GlobalStatsService
+  let sessionsViewModel: CLISessionsViewModel?
   let showQuitButton: Bool
 
-  public init(service: GlobalStatsService, showQuitButton: Bool = true) {
+  public init(
+    service: GlobalStatsService,
+    sessionsViewModel: CLISessionsViewModel? = nil,
+    showQuitButton: Bool = true
+  ) {
     self.service = service
+    self.sessionsViewModel = sessionsViewModel
     self.showQuitButton = showQuitButton
   }
 
@@ -43,6 +49,14 @@ public struct GlobalStatsMenuView: View {
         // Model breakdown
         modelBreakdownSection
 
+        // Orphaned processes (only if any exist)
+        if let vm = sessionsViewModel, vm.orphanedProcessCount > 0 {
+          Divider()
+            .padding(.vertical, 8)
+
+          orphanedProcessesSection(viewModel: vm)
+        }
+
         Divider()
           .padding(.vertical, 8)
 
@@ -68,6 +82,9 @@ public struct GlobalStatsMenuView: View {
     }
     .padding(12)
     .frame(width: 280)
+    .onAppear {
+      sessionsViewModel?.refreshOrphanedProcessCount()
+    }
   }
 
   // MARK: - Header Section
@@ -165,6 +182,38 @@ public struct GlobalStatsMenuView: View {
             .fontWeight(.medium)
         }
       }
+    }
+  }
+
+  // MARK: - Orphaned Processes Section
+
+  @ViewBuilder
+  private func orphanedProcessesSection(viewModel: CLISessionsViewModel) -> some View {
+    let count = viewModel.orphanedProcessCount
+
+    VStack(alignment: .leading, spacing: 6) {
+      HStack {
+        Image(systemName: "exclamationmark.triangle.fill")
+          .foregroundColor(.orange)
+          .frame(width: 16)
+        Text("Orphaned Processes")
+          .font(.caption)
+        Spacer()
+        Text("\(count)")
+          .font(.caption)
+          .fontWeight(.medium)
+          .foregroundColor(.orange)
+      }
+
+      Button(action: { viewModel.killOrphanedProcesses() }) {
+        HStack {
+          Image(systemName: "xmark.circle.fill")
+            .foregroundColor(.red)
+          Text("Kill All")
+            .font(.caption)
+        }
+      }
+      .buttonStyle(.plain)
     }
   }
 


### PR DESCRIPTION
## Summary
- Add orphaned processes section to GlobalStatsMenuView with count and "Kill All" button
- Add `refreshOrphanedProcessCount()` and `killOrphanedProcesses()` to CLISessionsViewModel
- Expose `currentProcessPID` on TerminalContainerView to identify active PIDs
- Pass sessionsViewModel to GlobalStatsMenuView for orphan detection

Depends on #57 (merged)

## Test plan
- [ ] Build the app
- [ ] Open menu bar stats - should show orphaned processes section if any exist
- [ ] Click "Kill All" - count should go to 0 and section should disappear

🤖 Generated with [Claude Code](https://claude.com/claude-code)