### PR TITLE
Add approve/reject action bar to pending changes view

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringCardView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringCardView.swift
@@ -199,7 +199,10 @@ public struct MonitoringCardView: View {
         session: item.session,
         pendingToolUse: item.pendingToolUse,
         claudeClient: claudeClient,
-        onDismiss: { pendingChangesSheetItem = nil }
+        onDismiss: { pendingChangesSheetItem = nil },
+        onApprovalResponse: { response, session in
+          viewModel?.showTerminalWithPrompt(for: session, prompt: response)
+        }
       )
     }
     .sheet(isPresented: $showingNameSheet) {


### PR DESCRIPTION
## Summary

- Add action bar with Accept and Reject buttons to PendingChangesView
- Buttons use bordered outline style with adaptive colors for light/dark mode
- Keyboard shortcuts: Return (accept), Escape (reject)
- Wire up approval response callback to send responses to CLI session

## Test plan

- [ ] Open pending changes sheet from monitoring card
- [ ] Verify buttons display with correct colors in dark mode (coral/green)
- [ ] Verify buttons display with correct colors in light mode (deep red/green)
- [ ] Test keyboard shortcuts (Return to accept, Escape to reject)
- [ ] Verify approval/rejection sends correct response to terminal

🤖 Generated with [Claude Code](https://claude.com/claude-code)