### PR TITLE
Add Remix feature

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/GitWorktreeService.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/GitWorktreeService.swift
@@ -568,6 +568,23 @@ public actor GitWorktreeService {
     return output
   }
 
+  // MARK: - Stash Helpers
+
+  /// Captures uncommitted working tree state without modifying it.
+  /// Returns the stash object SHA, or nil if there is nothing to stash.
+  public func captureStash(at repoPath: String) async throws -> String? {
+    let gitRoot = try await findGitRoot(at: repoPath)
+    let output = try await runGitCommand(["stash", "create"], at: gitRoot)
+    let sha = output.trimmingCharacters(in: .whitespacesAndNewlines)
+    return sha.isEmpty ? nil : sha
+  }
+
+  /// Applies a stash object (by SHA) in the given directory.
+  public func applyStash(_ ref: String, at path: String) async throws {
+    let gitRoot = try await findGitRoot(at: path)
+    try await runGitCommand(["stash", "apply", ref], at: gitRoot, timeout: 60)
+  }
+
   // MARK: - Git Status Helpers
 
   /// Returns the current branch name at the given path

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringCardView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringCardView.swift
@@ -499,6 +499,12 @@ public struct MonitoringCardView: View {
         showingNameSheet = true
       }
 
+      // Remix action
+      PopoverButton(icon: "arrowshape.zigzag.forward", title: "Remix") {
+        showingActionsPopover = false
+        viewModel?.remixSession(session)
+      }
+
       // Media actions (only in terminal mode)
       if showTerminal {
         Divider()

--- a/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/CLISessionsViewModel.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/CLISessionsViewModel.swift
@@ -1172,6 +1172,63 @@ public final class CLISessionsViewModel {
   ///   - worktree: The worktree to open
   ///   - skipCheckout: If true, skips git checkout even for non-worktrees
   /// - Returns: An error if launching failed, nil on success
+  /// Creates a git worktree from the session's HEAD, optionally carries uncommitted changes,
+  /// then opens a new hub session pre-filled with a reference to the original.
+  public func remixSession(_ session: CLISession) {
+    Task { @MainActor in
+      let worktreeService = GitWorktreeService()
+      let projectName = session.projectName
+      let branchSuffix = session.branchName.map { GitWorktreeService.sanitizeBranchName($0) } ?? "no-branch"
+      let timestamp = Int(Date().timeIntervalSince1970)
+      let branchName = "remix-\(branchSuffix)-\(session.shortId)-\(timestamp)"
+      let dirName = "\(projectName)-\(branchName)"
+
+      do {
+        // 1. Capture uncommitted state as a stash object (non-destructive)
+        let stashRef = try await worktreeService.captureStash(at: session.projectPath)
+
+        // 2. Create worktree at HEAD
+        let worktreePath = try await worktreeService.createWorktreeWithNewBranch(
+          at: session.projectPath,
+          newBranchName: branchName,
+          directoryName: dirName
+        )
+
+        // 3. Apply uncommitted changes into the new worktree (if any existed)
+        if let stashRef {
+          try await worktreeService.applyStash(stashRef, at: worktreePath)
+        }
+
+        let worktree = WorktreeBranch(
+          name: branchName,
+          path: worktreePath,
+          isWorktree: true,
+          sessions: [],
+          isExpanded: true
+        )
+
+        // Build a transcript reference to orient the new session.
+        // sessionFilePath is the canonical, provider-agnostic path already stored on the model:
+        //   - Claude sessions: ~/.claude/projects/{encoded-path}/{sessionId}.jsonl
+        //   - Codex sessions:  ~/.codex/sessions/{date-path}/{sessionId}.jsonl
+        // The fallback only fires for Claude sessions where sessionFilePath was not populated
+        // at scan time; it must never be reached for Codex (sessionFilePath is always set there).
+        var reference = "If you need specific details from the previous session, read the full transcript at:"
+        if let filePath = session.sessionFilePath {
+          reference += " \(filePath)"
+        } else {
+          // Claude-specific fallback: reconstruct the path from the encoded project path.
+          let encodedPath = session.projectPath.claudeProjectPathEncoded
+          reference += " ~/.claude/projects/\(encodedPath)/\(session.id).jsonl"
+        }
+
+        startNewSessionInHub(worktree, initialPrompt: reference)
+      } catch {
+        AppLogger.session.error("[Remix] Failed: \(error)")
+      }
+    }
+  }
+
   /// Starts a new Claude session in the Hub's embedded terminal (not external terminal)
   /// - Parameters:
   ///   - worktree: The worktree to start the session in


### PR DESCRIPTION
## Summary

- Adds a **Remix** action to the `+` popover on every `MonitoringCardView` (Claude + Codex)
- Tapping Remix creates a git worktree at HEAD via `GitWorktreeService`, carries over any uncommitted changes using `git stash create` / `git stash apply` (non-destructive), then opens a new hub session pre-populated with a reference to the original session transcript
- Branch naming: `remix-{branch}-{shortId}-{timestamp}` — unique per operation, encodes branch, session, and time

## New additions (no regressions)

- `GitWorktreeService`: `captureStash(at:)` and `applyStash(_:at:)` helpers
- `MonitoringCardView`: Remix `PopoverButton` with `arrowshape.zigzag.forward` icon
- `CLISessionsViewModel`: `remixSession(_:)` method

## Test plan

- [ ] Open any Claude session card, tap `+`, confirm **Remix** appears
- [ ] Tap Remix → new card appears in pending state
- [ ] Confirm new worktree directory `{projectName}-remix-{branch}-{shortId}-{timestamp}` created as sibling to repo
- [ ] Confirm `git worktree list` shows the new worktree
- [ ] Confirm new session terminal auto-sends the transcript reference message
- [ ] Remix the same session twice → no collision, two distinct worktrees created
- [ ] Repeat with a Codex session → transcript path points to `~/.codex/sessions/...`