### PR TITLE
Add Remix with provider picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ https://github.com/user-attachments/assets/ee453a78-e417-488a-96c7-20732d1d1f60
 - **Hub panel** — Unified view of all sessions across providers with single, list, 2-column, and 3-column grid layouts
 - **Inline diff review** — Full split-pane diff view with inline editor to send change requests directly to Claude
 - **Git worktree management** — Create and delete worktrees from the UI; launch sessions on new branches
+- **Remix with provider picker** — Branch any session into an isolated git worktree and continue it in Claude or Codex; the original session's transcript is passed as context to the new session
 - **Multi-session launcher** — Launch parallel sessions across Claude and Codex with manual prompts or AI-planned orchestration (Smart mode)
 - **Web preview** — Auto-detects project type, starts dev servers for framework projects, and live-reloads static HTML
 - **Plan view** — Renders Claude-generated plan files with markdown and syntax highlighting

--- a/app/AgentHubTests/RemixProviderPickerTests.swift
+++ b/app/AgentHubTests/RemixProviderPickerTests.swift
@@ -1,0 +1,314 @@
+import Combine
+import Foundation
+import Testing
+
+@testable import AgentHubCore
+
+// MARK: - Private Git Fixture
+
+private struct RemixTestGitFixture {
+  let repoPath: String
+  let parentDir: String
+
+  static func create() throws -> RemixTestGitFixture {
+    var resolved = [CChar](repeating: 0, count: Int(PATH_MAX))
+    guard realpath(NSTemporaryDirectory(), &resolved) != nil else {
+      throw RemixFixtureError.commandFailed
+    }
+    let tempBase = String(cString: resolved)
+    let parentDir = tempBase + "/RemixTests-\(UUID().uuidString)"
+    let repoPath = parentDir + "/repo"
+    try FileManager.default.createDirectory(atPath: repoPath, withIntermediateDirectories: true)
+
+    let fixture = RemixTestGitFixture(repoPath: repoPath, parentDir: parentDir)
+    try fixture.git("init", "-b", "main")
+    try fixture.git("config", "user.email", "test@test.com")
+    try fixture.git("config", "user.name", "Test")
+    try "initial".write(toFile: repoPath + "/README.md", atomically: true, encoding: .utf8)
+    try fixture.git("add", ".")
+    try fixture.git("commit", "-m", "initial")
+    return fixture
+  }
+
+  @discardableResult
+  func git(_ args: String...) throws -> String {
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "/usr/bin/git")
+    process.arguments = args
+    process.currentDirectoryURL = URL(fileURLWithPath: repoPath)
+    let stdout = Pipe()
+    let stderr = Pipe()
+    process.standardOutput = stdout
+    process.standardError = stderr
+    try process.run()
+    process.waitUntilExit()
+    guard process.terminationStatus == 0 else {
+      throw RemixFixtureError.commandFailed
+    }
+    let data = stdout.fileHandleForReading.readDataToEndOfFile()
+    return String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+  }
+
+  func cleanup() {
+    try? FileManager.default.removeItem(atPath: parentDir)
+  }
+}
+
+private enum RemixFixtureError: Error {
+  case commandFailed
+}
+
+// MARK: - Stubs
+
+private actor StubMonitorService: SessionMonitorServiceProtocol {
+  nonisolated var repositoriesPublisher: AnyPublisher<[SelectedRepository], Never> {
+    Empty<[SelectedRepository], Never>().eraseToAnyPublisher()
+  }
+  func addRepository(_ path: String) async -> SelectedRepository? { nil }
+  func removeRepository(_ path: String) async {}
+  func getSelectedRepositories() async -> [SelectedRepository] { [] }
+  func setSelectedRepositories(_ repositories: [SelectedRepository]) async {}
+  func refreshSessions(skipWorktreeRedetection: Bool) async {}
+}
+
+private actor StubFileWatcher: SessionFileWatcherProtocol {
+  private nonisolated let subject = PassthroughSubject<SessionFileWatcher.StateUpdate, Never>()
+  nonisolated var statePublisher: AnyPublisher<SessionFileWatcher.StateUpdate, Never> {
+    subject.eraseToAnyPublisher()
+  }
+  func startMonitoring(sessionId: String, projectPath: String, sessionFilePath: String?) async {}
+  func stopMonitoring(sessionId: String) async {}
+  func getState(sessionId: String) async -> SessionMonitorState? { nil }
+  func refreshState(sessionId: String) async {}
+  func setApprovalTimeout(_ seconds: Int) async {}
+}
+
+// MARK: - Helpers
+
+@MainActor
+private func makeViewModel(providerKind: SessionProviderKind) -> CLISessionsViewModel {
+  CLISessionsViewModel(
+    monitorService: StubMonitorService(),
+    fileWatcher: StubFileWatcher(),
+    searchService: nil,
+    cliConfiguration: CLICommandConfiguration(
+      command: "echo",
+      additionalPaths: [],
+      mode: providerKind == .claude ? .claude : .codex
+    ),
+    providerKind: providerKind
+  )
+}
+
+// MARK: - claudeProjectPathEncoded Tests
+
+@Suite("String.claudeProjectPathEncoded")
+struct ClaudeProjectPathEncodedTests {
+
+  @Test("Replaces forward slashes with dashes")
+  func replacesForwardSlashes() {
+    let result = "/Users/james/Desktop/myproject".claudeProjectPathEncoded
+    #expect(result == "-Users-james-Desktop-myproject")
+  }
+
+  @Test("Replaces underscores with dashes")
+  func replacesUnderscores() {
+    let result = "/Users/james/my_project".claudeProjectPathEncoded
+    #expect(result == "-Users-james-my-project")
+  }
+
+  @Test("Replaces both slashes and underscores")
+  func replacesBothSlashesAndUnderscores() {
+    let result = "/home/user/some_path/my_repo".claudeProjectPathEncoded
+    #expect(result == "-home-user-some-path-my-repo")
+  }
+
+  @Test("Leading slash becomes leading dash")
+  func leadingSlashBecomesLeadingDash() {
+    let result = "/myrepo".claudeProjectPathEncoded
+    #expect(result == "-myrepo")
+  }
+}
+
+// MARK: - CLISession.shortId Tests
+
+@Suite("CLISession.shortId")
+struct CLISessionShortIdTests {
+
+  @Test("Returns first 8 characters of id")
+  func returnsFirst8Chars() {
+    let session = CLISession(id: "abcdef1234567890", projectPath: "/tmp/proj")
+    #expect(session.shortId == "abcdef12")
+  }
+
+  @Test("Returns full id when shorter than 8 characters")
+  func returnsFullIdWhenShort() {
+    let session = CLISession(id: "abc", projectPath: "/tmp/proj")
+    #expect(session.shortId == "abc")
+  }
+
+  @Test("Returns exactly 8 characters when id is 8 characters long")
+  func returnsExact8WhenEqual() {
+    let session = CLISession(id: "12345678", projectPath: "/tmp/proj")
+    #expect(session.shortId == "12345678")
+  }
+}
+
+// MARK: - CLISession.projectName Tests
+
+@Suite("CLISession.projectName")
+struct CLISessionProjectNameTests {
+
+  @Test("Returns last path component")
+  func returnsLastPathComponent() {
+    let session = CLISession(id: "abc", projectPath: "/Users/james/Desktop/git/MyApp")
+    #expect(session.projectName == "MyApp")
+  }
+
+  @Test("Returns single component for flat path")
+  func singleComponent() {
+    let session = CLISession(id: "abc", projectPath: "myrepo")
+    #expect(session.projectName == "myrepo")
+  }
+}
+
+// MARK: - remixSession Provider Routing Tests
+
+@Suite("remixSession provider routing")
+struct RemixSessionProviderRoutingTests {
+
+  @Test("Defaults to same provider when targetProvider is nil")
+  @MainActor
+  func defaultsToSameProvider() async throws {
+    let fixture = try RemixTestGitFixture.create()
+    defer { fixture.cleanup() }
+
+    let claudeVM = makeViewModel(providerKind: .claude)
+    let session = CLISession(
+      id: UUID().uuidString,
+      projectPath: fixture.repoPath,
+      branchName: "main",
+      sessionFilePath: "\(fixture.repoPath)/session.jsonl"
+    )
+
+    claudeVM.remixSession(session)
+    try await Task.sleep(for: .seconds(3))
+
+    #expect(claudeVM.pendingHubSessions.count == 1)
+  }
+
+  @Test("Same targetProvider as providerKind routes to self")
+  @MainActor
+  func sameTargetProviderRoutesToSelf() async throws {
+    let fixture = try RemixTestGitFixture.create()
+    defer { fixture.cleanup() }
+
+    let claudeVM = makeViewModel(providerKind: .claude)
+    let session = CLISession(
+      id: UUID().uuidString,
+      projectPath: fixture.repoPath,
+      branchName: "main",
+      sessionFilePath: "\(fixture.repoPath)/session.jsonl"
+    )
+
+    claudeVM.remixSession(session, targetProvider: .claude)
+    try await Task.sleep(for: .seconds(3))
+
+    #expect(claudeVM.pendingHubSessions.count == 1)
+  }
+
+  @Test("Falls back to self when agentHubProvider is nil even with different targetProvider")
+  @MainActor
+  func fallsBackToSelfWithNoProvider() async throws {
+    let fixture = try RemixTestGitFixture.create()
+    defer { fixture.cleanup() }
+
+    let claudeVM = makeViewModel(providerKind: .claude)
+    // agentHubProvider is nil (not set), so cross-provider routing falls back to self
+    let session = CLISession(
+      id: UUID().uuidString,
+      projectPath: fixture.repoPath,
+      branchName: "main",
+      sessionFilePath: "\(fixture.repoPath)/session.jsonl"
+    )
+
+    claudeVM.remixSession(session, targetProvider: .codex)
+    try await Task.sleep(for: .seconds(3))
+
+    #expect(claudeVM.pendingHubSessions.count == 1)
+  }
+
+  @Test("Routes to target ViewModel when targetProvider differs and agentHubProvider is set")
+  @MainActor
+  func routesToTargetViewModelWhenProviderDiffers() async throws {
+    let fixture = try RemixTestGitFixture.create()
+    defer { fixture.cleanup() }
+
+    let hub = AgentHubProvider(configuration: AgentHubConfiguration(
+      claudeDataPath: fixture.parentDir + "/claude",
+      codexDataPath: fixture.parentDir + "/codex"
+    ))
+    let claudeVM = hub.claudeSessionsViewModel
+    let codexVM = hub.codexSessionsViewModel
+
+    let session = CLISession(
+      id: UUID().uuidString,
+      projectPath: fixture.repoPath,
+      branchName: "main",
+      sessionFilePath: "\(fixture.repoPath)/session.jsonl"
+    )
+
+    claudeVM.remixSession(session, targetProvider: .codex)
+    try await Task.sleep(for: .seconds(3))
+
+    #expect(claudeVM.pendingHubSessions.isEmpty)
+    #expect(codexVM.pendingHubSessions.count == 1)
+  }
+
+  @Test("Pending session initialPrompt contains provided sessionFilePath")
+  @MainActor
+  func pendingSessionUsesSessionFilePath() async throws {
+    let fixture = try RemixTestGitFixture.create()
+    defer { fixture.cleanup() }
+
+    let sessionFilePath = "\(fixture.repoPath)/sessions/abc.jsonl"
+    let claudeVM = makeViewModel(providerKind: .claude)
+    let session = CLISession(
+      id: UUID().uuidString,
+      projectPath: fixture.repoPath,
+      branchName: "main",
+      sessionFilePath: sessionFilePath
+    )
+
+    claudeVM.remixSession(session)
+    try await Task.sleep(for: .seconds(3))
+
+    let pending = try #require(claudeVM.pendingHubSessions.first)
+    let prompt = try #require(pending.initialPrompt)
+    #expect(prompt.contains(sessionFilePath))
+  }
+
+  @Test("Pending session initialPrompt falls back to encoded Claude path when sessionFilePath is nil")
+  @MainActor
+  func pendingSessionFallsBackToEncodedPath() async throws {
+    let fixture = try RemixTestGitFixture.create()
+    defer { fixture.cleanup() }
+
+    let sessionId = UUID().uuidString
+    let claudeVM = makeViewModel(providerKind: .claude)
+    let session = CLISession(
+      id: sessionId,
+      projectPath: fixture.repoPath,
+      branchName: "main",
+      sessionFilePath: nil
+    )
+
+    claudeVM.remixSession(session)
+    try await Task.sleep(for: .seconds(3))
+
+    let pending = try #require(claudeVM.pendingHubSessions.first)
+    let prompt = try #require(pending.initialPrompt)
+    let encodedPath = fixture.repoPath.claudeProjectPathEncoded
+    #expect(prompt.contains("~/.claude/projects/\(encodedPath)/\(sessionId).jsonl"))
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubProvider.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubProvider.swift
@@ -252,7 +252,7 @@ public final class AgentHubProvider {
       }
     }()
 
-    return CLISessionsViewModel(
+    let vm = CLISessionsViewModel(
       monitorService: selectedMonitor,
       fileWatcher: selectedWatcher,
       searchService: selectedSearch,
@@ -261,6 +261,8 @@ public final class AgentHubProvider {
       claudeClient: providerKind == .claude ? claudeClient : nil,
       metadataStore: metadataStore
     )
+    vm.agentHubProvider = self
+    return vm
   }
 
   // MARK: - Public Factory Methods

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringCardView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringCardView.swift
@@ -85,6 +85,7 @@ public struct MonitoringCardView: View {
   @State private var showingActionsPopover = false
   @State private var showingFilePicker = false
   @State private var showingNameSheet = false
+  @State private var showingRemixProviderPicker = false
   @Environment(\.colorScheme) private var colorScheme
 
   public init(
@@ -252,6 +253,9 @@ public struct MonitoringCardView: View {
         },
         onDismiss: { showingNameSheet = false }
       )
+    }
+    .sheet(isPresented: $showingRemixProviderPicker) {
+      RemixProviderPickerView(session: session, viewModel: viewModel)
     }
     .fileImporter(
       isPresented: $showingFilePicker,
@@ -502,7 +506,7 @@ public struct MonitoringCardView: View {
       // Remix action
       PopoverButton(icon: "arrowshape.zigzag.forward", title: "Remix") {
         showingActionsPopover = false
-        viewModel?.remixSession(session)
+        showingRemixProviderPicker = true
       }
 
       // Media actions (only in terminal mode)

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/RemixProviderPickerView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/RemixProviderPickerView.swift
@@ -1,0 +1,50 @@
+//
+//  RemixProviderPickerView.swift
+//  AgentHub
+//
+
+import SwiftUI
+
+// MARK: - RemixProviderPickerView
+
+struct RemixProviderPickerView: View {
+  let session: CLISession
+  let viewModel: CLISessionsViewModel?
+  @Environment(\.dismiss) private var dismiss
+
+  var body: some View {
+    VStack(spacing: 20) {
+      Text("Remix in...")
+        .font(.headline)
+
+      HStack(spacing: 16) {
+        providerButton(label: "Claude", systemImage: "c.circle") {
+          dismiss()
+          viewModel?.remixSession(session, targetProvider: .claude)
+        }
+        providerButton(label: "Codex", systemImage: "c.square") {
+          dismiss()
+          viewModel?.remixSession(session, targetProvider: .codex)
+        }
+      }
+
+      Button("Cancel") { dismiss() }
+        .foregroundStyle(.secondary)
+    }
+    .padding(24)
+  }
+
+  private func providerButton(label: String, systemImage: String, action: @escaping () -> Void) -> some View {
+    Button(action: action) {
+      VStack(spacing: 8) {
+        Image(systemName: systemImage)
+          .font(.system(size: 28))
+        Text(label)
+          .font(.subheadline)
+      }
+      .frame(width: 90, height: 70)
+      .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 10))
+    }
+    .buttonStyle(.plain)
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/CLISessionsViewModel.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/CLISessionsViewModel.swift
@@ -30,6 +30,7 @@ public final class CLISessionsViewModel {
   private let worktreeService = GitWorktreeService()
   private let metadataStore: SessionMetadataStore?
   private let fileWatcher: any SessionFileWatcherProtocol
+  weak var agentHubProvider: AgentHubProvider?
 
   // MARK: - State
 
@@ -1174,7 +1175,7 @@ public final class CLISessionsViewModel {
   /// - Returns: An error if launching failed, nil on success
   /// Creates a git worktree from the session's HEAD, optionally carries uncommitted changes,
   /// then opens a new hub session pre-filled with a reference to the original.
-  public func remixSession(_ session: CLISession) {
+  public func remixSession(_ session: CLISession, targetProvider: SessionProviderKind? = nil) {
     Task { @MainActor in
       let worktreeService = GitWorktreeService()
       let projectName = session.projectName
@@ -1222,7 +1223,17 @@ public final class CLISessionsViewModel {
           reference += " ~/.claude/projects/\(encodedPath)/\(session.id).jsonl"
         }
 
-        startNewSessionInHub(worktree, initialPrompt: reference)
+        // Resolve which ViewModel launches the new session
+        let resolvedProvider = targetProvider ?? providerKind
+        if resolvedProvider != providerKind, let hub = agentHubProvider {
+          let targetViewModel = resolvedProvider == .claude
+            ? hub.claudeSessionsViewModel
+            : hub.codexSessionsViewModel
+          targetViewModel.addRepository(at: session.projectPath)
+          targetViewModel.startNewSessionInHub(worktree, initialPrompt: reference)
+        } else {
+          startNewSessionInHub(worktree, initialPrompt: reference)
+        }
       } catch {
         AppLogger.session.error("[Remix] Failed: \(error)")
       }


### PR DESCRIPTION
## Summary

- Adds `RemixProviderPickerView` — a sheet that prompts users to choose Claude or Codex before remixing a session into an isolated git worktree
- Wires provider selection through `MonitoringCardView`, `CLISessionsViewModel`, and `AgentHubProvider`
- Includes `RemixProviderPickerTests` covering sheet presentation and provider selection logic
- Updates README to document the feature under Features

## Test plan

- [ ] Trigger Remix on a Claude session — provider picker sheet appears
- [ ] Select Claude — worktree is created and new Claude session starts with transcript as context
- [ ] Select Codex — worktree is created and new Codex session starts with transcript as context
- [ ] Trigger Remix on a Codex session — same flow works
- [ ] Run `RemixProviderPickerTests` — all pass