### PR TITLE
Add Codex global stats to menu bar

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubDefaults.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubDefaults.swift
@@ -64,7 +64,11 @@ public enum AgentHubDefaults {
   /// Type: String (default: "Claude")
   public static let selectedSidePanelProvider = "\(keyPrefix)sidepanel.selectedProvider"
 
-  // MARK: - Theme Settings
+  // MARK: - Stats Settings
+
+  /// Selected provider in stats view segmented control
+  /// Type: String (default: "Claude")
+  public static let selectedStatsProvider = "\(keyPrefix)stats.selectedProvider"
 
   // MARK: - UI Settings
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubProvider.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubProvider.swift
@@ -51,9 +51,14 @@ public final class AgentHubProvider {
     GitWorktreeService()
   }()
 
-  /// Global stats service for usage metrics
+  /// Global stats service for Claude usage metrics
   public private(set) lazy var statsService: GlobalStatsService = {
     GlobalStatsService(claudePath: configuration.claudeDataPath)
+  }()
+
+  /// Global stats service for Codex usage metrics
+  public private(set) lazy var codexStatsService: CodexGlobalStatsService = {
+    CodexGlobalStatsService(codexPath: configuration.codexDataPath)
   }()
 
   /// Codex file watcher for real-time monitoring

--- a/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubViews.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubViews.swift
@@ -80,7 +80,10 @@ public struct AgentHubSessionsView: View {
             // IntelligencePopoverButton(isShowingOverlay: $isShowingIntelligenceOverlay)
             // Stats button (popover mode only)
             if provider.displaySettings.isPopoverMode {
-              GlobalStatsPopoverButton(service: provider.statsService)
+              GlobalStatsPopoverButton(
+                claudeService: provider.statsService,
+                codexService: provider.codexStatsService
+              )
             }
           }
           .frame(maxWidth: .infinity)
@@ -124,7 +127,8 @@ public struct AgentHubMenuBarContent: View {
   public var body: some View {
     if let provider = agentHub {
       GlobalStatsMenuView(
-        service: provider.statsService,
+        claudeService: provider.statsService,
+        codexService: provider.codexStatsService,
         sessionsViewModel: provider.sessionsViewModel
       )
     } else {
@@ -159,9 +163,6 @@ public struct AgentHubMenuBarLabel: View {
   }
 
   public var body: some View {
-    HStack(spacing: 4) {
-      Image(systemName: "sparkle")
-      Text(provider.statsService.formattedTotalTokens)
-    }
+    Image(systemName: "apple.terminal.on.rectangle")
   }
 }

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/CodexGlobalStatsService.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/CodexGlobalStatsService.swift
@@ -1,0 +1,304 @@
+//
+//  CodexGlobalStatsService.swift
+//  AgentHub
+//
+//  Service that aggregates global Codex usage statistics from session JSONL files.
+//
+
+import Foundation
+import Observation
+import os
+
+// MARK: - CodexGlobalStatsService
+
+/// Service that monitors and provides global Codex usage statistics
+/// by aggregating data from all session JSONL files in ~/.codex/sessions/
+@Observable
+public final class CodexGlobalStatsService: @unchecked Sendable {
+
+  // MARK: - Properties
+
+  /// Total tokens across all sessions (input + output)
+  public private(set) var totalTokens: Int = 0
+
+  /// Total number of session files
+  public private(set) var totalSessions: Int = 0
+
+  /// Total messages across all sessions
+  public private(set) var totalMessages: Int = 0
+
+  /// Model usage statistics grouped by model name
+  public private(set) var modelStats: [String: CodexModelUsage] = [:]
+
+  /// Whether stats are available (sessions directory exists)
+  public private(set) var isAvailable: Bool = false
+
+  /// Whether stats are currently loading
+  public private(set) var isLoading: Bool = false
+
+  /// Last time stats were updated
+  public private(set) var lastUpdated: Date?
+
+  private let sessionsDirectoryPath: String
+  private var directoryWatcher: DispatchSourceFileSystemObject?
+  private var fileDescriptor: Int32 = -1
+  private var isLoadingInProgress = false
+  private var pendingReload = false
+  private var debounceWorkItem: DispatchWorkItem?
+  private var loadingTask: Task<Void, Never>?
+
+  // MARK: - Computed Properties
+
+  /// Formatted total tokens (e.g., "10.5M", "150K")
+  public var formattedTotalTokens: String {
+    formatTokenCount(totalTokens)
+  }
+
+  /// Model-specific stats sorted by token count
+  public var sortedModelStats: [(name: String, usage: CodexModelUsage)] {
+    modelStats.map { (name: formatModelName($0.key), usage: $0.value) }
+      .sorted { $0.usage.totalTokens > $1.usage.totalTokens }
+  }
+
+  // MARK: - Initialization
+
+  public init(codexPath: String = "~/.codex") {
+    let expandedPath = NSString(string: codexPath).expandingTildeInPath
+    self.sessionsDirectoryPath = "\(expandedPath)/sessions"
+
+    // Check availability synchronously (fast), load data async
+    isAvailable = FileManager.default.fileExists(atPath: sessionsDirectoryPath)
+    loadStatsAsync()
+    startWatching()
+  }
+
+  deinit {
+    loadingTask?.cancel()
+    stopWatching()
+  }
+
+  // MARK: - Public API
+
+  /// Manually refresh stats
+  public func refresh() {
+    loadStatsAsync()
+  }
+
+  /// Cancel any in-progress loading operation
+  public func cancelLoading() {
+    loadingTask?.cancel()
+    loadingTask = nil
+    DispatchQueue.main.async { [weak self] in
+      self?.isLoading = false
+      self?.isLoadingInProgress = false
+    }
+  }
+
+  // MARK: - Private Methods
+
+  private func loadStatsAsync() {
+    let fileManager = FileManager.default
+
+    guard fileManager.fileExists(atPath: sessionsDirectoryPath) else {
+      DispatchQueue.main.async { [weak self] in
+        self?.isAvailable = false
+      }
+      return
+    }
+
+    // Prevent concurrent loading - queue a reload instead
+    if isLoadingInProgress {
+      pendingReload = true
+      return
+    }
+
+    // Cancel any existing task
+    loadingTask?.cancel()
+
+    isLoadingInProgress = true
+    DispatchQueue.main.async { [weak self] in
+      self?.isLoading = true
+    }
+
+    loadingTask = Task.detached(priority: .userInitiated) { [weak self] in
+      guard let self else { return }
+
+      let jsonlFiles = self.findAllJSONLFiles()
+
+      var aggregatedTokens = 0
+      var aggregatedMessages = 0
+      var aggregatedModelStats: [String: CodexModelUsage] = [:]
+
+      for filePath in jsonlFiles {
+        // Check for cancellation between files
+        if Task.isCancelled { return }
+
+        // Use lightweight parser optimized for global stats
+        let parseResult = CodexSessionJSONLParser.parseForGlobalStats(at: filePath)
+
+        let sessionTokens = parseResult.totalInputTokens + parseResult.totalOutputTokens
+        aggregatedTokens += sessionTokens
+        aggregatedMessages += parseResult.messageCount
+
+        if let model = parseResult.model {
+          var existing = aggregatedModelStats[model] ?? CodexModelUsage()
+          existing.inputTokens += parseResult.totalInputTokens
+          existing.outputTokens += parseResult.totalOutputTokens
+          existing.cacheReadTokens += parseResult.cacheReadTokens
+          existing.messageCount += parseResult.messageCount
+          existing.sessionCount += 1
+          aggregatedModelStats[model] = existing
+        }
+      }
+
+      // Final cancellation check before updating UI
+      if Task.isCancelled { return }
+
+      let sessionCount = jsonlFiles.count
+
+      await MainActor.run { [weak self] in
+        guard let self else { return }
+        self.totalTokens = aggregatedTokens
+        self.totalSessions = sessionCount
+        self.totalMessages = aggregatedMessages
+        self.modelStats = aggregatedModelStats
+        self.isAvailable = true
+        self.lastUpdated = Date()
+        self.isLoading = false
+        self.isLoadingInProgress = false
+
+        // If a reload was requested while we were loading, do it now
+        if self.pendingReload {
+          self.pendingReload = false
+          self.loadStatsAsync()
+        }
+      }
+    }
+  }
+
+  /// Recursively finds all .jsonl files in the sessions directory
+  /// Codex stores sessions in nested date directories: ~/.codex/sessions/2026/01/02/
+  private func findAllJSONLFiles() -> [String] {
+    var jsonlFiles: [String] = []
+    let fileManager = FileManager.default
+
+    guard let enumerator = fileManager.enumerator(
+      at: URL(fileURLWithPath: sessionsDirectoryPath),
+      includingPropertiesForKeys: [.isRegularFileKey],
+      options: [.skipsHiddenFiles]
+    ) else {
+      return []
+    }
+
+    for case let fileURL as URL in enumerator {
+      if fileURL.pathExtension == "jsonl" {
+        jsonlFiles.append(fileURL.path)
+      }
+    }
+
+    return jsonlFiles
+  }
+
+  private func startWatching() {
+    let fileManager = FileManager.default
+
+    // Create directory if it doesn't exist
+    if !fileManager.fileExists(atPath: sessionsDirectoryPath) {
+      // Try again later when directory might exist
+      DispatchQueue.global().asyncAfter(deadline: .now() + 5) { [weak self] in
+        self?.startWatching()
+      }
+      return
+    }
+
+    fileDescriptor = open(sessionsDirectoryPath, O_EVTONLY)
+    guard fileDescriptor >= 0 else {
+      AppLogger.stats.error("Could not open Codex sessions directory for watching")
+      return
+    }
+
+    let source = DispatchSource.makeFileSystemObjectSource(
+      fileDescriptor: fileDescriptor,
+      eventMask: [.write, .extend, .attrib, .link],
+      queue: DispatchQueue.global(qos: .utility)
+    )
+
+    source.setEventHandler { [weak self] in
+      guard let self else { return }
+      // Debounce: cancel previous pending reload, schedule new one
+      self.debounceWorkItem?.cancel()
+      let workItem = DispatchWorkItem { [weak self] in
+        self?.loadStatsAsync()
+      }
+      self.debounceWorkItem = workItem
+      DispatchQueue.main.asyncAfter(deadline: .now() + 1.0, execute: workItem)
+    }
+
+    source.setCancelHandler { [weak self] in
+      if let fd = self?.fileDescriptor, fd >= 0 {
+        close(fd)
+      }
+    }
+
+    source.resume()
+    directoryWatcher = source
+  }
+
+  private func stopWatching() {
+    directoryWatcher?.cancel()
+    directoryWatcher = nil
+  }
+
+  // MARK: - Formatting Helpers
+
+  private func formatTokenCount(_ count: Int) -> String {
+    if count >= 1_000_000_000 {
+      let billions = Double(count) / 1_000_000_000
+      return String(format: "%.1fB", billions)
+    } else if count >= 1_000_000 {
+      let millions = Double(count) / 1_000_000
+      return String(format: "%.1fM", millions)
+    } else if count >= 1_000 {
+      let thousands = Double(count) / 1_000
+      return String(format: "%.1fK", thousands)
+    }
+    return "\(count)"
+  }
+
+  private func formatModelName(_ model: String) -> String {
+    // Handle common Codex model name patterns
+    if model.lowercased().contains("o3") {
+      return "o3"
+    } else if model.lowercased().contains("o4-mini") {
+      return "o4-mini"
+    } else if model.lowercased().contains("gpt-4") {
+      return "GPT-4"
+    } else if model.lowercased().contains("gpt-3") {
+      return "GPT-3.5"
+    }
+    // Return short form if model name is too long
+    if model.count > 20 {
+      return String(model.prefix(17)) + "..."
+    }
+    return model
+  }
+}
+
+// MARK: - CodexModelUsage
+
+/// Usage statistics for a single Codex model
+public struct CodexModelUsage: Sendable {
+  public var inputTokens: Int = 0
+  public var outputTokens: Int = 0
+  public var cacheReadTokens: Int = 0
+  public var cacheCreationTokens: Int = 0
+  public var messageCount: Int = 0
+  public var sessionCount: Int = 0
+
+  public init() {}
+
+  /// Total tokens for this model
+  public var totalTokens: Int {
+    inputTokens + outputTokens
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/GlobalStatsPopoverButton.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/GlobalStatsPopoverButton.swift
@@ -7,33 +7,38 @@ import SwiftUI
 
 /// A toolbar button that shows stats in a popover
 public struct GlobalStatsPopoverButton: View {
-  let service: GlobalStatsService
+  let claudeService: GlobalStatsService
+  let codexService: CodexGlobalStatsService?
   @State private var isShowingPopover = false
 
+  public init(claudeService: GlobalStatsService, codexService: CodexGlobalStatsService? = nil) {
+    self.claudeService = claudeService
+    self.codexService = codexService
+  }
+
+  /// Backwards-compatible initializer
   public init(service: GlobalStatsService) {
-    self.service = service
+    self.claudeService = service
+    self.codexService = nil
   }
 
   public var body: some View {
     Button(action: { isShowingPopover.toggle() }) {
-      HStack(spacing: 4) {
-        Image(systemName: "sparkle")
-          .font(.system(size: DesignTokens.IconSize.sm))
-        Text(service.formattedTotalTokens)
-          .font(.caption)
-          .fontWeight(.medium)
-          .fontDesign(.monospaced)
-          .padding(.trailing, 8)
-      }
-      .foregroundColor(.brandPrimary)
-      .padding(.horizontal, 4)
-      .padding(.vertical, 2)
+      Image(systemName: "apple.terminal.on.rectangle")
+        .font(.system(size: DesignTokens.IconSize.md))
+        .foregroundColor(.brandPrimary)
+        .padding(.horizontal, 4)
+        .padding(.vertical, 2)
     }
     .buttonStyle(.plain)
     .contentShape(Rectangle())
-    .help("Claude Code Stats: \(service.formattedTotalTokens) tokens")
+    .help("View Stats")
     .popover(isPresented: $isShowingPopover, arrowEdge: .bottom) {
-      GlobalStatsMenuView(service: service, showQuitButton: false)
+      GlobalStatsMenuView(
+        claudeService: claudeService,
+        codexService: codexService,
+        showQuitButton: false
+      )
     }
   }
 }

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/StatsProviderSegmentedControl.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/StatsProviderSegmentedControl.swift
@@ -1,0 +1,74 @@
+//
+//  StatsProviderSegmentedControl.swift
+//  AgentHub
+//
+//  Compact segmented control for switching between Claude and Codex stats.
+//
+
+import SwiftUI
+
+/// A compact segmented control for the stats view with underline indicator
+public struct StatsProviderSegmentedControl: View {
+  @Binding var selectedProvider: SessionProviderKind
+  let claudeSessionCount: Int
+  let codexSessionCount: Int
+
+  public init(
+    selectedProvider: Binding<SessionProviderKind>,
+    claudeSessionCount: Int = 0,
+    codexSessionCount: Int = 0
+  ) {
+    self._selectedProvider = selectedProvider
+    self.claudeSessionCount = claudeSessionCount
+    self.codexSessionCount = codexSessionCount
+  }
+
+  public var body: some View {
+    VStack(spacing: 0) {
+      HStack(spacing: 16) {
+        segmentButton(for: .claude, count: claudeSessionCount)
+        segmentButton(for: .codex, count: codexSessionCount)
+        Spacer()
+      }
+
+      // Underline
+      GeometryReader { geometry in
+        let segmentWidth = geometry.size.width / 2
+        Rectangle()
+          .fill(Color.brandPrimary(for: selectedProvider))
+          .frame(width: selectedProvider == .claude ? 80 : 100, height: 2)
+          .offset(x: selectedProvider == .claude ? 0 : 96)
+          .animation(.easeInOut(duration: 0.2), value: selectedProvider)
+      }
+      .frame(height: 2)
+      .padding(.top, 6)
+    }
+  }
+
+  private func segmentButton(for provider: SessionProviderKind, count: Int) -> some View {
+    Button {
+      selectedProvider = provider
+    } label: {
+      HStack(spacing: 6) {
+        Text("\(provider.rawValue) (\(count))")
+          .font(.system(.subheadline, weight: .medium))
+          .foregroundColor(
+            selectedProvider == provider
+              ? Color.brandPrimary(for: provider)
+              : .secondary
+          )
+
+        if provider == .codex {
+          Text("Beta")
+            .font(.system(size: 9, weight: .medium))
+            .foregroundColor(.secondary)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(Color.gray.opacity(0.2))
+            .clipShape(Capsule())
+        }
+      }
+    }
+    .buttonStyle(.plain)
+  }
+}


### PR DESCRIPTION
## Summary

- Add `CodexGlobalStatsService` for aggregating Codex session statistics from `~/.codex/sessions/`
- Add lightweight `parseForGlobalStats()` parser that reduces memory usage by ~9KB per session
- Implement Task-based cancellation support - loading stops when menu closes
- Add `StatsProviderSegmentedControl` with underline style showing session counts and Beta badge
- Update `GlobalStatsMenuView` to support switching between Claude and Codex providers
- Simplify menu bar label to use terminal icon

## Test plan

- [ ] Open menu bar dropdown and verify Claude stats display correctly
- [ ] Switch to Codex tab and verify stats load
- [ ] Close menu while Codex is loading - verify loading stops
- [ ] Verify segmented control shows correct session counts
- [ ] Verify Beta badge appears next to Codex

🤖 Generated with [Claude Code](https://claude.com/claude-code)