### PR TITLE
Add cliCommand property for white-label CLI support

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubConfiguration.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubConfiguration.swift
@@ -32,18 +32,24 @@ public struct AgentHubConfiguration: Sendable {
   /// Display mode for stats (menu bar or popover)
   public var statsDisplayMode: StatsDisplayMode
 
+  /// The CLI command name to use (default: "claude")
+  /// Companies can configure this for white-labeling (e.g., "acme" instead of "claude")
+  public var cliCommand: String
+
   /// Creates a configuration with custom values
   public init(
     claudeDataPath: String = "~/.claude",
     enableDebugLogging: Bool = false,
     additionalCLIPaths: [String] = [],
-    statsDisplayMode: StatsDisplayMode = .menuBar
+    statsDisplayMode: StatsDisplayMode = .menuBar,
+    cliCommand: String = "claude"
   ) {
     let expanded = NSString(string: claudeDataPath).expandingTildeInPath
     self.claudeDataPath = expanded
     self.enableDebugLogging = enableDebugLogging
     self.additionalCLIPaths = additionalCLIPaths
     self.statsDisplayMode = statsDisplayMode
+    self.cliCommand = cliCommand
   }
 
   /// Default configuration with sensible defaults

--- a/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubProvider.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubProvider.swift
@@ -111,6 +111,7 @@ public final class AgentHubProvider {
   private func createClaudeClient() -> (any ClaudeCode)? {
     do {
       var config = ClaudeCodeConfiguration.withNvmSupport()
+      config.command = configuration.cliCommand
       config.enableDebugLogging = configuration.enableDebugLogging
 
       let homeDir = NSHomeDirectory()


### PR DESCRIPTION
## Summary
- Adds `cliCommand` property to `AgentHubConfiguration` for white-labeling
- Companies can configure custom CLI command names (e.g., "acme" instead of "claude")
- The property is passed through to `ClaudeCodeConfiguration.command` when creating the client

## Test plan
- [ ] Build the app with `cmd+B` to verify compilation
- [ ] Configure `AgentHubConfiguration(cliCommand: "test-cmd")` and verify error messages show the custom command name

🤖 Generated with [Claude Code](https://claude.com/claude-code)