### PR TITLE
security: restrict temp script permissions to owner-only (0o700)

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/TerminalLauncher.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/TerminalLauncher.swift
@@ -219,7 +219,7 @@ public struct TerminalLauncher {
       try scriptContent.write(toFile: scriptPath, atomically: true, encoding: .utf8)
 
       // Make it executable
-      let attributes = [FileAttributeKey.posixPermissions: 0o755]
+      let attributes = [FileAttributeKey.posixPermissions: 0o700]
       try FileManager.default.setAttributes(attributes, ofItemAtPath: scriptPath)
 
       // Open the script with Terminal
@@ -313,7 +313,7 @@ public struct TerminalLauncher {
 
     do {
       try scriptContent.write(toFile: scriptPath, atomically: true, encoding: .utf8)
-      let attributes = [FileAttributeKey.posixPermissions: 0o755]
+      let attributes = [FileAttributeKey.posixPermissions: 0o700]
       try FileManager.default.setAttributes(attributes, ofItemAtPath: scriptPath)
 
       let url = URL(fileURLWithPath: scriptPath)
@@ -403,7 +403,7 @@ public struct TerminalLauncher {
 
     do {
       try scriptContent.write(toFile: scriptPath, atomically: true, encoding: .utf8)
-      let attributes = [FileAttributeKey.posixPermissions: 0o755]
+      let attributes = [FileAttributeKey.posixPermissions: 0o700]
       try FileManager.default.setAttributes(attributes, ofItemAtPath: scriptPath)
 
       let url = URL(fileURLWithPath: scriptPath)


### PR DESCRIPTION
## Summary

- Change `.command` script file permissions from `0o755` to `0o700` at all 3 creation points in TerminalLauncher
- Scripts may contain session IDs and prompts — should not be world-readable

Addresses issue #133 finding #5.

## Test plan

- [ ] Launch session via external Terminal — script executes normally (owner still has rwx)