### PR TITLE
Make terminal view default and disable polling in terminal mode

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringCardView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringCardView.swift
@@ -135,8 +135,8 @@ public struct MonitoringCardView: View {
         .padding(.horizontal, 12)
         .padding(.vertical, 8)
 
-      // Context bar (if available)
-      if let state = state, state.inputTokens > 0 {
+      // Context bar (only in monitor/list mode, not terminal mode)
+      if !showTerminal, let state = state, state.inputTokens > 0 {
         Divider()
 
         ContextWindowBar(
@@ -387,20 +387,22 @@ public struct MonitoringCardView: View {
       // Terminal/List segmented control (hidden when maximized)
       if !isMaximized {
         HStack(spacing: 4) {
-          Button(action: { withAnimation(.easeInOut(duration: 0.2)) { onToggleTerminal(false) } }) {
-            Image(systemName: "list.bullet")
-              .font(.caption)
-              .frame(width: 28, height: 22)
-              .foregroundColor(!showTerminal ? .brandPrimary : .secondary)
-              .contentShape(Rectangle())
-          }
-          .buttonStyle(.plain)
-
+          // Terminal button (left - default)
           Button(action: { withAnimation(.easeInOut(duration: 0.2)) { onToggleTerminal(true) } }) {
             Image(systemName: "terminal")
               .font(.caption)
               .frame(width: 28, height: 22)
               .foregroundColor(showTerminal ? .brandPrimary : .secondary)
+              .contentShape(Rectangle())
+          }
+          .buttonStyle(.plain)
+
+          // List/Monitor button (right)
+          Button(action: { withAnimation(.easeInOut(duration: 0.2)) { onToggleTerminal(false) } }) {
+            Image(systemName: "list.bullet")
+              .font(.caption)
+              .frame(width: 28, height: 22)
+              .foregroundColor(!showTerminal ? .brandPrimary : .secondary)
               .contentShape(Rectangle())
           }
           .buttonStyle(.plain)


### PR DESCRIPTION
## Summary

- Default new monitored sessions to terminal view instead of monitor/list mode
- Stop file watcher and status timer when in terminal mode (no polling overhead)
- Start polling only when user switches to monitor/list mode (at 1.5s interval)
- Swap segmented control order: Terminal (left) / List (right)
- Hide token counts (ContextWindowBar) in terminal mode
- Add `[Polling]` prefixed logs for debugging start/stop/tick events

## Performance Impact

Sessions in terminal mode now have **zero polling overhead** - no timers, no file watchers, no Combine subscriptions running.

## Discussion: Auto-Prompt on "Start in Hub"

Currently, "Start in Hub" sends an automatic "Hello!" prompt to create the session file. This is needed because:

1. Claude Code only creates the session `.jsonl` file after the first message
2. The directory watcher detects this file to obtain the session ID
3. Without a session ID, we can't transition from pending → real session

**Question:** Now that we're not polling in terminal mode, do we still need the auto-prompt? 

**Answer:** Yes, the auto-prompt is still required. It triggers session file creation, which is independent of polling. Without it:
- No session file created → No session ID obtained
- Watcher times out after 15 seconds
- Pending session gets cleaned up

The polling changes don't affect this - row visibility comes from `monitoredSessionIds` and `monitoredSessionBackup`, not from polling state.

## Test plan

- [ ] Start a new session via "Start in Hub" - should open in terminal view
- [ ] Verify terminal icon is on left, list icon on right in segmented control
- [ ] Verify no `[Polling] TICK` logs appear while in terminal mode
- [ ] Switch to monitor/list mode - verify status badge and token counts appear
- [ ] Switch back to terminal - verify `[Polling] STOP` logs appear
- [ ] Restart app - verify sessions restore correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)