### PR TITLE
Show code changes preview button immediately

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringCardView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringCardView.swift
@@ -502,10 +502,9 @@ public struct MonitoringCardView: View {
 
       Spacer()
 
-      // Pending changes preview button
+      // Pending changes preview button - show immediately when code change tool is detected
       if let pendingToolUse = state?.pendingToolUse,
-         pendingToolUse.isCodeChangeTool,
-         case .awaitingApproval = state?.status {
+         pendingToolUse.isCodeChangeTool {
         Button(action: {
           pendingChangesSheetItem = PendingChangesSheetItem(
             session: session,


### PR DESCRIPTION
## Summary
- Remove `.awaitingApproval` status gate from Preview button visibility
- Preview button now appears immediately when Edit/Write/MultiEdit tool is detected
- Sound notification timing unchanged (still tied to `approvalTimeoutSeconds`)

## Test plan
- [ ] Build and run the app
- [ ] Start a monitored session
- [ ] Trigger an Edit/Write tool call
- [ ] Verify Preview button appears immediately (not after 5 second delay)
- [ ] Verify sound still plays after `approvalTimeoutSeconds` delay

🤖 Generated with [Claude Code](https://claude.com/claude-code)