### PR TITLE
Skip greetings in session preview

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/CLISessionMonitorService.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/CLISessionMonitorService.swift
@@ -224,7 +224,8 @@ public actor CLISessionMonitorService {
             }
 
             let sortedEntries = entries.sorted { $0.timestamp < $1.timestamp }
-            let firstMessage = sortedEntries.first?.display
+            let firstMessage = sortedEntries.first { !isGreeting($0.display) }?.display
+              ?? sortedEntries.first?.display
             let lastMessage = sortedEntries.last?.display
 
             let session = CLISession(
@@ -300,7 +301,8 @@ public actor CLISessionMonitorService {
 
           // Get the first and last message (sorted by timestamp)
           let sortedEntries = entries.sorted { $0.timestamp < $1.timestamp }
-          let firstMessage = sortedEntries.first?.display
+          let firstMessage = sortedEntries.first { !isGreeting($0.display) }?.display
+            ?? sortedEntries.first?.display
           let lastMessage = sortedEntries.last?.display
 
           let session = CLISession(
@@ -328,6 +330,28 @@ public actor CLISessionMonitorService {
 
     selectedRepositories = updatedRepositories
     repositoriesSubject.send(selectedRepositories)
+  }
+
+  // MARK: - Message Utilities
+
+  // TEMPORARY FIX: Skip greetings to show meaningful session previews.
+  // This works around the issue where sessions disappear from the Hub during refresh
+  // when no session ID is found (happens after only the first message is sent).
+  // TODO: Remove once the session refresh/ID detection issue is properly fixed.
+
+  /// Common greetings to skip when finding a meaningful first message
+  private static let greetingPatterns: Set<String> = [
+    "hello", "hello!", "hello.",
+    "hi", "hi!", "hi.",
+    "hey", "hey!", "hey.",
+    "greetings", "greetings!",
+    "howdy", "yo", "sup"
+  ]
+
+  /// Checks if a message is a simple greeting that provides no context
+  private func isGreeting(_ message: String) -> Bool {
+    let normalized = message.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    return Self.greetingPatterns.contains(normalized)
   }
 
   // MARK: - Worktree Detection


### PR DESCRIPTION
## Summary
- Add greeting detection to show meaningful session previews instead of "Hello!"
- Sessions started from Hub default to "Hello!" making them hard to distinguish
- Now finds first non-greeting message, with fallback to original behavior if all messages are greetings

## Test plan
- [ ] Build and run the app
- [ ] Start a new session from Hub (uses default "Hello!")
- [ ] Send a follow-up message like "Can you help me refactor this code?"
- [ ] Verify session list shows "Can you help me refactor this code?" not "Hello!"
- [ ] Verify sessions with only greetings still display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)