### PR TITLE
Add PR-style code review comments to diff viewer

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/Models/DiffComment.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Models/DiffComment.swift
@@ -1,0 +1,44 @@
+//
+//  DiffComment.swift
+//  AgentHub
+//
+//  Created by Assistant on 1/29/26.
+//
+
+import Foundation
+
+/// A review comment on a specific line in a diff view.
+///
+/// Supports PR-style code review where users can leave multiple comments
+/// on different lines across files, then batch-send them to Claude.
+struct DiffComment: Identifiable, Equatable, Sendable {
+  let id: UUID
+  let timestamp: Date
+  let filePath: String
+  let lineNumber: Int
+  let side: String  // "left", "right", "unified"
+  let lineContent: String
+  var text: String
+
+  /// Unique key for identifying a comment's location.
+  /// Used to detect if a line already has a comment.
+  var locationKey: String { "\(filePath):\(lineNumber):\(side)" }
+
+  init(
+    id: UUID = UUID(),
+    timestamp: Date = Date(),
+    filePath: String,
+    lineNumber: Int,
+    side: String,
+    lineContent: String,
+    text: String
+  ) {
+    self.id = id
+    self.timestamp = timestamp
+    self.filePath = filePath
+    self.lineNumber = lineNumber
+    self.side = side
+    self.lineContent = lineContent
+    self.text = text
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/DiffCommentRow.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/DiffCommentRow.swift
@@ -1,0 +1,197 @@
+//
+//  DiffCommentRow.swift
+//  AgentHub
+//
+//  Created by Assistant on 1/29/26.
+//
+
+import SwiftUI
+
+/// A row displaying a single diff comment with inline edit/delete actions.
+/// Uses flat styling consistent with CLISessionRow.
+struct DiffCommentRow: View {
+
+  // MARK: - Properties
+
+  /// The diff comment to display in this row.
+  let comment: DiffComment
+
+  /// Called when the user saves an edited comment with new text.
+  let onSave: (String) -> Void
+
+  /// Called when the user taps the delete button.
+  let onDelete: () -> Void
+
+  @State private var isHovered = false
+  @State private var isEditing = false
+  @State private var editText: String = ""
+
+  // MARK: - Body
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 4) {
+      // Location header
+      locationRow
+
+      // Line content (code preview)
+      Text(comment.lineContent)
+        .font(.system(.caption, design: .monospaced))
+        .foregroundColor(.secondary)
+        .lineLimit(1)
+        .truncationMode(.middle)
+
+      // Comment text or edit field
+      if isEditing {
+        editingView
+          .transition(.opacity.combined(with: .scale(scale: 0.95, anchor: .top)))
+      } else {
+        Text(comment.text)
+          .font(.caption)
+          .foregroundColor(.primary.opacity(0.9))
+          .lineLimit(2)
+          .transition(.opacity)
+      }
+    }
+    .padding(.vertical, 8)
+    .padding(.horizontal, 10)
+    .contentShape(Rectangle())
+    .agentHubFlatRow(isHighlighted: isEditing)
+    .onHover { hovering in
+      isHovered = hovering
+    }
+  }
+
+  // MARK: - Editing View
+
+  private var editingView: some View {
+    VStack(alignment: .leading, spacing: 6) {
+      TextEditor(text: $editText)
+        .font(.callout)
+        .scrollContentBackground(.hidden)
+        .background(Color.primary.opacity(0.05))
+        .overlay(
+          RoundedRectangle(cornerRadius: 4)
+            .stroke(Color.primary.opacity(0.2), lineWidth: 1)
+        )
+        .clipShape(RoundedRectangle(cornerRadius: 4))
+        .frame(minHeight: 40, maxHeight: 80)
+
+      HStack(spacing: 8) {
+        Spacer()
+
+        Button("Cancel") {
+          isEditing = false
+          editText = ""
+        }
+        .buttonStyle(.plain)
+        .font(.caption)
+        .foregroundColor(.secondary)
+
+        Button("Save") {
+          onSave(editText)
+          isEditing = false
+          editText = ""
+        }
+        .buttonStyle(.plain)
+        .font(.caption.bold())
+        .foregroundColor(.brandPrimary)
+        .disabled(editText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+      }
+      .padding(.horizontal, 4)
+    }
+  }
+
+  // MARK: - Location Row
+
+  private var locationRow: some View {
+    HStack(spacing: 6) {
+      // Comment indicator
+      Image(systemName: "text.bubble.fill")
+        .font(.caption2)
+        .foregroundColor(.primary)
+
+      // Line number
+      Text("Line \(comment.lineNumber)")
+        .font(.system(.caption, design: .monospaced, weight: .semibold))
+        .foregroundColor(.primary)
+
+      // Side indicator
+      Text("(\(comment.side == "left" ? "old" : "new"))")
+        .font(.caption2)
+        .foregroundColor(.secondary)
+
+      Spacer()
+
+      // Action buttons (always rendered to prevent layout shift, opacity controlled by hover)
+      HStack(spacing: 6) {
+        Button {
+          editText = comment.text
+          withAnimation(.easeOut(duration: 0.2)) {
+            isEditing = true
+          }
+        } label: {
+          Image(systemName: "pencil")
+            .font(.caption2)
+            .foregroundColor(.primary)
+            .frame(width: 24, height: 24)
+            .contentShape(Rectangle())
+            .background(
+              RoundedRectangle(cornerRadius: 6)
+                .stroke(Color.primary.opacity(0.3), lineWidth: 1)
+            )
+        }
+        .buttonStyle(.plain)
+        .help("Edit comment")
+
+        Button(action: onDelete) {
+          Image(systemName: "trash")
+            .font(.caption2)
+            .foregroundColor(.red)
+            .frame(width: 24, height: 24)
+            .contentShape(Rectangle())
+            .background(
+              RoundedRectangle(cornerRadius: 6)
+                .stroke(Color.red.opacity(0.3), lineWidth: 1)
+            )
+        }
+        .buttonStyle(.plain)
+        .help("Delete comment")
+      }
+      .opacity(isHovered && !isEditing ? 1 : 0)
+      .animation(.easeInOut(duration: 0.15), value: isHovered)
+    }
+  }
+}
+
+// MARK: - Preview
+
+#Preview {
+  VStack(spacing: 0) {
+    DiffCommentRow(
+      comment: DiffComment(
+        filePath: "/path/to/Example.swift",
+        lineNumber: 42,
+        side: "right",
+        lineContent: "let result = calculateValue()",
+        text: "Consider adding error handling here for the case when calculation fails."
+      ),
+      onSave: { _ in },
+      onDelete: {}
+    )
+
+    Divider()
+
+    DiffCommentRow(
+      comment: DiffComment(
+        filePath: "/path/to/Example.swift",
+        lineNumber: 58,
+        side: "left",
+        lineContent: "// TODO: refactor this later",
+        text: "This should be addressed"
+      ),
+      onSave: { _ in },
+      onDelete: {}
+    )
+  }
+  .frame(width: 350)
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/DiffCommentsPanelView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/DiffCommentsPanelView.swift
@@ -1,0 +1,226 @@
+//
+//  DiffCommentsPanelView.swift
+//  AgentHub
+//
+//  Created by Assistant on 1/29/26.
+//
+
+import SwiftUI
+
+/// A collapsible panel showing all pending review comments.
+///
+/// Displays at the bottom of the diff viewer with a header showing count
+/// and actions to send all comments to Claude or clear them.
+struct DiffCommentsPanelView: View {
+
+  // MARK: - Properties
+
+  /// The shared state manager containing all pending review comments.
+  @Bindable var commentsState: DiffCommentsState
+
+  /// Called when the user taps "Send to Claude" to submit all comments as a batch.
+  let onSendToCloud: () -> Void
+
+  @State private var showClearConfirmation = false
+
+  // MARK: - Body
+
+  var body: some View {
+    VStack(spacing: 0) {
+      // Header bar (always visible when there are comments)
+      headerBar
+
+      // Content (shown when expanded)
+      if commentsState.isPanelExpanded {
+        Divider()
+
+        ScrollView {
+          let sortedFiles = commentsState.commentsByFile.keys.sorted()
+          VStack(alignment: .leading, spacing: 0) {
+            ForEach(Array(sortedFiles.enumerated()), id: \.element) { index, filePath in
+              if let comments = commentsState.commentsByFile[filePath] {
+                if index > 0 {
+                  Divider()
+                    .padding(.vertical, 4)
+                }
+                fileSection(filePath: filePath, comments: comments)
+              }
+            }
+          }
+          .padding(.vertical, 8)
+        }
+        .frame(maxHeight: 200)
+      }
+    }
+    .background(Color.surfaceElevated)
+    .overlay(
+      Rectangle()
+        .frame(height: 1)
+        .foregroundColor(Color(NSColor.separatorColor)),
+      alignment: .top
+    )
+    .confirmationDialog(
+      "Clear All Comments",
+      isPresented: $showClearConfirmation,
+      titleVisibility: .visible
+    ) {
+      Button("Clear All", role: .destructive) {
+        commentsState.clearAll()
+      }
+      Button("Cancel", role: .cancel) {}
+    } message: {
+      Text("This will remove all \(commentsState.commentCount) pending comments. This action cannot be undone.")
+    }
+  }
+
+  // MARK: - Header Bar
+
+  private var headerBar: some View {
+    HStack(spacing: 12) {
+      // Expand/collapse button with count
+      Button {
+        withAnimation(.easeInOut(duration: 0.2)) {
+          commentsState.isPanelExpanded.toggle()
+        }
+      } label: {
+        HStack(spacing: 6) {
+          Image(systemName: commentsState.isPanelExpanded ? "chevron.down" : "chevron.up")
+            .font(.caption.bold())
+
+          Image(systemName: "text.bubble.fill")
+            .font(.caption)
+
+          Text("\(commentsState.commentCount) Comment\(commentsState.commentCount == 1 ? "" : "s")")
+            .font(.caption.bold())
+        }
+        .foregroundColor(.primary)
+      }
+      .buttonStyle(.plain)
+
+      Spacer()
+
+      // Clear all button
+      Button {
+        showClearConfirmation = true
+      } label: {
+        HStack(spacing: 4) {
+          Image(systemName: "trash")
+            .font(.caption)
+          Text("Clear")
+            .font(.caption)
+        }
+        .foregroundColor(.secondary)
+      }
+      .buttonStyle(.plain)
+      .help("Clear all comments")
+
+      // Send to Claude button
+      Button(action: onSendToCloud) {
+        HStack(spacing: 4) {
+          Image(systemName: "paperplane")
+            .font(.caption)
+          Text("Send \(commentsState.commentCount) to Claude")
+            .font(.caption.bold())
+        }
+        .foregroundColor(.primary)
+        .padding(.horizontal, 12)
+        .padding(.vertical, 6)
+        .background(
+          RoundedRectangle(cornerRadius: 6)
+            .stroke(Color.primary.opacity(0.3), lineWidth: 1)
+        )
+      }
+      .buttonStyle(.plain)
+      .help("Send all comments to Claude (⌘⇧↵)")
+    }
+    .padding(.horizontal, 12)
+    .padding(.vertical, 8)
+  }
+
+  // MARK: - File Section
+
+  private func fileSection(filePath: String, comments: [DiffComment]) -> some View {
+    VStack(alignment: .leading, spacing: 0) {
+      // File header
+      HStack(spacing: 6) {
+        Image(systemName: "doc.text.fill")
+          .font(.caption)
+          .foregroundColor(.primary)
+
+        Text(URL(fileURLWithPath: filePath).lastPathComponent)
+          .font(.system(.caption, design: .monospaced, weight: .semibold))
+          .foregroundColor(.primary)
+
+        Text("(\(comments.count))")
+          .font(.caption2)
+          .foregroundColor(.secondary)
+
+        Spacer()
+      }
+      .padding(.vertical, 6)
+      .padding(.horizontal, 10)
+
+      // Comments for this file with dividers
+      ForEach(Array(comments.enumerated()), id: \.element.id) { index, comment in
+        if index > 0 {
+          Divider()
+            .padding(.leading, 10)
+        }
+
+        DiffCommentRow(
+          comment: comment,
+          onSave: { newText in
+            commentsState.updateComment(id: comment.id, newText: newText)
+          },
+          onDelete: { commentsState.removeComment(id: comment.id) }
+        )
+      }
+    }
+  }
+}
+
+// MARK: - Preview
+
+#Preview {
+  struct PreviewWrapper: View {
+    @State var commentsState = DiffCommentsState()
+
+    var body: some View {
+      VStack {
+        Spacer()
+
+        DiffCommentsPanelView(
+          commentsState: commentsState,
+          onSendToCloud: {}
+        )
+      }
+      .frame(width: 800, height: 400)
+      .onAppear {
+        commentsState.addComment(
+          filePath: "/path/to/Example.swift",
+          lineNumber: 42,
+          side: "right",
+          lineContent: "let result = calculateValue()",
+          text: "Consider adding error handling here"
+        )
+        commentsState.addComment(
+          filePath: "/path/to/Example.swift",
+          lineNumber: 58,
+          side: "left",
+          lineContent: "// TODO: refactor",
+          text: "This should be addressed"
+        )
+        commentsState.addComment(
+          filePath: "/path/to/Other.swift",
+          lineNumber: 10,
+          side: "right",
+          lineContent: "func doSomething()",
+          text: "Add documentation"
+        )
+        commentsState.isPanelExpanded = true
+      }
+    }
+  }
+
+  return PreviewWrapper()
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/DiffCommentsState.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/DiffCommentsState.swift
@@ -1,0 +1,186 @@
+//
+//  DiffCommentsState.swift
+//  AgentHub
+//
+//  Created by Assistant on 1/29/26.
+//
+
+import SwiftUI
+
+/// Observable state manager for PR-style review comments on diffs.
+///
+/// Manages a collection of comments keyed by location, allowing users to
+/// accumulate multiple comments across lines/files before batch-sending to Claude.
+@Observable @MainActor
+final class DiffCommentsState {
+
+  // MARK: - Properties
+
+  /// Comments keyed by location (filePath:lineNumber:side)
+  private(set) var comments: [String: DiffComment] = [:]
+
+  /// Whether the comments panel is expanded
+  var isPanelExpanded: Bool = false
+
+  // MARK: - Computed Properties
+
+  /// All comments ordered by timestamp (oldest first)
+  var orderedComments: [DiffComment] {
+    comments.values.sorted { $0.timestamp < $1.timestamp }
+  }
+
+  /// Comments grouped by file path
+  var commentsByFile: [String: [DiffComment]] {
+    Dictionary(grouping: comments.values) { $0.filePath }
+      .mapValues { $0.sorted { $0.lineNumber < $1.lineNumber } }
+  }
+
+  /// Total number of comments
+  var commentCount: Int {
+    comments.count
+  }
+
+  /// Whether there are any pending comments
+  var hasComments: Bool {
+    !comments.isEmpty
+  }
+
+  // MARK: - Methods
+
+  /// Adds or updates a comment at the specified location.
+  ///
+  /// - Parameters:
+  ///   - filePath: The file path where the comment is made
+  ///   - lineNumber: The line number of the comment
+  ///   - side: Which side of the diff ("left", "right", or "unified")
+  ///   - lineContent: The content of the line being commented on
+  ///   - text: The comment text
+  /// - Returns: The created or updated comment
+  @discardableResult
+  func addComment(
+    filePath: String,
+    lineNumber: Int,
+    side: String,
+    lineContent: String,
+    text: String
+  ) -> DiffComment {
+    let locationKey = "\(filePath):\(lineNumber):\(side)"
+
+    if var existingComment = comments[locationKey] {
+      // Update existing comment
+      existingComment.text = text
+      comments[locationKey] = existingComment
+      return existingComment
+    } else {
+      // Create new comment
+      let comment = DiffComment(
+        filePath: filePath,
+        lineNumber: lineNumber,
+        side: side,
+        lineContent: lineContent,
+        text: text
+      )
+      comments[locationKey] = comment
+      return comment
+    }
+  }
+
+  /// Updates the text of an existing comment.
+  ///
+  /// - Parameters:
+  ///   - id: The ID of the comment to update
+  ///   - newText: The new comment text
+  func updateComment(id: UUID, newText: String) {
+    guard let locationKey = comments.first(where: { $0.value.id == id })?.key else {
+      return
+    }
+    comments[locationKey]?.text = newText
+  }
+
+  /// Removes a comment by its ID.
+  ///
+  /// - Parameter id: The ID of the comment to remove
+  func removeComment(id: UUID) {
+    guard let locationKey = comments.first(where: { $0.value.id == id })?.key else {
+      return
+    }
+    comments.removeValue(forKey: locationKey)
+  }
+
+  /// Removes a comment by its location.
+  ///
+  /// - Parameters:
+  ///   - filePath: The file path of the comment
+  ///   - lineNumber: The line number of the comment
+  ///   - side: The side of the diff
+  func removeComment(filePath: String, lineNumber: Int, side: String) {
+    let locationKey = "\(filePath):\(lineNumber):\(side)"
+    comments.removeValue(forKey: locationKey)
+  }
+
+  /// Checks if a line already has a comment.
+  ///
+  /// - Parameters:
+  ///   - filePath: The file path to check
+  ///   - lineNumber: The line number to check
+  ///   - side: The side of the diff
+  /// - Returns: True if a comment exists at this location
+  func hasComment(filePath: String, lineNumber: Int, side: String) -> Bool {
+    let locationKey = "\(filePath):\(lineNumber):\(side)"
+    return comments[locationKey] != nil
+  }
+
+  /// Gets the comment at a specific location.
+  ///
+  /// - Parameters:
+  ///   - filePath: The file path
+  ///   - lineNumber: The line number
+  ///   - side: The side of the diff
+  /// - Returns: The comment at this location, or nil if none exists
+  func getComment(filePath: String, lineNumber: Int, side: String) -> DiffComment? {
+    let locationKey = "\(filePath):\(lineNumber):\(side)"
+    return comments[locationKey]
+  }
+
+  /// Clears all comments.
+  func clearAll() {
+    comments.removeAll()
+  }
+
+  /// Generates a formatted prompt for Claude from all comments.
+  ///
+  /// Format:
+  /// ```
+  /// I have the following review comments on the code changes:
+  ///
+  /// ## /full/path/to/FileName.swift
+  ///
+  /// **Line 42** (new):
+  /// ```
+  /// let result = calculateValue()
+  /// ```
+  /// Comment: Consider adding error handling here
+  /// ```
+  ///
+  /// - Returns: The formatted prompt string
+  func generatePrompt() -> String {
+    guard hasComments else { return "" }
+
+    var prompt = "I have the following review comments on the code changes:\n"
+
+    for (filePath, fileComments) in commentsByFile {
+      prompt += "\n## \(filePath)\n"
+
+      for comment in fileComments {
+        let sideLabel = comment.side == "left" ? "old" : "new"
+        prompt += "\n**Line \(comment.lineNumber)** (\(sideLabel)):\n"
+        prompt += "```\n\(comment.lineContent)\n```\n"
+        prompt += "Comment: \(comment.text)\n"
+      }
+    }
+
+    prompt += "\nPlease address these review comments."
+
+    return prompt
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/GitDiffView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/GitDiffView.swift
@@ -39,6 +39,8 @@ public struct GitDiffView: View {
   @State private var inlineEditorState = InlineEditorState()
   @State private var diffMode: DiffMode = .unstaged
   @State private var detectedBaseBranch: String?
+  @State private var commentsState = DiffCommentsState()
+  @State private var showDiscardCommentsAlert = false
 
   private let gitDiffService = GitDiffService()
 
@@ -71,13 +73,23 @@ public struct GitDiffView: View {
       } else if diffState.files.isEmpty {
         emptyState
       } else {
-        HSplitView {
-          // File list sidebar
-          fileListSidebar
-            .frame(minWidth: 200, idealWidth: 250, maxWidth: 300)
+        VStack(spacing: 0) {
+          HSplitView {
+            // File list sidebar
+            fileListSidebar
+              .frame(minWidth: 200, idealWidth: 250, maxWidth: 300)
 
-          // Diff viewer
-          diffViewer
+            // Diff viewer
+            diffViewer
+          }
+
+          // Comments panel (shown when there are comments)
+          if commentsState.hasComments {
+            DiffCommentsPanelView(
+              commentsState: commentsState,
+              onSendToCloud: sendAllCommentsToCloud
+            )
+          }
         }
       }
     }
@@ -90,11 +102,29 @@ public struct GitDiffView: View {
         }
         return .handled
       }
+      // Check for unsent comments before dismissing
+      if commentsState.hasComments {
+        showDiscardCommentsAlert = true
+        return .handled
+      }
       onDismiss()
       return .handled
     }
     .task {
       await loadChanges(for: diffMode)
+    }
+    .confirmationDialog(
+      "Discard Unsent Comments?",
+      isPresented: $showDiscardCommentsAlert,
+      titleVisibility: .visible
+    ) {
+      Button("Discard \(commentsState.commentCount) Comment\(commentsState.commentCount == 1 ? "" : "s")", role: .destructive) {
+        commentsState.clearAll()
+        onDismiss()
+      }
+      Button("Cancel", role: .cancel) {}
+    } message: {
+      Text("You have \(commentsState.commentCount) unsent comment\(commentsState.commentCount == 1 ? "" : "s"). Closing will discard them.")
     }
   }
 
@@ -113,6 +143,23 @@ public struct GitDiffView: View {
         Text("(\(diffState.fileCount) files)")
           .font(.title3)
           .foregroundColor(.secondary)
+
+        // Comment count badge
+        if commentsState.hasComments {
+          HStack(spacing: 4) {
+            Image(systemName: "text.bubble.fill")
+              .font(.caption)
+            Text("\(commentsState.commentCount)")
+              .font(.caption.bold())
+          }
+          .foregroundColor(.white)
+          .padding(.horizontal, 8)
+          .padding(.vertical, 4)
+          .background(
+            Capsule()
+              .fill(Color.brandPrimary)
+          )
+        }
       }
 
       Spacer()
@@ -148,7 +195,11 @@ public struct GitDiffView: View {
       Spacer()
 
       Button("Close") {
-        onDismiss()
+        if commentsState.hasComments {
+          showDiscardCommentsAlert = true
+        } else {
+          onDismiss()
+        }
       }
     }
     .padding()
@@ -285,6 +336,7 @@ public struct GitDiffView: View {
             diffStyle: $diffStyle,
             overflowMode: $overflowMode,
             inlineEditorState: inlineEditorState,
+            commentsState: commentsState,
             claudeClient: claudeClient,
             session: session,
             onDismissView: onDismiss,
@@ -415,6 +467,37 @@ public struct GitDiffView: View {
       }
     }
   }
+
+  // MARK: - Comments Actions
+
+  /// Sends all pending comments to Claude as a batch review
+  private func sendAllCommentsToCloud() {
+    guard commentsState.hasComments else { return }
+
+    let prompt = commentsState.generatePrompt()
+
+    // Use callback if provided (redirects to built-in terminal)
+    if let callback = onInlineRequestSubmit {
+      callback(prompt, session)
+      commentsState.clearAll()
+      onDismiss()
+    } else if let client = claudeClient {
+      // Fallback to external Terminal
+      if let error = TerminalLauncher.launchTerminalWithSession(
+        session.id,
+        claudeClient: client,
+        projectPath: session.projectPath,
+        initialPrompt: prompt
+      ) {
+        inlineEditorState.errorMessage = error.localizedDescription
+      } else {
+        // Clear comments and dismiss
+        commentsState.clearAll()
+        onDismiss()
+      }
+    }
+  }
+
 }
 
 // MARK: - GitDiffFileRow
@@ -490,6 +573,7 @@ private struct GitDiffContentView: View {
   @Binding var diffStyle: DiffStyle
   @Binding var overflowMode: OverflowMode
   @Bindable var inlineEditorState: InlineEditorState
+  @Bindable var commentsState: DiffCommentsState
   let claudeClient: (any ClaudeCode)?
   let session: CLISession
   let onDismissView: () -> Void
@@ -561,6 +645,7 @@ private struct GitDiffContentView: View {
                 let prompt = buildInlinePrompt(
                   question: message,
                   lineNumber: lineNumber,
+                  side: side,
                   lineContent: inlineEditorState.lineContent ?? "",
                   fileName: file
                 )
@@ -584,7 +669,22 @@ private struct GitDiffContentView: View {
                     onDismissView()
                   }
                 }
-              }
+              },
+              onAddComment: { message, lineNumber, side, file, lineContent in
+                // Add comment to the collection
+                commentsState.addComment(
+                  filePath: file,
+                  lineNumber: lineNumber,
+                  side: side,
+                  lineContent: lineContent,
+                  text: message
+                )
+                // Auto-expand panel when first comment is added
+                if commentsState.commentCount == 1 {
+                  commentsState.isPanelExpanded = true
+                }
+              },
+              commentsState: commentsState
             )
           }
         }
@@ -678,16 +778,23 @@ private struct GitDiffContentView: View {
   private func buildInlinePrompt(
     question: String,
     lineNumber: Int,
+    side: String,
     lineContent: String,
     fileName: String
   ) -> String {
+    let sideLabel = side == "left" ? "old" : "new"
     return """
-      I'm looking at line \(lineNumber) in \(fileName):
+      I have the following review comment on the code changes:
+
+      ## \(fileName)
+
+      **Line \(lineNumber)** (\(sideLabel)):
       ```
       \(lineContent)
       ```
+      Comment: \(question)
 
-      \(question)
+      Please address this review comment.
       """
   }
 }

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/InlineEditorView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/InlineEditorView.swift
@@ -10,6 +10,10 @@ import AppKit
 
 /// A compact floating text editor for asking questions about specific diff lines.
 /// Appears below clicked lines in the diff view.
+///
+/// Supports two modes:
+/// - **Send immediately**: Press Enter to send the comment to Claude right away
+/// - **Add to review**: Press Cmd+Enter to add the comment to the review collection
 struct InlineEditorView: View {
 
   // MARK: - Properties
@@ -18,13 +22,57 @@ struct InlineEditorView: View {
   let side: String
   let fileName: String
   let errorMessage: String?
+
+  /// Called when user presses Enter - sends immediately to Claude
   let onSubmit: (String) -> Void
+
+  /// Called when user presses Cmd+Enter - adds to comment collection (optional)
+  let onAddComment: ((String) -> Void)?
+
+  /// Called when user wants to delete an existing comment (optional, edit mode only)
+  let onDeleteComment: (() -> Void)?
+
   let onDismiss: () -> Void
+
+  /// The initial text to pre-fill (for editing existing comments)
+  let initialText: String
+
+  /// Whether this is editing an existing comment
+  let isEditMode: Bool
 
   @State private var text: String = ""
   @FocusState private var isFocused: Bool
 
-  private var placeholder: String { "Add suggestion to line \(lineNumber)" }
+  private var placeholder: String {
+    isEditMode ? "Update comment on line \(lineNumber)" : "Add suggestion to line \(lineNumber)"
+  }
+
+  // MARK: - Initializers
+
+  init(
+    lineNumber: Int,
+    side: String,
+    fileName: String,
+    errorMessage: String?,
+    onSubmit: @escaping (String) -> Void,
+    onAddComment: ((String) -> Void)? = nil,
+    onDeleteComment: (() -> Void)? = nil,
+    onDismiss: @escaping () -> Void,
+    initialText: String = "",
+    isEditMode: Bool = false
+  ) {
+    self.lineNumber = lineNumber
+    self.side = side
+    self.fileName = fileName
+    self.errorMessage = errorMessage
+    self.onSubmit = onSubmit
+    self.onAddComment = onAddComment
+    self.onDeleteComment = onDeleteComment
+    self.onDismiss = onDismiss
+    self.initialText = initialText
+    self.isEditMode = isEditMode
+    self._text = State(initialValue: initialText)
+  }
 
   // MARK: - Body
 
@@ -70,8 +118,18 @@ struct InlineEditorView: View {
       // Dismiss button
       dismissButton
 
+      // Delete button (only in edit mode)
+      if isEditMode, onDeleteComment != nil {
+        deleteButton
+      }
+
       // Text input
       textEditorView
+
+      // Add comment button (if callback provided)
+      if onAddComment != nil {
+        addCommentButton
+      }
 
       // Send button (rounded square with arrow)
       sendButton
@@ -156,7 +214,55 @@ struct InlineEditorView: View {
         .stroke(Color(NSColor.separatorColor), lineWidth: 1)
     )
     .disabled(isTextEmpty)
-    .help("Send (Enter)")
+    .help("Send to Claude (Enter)")
+  }
+
+  // MARK: - Add Comment Button
+
+  private var addCommentButton: some View {
+    Button(action: addComment) {
+      Image(systemName: isEditMode ? "checkmark" : "plus")
+        .font(.system(size: 14, weight: .semibold))
+        .foregroundColor(isTextEmpty ? .secondary : .primary)
+    }
+    .buttonStyle(.plain)
+    .frame(width: 32, height: 32)
+    .background(
+      RoundedRectangle(cornerRadius: 8)
+        .fill(Color(NSColor.controlBackgroundColor))
+    )
+    .overlay(
+      RoundedRectangle(cornerRadius: 8)
+        .stroke(isTextEmpty ? Color(NSColor.separatorColor) : Color.brandPrimary.opacity(0.5), lineWidth: 1)
+    )
+    .disabled(isTextEmpty)
+    .help(isEditMode ? "Update comment (⌘↵)" : "Add to review (⌘↵)")
+  }
+
+  // MARK: - Delete Button
+
+  private var deleteButton: some View {
+    Button {
+      onDeleteComment?()
+    } label: {
+      Image(systemName: "trash")
+        .font(.system(size: 12, weight: .medium))
+        .foregroundColor(.red)
+        .frame(width: 24, height: 24)
+        .contentShape(Rectangle())
+    }
+    .buttonStyle(.plain)
+    .frame(width: 24, height: 24)
+    .background(
+      RoundedRectangle(cornerRadius: 6)
+        .fill(Color(NSColor.controlBackgroundColor))
+    )
+    .overlay(
+      RoundedRectangle(cornerRadius: 6)
+        .stroke(Color.red.opacity(0.3), lineWidth: 1)
+    )
+    .contentShape(Rectangle())
+    .help("Delete comment")
   }
 
   // MARK: - Helpers
@@ -177,17 +283,32 @@ struct InlineEditorView: View {
     onSubmit(messageText)
   }
 
+  /// Adds the comment to the review collection without sending to Claude.
+  private func addComment() {
+    guard !isTextEmpty, let callback = onAddComment else { return }
+    let messageText = text.trimmingCharacters(in: .whitespacesAndNewlines)
+    text = ""
+    callback(messageText)
+  }
+
   /// Handles keyboard shortcuts for the inline editor.
   ///
-  /// - **Enter**: Submits the message (calls `submitMessage()`)
+  /// - **Enter**: Submits the message immediately to Claude
+  /// - **Cmd+Enter**: Adds comment to review collection (if callback provided)
   /// - **Shift+Enter**: Inserts a new line (returns `.ignored` to allow default behavior)
   /// - **Escape**: Dismisses the editor without submitting
   private func handleKeyPress(_ key: KeyPress) -> KeyPress.Result {
     switch key.key {
     case .return:
       if key.modifiers.contains(.shift) {
+        // Shift+Enter: insert newline
         return .ignored
+      } else if key.modifiers.contains(.command) {
+        // Cmd+Enter: add to comment collection
+        addComment()
+        return .handled
       }
+      // Enter: submit immediately
       submitMessage()
       return .handled
 
@@ -211,6 +332,37 @@ struct InlineEditorView: View {
     errorMessage: nil,
     onSubmit: { _ in },
     onDismiss: { }
+  )
+  .padding(40)
+  .background(Color.gray.opacity(0.2))
+}
+
+#Preview("With Add Comment") {
+  InlineEditorView(
+    lineNumber: 42,
+    side: "right",
+    fileName: "Example.swift",
+    errorMessage: nil,
+    onSubmit: { _ in },
+    onAddComment: { _ in },
+    onDismiss: { }
+  )
+  .padding(40)
+  .background(Color.gray.opacity(0.2))
+}
+
+#Preview("Edit Mode") {
+  InlineEditorView(
+    lineNumber: 42,
+    side: "right",
+    fileName: "Example.swift",
+    errorMessage: nil,
+    onSubmit: { _ in },
+    onAddComment: { _ in },
+    onDeleteComment: { },
+    onDismiss: { },
+    initialText: "Consider adding error handling here",
+    isEditMode: true
   )
   .padding(40)
   .background(Color.gray.opacity(0.2))


### PR DESCRIPTION
## Summary
- Adds a new feature allowing users to collect review comments on diff lines and send them to Claude as a batch, similar to PR code reviews
- Cmd+Enter on a diff line adds comment to review collection (vs Enter to send immediately)
- Collapsible comments panel at bottom of diff view shows all pending comments
- Inline editing of comments directly in the panel via pencil button with smooth animations
- Batch send all comments to Claude with consistent prompt format
- Confirmation dialog when closing with unsent comments

## Test plan
- [ ] Open diff view and click on a line
- [ ] Press Cmd+Enter to add a comment to the review collection
- [ ] Verify comment appears in the collapsible panel at bottom
- [ ] Hover over comment row and tap pencil to edit inline
- [ ] Verify Save/Cancel work correctly with animations
- [ ] Add multiple comments across different files
- [ ] Click "Send to Claude" and verify prompt includes full file paths
- [ ] Test single request (Enter) uses same prompt format as batch
- [ ] Test closing with unsent comments shows confirmation dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)