### PR TITLE
Add --dangerously-skip-permissions option for new sessions

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/Models/PendingHubSession.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Models/PendingHubSession.swift
@@ -14,12 +14,18 @@ public struct PendingHubSession: Identifiable {
   public let worktree: WorktreeBranch
   public let startedAt: Date
   public let initialPrompt: String?
+  public let dangerouslySkipPermissions: Bool
 
-  public init(worktree: WorktreeBranch, initialPrompt: String? = "Hello!") {
+  public init(
+    worktree: WorktreeBranch,
+    initialPrompt: String? = "Hello!",
+    dangerouslySkipPermissions: Bool = false
+  ) {
     self.id = UUID()
     self.worktree = worktree
     self.startedAt = Date()
     self.initialPrompt = initialPrompt
+    self.dangerouslySkipPermissions = dangerouslySkipPermissions
   }
 
   /// Creates a placeholder CLISession for use with MonitoringCardView

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/CLIRepositoryTreeView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/CLIRepositoryTreeView.swift
@@ -23,7 +23,9 @@ public struct CLIRepositoryTreeView: View {
   let onToggleMonitoring: (CLISession) -> Void
   let onCreateWorktree: () -> Void
   let onOpenTerminalForWorktree: (WorktreeBranch) -> Void
+  let onOpenTerminalDangerousForWorktree: (WorktreeBranch) -> Void
   let onStartInHubForWorktree: (WorktreeBranch) -> Void
+  let onStartInHubDangerousForWorktree: (WorktreeBranch) -> Void
   let onDeleteWorktree: ((WorktreeBranch) -> Void)?
   let getCustomName: ((String) -> String?)?
   var showLastMessage: Bool = false
@@ -46,7 +48,9 @@ public struct CLIRepositoryTreeView: View {
     onToggleMonitoring: @escaping (CLISession) -> Void,
     onCreateWorktree: @escaping () -> Void,
     onOpenTerminalForWorktree: @escaping (WorktreeBranch) -> Void,
+    onOpenTerminalDangerousForWorktree: @escaping (WorktreeBranch) -> Void = { _ in },
     onStartInHubForWorktree: @escaping (WorktreeBranch) -> Void,
+    onStartInHubDangerousForWorktree: @escaping (WorktreeBranch) -> Void = { _ in },
     onDeleteWorktree: ((WorktreeBranch) -> Void)? = nil,
     getCustomName: ((String) -> String?)? = nil,
     showLastMessage: Bool = false,
@@ -65,7 +69,9 @@ public struct CLIRepositoryTreeView: View {
     self.onToggleMonitoring = onToggleMonitoring
     self.onCreateWorktree = onCreateWorktree
     self.onOpenTerminalForWorktree = onOpenTerminalForWorktree
+    self.onOpenTerminalDangerousForWorktree = onOpenTerminalDangerousForWorktree
     self.onStartInHubForWorktree = onStartInHubForWorktree
+    self.onStartInHubDangerousForWorktree = onStartInHubDangerousForWorktree
     self.onDeleteWorktree = onDeleteWorktree
     self.getCustomName = getCustomName
     self.showLastMessage = showLastMessage
@@ -92,7 +98,9 @@ public struct CLIRepositoryTreeView: View {
             providerKind: providerKind,
             onToggleExpanded: { onToggleWorktreeExpanded(worktree) },
             onOpenTerminal: { onOpenTerminalForWorktree(worktree) },
+            onOpenTerminalDangerous: { onOpenTerminalDangerousForWorktree(worktree) },
             onStartInHub: { onStartInHubForWorktree(worktree) },
+            onStartInHubDangerous: { onStartInHubDangerousForWorktree(worktree) },
             onDeleteWorktree: {
               worktreeToDelete = worktree
               showDeleteConfirmation = true

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/CLISessionsListView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/CLISessionsListView.swift
@@ -537,10 +537,18 @@ public struct CLISessionsListView: View {
                 }
               }
             },
+            onOpenTerminalDangerousForWorktree: { worktree in
+              // Open in terminal with --dangerously-skip-permissions flag
+              _ = viewModel.openTerminalInWorktree(worktree, skipCheckout: true, dangerouslySkipPermissions: true)
+            },
             onStartInHubForWorktree: { worktree in
               // Start a new session in the Hub's embedded terminal
               // No external terminal is opened - runs directly in the embedded terminal
               viewModel.startNewSessionInHub(worktree)
+            },
+            onStartInHubDangerousForWorktree: { worktree in
+              // Start a new session in the Hub with --dangerously-skip-permissions flag
+              viewModel.startNewSessionInHub(worktree, dangerouslySkipPermissions: true)
             },
             onDeleteWorktree: { worktree in
               Task {

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/CLIWorktreeBranchRow.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/CLIWorktreeBranchRow.swift
@@ -17,7 +17,9 @@ public struct CLIWorktreeBranchRow: View {
   let providerKind: SessionProviderKind
   let onToggleExpanded: () -> Void
   let onOpenTerminal: () -> Void
+  let onOpenTerminalDangerous: () -> Void
   let onStartInHub: () -> Void
+  let onStartInHubDangerous: () -> Void
   let onDeleteWorktree: (() -> Void)?
   let onConnectSession: (CLISession) -> Void
   let onCopySessionId: (CLISession) -> Void
@@ -77,7 +79,9 @@ public struct CLIWorktreeBranchRow: View {
     providerKind: SessionProviderKind = .claude,
     onToggleExpanded: @escaping () -> Void,
     onOpenTerminal: @escaping () -> Void,
+    onOpenTerminalDangerous: @escaping () -> Void = {},
     onStartInHub: @escaping () -> Void,
+    onStartInHubDangerous: @escaping () -> Void = {},
     onDeleteWorktree: (() -> Void)? = nil,
     onConnectSession: @escaping (CLISession) -> Void,
     onCopySessionId: @escaping (CLISession) -> Void,
@@ -94,7 +98,9 @@ public struct CLIWorktreeBranchRow: View {
     self.providerKind = providerKind
     self.onToggleExpanded = onToggleExpanded
     self.onOpenTerminal = onOpenTerminal
+    self.onOpenTerminalDangerous = onOpenTerminalDangerous
     self.onStartInHub = onStartInHub
+    self.onStartInHubDangerous = onStartInHubDangerous
     self.onDeleteWorktree = onDeleteWorktree
     self.onConnectSession = onConnectSession
     self.onCopySessionId = onCopySessionId
@@ -197,13 +203,28 @@ public struct CLIWorktreeBranchRow: View {
           .help("Start new \(providerLabel) session")
           .popover(isPresented: $showNewSessionMenu, arrowEdge: .bottom) {
             VStack(alignment: .leading, spacing: 0) {
+              // Start in Hub (Recommended)
               Button(action: {
                 showNewSessionMenu = false
                 onStartInHub()
               }) {
-                Label("Start in Hub", systemImage: "square.grid.2x2")
+                Label("Start in Hub (Recommended)", systemImage: "square.grid.2x2")
                   .frame(maxWidth: .infinity, alignment: .leading)
                   .foregroundColor(.brandPrimary(for: providerKind))
+              }
+              .buttonStyle(.plain)
+              .padding(.horizontal, 12)
+              .padding(.vertical, 8)
+              .contentShape(Rectangle())
+
+              // Start in Hub (Dangerously)
+              Button(action: {
+                showNewSessionMenu = false
+                onStartInHubDangerous()
+              }) {
+                Label("Start in Hub (Dangerously)", systemImage: "exclamationmark.triangle")
+                  .frame(maxWidth: .infinity, alignment: .leading)
+                  .foregroundColor(.orange)
               }
               .buttonStyle(.plain)
               .padding(.horizontal, 12)
@@ -213,12 +234,27 @@ public struct CLIWorktreeBranchRow: View {
               if supportsExternalTerminal {
                 Divider()
 
+                // Open in Terminal (Recommended)
                 Button(action: {
                   showNewSessionMenu = false
                   onOpenTerminal()
                 }) {
-                  Label("Open in Terminal", systemImage: "terminal")
+                  Label("Open in Terminal (Recommended)", systemImage: "terminal")
                     .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                .buttonStyle(.plain)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 8)
+                .contentShape(Rectangle())
+
+                // Open in Terminal (Dangerously)
+                Button(action: {
+                  showNewSessionMenu = false
+                  onOpenTerminalDangerous()
+                }) {
+                  Label("Open in Terminal (Dangerously)", systemImage: "exclamationmark.triangle")
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .foregroundColor(.orange)
                 }
                 .buttonStyle(.plain)
                 .padding(.horizontal, 12)
@@ -227,7 +263,7 @@ public struct CLIWorktreeBranchRow: View {
               }
             }
             .padding(.vertical, 8)
-            .frame(width: 180)
+            .frame(width: 260)
           }
         }
         .padding(.vertical, 14)

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringCardView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringCardView.swift
@@ -50,6 +50,7 @@ public struct MonitoringCardView: View {
   let initialPrompt: String?
   let terminalKey: String?  // Key for terminal storage (session ID or "pending-{pendingId}")
   let viewModel: CLISessionsViewModel?
+  var dangerouslySkipPermissions: Bool = false
   let onToggleTerminal: (Bool) -> Void
   let onStopMonitoring: () -> Void
   let onConnect: () -> Void
@@ -81,6 +82,7 @@ public struct MonitoringCardView: View {
     initialPrompt: String? = nil,
     terminalKey: String? = nil,
     viewModel: CLISessionsViewModel? = nil,
+    dangerouslySkipPermissions: Bool = false,
     onToggleTerminal: @escaping (Bool) -> Void,
     onStopMonitoring: @escaping () -> Void,
     onConnect: @escaping () -> Void,
@@ -102,6 +104,7 @@ public struct MonitoringCardView: View {
     self.initialPrompt = initialPrompt
     self.terminalKey = terminalKey
     self.viewModel = viewModel
+    self.dangerouslySkipPermissions = dangerouslySkipPermissions
     self.onToggleTerminal = onToggleTerminal
     self.onStopMonitoring = onStopMonitoring
     self.onConnect = onConnect
@@ -605,7 +608,8 @@ public struct MonitoringCardView: View {
           projectPath: session.projectPath,
           cliConfiguration: viewModel?.cliConfiguration ?? .claudeDefault,
           initialPrompt: initialPrompt,
-          viewModel: viewModel
+          viewModel: viewModel,
+          dangerouslySkipPermissions: dangerouslySkipPermissions
         )
         .frame(minHeight: 300)
       } else {

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringPanelView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringPanelView.swift
@@ -286,6 +286,7 @@ public struct MonitoringPanelView: View {
         initialPrompt: pending.initialPrompt,
         terminalKey: "pending-\(pending.id.uuidString)",
         viewModel: viewModel,
+        dangerouslySkipPermissions: pending.dangerouslySkipPermissions,
         onToggleTerminal: { _ in },
         onStopMonitoring: {
           viewModel.cancelPendingSession(pending)
@@ -404,6 +405,7 @@ public struct MonitoringPanelView: View {
         initialPrompt: pending.initialPrompt,
         terminalKey: pendingId,
         viewModel: viewModel,
+        dangerouslySkipPermissions: pending.dangerouslySkipPermissions,
         onToggleTerminal: { _ in },
         onStopMonitoring: {
           viewModel.cancelPendingSession(pending)
@@ -502,6 +504,7 @@ public struct MonitoringPanelView: View {
               initialPrompt: pending.initialPrompt,
               terminalKey: pendingId,
               viewModel: viewModel,
+              dangerouslySkipPermissions: pending.dangerouslySkipPermissions,
               onToggleTerminal: { _ in },
               onStopMonitoring: {
                 viewModel.cancelPendingSession(pending)

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderMonitoringPanelView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderMonitoringPanelView.swift
@@ -364,6 +364,7 @@ public struct MultiProviderMonitoringPanelView: View {
               initialPrompt: pending.initialPrompt,
               terminalKey: "pending-\(pending.id.uuidString)",
               viewModel: viewModel,
+              dangerouslySkipPermissions: pending.dangerouslySkipPermissions,
               onToggleTerminal: { _ in },
               onStopMonitoring: { viewModel.cancelPendingSession(pending) },
               onConnect: { },
@@ -477,6 +478,7 @@ public struct MultiProviderMonitoringPanelView: View {
           initialPrompt: pending.initialPrompt,
           terminalKey: "pending-\(pending.id.uuidString)",
           viewModel: viewModel,
+          dangerouslySkipPermissions: pending.dangerouslySkipPermissions,
           onToggleTerminal: { _ in },
           onStopMonitoring: {
             viewModel.cancelPendingSession(pending)

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
@@ -706,8 +706,14 @@ private struct ProviderSectionView: View {
           onOpenTerminalForWorktree: { worktree in
             onOpenTerminalForWorktree(worktree)
           },
+          onOpenTerminalDangerousForWorktree: { worktree in
+            _ = viewModel.openTerminalInWorktree(worktree, skipCheckout: true, dangerouslySkipPermissions: true)
+          },
           onStartInHubForWorktree: { worktree in
             viewModel.startNewSessionInHub(worktree)
+          },
+          onStartInHubDangerousForWorktree: { worktree in
+            viewModel.startNewSessionInHub(worktree, dangerouslySkipPermissions: true)
           },
           onDeleteWorktree: { worktree in
             Task { await viewModel.deleteWorktree(worktree) }

--- a/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/CLISessionsViewModel.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/CLISessionsViewModel.swift
@@ -218,7 +218,8 @@ public final class CLISessionsViewModel {
     projectPath: String,
     cliConfiguration: CLICommandConfiguration? = nil,
     initialPrompt: String?,
-    isDark: Bool = true
+    isDark: Bool = true,
+    dangerouslySkipPermissions: Bool = false
   ) -> TerminalContainerView {
     if let existing = activeTerminals[key] {
       #if DEBUG
@@ -244,7 +245,8 @@ public final class CLISessionsViewModel {
       projectPath: projectPath,
       cliConfiguration: config,
       initialPrompt: initialPrompt,
-      isDark: isDark
+      isDark: isDark,
+      dangerouslySkipPermissions: dangerouslySkipPermissions
     )
     activeTerminals[key] = terminal
     return terminal
@@ -953,8 +955,9 @@ public final class CLISessionsViewModel {
   /// - Parameters:
   ///   - worktree: The worktree to open
   ///   - skipCheckout: If true, skips git checkout even for non-worktrees (already on correct branch)
+  ///   - dangerouslySkipPermissions: If true, adds --dangerously-skip-permissions flag
   /// - Returns: An error if launching failed, nil on success
-  public func openTerminalInWorktree(_ worktree: WorktreeBranch, skipCheckout: Bool = false) -> Error? {
+  public func openTerminalInWorktree(_ worktree: WorktreeBranch, skipCheckout: Bool = false, dangerouslySkipPermissions: Bool = false) -> Error? {
     guard providerKind == .claude else {
       return NSError(
         domain: "CLISessionsViewModel",
@@ -975,7 +978,8 @@ public final class CLISessionsViewModel {
       branchName: worktree.name,
       isWorktree: worktree.isWorktree,
       skipCheckout: skipCheckout,
-      claudeClient: claudeClient
+      claudeClient: claudeClient,
+      dangerouslySkipPermissions: dangerouslySkipPermissions
     )
   }
 
@@ -1060,12 +1064,18 @@ public final class CLISessionsViewModel {
   ///   - skipCheckout: If true, skips git checkout even for non-worktrees
   /// - Returns: An error if launching failed, nil on success
   /// Starts a new Claude session in the Hub's embedded terminal (not external terminal)
-  /// - Parameter worktree: The worktree to start the session in
-  public func startNewSessionInHub(_ worktree: WorktreeBranch) {
+  /// - Parameters:
+  ///   - worktree: The worktree to start the session in
+  ///   - dangerouslySkipPermissions: If true, adds --dangerously-skip-permissions flag
+  public func startNewSessionInHub(_ worktree: WorktreeBranch, dangerouslySkipPermissions: Bool = false) {
     // Each pending session gets a unique ID, so no need to clear existing terminals
     // Terminals are now keyed by session ID, not worktree path
     // No auto-prompt: let user type naturally in the terminal
-    let pending = PendingHubSession(worktree: worktree, initialPrompt: nil)
+    let pending = PendingHubSession(
+      worktree: worktree,
+      initialPrompt: nil,
+      dangerouslySkipPermissions: dangerouslySkipPermissions
+    )
     pendingHubSessions.append(pending)
 
 #if DEBUG


### PR DESCRIPTION
## Summary

- Add separate menu options to start sessions with `--dangerously-skip-permissions` flag
- This is a one-shot action (not persisted) - each session launch is an explicit choice
- The "+" popover menu now shows 4 options with "Dangerously" variants in orange
- Flag only applies to new sessions, not when resuming existing ones

## Test plan

- [ ] Click "+" on any worktree row and verify 4 options appear
- [ ] Test "Start in Hub (Dangerously)" - verify flag appears in terminal command
- [ ] Test "Open in Terminal (Dangerously)" - verify external terminal includes the flag
- [ ] Test normal options still work without the flag
- [ ] Verify resuming existing sessions does not include the flag

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)