### PR TITLE
Add syntax highlighting for code blocks in plan mode

### DIFF
--- a/app/AgentHub.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/app/AgentHub.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "1cad70013da4e4607da47df5033dc5400b17e3de18694a469065b11adad36951",
+  "originHash" : "0902c7a92d5daddf48b1355b43dd3d941d9c296fc8885595c4e2aa07c311d27d",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -26,6 +26,15 @@
       "state" : {
         "revision" : "2cf6c756e1e5ef6901ebae16576a7e4e4b834622",
         "version" : "6.29.3"
+      }
+    },
+    {
+      "identity" : "highlightswift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/appstefan/HighlightSwift",
+      "state" : {
+        "revision" : "784ca3ccfc8a2cf724fbb2f06cb6ec3329424da3",
+        "version" : "1.1.0"
       }
     },
     {

--- a/app/modules/AgentHubCore/Package.resolved
+++ b/app/modules/AgentHubCore/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "8b09c58a291970f3f75281f6d1a1a307215a9e296869ec2033a6e2bdc3331f5c",
+  "originHash" : "bc5e24ab7c6e9d7cb4a84784d4e942b57144ec85dfcc6a42e78c63d03cf0d045",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -26,6 +26,15 @@
       "state" : {
         "revision" : "2cf6c756e1e5ef6901ebae16576a7e4e4b834622",
         "version" : "6.29.3"
+      }
+    },
+    {
+      "identity" : "highlightswift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/appstefan/HighlightSwift",
+      "state" : {
+        "revision" : "784ca3ccfc8a2cf724fbb2f06cb6ec3329424da3",
+        "version" : "1.1.0"
       }
     },
     {

--- a/app/modules/AgentHubCore/Package.swift
+++ b/app/modules/AgentHubCore/Package.swift
@@ -19,6 +19,7 @@ let package = Package(
     .package(url: "https://github.com/migueldeicaza/SwiftTerm", from: "1.2.0"),
     .package(url: "https://github.com/gonzalezreal/swift-markdown-ui", from: "2.0.0"),
     .package(url: "https://github.com/groue/GRDB.swift", from: "6.24.0"),
+    .package(url: "https://github.com/appstefan/HighlightSwift", from: "1.1.0"),
   ],
   targets: [
     .target(
@@ -29,6 +30,7 @@ let package = Package(
         .product(name: "SwiftTerm", package: "SwiftTerm"),
         .product(name: "MarkdownUI", package: "swift-markdown-ui"),
         .product(name: "GRDB", package: "GRDB.swift"),
+        .product(name: "HighlightSwift", package: "HighlightSwift"),
       ],
       path: "Sources/AgentHub",
       swiftSettings: [

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/HighlightCodeSyntaxHighlighter.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/HighlightCodeSyntaxHighlighter.swift
@@ -1,0 +1,137 @@
+//
+//  HighlightCodeSyntaxHighlighter.swift
+//  AgentHub
+//
+//  Created by Assistant on 1/30/26.
+//
+
+import HighlightSwift
+import MarkdownUI
+import SwiftUI
+
+// MARK: - HighlightCodeSyntaxHighlighter
+
+/// A syntax highlighter for MarkdownUI that uses HighlightSwift for multi-language support.
+///
+/// Supports 50+ languages with automatic detection and theme-aware coloring.
+struct HighlightCodeSyntaxHighlighter: CodeSyntaxHighlighter {
+  private let colorScheme: ColorScheme
+
+  init(colorScheme: ColorScheme) {
+    self.colorScheme = colorScheme
+  }
+
+  func highlightCode(_ code: String, language: String?) -> Text {
+    // HighlightSwift's attributedText is async, but CodeSyntaxHighlighter expects sync
+    // Use a blocking approach with a semaphore
+    let semaphore = DispatchSemaphore(value: 0)
+    var result: Text = Text(code)
+
+    let highlight = Highlight()
+    let highlightLang = mapLanguage(language)
+    let colors: HighlightColors = colorScheme == .dark ? .dark(.github) : .light(.github)
+
+    Task.detached(priority: .high) {
+      do {
+        let attributed: AttributedString
+        if let lang = highlightLang {
+          attributed = try await highlight.attributedText(code, language: lang, colors: colors)
+        } else {
+          attributed = try await highlight.attributedText(code, colors: colors)
+        }
+        result = attributedStringToText(attributed)
+      } catch {
+        // Fallback to plain text on error
+        result = Text(code)
+      }
+      semaphore.signal()
+    }
+
+    // Wait with timeout to avoid blocking forever
+    _ = semaphore.wait(timeout: .now() + 2.0)
+    return result
+  }
+
+  // MARK: - Private Helpers
+
+  /// Maps markdown language hints to HighlightSwift HighlightLanguage enum
+  private func mapLanguage(_ language: String?) -> HighlightLanguage? {
+    guard let lang = language?.lowercased() else { return nil }
+
+    switch lang {
+    case "swift": return .swift
+    case "python", "py": return .python
+    case "javascript", "js": return .javaScript
+    case "typescript", "ts": return .typeScript
+    case "bash", "sh", "shell", "zsh": return .bash
+    case "json": return .json
+    case "yaml", "yml": return .yaml
+    case "html": return .html
+    case "xml": return .html
+    case "css": return .css
+    case "sql": return .sql
+    case "ruby", "rb": return .ruby
+    case "go", "golang": return .go
+    case "rust", "rs": return .rust
+    case "java": return .java
+    case "kotlin", "kt": return .kotlin
+    case "c": return .c
+    case "cpp", "c++", "cxx": return .cPlusPlus
+    case "csharp", "c#", "cs": return .cSharp
+    case "php": return .php
+    case "markdown", "md": return .markdown
+    case "diff": return .diff
+    case "dockerfile", "docker": return .dockerfile
+    case "makefile", "make": return .makefile
+    case "graphql", "gql": return .graphQL
+    case "r": return .r
+    case "scala": return .scala
+    case "lua": return .lua
+    case "perl": return .perl
+    case "haskell", "hs": return .haskell
+    case "elixir", "ex": return .elixir
+    case "erlang", "erl": return .erlang
+    case "clojure", "clj": return .clojure
+    case "objc", "objective-c", "objectivec": return .objectiveC
+    case "dart": return .dart
+    case "julia": return .julia
+    case "toml": return .toml
+    case "scss": return .scss
+    case "less": return .less
+    case "latex", "tex": return .latex
+    default: return nil
+    }
+  }
+}
+
+// MARK: - AttributedString to Text Conversion
+
+/// Converts an AttributedString to SwiftUI Text with proper styling
+private func attributedStringToText(_ attributedString: AttributedString) -> Text {
+  var result = Text("")
+
+  for run in attributedString.runs {
+    let string = String(attributedString[run.range].characters)
+    var text = Text(string)
+
+    // Apply foreground color from the attributed string
+    #if canImport(AppKit)
+    if let foregroundColor = run[AttributeScopes.AppKitAttributes.ForegroundColorAttribute.self] {
+      text = text.foregroundColor(Color(foregroundColor))
+    }
+    #endif
+
+    result = result + text
+  }
+
+  return result
+}
+
+// MARK: - CodeSyntaxHighlighter Extension
+
+extension CodeSyntaxHighlighter where Self == HighlightCodeSyntaxHighlighter {
+  /// Creates a syntax highlighter using HighlightSwift with theme-aware colors
+  static func highlightSwift(colorScheme: ColorScheme) -> Self {
+    HighlightCodeSyntaxHighlighter(colorScheme: colorScheme)
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MarkdownView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MarkdownView.swift
@@ -16,21 +16,33 @@ import SwiftUI
 /// to match the AgentHub design system.
 public struct MarkdownView: View {
   let content: String
+  let includeScrollView: Bool
 
-  public init(content: String) {
+  @Environment(\.colorScheme) private var colorScheme
+
+  public init(content: String, includeScrollView: Bool = true) {
     self.content = content
+    self.includeScrollView = includeScrollView
   }
 
   public var body: some View {
-    ScrollView {
-      Markdown(content)
-        .markdownTheme(.agentHub)
-        .markdownCodeSyntaxHighlighter(.plainText)
-        .textSelection(.enabled)
-        .padding()
-        .frame(maxWidth: .infinity, alignment: .leading)
+    if includeScrollView {
+      ScrollView {
+        markdownContent
+      }
+      .background(Color.surfaceCanvas)
+    } else {
+      markdownContent
     }
-    .background(Color.surfaceCanvas)
+  }
+
+  private var markdownContent: some View {
+    Markdown(content)
+      .markdownTheme(.agentHub)
+      .markdownCodeSyntaxHighlighter(.highlightSwift(colorScheme: colorScheme))
+      .textSelection(.enabled)
+      .padding()
+      .frame(maxWidth: .infinity, alignment: .leading)
   }
 }
 
@@ -39,10 +51,72 @@ public struct MarkdownView: View {
 extension MarkdownUI.Theme {
   /// Custom theme for plan markdown display
   static let agentHub = Theme()
+    // MARK: - Headings
+    .heading1 { configuration in
+      configuration.label
+        .markdownTextStyle {
+          FontWeight(.bold)
+          FontSize(.em(2.0))
+        }
+        .markdownMargin(top: .em(1.5), bottom: .em(0.5))
+    }
+    .heading2 { configuration in
+      configuration.label
+        .markdownTextStyle {
+          FontWeight(.semibold)
+          FontSize(.em(1.6))
+        }
+        .markdownMargin(top: .em(1.25), bottom: .em(0.375))
+    }
+    .heading3 { configuration in
+      configuration.label
+        .markdownTextStyle {
+          FontWeight(.semibold)
+          FontSize(.em(1.35))
+        }
+        .markdownMargin(top: .em(1.0), bottom: .em(0.25))
+    }
+    .heading4 { configuration in
+      configuration.label
+        .markdownTextStyle {
+          FontWeight(.semibold)
+          FontSize(.em(1.2))
+        }
+        .markdownMargin(top: .em(0.75), bottom: .em(0.25))
+    }
+    .heading5 { configuration in
+      configuration.label
+        .markdownTextStyle {
+          FontWeight(.medium)
+          FontSize(.em(1.1))
+        }
+        .markdownMargin(top: .em(0.5), bottom: .em(0.25))
+    }
+    .heading6 { configuration in
+      configuration.label
+        .markdownTextStyle {
+          FontWeight(.medium)
+          FontSize(.em(1.0))
+          ForegroundColor(.secondary)
+        }
+        .markdownMargin(top: .em(0.5), bottom: .em(0.25))
+    }
+    // MARK: - Paragraph
+    .paragraph { configuration in
+      configuration.label
+        .markdownTextStyle {
+          FontSize(.em(1.1))
+        }
+        .lineSpacing(6)
+        .markdownMargin(top: .zero, bottom: .em(0.75))
+    }
+    // MARK: - Inline Code
     .code {
       FontFamilyVariant(.monospaced)
-      FontSize(.em(0.9))
+      FontSize(.em(0.95))
+      BackgroundColor(Color.surfaceCard.opacity(0.6))
     }
+    // MARK: - Code Block
     .codeBlock { configuration in
       ScrollView(.horizontal, showsIndicators: true) {
         configuration.label
@@ -54,16 +128,57 @@ extension MarkdownUI.Theme {
       }
       .background(Color.surfaceCard)
       .clipShape(RoundedRectangle(cornerRadius: DesignTokens.Radius.sm))
+      .overlay(
+        RoundedRectangle(cornerRadius: DesignTokens.Radius.sm)
+          .stroke(Color.borderSubtle, lineWidth: 1)
+      )
+      .markdownMargin(top: .em(0.5), bottom: .em(0.75))
     }
+    // MARK: - Blockquote
     .blockquote { configuration in
       HStack(spacing: 0) {
-        Rectangle()
-          .fill(Color.secondary.opacity(0.3))
-          .frame(width: 3)
+        RoundedRectangle(cornerRadius: 2)
+          .fill(Color.brandPrimary)
+          .frame(width: 4)
         configuration.label
+          .markdownTextStyle {
+            FontStyle(.italic)
+            ForegroundColor(.secondary)
+          }
           .padding(.leading, DesignTokens.Spacing.md)
       }
       .padding(.vertical, DesignTokens.Spacing.xs)
+      .markdownMargin(top: .em(0.5), bottom: .em(0.5))
+    }
+    // MARK: - Links
+    .link {
+      ForegroundColor(Color.brandPrimary)
+    }
+    // MARK: - Lists
+    .listItem { configuration in
+      configuration.label
+        .markdownMargin(top: .em(0.125), bottom: .em(0.125))
+    }
+    // MARK: - Thematic Break (Horizontal Rule)
+    .thematicBreak {
+      Divider()
+        .markdownMargin(top: .em(1.0), bottom: .em(1.0))
+    }
+    // MARK: - Table
+    .table { configuration in
+      configuration.label
+        .markdownTableBorderStyle(
+          .init(color: .borderSubtle, width: 1)
+        )
+        .markdownMargin(top: .em(0.5), bottom: .em(0.75))
+    }
+    .tableCell { configuration in
+      configuration.label
+        .markdownTextStyle {
+          FontSize(.em(1.0))
+        }
+        .padding(.vertical, DesignTokens.Spacing.xs)
+        .padding(.horizontal, DesignTokens.Spacing.sm)
     }
 }
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/PlanView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/PlanView.swift
@@ -59,7 +59,7 @@ public struct PlanView: View {
     }
     .frame(
       minWidth: 700, idealWidth: 900, maxWidth: .infinity,
-      minHeight: 500, idealHeight: 700, maxHeight: .infinity
+      minHeight: 550, idealHeight: 750, maxHeight: .infinity
     )
     .onKeyPress(.escape) {
       onDismiss()
@@ -180,8 +180,35 @@ public struct PlanView: View {
 
   // MARK: - Markdown Content
 
+  @Environment(\.colorScheme) private var colorScheme
+
   private func markdownContent(_ text: String) -> some View {
-    MarkdownView(content: text)
+    ScrollView {
+      MarkdownView(content: text, includeScrollView: false)
+        .padding(DesignTokens.Spacing.lg)
+        .background(cardBackground)
+        .clipShape(RoundedRectangle(cornerRadius: DesignTokens.Radius.md, style: .continuous))
+        .overlay(
+          RoundedRectangle(cornerRadius: DesignTokens.Radius.md, style: .continuous)
+            .stroke(Color.borderSubtle, lineWidth: 1)
+        )
+        .shadow(
+          color: cardShadowColor,
+          radius: 8,
+          x: 0,
+          y: 2
+        )
+        .padding(DesignTokens.Spacing.xl)
+    }
+    .background(Color.surfaceCanvas)
+  }
+
+  private var cardBackground: Color {
+    colorScheme == .dark ? Color(white: 0.08) : Color.white
+  }
+
+  private var cardShadowColor: Color {
+    colorScheme == .dark ? Color.black.opacity(0.3) : Color.black.opacity(0.08)
   }
 
   // MARK: - Load Content


### PR DESCRIPTION
## Summary
- Integrate HighlightSwift for multi-language syntax highlighting in code blocks
- Support 50+ languages with automatic detection and theme-aware colors (light/dark)
- Improve MarkdownView theming with better heading styles, blockquotes, tables, and code block appearance
- Fix QoS priority inversion by using high-priority detached task

## Test plan
- [ ] Build with `Cmd+B`
- [ ] Open a PlanView with code blocks in different languages (Swift, Python, JS, etc.)
- [ ] Verify syntax highlighting appears correctly
- [ ] Toggle between light/dark mode and verify colors adapt
- [ ] Verify no QoS priority inversion warnings in Xcode console

🤖 Generated with [Claude Code](https://claude.ai/code)