### PR TITLE
Remove layout mode persistence and add refresh button

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringPanelView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringPanelView.swift
@@ -96,8 +96,7 @@ public struct MonitoringPanelView: View {
   @Bindable var viewModel: CLISessionsViewModel
   let claudeClient: (any ClaudeCode)?
   @State private var sessionFileSheetItem: SessionFileSheetItem?
-  @AppStorage(AgentHubDefaults.monitoringPanelLayoutMode)
-  private var layoutModeRawValue: Int = LayoutMode.list.rawValue
+  @State private var layoutModeRawValue: Int = LayoutMode.list.rawValue
   @State private var maximizedSessionId: String?
   @Environment(\.colorScheme) private var colorScheme
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderMonitoringPanelView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderMonitoringPanelView.swift
@@ -129,8 +129,7 @@ public struct MultiProviderMonitoringPanelView: View {
   @Bindable var codexViewModel: CLISessionsViewModel
 
   @State private var sessionFileSheetItem: SessionFileSheetItem?
-  @AppStorage(AgentHubDefaults.monitoringPanelLayoutMode)
-  private var layoutModeRawValue: Int = LayoutMode.list.rawValue
+  @State private var layoutModeRawValue: Int = LayoutMode.list.rawValue
   @State private var maximizedSessionId: String?
   @Environment(\.colorScheme) private var colorScheme
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
@@ -519,6 +519,24 @@ public struct MultiProviderSessionsListView: View {
         }
         .buttonStyle(.plain)
         .help(currentViewModel.showLastMessage ? "Showing last message" : "Showing first message")
+
+        // Refresh button
+        Button(action: { currentViewModel.refresh() }) {
+          Image(systemName: "arrow.clockwise")
+            .font(.system(size: DesignTokens.IconSize.md))
+            .frame(width: 28, height: 28)
+            .background(
+              RoundedRectangle(cornerRadius: DesignTokens.Radius.sm)
+                .fill(Color.surfaceOverlay)
+            )
+            .overlay(
+              RoundedRectangle(cornerRadius: DesignTokens.Radius.sm)
+                .stroke(Color.borderSubtle, lineWidth: 1)
+            )
+        }
+        .buttonStyle(.plain)
+        .disabled(isLoading)
+        .help("Refresh sessions")
       }
       .padding(.horizontal, 4)
     }


### PR DESCRIPTION
## Summary
- Remove `@AppStorage` persistence for monitoring panel layout mode, replacing with `@State` so the app always starts in list mode on launch
- Add refresh button to sessions list toolbar for manual session refresh

## Test plan
- [ ] Build and run the app
- [ ] Change layout mode to 2-column or 3-column grid
- [ ] Quit and relaunch the app
- [ ] Verify monitoring panel shows list mode (not previously selected mode)
- [ ] Verify refresh button appears in sessions list toolbar and triggers a refresh

