### PR TITLE
Replace SwiftTerm fork with official v1.11.0 release

### DIFF
--- a/app/AgentHub.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/app/AgentHub.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -283,10 +283,10 @@
     {
       "identity" : "swiftterm",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/jamesrochabrun/SwiftTerm",
+      "location" : "https://github.com/migueldeicaza/SwiftTerm",
       "state" : {
-        "branch" : "fix/package-manifest-trailing-commas",
-        "revision" : "3a8d38e9cfe8f6000ebb8db13d2eb17beceb091e"
+        "revision" : "36642aa383e14834604bb5f2bafbbde47142bd0c",
+        "version" : "1.11.0"
       }
     },
     {

--- a/app/modules/AgentHubCore/Package.resolved
+++ b/app/modules/AgentHubCore/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "3c7a1493c521895ac51e28cb73aab3bb308e0d9972a008d74ce463ddfdbb6a6c",
+  "originHash" : "1753f6839d31b7554a1884805af2c782b46c47ec5d44db08076a6f3b62c21c2c",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -274,10 +274,10 @@
     {
       "identity" : "swiftterm",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/jamesrochabrun/SwiftTerm",
+      "location" : "https://github.com/migueldeicaza/SwiftTerm",
       "state" : {
-        "branch" : "fix/package-manifest-trailing-commas",
-        "revision" : "3a8d38e9cfe8f6000ebb8db13d2eb17beceb091e"
+        "revision" : "36642aa383e14834604bb5f2bafbbde47142bd0c",
+        "version" : "1.11.0"
       }
     },
     {

--- a/app/modules/AgentHubCore/Package.swift
+++ b/app/modules/AgentHubCore/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
   dependencies: [
     .package(url: "https://github.com/jamesrochabrun/ClaudeCodeSDK", exact: "1.2.4"),
     .package(url: "https://github.com/jamesrochabrun/PierreDiffsSwift", exact: "1.1.4"),
-    .package(url: "https://github.com/jamesrochabrun/SwiftTerm", branch: "fix/package-manifest-trailing-commas"),
+    .package(url: "https://github.com/migueldeicaza/SwiftTerm", exact: "1.11.0"),
     .package(url: "https://github.com/gonzalezreal/swift-markdown-ui", from: "2.0.0"),
     .package(url: "https://github.com/groue/GRDB.swift", from: "6.24.0"),
     .package(url: "https://github.com/appstefan/HighlightSwift", from: "1.1.0"),


### PR DESCRIPTION
## Summary
- Replace `jamesrochabrun/SwiftTerm` fork (branch `fix/package-manifest-trailing-commas`) with the official upstream `migueldeicaza/SwiftTerm` pinned at exact version `1.11.0`
- Updates both `Package.swift` and `Package.resolved` files

## Test plan
- [ ] Build the project in Xcode and verify it compiles cleanly
- [ ] Verify embedded terminal functionality still works (monitor mode ↔ terminal mode)