### PR TITLE
Move archive action to session rows with animated removal

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/CollapsibleSelectedSessionsPanel.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/CollapsibleSelectedSessionsPanel.swift
@@ -122,10 +122,17 @@ public struct CollapsibleSelectedSessionsPanel: View {
             isPending: item.isPending,
             isPrimary: item.id == primarySessionId,
             customName: customName(for: item),
-            colorScheme: colorScheme
-          ) {
-            primarySessionId = item.id
-          }
+            colorScheme: colorScheme,
+            onArchive: item.isPending ? nil : {
+              switch item.providerKind {
+              case .claude: claudeViewModel.stopMonitoring(session: item.session)
+              case .codex: codexViewModel.stopMonitoring(session: item.session)
+              }
+            },
+            onSelect: {
+              primarySessionId = item.id
+            }
+          )
         }
       }
       .padding(.horizontal, 4)
@@ -321,10 +328,14 @@ public struct SingleProviderCollapsibleSelectedSessionsPanel: View {
             isPending: item.isPending,
             isPrimary: item.id == primarySessionId,
             customName: viewModel.sessionCustomNames[item.session.id],
-            colorScheme: colorScheme
-          ) {
-            primarySessionId = item.id
-          }
+            colorScheme: colorScheme,
+            onArchive: item.isPending ? nil : {
+              viewModel.stopMonitoring(session: item.session)
+            },
+            onSelect: {
+              primarySessionId = item.id
+            }
+          )
         }
       }
       .padding(.horizontal, 4)

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/CollapsibleSessionRow.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/CollapsibleSessionRow.swift
@@ -10,9 +10,11 @@ struct CollapsibleSessionRow: View {
   let isPrimary: Bool
   let customName: String?
   let colorScheme: ColorScheme
+  let onArchive: (() -> Void)?
   let onSelect: () -> Void
 
   @State private var gradientProgress: CGFloat = 0
+  @State private var showArchiveConfirm = false
 
   private var tildeProjectPath: String {
     let home = FileManager.default.homeDirectoryForCurrentUser.path
@@ -147,7 +149,51 @@ struct CollapsibleSessionRow: View {
           )
       }
     )
+    .overlay(alignment: .bottomTrailing) {
+      if !isPending, let onArchive {
+        Group {
+          if showArchiveConfirm {
+            Button {
+              showArchiveConfirm = false
+              onArchive()
+            } label: {
+              Text("Confirm")
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundColor(.white)
+                .padding(.horizontal, 6)
+                .padding(.vertical, 2)
+                .background(Color.brandPrimary(for: providerKind))
+                .clipShape(RoundedRectangle(cornerRadius: 4))
+            }
+            .buttonStyle(.plain)
+          } else {
+            Button {
+              withAnimation(.easeInOut(duration: 0.15)) {
+                showArchiveConfirm = true
+              }
+            } label: {
+              Image(systemName: "archivebox")
+                .font(.system(size: 11))
+                .foregroundColor(.secondary)
+                .frame(width: 20, height: 20)
+            }
+            .buttonStyle(.plain)
+            .help("Archive session")
+          }
+        }
+        .transition(.opacity.combined(with: .scale(scale: 0.8)))
+        .padding(.trailing, 8)
+        .padding(.bottom, 8)
+      }
+    }
     .padding(.vertical, 8)
+    .onHover { hovering in
+      if !hovering && showArchiveConfirm {
+        withAnimation(.easeInOut(duration: 0.15)) {
+          showArchiveConfirm = false
+        }
+      }
+    }
     .onAppear {
       gradientProgress = isPrimary ? 1 : 0
     }
@@ -209,6 +255,7 @@ struct CollapsibleSessionRow: View {
         isPrimary: true,
         customName: nil,
         colorScheme: .dark,
+        onArchive: {},
         onSelect: {}
       )
 
@@ -224,6 +271,7 @@ struct CollapsibleSessionRow: View {
         isPrimary: false,
         customName: nil,
         colorScheme: .dark,
+        onArchive: {},
         onSelect: {}
       )
 
@@ -242,6 +290,7 @@ struct CollapsibleSessionRow: View {
         isPrimary: true,
         customName: nil,
         colorScheme: .dark,
+        onArchive: {},
         onSelect: {}
       )
 
@@ -257,6 +306,7 @@ struct CollapsibleSessionRow: View {
         isPrimary: false,
         customName: nil,
         colorScheme: .dark,
+        onArchive: {},
         onSelect: {}
       )
 
@@ -275,6 +325,7 @@ struct CollapsibleSessionRow: View {
         isPrimary: true,
         customName: nil,
         colorScheme: .dark,
+        onArchive: nil,
         onSelect: {}
       )
 
@@ -290,6 +341,7 @@ struct CollapsibleSessionRow: View {
         isPrimary: false,
         customName: nil,
         colorScheme: .dark,
+        onArchive: nil,
         onSelect: {}
       )
 
@@ -308,6 +360,7 @@ struct CollapsibleSessionRow: View {
         isPrimary: true,
         customName: "Auth Refactor",
         colorScheme: .dark,
+        onArchive: {},
         onSelect: {}
       )
 
@@ -326,6 +379,7 @@ struct CollapsibleSessionRow: View {
         isPrimary: true,
         customName: nil,
         colorScheme: .light,
+        onArchive: {},
         onSelect: {}
       )
       .environment(\.colorScheme, .light)
@@ -342,6 +396,7 @@ struct CollapsibleSessionRow: View {
         isPrimary: false,
         customName: nil,
         colorScheme: .light,
+        onArchive: {},
         onSelect: {}
       )
       .environment(\.colorScheme, .light)

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringCardView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringCardView.swift
@@ -481,20 +481,6 @@ public struct MonitoringCardView: View {
 //      .buttonStyle(.plain)
 //      .help(isMaximized ? "Minimize" : "Maximize")
 
-      // Close button (inline, hidden when maximized or side panel is open)
-      if !isMaximized && !isSidePanelOpen {
-        Button {
-          webPreviewSheetItem = nil
-          onStopMonitoring()
-        } label: {
-          Image(systemName: "xmark")
-            .font(.caption)
-            .foregroundColor(.secondary)
-            .frame(width: 24, height: 24)
-        }
-        .buttonStyle(.plain)
-        .help("Stop monitoring")
-      }
     }
   }
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
@@ -456,10 +456,23 @@ public struct MultiProviderSessionsListView: View {
             isPending: item.isPending,
             isPrimary: item.id == primarySessionId,
             customName: selectedSessionCustomName(for: item),
-            colorScheme: colorScheme
-          ) {
-            primarySessionId = item.id
-          }
+            colorScheme: colorScheme,
+            onArchive: item.isPending ? nil : {
+              withAnimation(.easeInOut(duration: 0.25)) {
+                switch item.providerKind {
+                case .claude: claudeViewModel.stopMonitoring(session: item.session)
+                case .codex: codexViewModel.stopMonitoring(session: item.session)
+                }
+              }
+            },
+            onSelect: {
+              primarySessionId = item.id
+            }
+          )
+          .transition(.asymmetric(
+            insertion: .opacity,
+            removal: .move(edge: .trailing).combined(with: .opacity)
+          ))
         }
       }
       .padding(.bottom, 8)


### PR DESCRIPTION
## Summary
- Adds an inline archive button (archivebox icon) to each `CollapsibleSessionRow` with a two-step confirm flow
- Moves hover detection from the small button group to the entire row so the "Confirm" label stays visible until the cursor leaves the row
- Removes the close button from `MonitoringCardView` since archiving now lives on the session rows
- Animates archived rows sliding out to the right with a combined move + opacity transition

## Test plan
- [ ] Hover over a non-pending session row — archive icon should appear at bottom-right
- [ ] Click the archive icon — "Confirm" label should appear and stay visible while cursor is on the row
- [ ] Move cursor off the row — "Confirm" should revert to the archive icon
- [ ] Click "Confirm" — row should slide out to the right with animation
- [ ] Verify pending sessions do not show the archive button

🤖 Generated with [Claude Code](https://claude.com/claude-code)