### PR TITLE
Add session status indicator and stabilize Projects list sort

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/CollapsibleSelectedSessionsPanel.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/CollapsibleSelectedSessionsPanel.swift
@@ -122,6 +122,7 @@ public struct CollapsibleSelectedSessionsPanel: View {
             isPending: item.isPending,
             isPrimary: item.id == primarySessionId,
             customName: customName(for: item),
+            sessionStatus: item.sessionStatus,
             colorScheme: colorScheme,
             onArchive: item.isPending ? nil : {
               switch item.providerKind {
@@ -148,6 +149,7 @@ public struct CollapsibleSelectedSessionsPanel: View {
     let providerKind: SessionProviderKind
     let timestamp: Date
     let isPending: Bool
+    let sessionStatus: SessionStatus?
   }
 
   private var items: [SelectedSessionItem] {
@@ -159,7 +161,8 @@ public struct CollapsibleSelectedSessionsPanel: View {
         session: pending.placeholderSession,
         providerKind: .claude,
         timestamp: pending.startedAt,
-        isPending: true
+        isPending: true,
+        sessionStatus: nil
       ))
     }
 
@@ -169,7 +172,8 @@ public struct CollapsibleSelectedSessionsPanel: View {
         session: pending.placeholderSession,
         providerKind: .codex,
         timestamp: pending.startedAt,
-        isPending: true
+        isPending: true,
+        sessionStatus: nil
       ))
     }
 
@@ -178,8 +182,9 @@ public struct CollapsibleSelectedSessionsPanel: View {
         id: "claude-\(item.session.id)",
         session: item.session,
         providerKind: .claude,
-        timestamp: item.state?.lastActivityAt ?? item.session.lastActivityAt,
-        isPending: false
+        timestamp: item.session.lastActivityAt,
+        isPending: false,
+        sessionStatus: item.state?.status
       ))
     }
 
@@ -188,8 +193,9 @@ public struct CollapsibleSelectedSessionsPanel: View {
         id: "codex-\(item.session.id)",
         session: item.session,
         providerKind: .codex,
-        timestamp: item.state?.lastActivityAt ?? item.session.lastActivityAt,
-        isPending: false
+        timestamp: item.session.lastActivityAt,
+        isPending: false,
+        sessionStatus: item.state?.status
       ))
     }
 
@@ -328,6 +334,7 @@ public struct SingleProviderCollapsibleSelectedSessionsPanel: View {
             isPending: item.isPending,
             isPrimary: item.id == primarySessionId,
             customName: viewModel.sessionCustomNames[item.session.id],
+            sessionStatus: item.sessionStatus,
             colorScheme: colorScheme,
             onArchive: item.isPending ? nil : {
               viewModel.stopMonitoring(session: item.session)
@@ -350,6 +357,7 @@ public struct SingleProviderCollapsibleSelectedSessionsPanel: View {
     let session: CLISession
     let timestamp: Date
     let isPending: Bool
+    let sessionStatus: SessionStatus?
   }
 
   private var items: [SelectedSessionItem] {
@@ -360,7 +368,8 @@ public struct SingleProviderCollapsibleSelectedSessionsPanel: View {
         id: "pending-\(pending.id.uuidString)",
         session: pending.placeholderSession,
         timestamp: pending.startedAt,
-        isPending: true
+        isPending: true,
+        sessionStatus: nil
       ))
     }
 
@@ -368,8 +377,9 @@ public struct SingleProviderCollapsibleSelectedSessionsPanel: View {
       results.append(SelectedSessionItem(
         id: item.session.id,
         session: item.session,
-        timestamp: item.state?.lastActivityAt ?? item.session.lastActivityAt,
-        isPending: false
+        timestamp: item.session.lastActivityAt,
+        isPending: false,
+        sessionStatus: item.state?.status
       ))
     }
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/CollapsibleSessionRow.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/CollapsibleSessionRow.swift
@@ -9,6 +9,7 @@ struct CollapsibleSessionRow: View {
   let isPending: Bool
   let isPrimary: Bool
   let customName: String?
+  let sessionStatus: SessionStatus?
   let colorScheme: ColorScheme
   let onArchive: (() -> Void)?
   let onSelect: () -> Void
@@ -22,6 +23,35 @@ struct CollapsibleSessionRow: View {
       return "~" + session.projectPath.dropFirst(home.count)
     }
     return session.projectPath
+  }
+
+  private var statusColor: Color {
+    guard let sessionStatus else { return .brandPrimary(for: providerKind) }
+    switch sessionStatus {
+    case .thinking: return .blue
+    case .executingTool: return .orange
+    case .waitingForUser: return .green
+    case .awaitingApproval: return .yellow
+    case .idle: return .gray
+    }
+  }
+
+  private var isActiveStatus: Bool {
+    guard let sessionStatus else { return false }
+    switch sessionStatus {
+    case .thinking, .executingTool: return true
+    default: return false
+    }
+  }
+
+  private func statusDisplayText(_ status: SessionStatus) -> String {
+    switch status {
+    case .thinking: return "Working"
+    case .executingTool(let name): return name
+    case .waitingForUser: return "Ready"
+    case .awaitingApproval(let tool): return "Approval: \(tool)"
+    case .idle: return "Idle"
+    }
   }
 
   var body: some View {
@@ -102,16 +132,25 @@ struct CollapsibleSessionRow: View {
             .foregroundColor(.brandPrimary(for: providerKind))
         }
 
-        // Dot + timestamp
+        // Dot + timestamp + status
         HStack(spacing: 5) {
           Circle()
-            .fill(Color.brandPrimary(for: providerKind))
+            .fill(statusColor)
             .frame(width: 6, height: 6)
+            .opacity(isActiveStatus ? 1.0 : 0.6)
 
           Text(timestamp.timeAgoDisplay())
             .font(.system(size: 11))
             .foregroundColor(.secondary)
+
+          if let sessionStatus, sessionStatus != .idle {
+            Text("· \(statusDisplayText(sessionStatus))")
+              .font(.system(size: 11))
+              .foregroundColor(statusColor)
+              .lineLimit(1)
+          }
         }
+        .animation(.easeInOut(duration: 0.3), value: sessionStatus)
 
         // First message preview
         if let message = session.firstMessage, !message.isEmpty {
@@ -255,6 +294,7 @@ struct CollapsibleSessionRow: View {
         isPending: false,
         isPrimary: true,
         customName: nil,
+        sessionStatus: .thinking,
         colorScheme: .dark,
         onArchive: {},
         onSelect: {}
@@ -271,6 +311,7 @@ struct CollapsibleSessionRow: View {
         isPending: false,
         isPrimary: false,
         customName: nil,
+        sessionStatus: .idle,
         colorScheme: .dark,
         onArchive: {},
         onSelect: {}
@@ -290,6 +331,7 @@ struct CollapsibleSessionRow: View {
         isPending: false,
         isPrimary: true,
         customName: nil,
+        sessionStatus: .executingTool(name: "Bash"),
         colorScheme: .dark,
         onArchive: {},
         onSelect: {}
@@ -306,6 +348,7 @@ struct CollapsibleSessionRow: View {
         isPending: false,
         isPrimary: false,
         customName: nil,
+        sessionStatus: .waitingForUser,
         colorScheme: .dark,
         onArchive: {},
         onSelect: {}
@@ -325,6 +368,7 @@ struct CollapsibleSessionRow: View {
         isPending: true,
         isPrimary: true,
         customName: nil,
+        sessionStatus: nil,
         colorScheme: .dark,
         onArchive: nil,
         onSelect: {}
@@ -341,6 +385,7 @@ struct CollapsibleSessionRow: View {
         isPending: true,
         isPrimary: false,
         customName: nil,
+        sessionStatus: nil,
         colorScheme: .dark,
         onArchive: nil,
         onSelect: {}
@@ -360,6 +405,7 @@ struct CollapsibleSessionRow: View {
         isPending: false,
         isPrimary: true,
         customName: "Auth Refactor",
+        sessionStatus: .awaitingApproval(tool: "Edit"),
         colorScheme: .dark,
         onArchive: {},
         onSelect: {}
@@ -379,6 +425,7 @@ struct CollapsibleSessionRow: View {
         isPending: false,
         isPrimary: true,
         customName: nil,
+        sessionStatus: .thinking,
         colorScheme: .light,
         onArchive: {},
         onSelect: {}
@@ -396,6 +443,7 @@ struct CollapsibleSessionRow: View {
         isPending: false,
         isPrimary: false,
         customName: nil,
+        sessionStatus: .idle,
         colorScheme: .light,
         onArchive: {},
         onSelect: {}

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
@@ -378,6 +378,7 @@ public struct MultiProviderSessionsListView: View {
     let providerKind: SessionProviderKind
     let timestamp: Date
     let isPending: Bool
+    let sessionStatus: SessionStatus?
   }
 
   private var selectedSessionItems: [SelectedSessionItem] {
@@ -389,7 +390,8 @@ public struct MultiProviderSessionsListView: View {
         session: pending.placeholderSession,
         providerKind: .claude,
         timestamp: pending.startedAt,
-        isPending: true
+        isPending: true,
+        sessionStatus: nil
       ))
     }
 
@@ -399,7 +401,8 @@ public struct MultiProviderSessionsListView: View {
         session: pending.placeholderSession,
         providerKind: .codex,
         timestamp: pending.startedAt,
-        isPending: true
+        isPending: true,
+        sessionStatus: nil
       ))
     }
 
@@ -408,8 +411,9 @@ public struct MultiProviderSessionsListView: View {
         id: "claude-\(item.session.id)",
         session: item.session,
         providerKind: .claude,
-        timestamp: item.state?.lastActivityAt ?? item.session.lastActivityAt,
-        isPending: false
+        timestamp: item.session.lastActivityAt,
+        isPending: false,
+        sessionStatus: item.state?.status
       ))
     }
 
@@ -418,8 +422,9 @@ public struct MultiProviderSessionsListView: View {
         id: "codex-\(item.session.id)",
         session: item.session,
         providerKind: .codex,
-        timestamp: item.state?.lastActivityAt ?? item.session.lastActivityAt,
-        isPending: false
+        timestamp: item.session.lastActivityAt,
+        isPending: false,
+        sessionStatus: item.state?.status
       ))
     }
 
@@ -456,6 +461,7 @@ public struct MultiProviderSessionsListView: View {
             isPending: item.isPending,
             isPrimary: item.id == primarySessionId,
             customName: selectedSessionCustomName(for: item),
+            sessionStatus: item.sessionStatus,
             colorScheme: colorScheme,
             onArchive: item.isPending ? nil : {
               withAnimation(.easeInOut(duration: 0.25)) {


### PR DESCRIPTION
## Summary
- **Stabilize Projects list sort order** — use the session's static `lastActivityAt` timestamp instead of the live-updating monitor state timestamp, preventing the list from constantly reordering on every state change
- **Add status indicator to session rows** — colored dot + label shows session state at a glance (Working, tool name, Ready, Approval: tool) with smooth color transitions
- Wire `SessionStatus?` through `SelectedSessionItem` in all three panel views (`MultiProviderSessionsListView`, `CollapsibleSelectedSessionsPanel`, `SingleProviderCollapsibleSelectedSessionsPanel`)

## Test plan
- [ ] Build succeeds with no compilation errors
- [ ] Launch 2-3 sessions across Claude/Codex providers
- [ ] Verify Projects list no longer reorders when monitored sessions update state
- [ ] Active sessions show colored dots (blue for thinking, orange for tool execution) + status text
- [ ] Idle sessions show gray dot at reduced opacity
- [ ] Sessions awaiting approval show yellow dot + "Approval: ToolName"
- [ ] Dot color transitions animate smoothly on status changes
- [ ] Previews render correctly with varied status states

