### PR TITLE
Add local push notifications for tool approval

### DIFF
--- a/app/AgentHub/AgentHubApp.swift
+++ b/app/AgentHub/AgentHubApp.swift
@@ -7,12 +7,13 @@
 
 import SwiftUI
 import AgentHubCore
+import UserNotifications
 
 // MARK: - App Delegate
 
 /// Handles app lifecycle events for process cleanup
 @MainActor
-class AppDelegate: NSObject, NSApplicationDelegate {
+class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDelegate {
   /// Shared provider instance - created here so it's available for lifecycle events
   let provider = AgentHubProvider()
 
@@ -20,6 +21,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
   let updateController = UpdateController()
 
   func applicationDidFinishLaunching(_ notification: Notification) {
+    UNUserNotificationCenter.current().delegate = self
     // Note: We intentionally do NOT clean up orphaned processes here
     // because we can't distinguish between processes spawned by AgentHub
     // vs processes the user started directly in Terminal.app
@@ -30,6 +32,27 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     provider.terminateAllTerminals()
     // Stop all dev servers spawned for web preview
     DevServerManager.shared.stopAllServers()
+  }
+
+  // MARK: - UNUserNotificationCenterDelegate
+
+  nonisolated func userNotificationCenter(
+    _ center: UNUserNotificationCenter,
+    didReceive response: UNNotificationResponse,
+    withCompletionHandler completionHandler: @escaping () -> Void
+  ) {
+    Task { @MainActor in
+      NSApp.activate(ignoringOtherApps: true)
+    }
+    completionHandler()
+  }
+
+  nonisolated func userNotificationCenter(
+    _ center: UNUserNotificationCenter,
+    willPresent notification: UNNotification,
+    withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
+  ) {
+    completionHandler([.banner, .sound])
   }
 }
 

--- a/app/AgentHub/Info.plist
+++ b/app/AgentHub/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+  <key>NSUserNotificationsUsageDescription</key>
+  <string>AgentHub sends notifications when a Claude or Codex session requires tool approval.</string>
   <key>SUFeedURL</key>
   <string>https://raw.githubusercontent.com/jamesrochabrun/AgentHub/main/appcast.xml</string>
   <key>SUPublicEDKey</key>

--- a/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubDefaults.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubDefaults.swift
@@ -40,6 +40,10 @@ public enum AgentHubDefaults {
   /// Type: Bool (default: true)
   public static let notificationSoundsEnabled = "\(keyPrefix)notifications.soundsEnabled"
 
+  /// Whether push notifications are enabled for tool approvals
+  /// Type: Bool (default: true)
+  public static let pushNotificationsEnabled = "\(keyPrefix)notifications.pushEnabled"
+
   /// Persisted selected repositories (JSON-encoded array of paths)
   /// Type: Data (JSON-encoded [String])
   /// Note: Used with provider suffix (e.g., `.claude` or `.codex`) for provider-specific storage

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/ApprovalNotificationService.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/ApprovalNotificationService.swift
@@ -9,10 +9,11 @@ import Foundation
 #if canImport(AppKit)
 import AppKit
 #endif
+import UserNotifications
 
 // MARK: - ApprovalNotificationService
 
-/// Service for playing alert sounds when tools need approval
+/// Service for playing alert sounds and sending push notifications when tools need approval
 public final class ApprovalNotificationService {
 
   // MARK: - Singleton
@@ -23,17 +24,21 @@ public final class ApprovalNotificationService {
 
   private init() {}
 
-  // MARK: - Permission (no longer needed, but keep for API compatibility)
+  // MARK: - Permission
 
   @discardableResult
   public func requestPermission() async -> Bool {
-    // No permission needed for playing sounds
-    return true
+    do {
+      let granted = try await UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound])
+      return granted
+    } catch {
+      return false
+    }
   }
 
-  // MARK: - Play Alert Sound
+  // MARK: - Send Approval Notification
 
-  /// Play an alert sound when a tool needs approval
+  /// Send an approval notification (sound and/or push) when a tool needs approval
   /// - Parameters:
   ///   - sessionId: The session ID
   ///   - toolName: The name of the tool awaiting approval
@@ -48,12 +53,21 @@ public final class ApprovalNotificationService {
     lastMessage: String? = nil
   ) {
     playAlertSound()
+    if pushNotificationsEnabled {
+      Task(priority: .userInitiated) {
+        await sendPushNotification(toolName: toolName, projectPath: projectPath, sessionId: sessionId)
+      }
+    }
   }
 
   // MARK: - Private
 
   private var soundsEnabled: Bool {
     UserDefaults.standard.object(forKey: AgentHubDefaults.notificationSoundsEnabled) as? Bool ?? true
+  }
+
+  private var pushNotificationsEnabled: Bool {
+    UserDefaults.standard.object(forKey: AgentHubDefaults.pushNotificationsEnabled) as? Bool ?? true
   }
 
   private func playAlertSound() {
@@ -63,5 +77,29 @@ public final class ApprovalNotificationService {
     // Play system alert sound
     NSSound.beep()
     #endif
+  }
+
+  private func sendPushNotification(toolName: String, projectPath: String?, sessionId: String) async {
+    let content = UNMutableNotificationContent()
+    content.title = "Approval Required"
+    content.body = "\(toolName) needs your approval"
+    if let projectPath {
+      content.subtitle = URL(fileURLWithPath: projectPath).lastPathComponent
+    }
+    content.sound = .none
+    content.userInfo = ["sessionId": sessionId]
+
+    let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 0.1, repeats: false)
+    let request = UNNotificationRequest(
+      identifier: "approval-\(sessionId)",
+      content: content,
+      trigger: trigger
+    )
+
+    do {
+      try await UNUserNotificationCenter.current().add(request)
+    } catch {
+      // Silently fail — notification is a best-effort enhancement
+    }
   }
 }

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/SettingsView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/SettingsView.swift
@@ -17,6 +17,9 @@ public struct SettingsView: View {
   @AppStorage(AgentHubDefaults.notificationSoundsEnabled)
   private var notificationSoundsEnabled: Bool = true
 
+  @AppStorage(AgentHubDefaults.pushNotificationsEnabled)
+  private var pushNotificationsEnabled: Bool = true
+
   @AppStorage(AgentHubDefaults.claudeCommand)
   private var claudeCommand: String = "claude"
 
@@ -107,6 +110,14 @@ public struct SettingsView: View {
           VStack(alignment: .leading, spacing: 2) {
             Text("Notification sounds")
             Text("Play a sound when tools require approval")
+              .font(.caption)
+              .foregroundColor(.secondary)
+          }
+        }
+        Toggle(isOn: $pushNotificationsEnabled) {
+          VStack(alignment: .leading, spacing: 2) {
+            Text("Push notifications")
+            Text("Show a notification banner when tools require approval")
               .font(.caption)
               .foregroundColor(.secondary)
           }


### PR DESCRIPTION
## Summary

- Replaces the no-op `requestPermission()` with a real `UNUserNotificationCenter.requestAuthorization` call so macOS permission is requested on first launch
- Sends a `UNNotificationRequest` when a session transitions to `.awaitingApproval`, deduplicated by session ID so repeated approvals don't stack
- `AppDelegate` now conforms to `UNUserNotificationCenterDelegate`: tapping the banner brings AgentHub to the foreground, and banners show even when the app is frontmost
- Adds a **Push notifications** toggle in Settings (independent of the existing sound toggle)
- Adds `NSUserNotificationsUsageDescription` to `Info.plist`
- Uses `Task(priority: .userInitiated)` + `UNTimeIntervalNotificationTrigger(timeInterval: 0.1)` to minimize banner delivery latency

## Test plan

- [ ] On first launch after update, macOS prompts for notification permission
- [ ] Trigger a tool approval — notification banner appears shortly after the alert sound
- [ ] Clicking the banner brings AgentHub to the foreground
- [ ] With app frontmost, banner still appears (willPresent delegate)
- [ ] Rapid repeated approvals for the same session don't stack duplicate banners
- [ ] Disabling "Push notifications" in Settings suppresses banners while sound still plays
- [ ] Disabling "Notification sounds" in Settings suppresses sound while banners still appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)