### PR TITLE
Document Cmd++ and Cmd+- font size shortcuts in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ Updates are delivered automatically via [Sparkle](https://sparkle-project.org/) 
 | **Cmd+[** | Navigate to previous session |
 | **Cmd+]** | Navigate to next session |
 | **Cmd+\\** | Toggle focus mode (single ↔ previous layout) |
+| **Cmd++** | Increase terminal font size |
+| **Cmd+-** | Decrease terminal font size |
 | **Escape** | Dismiss maximized card / side panel / sheet |
 
 ### Diff View


### PR DESCRIPTION
## Summary
- Added `Cmd++` (increase font size) and `Cmd+-` (decrease font size) to the keyboard shortcuts table in the README

## Test plan
- [ ] Verify shortcuts appear correctly in the README keyboard shortcuts section