### PR TITLE
Add session archiving and deletion

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/Models/SessionMetadata.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Models/SessionMetadata.swift
@@ -18,6 +18,9 @@ public struct SessionMetadata: Codable, Sendable, FetchableRecord, PersistableRe
   /// User-provided name for the session (optional)
   public var customName: String?
 
+  /// Whether the session is archived (hidden from main view)
+  public var isArchived: Bool
+
   /// When the metadata was created
   public var createdAt: Date
 
@@ -33,11 +36,13 @@ public struct SessionMetadata: Codable, Sendable, FetchableRecord, PersistableRe
   public init(
     sessionId: String,
     customName: String? = nil,
+    isArchived: Bool = false,
     createdAt: Date = Date(),
     updatedAt: Date = Date()
   ) {
     self.sessionId = sessionId
     self.customName = customName
+    self.isArchived = isArchived
     self.createdAt = createdAt
     self.updatedAt = updatedAt
   }

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/CLIRepositoryTreeView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/CLIRepositoryTreeView.swift
@@ -21,6 +21,8 @@ public struct CLIRepositoryTreeView: View {
   let onOpenSessionFile: (CLISession) -> Void
   let isSessionMonitored: (String) -> Bool
   let onToggleMonitoring: (CLISession) -> Void
+  let onArchiveSession: (CLISession) -> Void
+  let onDeleteSession: (CLISession) -> Void
   let onCreateWorktree: () -> Void
   let onOpenTerminalForWorktree: (WorktreeBranch) -> Void
   let onOpenTerminalDangerousForWorktree: (WorktreeBranch) -> Void
@@ -46,6 +48,8 @@ public struct CLIRepositoryTreeView: View {
     onOpenSessionFile: @escaping (CLISession) -> Void,
     isSessionMonitored: @escaping (String) -> Bool,
     onToggleMonitoring: @escaping (CLISession) -> Void,
+    onArchiveSession: @escaping (CLISession) -> Void,
+    onDeleteSession: @escaping (CLISession) -> Void,
     onCreateWorktree: @escaping () -> Void,
     onOpenTerminalForWorktree: @escaping (WorktreeBranch) -> Void,
     onOpenTerminalDangerousForWorktree: @escaping (WorktreeBranch) -> Void = { _ in },
@@ -67,6 +71,8 @@ public struct CLIRepositoryTreeView: View {
     self.onOpenSessionFile = onOpenSessionFile
     self.isSessionMonitored = isSessionMonitored
     self.onToggleMonitoring = onToggleMonitoring
+    self.onArchiveSession = onArchiveSession
+    self.onDeleteSession = onDeleteSession
     self.onCreateWorktree = onCreateWorktree
     self.onOpenTerminalForWorktree = onOpenTerminalForWorktree
     self.onOpenTerminalDangerousForWorktree = onOpenTerminalDangerousForWorktree
@@ -110,6 +116,8 @@ public struct CLIRepositoryTreeView: View {
             onOpenSessionFile: onOpenSessionFile,
             isSessionMonitored: isSessionMonitored,
             onToggleMonitoring: onToggleMonitoring,
+            onArchiveSession: onArchiveSession,
+            onDeleteSession: onDeleteSession,
             getCustomName: getCustomName,
             showLastMessage: showLastMessage,
             isDebugMode: isDebugMode,
@@ -263,6 +271,8 @@ public struct CLIRepositoryTreeView: View {
       onOpenSessionFile: { _ in },
       isSessionMonitored: { _ in false },
       onToggleMonitoring: { _ in },
+      onArchiveSession: { _ in },
+      onDeleteSession: { _ in },
       onCreateWorktree: { },
       onOpenTerminalForWorktree: { _ in },
       onStartInHubForWorktree: { _ in }
@@ -290,6 +300,8 @@ public struct CLIRepositoryTreeView: View {
       onOpenSessionFile: { _ in },
       isSessionMonitored: { _ in false },
       onToggleMonitoring: { _ in },
+      onArchiveSession: { _ in },
+      onDeleteSession: { _ in },
       onCreateWorktree: { },
       onOpenTerminalForWorktree: { _ in },
       onStartInHubForWorktree: { _ in }

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/CLISessionRow.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/CLISessionRow.swift
@@ -20,6 +20,8 @@ public struct CLISessionRow: View {
   let onCopyId: () -> Void
   let onOpenFile: () -> Void
   let onToggleMonitoring: () -> Void
+  let onArchive: () -> Void
+  let onDelete: () -> Void
   var showLastMessage: Bool = false
 
   @State private var showCopyConfirmation = false
@@ -33,6 +35,8 @@ public struct CLISessionRow: View {
     onCopyId: @escaping () -> Void,
     onOpenFile: @escaping () -> Void,
     onToggleMonitoring: @escaping () -> Void,
+    onArchive: @escaping () -> Void,
+    onDelete: @escaping () -> Void,
     showLastMessage: Bool = false
   ) {
     self.session = session
@@ -43,6 +47,8 @@ public struct CLISessionRow: View {
     self.onCopyId = onCopyId
     self.onOpenFile = onOpenFile
     self.onToggleMonitoring = onToggleMonitoring
+    self.onArchive = onArchive
+    self.onDelete = onDelete
     self.showLastMessage = showLastMessage
   }
 
@@ -149,6 +155,30 @@ public struct CLISessionRow: View {
       .buttonStyle(.plain)
       .help("Copy full session ID")
 
+      // Resume in Hub button
+      Button {
+        onArchive()
+      } label: {
+        Image(systemName: "archivebox")
+          .font(.caption2)
+          .foregroundColor(.secondary)
+          .contentShape(Rectangle())
+      }
+      .buttonStyle(.plain)
+      .help("Archive session")
+
+      // Delete button
+      Button {
+        onDelete()
+      } label: {
+        Image(systemName: "trash")
+          .font(.caption2)
+          .foregroundColor(.secondary)
+          .contentShape(Rectangle())
+      }
+      .buttonStyle(.plain)
+      .help("Delete session")
+
       Spacer()
     }
   }
@@ -225,7 +255,9 @@ extension Date {
       onConnect: { },
       onCopyId: { },
       onOpenFile: { },
-      onToggleMonitoring: { }
+      onToggleMonitoring: { },
+      onArchive: { },
+      onDelete: { }
     )
 
     // Inactive worktree session with long message (being monitored)
@@ -245,7 +277,9 @@ extension Date {
       onConnect: { },
       onCopyId: { },
       onOpenFile: { },
-      onToggleMonitoring: { }
+      onToggleMonitoring: { },
+      onArchive: { },
+      onDelete: { }
     )
 
     // Session without slug (falls back to shortId)
@@ -264,7 +298,9 @@ extension Date {
       onConnect: { },
       onCopyId: { },
       onOpenFile: { },
-      onToggleMonitoring: { }
+      onToggleMonitoring: { },
+      onArchive: { },
+      onDelete: { }
     )
   }
   .padding()

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/CLIWorktreeBranchRow.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/CLIWorktreeBranchRow.swift
@@ -26,6 +26,8 @@ public struct CLIWorktreeBranchRow: View {
   let onOpenSessionFile: (CLISession) -> Void
   let isSessionMonitored: (String) -> Bool
   let onToggleMonitoring: (CLISession) -> Void
+  let onArchiveSession: (CLISession) -> Void
+  let onDeleteSession: (CLISession) -> Void
   let getCustomName: ((String) -> String?)?
   var showLastMessage: Bool = false
   var isDebugMode: Bool = false
@@ -88,6 +90,8 @@ public struct CLIWorktreeBranchRow: View {
     onOpenSessionFile: @escaping (CLISession) -> Void,
     isSessionMonitored: @escaping (String) -> Bool,
     onToggleMonitoring: @escaping (CLISession) -> Void,
+    onArchiveSession: @escaping (CLISession) -> Void,
+    onDeleteSession: @escaping (CLISession) -> Void,
     getCustomName: ((String) -> String?)? = nil,
     showLastMessage: Bool = false,
     isDebugMode: Bool = false,
@@ -107,6 +111,8 @@ public struct CLIWorktreeBranchRow: View {
     self.onOpenSessionFile = onOpenSessionFile
     self.isSessionMonitored = isSessionMonitored
     self.onToggleMonitoring = onToggleMonitoring
+    self.onArchiveSession = onArchiveSession
+    self.onDeleteSession = onDeleteSession
     self.getCustomName = getCustomName
     self.showLastMessage = showLastMessage
     self.isDebugMode = isDebugMode
@@ -293,6 +299,8 @@ public struct CLIWorktreeBranchRow: View {
                   onCopyId: { onCopySessionId(session) },
                   onOpenFile: { onOpenSessionFile(session) },
                   onToggleMonitoring: { onToggleMonitoring(session) },
+                  onArchive: { onArchiveSession(session) },
+                  onDelete: { onDeleteSession(session) },
                   showLastMessage: showLastMessage
                 )
               }
@@ -359,7 +367,9 @@ public struct CLIWorktreeBranchRow: View {
       onCopySessionId: { _ in },
       onOpenSessionFile: { _ in },
       isSessionMonitored: { _ in false },
-      onToggleMonitoring: { _ in }
+      onToggleMonitoring: { _ in },
+      onArchiveSession: { _ in },
+      onDeleteSession: { _ in }
     )
 
     Divider()
@@ -390,7 +400,9 @@ public struct CLIWorktreeBranchRow: View {
       onCopySessionId: { _ in },
       onOpenSessionFile: { _ in },
       isSessionMonitored: { _ in false },
-      onToggleMonitoring: { _ in }
+      onToggleMonitoring: { _ in },
+      onArchiveSession: { _ in },
+      onDeleteSession: { _ in }
     )
 
     Divider()
@@ -411,7 +423,9 @@ public struct CLIWorktreeBranchRow: View {
       onCopySessionId: { _ in },
       onOpenSessionFile: { _ in },
       isSessionMonitored: { _ in false },
-      onToggleMonitoring: { _ in }
+      onToggleMonitoring: { _ in },
+      onArchiveSession: { _ in },
+      onDeleteSession: { _ in }
     )
   }
   .padding()


### PR DESCRIPTION
  ## Summary
  - Add session archiving to hide sessions from the main view while keeping files on disk
  - Add session deletion with confirmation dialog to permanently remove session files
  - Add "Show archived" toggle button to filter bar for viewing/managing archived sessions
  - Add archive and delete buttons to session rows with appropriate icons
  - Store archive state in SQLite database with migration for new `isArchived` column
  - Properly stop monitoring when archiving or deleting active sessions

  ## Changes
  - **SessionMetadata model**: Added `isArchived` boolean field
  - **SessionMetadataStore**: Added `archiveSession`, `unarchiveSession`, `getArchivedSessionIds` methods with v3 migration
  - **CLISessionsViewModel**: Added archive/delete state management with proper cleanup and error logging
  - **UI components**: Added archive (archivebox) and delete (trash) buttons to CLISessionRow, with callbacks threaded through CLIRepositoryTreeView and
  CLIWorktreeBranchRow
  - **Filter toggle**: Added "Show archived" button to both single and multi-provider list views

  ## Test plan
  - [ ] Archive a session and verify it disappears from the main list
  - [ ] Toggle "Show archived" and verify archived sessions reappear
  - [ ] Delete a session and verify confirmation dialog appears
  - [ ] Confirm deletion and verify session file is removed from disk
  - [ ] Verify monitoring stops when archiving/deleting a monitored session
  - [ ] Quit and relaunch app - verify archive state persists

  🤖 Generated with [Claude Code](https://claude.ai/code)