### PR TITLE
Terminal-first mode with Preview/Plan support

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringCardView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringCardView.swift
@@ -543,10 +543,10 @@ public struct MonitoringCardView: View {
             Text("Plan")
               .font(.caption2)
           }
-          .foregroundColor(.secondary)
+          .foregroundColor(.orange)
           .padding(.horizontal, 8)
           .padding(.vertical, 4)
-          .background(Color.secondary.opacity(0.1))
+          .background(Color.orange.opacity(0.1))
           .clipShape(RoundedRectangle(cornerRadius: 4))
         }
         .buttonStyle(.plain)


### PR DESCRIPTION
## Summary
- Make terminal view the default when monitoring sessions
- Enable polling in terminal mode so Preview/Plan buttons work
- Remove auto-prompt when starting new sessions in Hub (users type naturally)
- Remove 15-second timeout in session watcher (waits indefinitely until user sends a message or closes the card)
- Keep progress bar hidden in terminal mode (visible only in monitor/list mode)
- Style Plan button with orange color to match Preview button

## Test plan
- [ ] Click "Start in Hub" - terminal should open without sending anything
- [ ] Wait 30+ seconds - terminal should NOT disappear
- [ ] Type a message - session should transition to real session
- [ ] Close card without typing - should clean up properly
- [ ] After typing a message, Preview/Plan buttons should appear when Claude is in those states
- [ ] Progress bar should remain hidden in terminal mode
- [ ] Switching to monitor mode should show progress bar with live data

🤖 Generated with [Claude Code](https://claude.ai/code)