### PR TITLE
Hide Today section when stats cache is stale

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/GlobalStatsService.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/GlobalStatsService.swift
@@ -215,6 +215,7 @@ public final class GlobalStatsService: @unchecked Sendable {
   private func formatDateForComparison(_ date: Date) -> String {
     let formatter = DateFormatter()
     formatter.dateFormat = "yyyy-MM-dd"
+    formatter.timeZone = TimeZone(identifier: "UTC")  // Match CLI format
     return formatter.string(from: date)
   }
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/GlobalStatsMenuView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/GlobalStatsMenuView.swift
@@ -40,11 +40,13 @@ public struct GlobalStatsMenuView: View {
         Divider()
           .padding(.vertical, 8)
 
-        // Today's activity
-        todaySection
+        // Today's activity (only shown when data exists)
+        if service.todayActivity != nil {
+          todaySection
 
-        Divider()
-          .padding(.vertical, 8)
+          Divider()
+            .padding(.vertical, 8)
+        }
 
         // Model breakdown
         modelBreakdownSection
@@ -152,10 +154,6 @@ public struct GlobalStatsMenuView: View {
           MiniStat(value: "\(today.sessionCount)", label: "sessions")
           MiniStat(value: "\(today.toolCallCount)", label: "tools")
         }
-      } else {
-        Text("No activity yet")
-          .font(.caption)
-          .foregroundColor(.secondary)
       }
     }
   }


### PR DESCRIPTION
## Summary
- Hides the "Today Activity" section in the menu bar when there's no data for the current date in stats-cache.json
- Removes the confusing "No activity yet" message that appeared when Claude Code CLI hadn't recomputed stats
- Adds UTC timezone to date formatter to prevent edge-case date mismatches near midnight

## Test plan
- [ ] Build and run AgentHub
- [ ] Verify the Today section is hidden when stats-cache.json doesn't have today's date
- [ ] Verify the Today section appears when stats exist for today
- [ ] Verify other sections (cost, tokens, model breakdown) display correctly

🤖 Generated with [Claude Code](https://claude.ai/code)