### PR TITLE
Add rounded borders to worktree row action buttons

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/CLIWorktreeBranchRow.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/CLIWorktreeBranchRow.swift
@@ -158,7 +158,12 @@ public struct CLIWorktreeBranchRow: View {
                 Image(systemName: "trash")
                   .font(.caption)
                   .foregroundColor(.brandSecondary.opacity(0.8))
-                  .padding(.horizontal, 2)
+                  .frame(width: 24, height: 24)
+                  .background(
+                    RoundedRectangle(cornerRadius: 6, style: .continuous)
+                      .stroke(Color.secondary.opacity(0.3), lineWidth: 1)
+                  )
+                  .contentShape(Rectangle())
               }
               .buttonStyle(.plain)
               .help("Delete worktree")
@@ -170,7 +175,12 @@ public struct CLIWorktreeBranchRow: View {
             Image(systemName: "plus")
               .font(.caption)
               .foregroundColor(.brandSecondary)
-              .padding(.horizontal, 2)
+              .frame(width: 24, height: 24)
+              .background(
+                RoundedRectangle(cornerRadius: 6, style: .continuous)
+                  .stroke(Color.secondary.opacity(0.3), lineWidth: 1)
+              )
+              .contentShape(Rectangle())
           }
           .buttonStyle(.plain)
           .help("Start new Claude session")


### PR DESCRIPTION
## Summary
- Add rounded border styling to trash and plus icon buttons in worktree rows
- Use fixed 24x24 frame for consistent square appearance matching the session count badge
- Add `contentShape(Rectangle())` modifier for full tap area coverage

## Test plan
- [ ] Verify trash and plus buttons have rounded borders
- [ ] Verify buttons appear square like the session count badge
- [ ] Verify entire button area is tappable

🤖 Generated with [Claude Code](https://claude.com/claude-code)