### PR TITLE
Select monitor row from active terminal focus

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringCardView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringCardView.swift
@@ -70,6 +70,7 @@ public struct MonitoringCardView: View {
   let onShowPlan: ((CLISession, PlanState) -> Void)?
   let onShowWebPreview: ((CLISession, String) -> Void)?
   let onPromptConsumed: (() -> Void)?
+  let onTerminalInteraction: (() -> Void)?
   let isMaximized: Bool
   let onToggleMaximize: () -> Void
   let isPrimarySession: Bool
@@ -110,6 +111,7 @@ public struct MonitoringCardView: View {
     onShowPlan: ((CLISession, PlanState) -> Void)? = nil,
     onShowWebPreview: ((CLISession, String) -> Void)? = nil,
     onPromptConsumed: (() -> Void)? = nil,
+    onTerminalInteraction: (() -> Void)? = nil,
     isMaximized: Bool = false,
     onToggleMaximize: @escaping () -> Void = {},
     isPrimarySession: Bool = false,
@@ -139,6 +141,7 @@ public struct MonitoringCardView: View {
     self.onShowPlan = onShowPlan
     self.onShowWebPreview = onShowWebPreview
     self.onPromptConsumed = onPromptConsumed
+    self.onTerminalInteraction = onTerminalInteraction
     self.isMaximized = isMaximized
     self.onToggleMaximize = onToggleMaximize
     self.isPrimarySession = isPrimarySession
@@ -684,7 +687,8 @@ public struct MonitoringCardView: View {
           initialPrompt: initialPrompt,
           initialInputText: initialInputText,
           viewModel: viewModel,
-          dangerouslySkipPermissions: dangerouslySkipPermissions
+          dangerouslySkipPermissions: dangerouslySkipPermissions,
+          onUserInteraction: onTerminalInteraction
         )
         .frame(minHeight: 300)
       } else {

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringPanelView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringPanelView.swift
@@ -331,6 +331,7 @@ public struct MonitoringPanelView: View {
         onCopySessionId: { },
         onOpenSessionFile: { },
         onRefreshTerminal: { },
+        onTerminalInteraction: { setPrimarySessionIfNeeded(sessionId) },
         isMaximized: true,
         onToggleMaximize: {
           withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) {
@@ -388,6 +389,7 @@ public struct MonitoringPanelView: View {
         onPromptConsumed: {
           viewModel.clearPendingPrompt(for: item.session.id)
         },
+        onTerminalInteraction: { setPrimarySessionIfNeeded(item.session.id) },
         isMaximized: true,
         onToggleMaximize: {
           withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) {
@@ -453,6 +455,7 @@ public struct MonitoringPanelView: View {
           onCopySessionId: { },
           onOpenSessionFile: { },
           onRefreshTerminal: { },
+          onTerminalInteraction: { setPrimarySessionIfNeeded(pendingId) },
           isMaximized: false,
           onToggleMaximize: { },
           isPrimarySession: true,
@@ -505,6 +508,7 @@ public struct MonitoringPanelView: View {
           onPromptConsumed: {
             viewModel.clearPendingPrompt(for: session.id)
           },
+          onTerminalInteraction: { setPrimarySessionIfNeeded(session.id) },
           isMaximized: false,
           onToggleMaximize: { },
           isPrimarySession: true,
@@ -543,6 +547,7 @@ public struct MonitoringPanelView: View {
         onCopySessionId: { },
         onOpenSessionFile: { },
         onRefreshTerminal: { },
+        onTerminalInteraction: { setPrimarySessionIfNeeded(pendingId) },
         isMaximized: maximizedSessionId == pendingId,
         onToggleMaximize: {
           withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) {
@@ -602,6 +607,7 @@ public struct MonitoringPanelView: View {
         onPromptConsumed: {
           viewModel.clearPendingPrompt(for: item.session.id)
         },
+        onTerminalInteraction: { setPrimarySessionIfNeeded(item.session.id) },
         isMaximized: maximizedSessionId == item.session.id,
         onToggleMaximize: {
           withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) {
@@ -649,6 +655,7 @@ public struct MonitoringPanelView: View {
               onCopySessionId: { },
               onOpenSessionFile: { },
               onRefreshTerminal: { },
+              onTerminalInteraction: { setPrimarySessionIfNeeded(pendingId) },
               isMaximized: maximizedSessionId == pendingId,
               onToggleMaximize: {
                 withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) {
@@ -705,6 +712,7 @@ public struct MonitoringPanelView: View {
               onPromptConsumed: {
                 viewModel.clearPendingPrompt(for: session.id)
               },
+              onTerminalInteraction: { setPrimarySessionIfNeeded(session.id) },
               isMaximized: maximizedSessionId == session.id,
               onToggleMaximize: {
                 withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) {
@@ -750,6 +758,11 @@ public struct MonitoringPanelView: View {
     }
 
     primarySessionId = effectivePrimarySessionId
+  }
+
+  private func setPrimarySessionIfNeeded(_ sessionId: String) {
+    guard primarySessionId != sessionId else { return }
+    primarySessionId = sessionId
   }
 }
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderMonitoringPanelView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderMonitoringPanelView.swift
@@ -446,6 +446,7 @@ public struct MultiProviderMonitoringPanelView: View {
           onCopySessionId: { },
           onOpenSessionFile: { },
           onRefreshTerminal: { },
+          onTerminalInteraction: { setPrimarySessionIfNeeded(item.id) },
           isMaximized: false,
           onToggleMaximize: { },
           isPrimarySession: true,
@@ -508,6 +509,7 @@ public struct MultiProviderMonitoringPanelView: View {
             onPromptConsumed: {
               viewModel.clearPendingPrompt(for: session.id)
             },
+            onTerminalInteraction: { setPrimarySessionIfNeeded(item.id) },
             isMaximized: false,
             onToggleMaximize: { },
             isPrimarySession: true,
@@ -587,6 +589,7 @@ public struct MultiProviderMonitoringPanelView: View {
               onCopySessionId: { },
               onOpenSessionFile: { },
               onRefreshTerminal: { },
+              onTerminalInteraction: { setPrimarySessionIfNeeded(item.id) },
               isMaximized: maximizedSessionId == item.id,
               onToggleMaximize: {
                 withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) {
@@ -640,6 +643,7 @@ public struct MultiProviderMonitoringPanelView: View {
               onPromptConsumed: {
                 viewModel.clearPendingPrompt(for: session.id)
               },
+              onTerminalInteraction: { setPrimarySessionIfNeeded(item.id) },
               isMaximized: maximizedSessionId == item.id,
               onToggleMaximize: {
                 withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) {
@@ -726,6 +730,7 @@ public struct MultiProviderMonitoringPanelView: View {
           onCopySessionId: { },
           onOpenSessionFile: { },
           onRefreshTerminal: { },
+          onTerminalInteraction: { setPrimarySessionIfNeeded(itemId) },
           isMaximized: true,
           onToggleMaximize: {
             withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) {
@@ -781,6 +786,7 @@ public struct MultiProviderMonitoringPanelView: View {
           onPromptConsumed: {
             viewModel.clearPendingPrompt(for: session.id)
           },
+          onTerminalInteraction: { setPrimarySessionIfNeeded(itemId) },
           isMaximized: true,
           onToggleMaximize: {
             withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) {
@@ -875,6 +881,11 @@ public struct MultiProviderMonitoringPanelView: View {
     }
 
     primarySessionId = effectivePrimarySessionId
+  }
+
+  private func setPrimarySessionIfNeeded(_ sessionId: String) {
+    guard primarySessionId != sessionId else { return }
+    primarySessionId = sessionId
   }
 }
 


### PR DESCRIPTION
## Summary
- update terminal integration to emit an interaction callback from embedded terminal views
- propagate terminal interaction through `MonitoringCardView` into single-provider and multi-provider monitoring panels
- set `primarySessionId` on terminal keyboard/click interaction so the matching left-panel monitor row becomes selected/highlighted while focused

## Validation
- `swift build` in `app/modules/AgentHubCore` succeeds
- build completes with pre-existing warnings unrelated to this change
