### PR TITLE
Add Toggle Focus Mode shortcut (Cmd+\)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,7 +115,7 @@ In Single layout, a side panel can show: `GitDiffView` (split-pane diff), `PlanV
 
 ### Keyboard Shortcuts
 
-Cmd+K (palette), Cmd+N (new session), Cmd+B (sidebar), Cmd+[/] (navigate sessions), Escape (dismiss).
+Cmd+K (palette), Cmd+N (new session), Cmd+B (sidebar), Cmd+[/] (navigate sessions), Cmd+\ (toggle focus mode), Escape (dismiss).
 
 ## Dependencies
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubDefaults.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubDefaults.swift
@@ -98,6 +98,10 @@ public enum AgentHubDefaults {
   /// Type: Int (default: 0 = single)
   public static let hubLayoutMode = "\(keyPrefix)hub.layoutMode"
 
+  /// Previous hub layout mode saved by Toggle Focus Mode (Cmd+\)
+  /// Type: Int (default: -1 = no saved layout)
+  public static let hubPreviousLayoutMode = "\(keyPrefix)hub.previousLayoutMode"
+
   /// Whether the selected sessions panel is expanded
   /// Type: Bool (default: true)
   public static let selectedSessionsPanelExpanded = "\(keyPrefix)ui.selectedSessionsPanelExpanded"

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/CommandPaletteView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/CommandPaletteView.swift
@@ -15,6 +15,7 @@ public enum CommandPaletteAction: Identifiable {
   case selectRepository(path: String, name: String)
   case openSettings
   case toggleSidebar
+  case toggleFocusMode
 
   public var id: String {
     switch self {
@@ -23,6 +24,7 @@ public enum CommandPaletteAction: Identifiable {
     case .selectRepository(let path, _): return "repo-\(path)"
     case .openSettings: return "settings"
     case .toggleSidebar: return "toggle-sidebar"
+    case .toggleFocusMode: return "toggle-focus-mode"
     }
   }
 
@@ -33,6 +35,7 @@ public enum CommandPaletteAction: Identifiable {
     case .selectRepository(_, let name): return name
     case .openSettings: return "Open Settings"
     case .toggleSidebar: return "Toggle Sidebar"
+    case .toggleFocusMode: return "Toggle Focus Mode"
     }
   }
 
@@ -50,6 +53,7 @@ public enum CommandPaletteAction: Identifiable {
     case .selectRepository(let path, _): return path
     case .openSettings: return "Open application settings"
     case .toggleSidebar: return "Show or hide the sidebar"
+    case .toggleFocusMode: return "Expand focused session or restore previous layout"
     }
   }
 
@@ -60,6 +64,7 @@ public enum CommandPaletteAction: Identifiable {
     case .selectRepository: return "folder"
     case .openSettings: return "gear"
     case .toggleSidebar: return "sidebar.left"
+    case .toggleFocusMode: return "arrow.up.left.and.arrow.down.right"
     }
   }
 
@@ -68,6 +73,7 @@ public enum CommandPaletteAction: Identifiable {
     case .newSession: return "⌘N"
     case .toggleSidebar: return "⌘B"
     case .openSettings: return "⌘,"
+    case .toggleFocusMode: return "⌘\\"
     default: return nil
     }
   }
@@ -94,6 +100,7 @@ public struct CommandPaletteView: View {
   private var quickActions: [CommandPaletteAction] {
     [
       .newSession,
+      .toggleFocusMode,
       .openSettings,
       .toggleSidebar,
     ]

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringPanelView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringPanelView.swift
@@ -104,6 +104,8 @@ public struct MonitoringPanelView: View {
   @Binding var primarySessionId: String?
   @AppStorage(AgentHubDefaults.hubLayoutMode)
   private var layoutModeRawValue: Int = LayoutMode.single.rawValue
+  @AppStorage(AgentHubDefaults.hubPreviousLayoutMode)
+  private var previousLayoutModeRawValue: Int = -1
   @Environment(\.colorScheme) private var colorScheme
   @Environment(\.runtimeTheme) private var runtimeTheme
 
@@ -262,7 +264,10 @@ public struct MonitoringPanelView: View {
       // Layout toggle (single / list / grid)
       HStack(spacing: 4) {
         ForEach(LayoutMode.allCases, id: \.rawValue) { mode in
-          Button(action: { withAnimation(.easeInOut(duration: 0.2)) { layoutModeRawValue = mode.rawValue } }) {
+          Button(action: {
+            previousLayoutModeRawValue = -1
+            withAnimation(.easeInOut(duration: 0.2)) { layoutModeRawValue = mode.rawValue }
+          }) {
             Image(systemName: mode.icon)
               .font(.caption)
               .frame(width: 28, height: 22)

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderMonitoringPanelView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderMonitoringPanelView.swift
@@ -221,6 +221,8 @@ public struct MultiProviderMonitoringPanelView: View {
   @Binding var primarySessionId: String?
   @AppStorage(AgentHubDefaults.hubLayoutMode)
   private var layoutModeRawValue: Int = LayoutMode.single.rawValue
+  @AppStorage(AgentHubDefaults.hubPreviousLayoutMode)
+  private var previousLayoutModeRawValue: Int = -1
   @Environment(\.colorScheme) private var colorScheme
   @Environment(\.runtimeTheme) private var runtimeTheme
 
@@ -339,7 +341,10 @@ public struct MultiProviderMonitoringPanelView: View {
       // Layout mode toggle (single / list / grid)
       HStack(spacing: 6) {
         ForEach(LayoutMode.allCases, id: \.self) { mode in
-          Button(action: { layoutModeRawValue = mode.rawValue }) {
+          Button(action: {
+            previousLayoutModeRawValue = -1
+            layoutModeRawValue = mode.rawValue
+          }) {
             Image(systemName: mode.icon)
               .font(.caption)
               .foregroundColor(layoutMode == mode ? .primary : .secondary)

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
@@ -42,6 +42,12 @@ public struct MultiProviderSessionsListView: View {
   @Environment(\.runtimeTheme) private var runtimeTheme
   @Environment(\.openSettings) private var openSettings
 
+  @AppStorage(AgentHubDefaults.hubLayoutMode)
+  private var layoutModeRawValue: Int = 0
+
+  @AppStorage(AgentHubDefaults.hubPreviousLayoutMode)
+  private var previousLayoutModeRawValue: Int = -1
+
   @AppStorage(AgentHubDefaults.selectedSidePanelProvider)
   private var selectedProviderRaw: String = "Claude"
 
@@ -219,6 +225,10 @@ public struct MultiProviderSessionsListView: View {
 
       Button("") { navigateSessionHistory(direction: .forward) }
         .keyboardShortcut("]", modifiers: .command)
+        .hidden()
+
+      Button("") { toggleFocusMode() }
+        .keyboardShortcut("\\", modifiers: .command)
         .hidden()
     }
   }
@@ -974,6 +984,9 @@ public struct MultiProviderSessionsListView: View {
 
     case .toggleSidebar:
       columnVisibility = columnVisibility == .all ? .detailOnly : .all
+
+    case .toggleFocusMode:
+      toggleFocusMode()
     }
   }
 
@@ -996,6 +1009,22 @@ public struct MultiProviderSessionsListView: View {
       let didPreselect = await multiLaunchViewModel.preselectRepository(path: preferredRepositoryPath)
       if !didPreselect {
         multiLaunchViewModel.selectRepository()
+      }
+    }
+  }
+
+  private func toggleFocusMode() {
+    let singleRaw = 0
+    if layoutModeRawValue != singleRaw {
+      previousLayoutModeRawValue = layoutModeRawValue
+      withAnimation(.easeInOut(duration: 0.2)) {
+        layoutModeRawValue = singleRaw
+      }
+    } else if previousLayoutModeRawValue >= 0 {
+      let restoreTo = previousLayoutModeRawValue
+      previousLayoutModeRawValue = -1
+      withAnimation(.easeInOut(duration: 0.2)) {
+        layoutModeRawValue = restoreTo
       }
     }
   }


### PR DESCRIPTION
## Summary
- Adds **Cmd+\** keyboard shortcut to toggle between single (focus) mode and the previous hub layout
- Saves the current layout before entering single mode; restores it on second press
- Manual layout button clicks clear saved state to prevent stale restores
- Adds "Toggle Focus Mode" to the command palette for discoverability

## Test plan
- [ ] Start in 2-column layout, press Cmd+\ — verify it switches to single mode
- [ ] Press Cmd+\ again — verify it restores 2-column layout
- [ ] Manually click single mode in header, press Cmd+\ — verify no-op (no saved layout)
- [ ] Cmd+\ to single, then manually click list, then Cmd+\ — verify it saves list and goes to single
- [ ] Open command palette (Cmd+K) — verify "Toggle Focus Mode" appears with ⌘\ shortcut hint

🤖 Generated with [Claude Code](https://claude.com/claude-code)