### PR TITLE
Add user-configurable terminal font size

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubDefaults.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubDefaults.swift
@@ -90,6 +90,10 @@ public enum AgentHubDefaults {
 
   // MARK: - UI Settings
 
+  /// Terminal font size in points
+  /// Type: Double (default: 12.0)
+  public static let terminalFontSize = "\(keyPrefix)terminal.fontSize"
+
   /// Monitoring panel layout mode (list, 2-column, 3-column grid)
   /// Type: Int (default: 0 = list)
   public static let monitoringPanelLayoutMode = "\(keyPrefix)ui.monitoringPanelLayoutMode"

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/EmbeddedTerminalView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/EmbeddedTerminalView.swift
@@ -43,6 +43,7 @@ class SafeLocalProcessTerminalView: ManagedLocalProcessTerminalView {
 /// Provides an embedded terminal for interacting with Claude sessions
 public struct EmbeddedTerminalView: NSViewRepresentable {
   @Environment(\.colorScheme) private var colorScheme
+  @AppStorage(AgentHubDefaults.terminalFontSize) private var terminalFontSize: Double = 12
 
   let terminalKey: String  // Key for terminal storage (session ID or "pending-{pendingId}")
   let sessionId: String?  // Optional: nil for new sessions, set for resume
@@ -114,6 +115,7 @@ public struct EmbeddedTerminalView: NSViewRepresentable {
     // Update colors when color scheme changes
     nsView.updateColors(isDark: colorScheme == .dark)
     nsView.onUserInteraction = onUserInteraction
+    nsView.updateFont(size: CGFloat(terminalFontSize))
 
     // If there's a pending prompt in the viewModel, send it (and clear it)
     // Use terminalKey (not sessionId) since it works for both pending and real sessions
@@ -266,6 +268,15 @@ public class TerminalContainerView: NSView, ManagedLocalProcessTerminalViewDeleg
     guard !hasPrefilledInitialInputText else { return }
     hasPrefilledInitialInputText = true
     typeText(text)
+  }
+
+  /// Updates terminal font size.
+  public func updateFont(size: CGFloat) {
+    guard let terminal = terminalView else { return }
+    let font = NSFont(name: "SF Mono", size: size)
+      ?? NSFont(name: "Menlo", size: size)
+      ?? NSFont.monospacedSystemFont(ofSize: size, weight: .regular)
+    terminal.font = font
   }
 
   /// Updates terminal colors based on color scheme.

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
@@ -49,6 +49,9 @@ public struct MultiProviderSessionsListView: View {
   @Environment(\.runtimeTheme) private var runtimeTheme
   @Environment(\.openSettings) private var openSettings
 
+  @AppStorage(AgentHubDefaults.terminalFontSize)
+  private var terminalFontSize: Double = 12
+
   @AppStorage(AgentHubDefaults.hubLayoutMode)
   private var layoutModeRawValue: Int = 0
 
@@ -266,6 +269,14 @@ public struct MultiProviderSessionsListView: View {
 
       Button("") { toggleFocusMode() }
         .keyboardShortcut("\\", modifiers: .command)
+        .hidden()
+
+      Button("") { terminalFontSize = min(terminalFontSize + 1, 24) }
+        .keyboardShortcut("+", modifiers: .command)
+        .hidden()
+
+      Button("") { terminalFontSize = max(terminalFontSize - 1, 8) }
+        .keyboardShortcut("-", modifiers: .command)
         .hidden()
     }
   }

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/SettingsView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/SettingsView.swift
@@ -11,6 +11,9 @@ public struct SettingsView: View {
   @AppStorage(AgentHubDefaults.smartModeEnabled)
   private var smartModeEnabled: Bool = false
 
+  @AppStorage(AgentHubDefaults.terminalFontSize)
+  private var terminalFontSize: Double = 12
+
   @AppStorage(AgentHubDefaults.notificationSoundsEnabled)
   private var notificationSoundsEnabled: Bool = true
 
@@ -119,6 +122,18 @@ public struct SettingsView: View {
             Text("Use AI to plan and orchestrate multi-session launches")
               .font(.caption)
               .foregroundColor(.secondary)
+          }
+        }
+      }
+
+      Section("Terminal") {
+        Stepper(value: $terminalFontSize, in: 8...24, step: 1) {
+          HStack {
+            Text("Font size")
+            Spacer()
+            Text("\(Int(terminalFontSize)) pt")
+              .foregroundColor(.secondary)
+              .monospacedDigit()
           }
         }
       }


### PR DESCRIPTION
## Summary
- Adds `terminalFontSize` UserDefaults key (8–24pt, default 12pt) to `AgentHubDefaults`
- `EmbeddedTerminalView` reads the value via `@AppStorage` and calls `updateFont(size:)` in `updateNSView`, so all running terminals update immediately on change
- Settings → Terminal section: stepper to adjust font size
- Cmd++ / Cmd+- keyboard shortcuts for live adjustment from anywhere in the app

## Test plan
- [ ] Open Settings → confirm "Terminal" section shows stepper with current font size
- [ ] Change stepper value and switch to a terminal tab — font updates immediately
- [ ] Press Cmd++ and Cmd+- — terminal font grows/shrinks live
- [ ] Quit and relaunch — font size persists
- [ ] Verify bounds clamp: stepper and shortcuts stay within 8–24pt