### PR TITLE
security: gate WebKit developerExtrasEnabled behind DEBUG

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/WebPreviewWebView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/WebPreviewWebView.swift
@@ -27,7 +27,9 @@ struct WebPreviewWebView: NSViewRepresentable {
 
   func makeNSView(context: Context) -> WKWebView {
     let configuration = WKWebViewConfiguration()
+    #if DEBUG
     configuration.preferences.setValue(true, forKey: "developerExtrasEnabled")
+    #endif
 
     let webView = WKWebView(frame: .zero, configuration: configuration)
     webView.navigationDelegate = context.coordinator


### PR DESCRIPTION
## Summary

- Wrap `developerExtrasEnabled` in `#if DEBUG` so WebKit Inspector is only available in debug builds

Addresses issue #133 finding #2.

## Test plan

- [ ] Debug build: right-click in WebPreview → "Inspect Element" still available
- [ ] Release build: inspector option not available