### PR TITLE
Auto-focus terminal on session selection

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderMonitoringPanelView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderMonitoringPanelView.swift
@@ -294,6 +294,12 @@ public struct MultiProviderMonitoringPanelView: View {
     .onChange(of: effectivePrimarySessionId) { _, _ in
       sidePanelContent = nil
     }
+    .onChange(of: primarySessionId) { _, newId in
+      guard let newId else { return }
+      if let item = filteredItems.first(where: { $0.id == newId }) {
+        item.viewModel.focusTerminal(forKey: item.sessionId)
+      }
+    }
     .onChange(of: canShowSidePanel) { _, canShow in
       if !canShow {
         withAnimation(.easeInOut(duration: 0.25)) {

--- a/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/CLISessionsViewModel.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/CLISessionsViewModel.swift
@@ -313,6 +313,18 @@ public final class CLISessionsViewModel {
     terminal.typeText(text)
   }
 
+  /// Focuses the terminal for a given key so it receives keyboard input.
+  /// Uses a short delay to let SwiftUI layout settle before requesting AppKit first responder.
+  public func focusTerminal(forKey key: String) {
+    Task { @MainActor in
+      try? await Task.sleep(for: .milliseconds(100))
+      guard let terminal = activeTerminals[key],
+            let terminalView = terminal.terminalView,
+            let window = terminalView.window else { return }
+      window.makeFirstResponder(terminalView)
+    }
+  }
+
   /// Sessions being started in Hub's embedded terminal (no session ID yet)
   public var pendingHubSessions: [PendingHubSession] = []
 


### PR DESCRIPTION
## Summary
- Adds `focusTerminal(forKey:)` to `CLISessionsViewModel` that requests AppKit first responder on the terminal view with a 100ms delay for SwiftUI layout settling
- Hooks into `.onChange(of: primarySessionId)` on the outer `VStack` in `MultiProviderMonitoringPanelView` to trigger focus on every session switch — covers single mode, list, and grid layouts

## Test plan
- [ ] Select a session from the sidebar — terminal should auto-focus, cursor active
- [ ] Switch sessions via command palette (Cmd+K) — terminal should auto-focus
- [ ] Switch sessions via keyboard shortcuts (Cmd+[/]) — terminal should auto-focus
- [ ] Verify clicking the terminal still works as before
- [ ] Verify rapid session switching doesn't cause issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)