### PR TITLE
Prefix worktree directory names with repository name

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/GitWorktreeService.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/GitWorktreeService.swift
@@ -287,6 +287,16 @@ public actor GitWorktreeService {
       .replacingOccurrences(of: "\\", with: "-")
   }
 
+  /// Creates a worktree directory name prefixed with the repository name
+  /// - Parameters:
+  ///   - branch: Branch name (e.g., "origin/feature/auth")
+  ///   - repoName: Repository name (e.g., "apps")
+  /// - Returns: Directory name (e.g., "apps-feature-auth")
+  public static func worktreeDirectoryName(for branch: String, repoName: String) -> String {
+    let sanitized = sanitizeBranchName(branch)
+    return "\(repoName)-\(sanitized)"
+  }
+
   // MARK: - Git Command Runner
 
   @discardableResult

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/WorktreeOrchestrationService.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/WorktreeOrchestrationService.swift
@@ -111,11 +111,12 @@ public final class WorktreeOrchestrationService {
     // Capture callback for use in Sendable closure
     let progressCallback = onWorktreeProgress
 
-    // Create worktree with the session's branch name
+    // Create worktree with the session's branch name, prefixed with repo name
+    let repoName = URL(fileURLWithPath: modulePath).lastPathComponent
     let worktreePath = try await gitService.createWorktreeWithNewBranch(
       at: modulePath,
       newBranchName: session.branchName,
-      directoryName: session.branchName,
+      directoryName: GitWorktreeService.worktreeDirectoryName(for: session.branchName, repoName: repoName),
       startPoint: nil
     ) { progress in
       // Forward detailed progress to callback on MainActor

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/CreateWorktreeSheet.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/CreateWorktreeSheet.swift
@@ -135,7 +135,7 @@ public struct CreateWorktreeSheet: View {
       TextField("feature/my-feature", text: $branchName)
         .textFieldStyle(.roundedBorder)
         .onChange(of: branchName) { _, newValue in
-          directoryName = GitWorktreeService.sanitizeBranchName(newValue)
+          directoryName = GitWorktreeService.worktreeDirectoryName(for: newValue, repoName: repositoryName)
         }
 
       Text("A new branch will be created with this name")


### PR DESCRIPTION
## Summary
- Worktree directories are now prefixed with the repository name for easier identification
- Example: `apps-feature-auth` instead of just `feature-auth`
- Addresses feedback about difficulty identifying which repo a worktree belongs to in the filesystem

## Test plan
- [ ] Create a worktree via UI - verify directory is named `{repoName}-{sanitizedBranch}`
- [ ] Use orchestration to create worktrees - verify same naming convention
- [ ] Verify sessions still group correctly under the repository

🤖 Generated with [Claude Code](https://claude.com/claude-code)