### PR TITLE
Add --worktree flag UI to local session launch

### DIFF
--- a/app/AgentHubTests/WorktreeCreationTests.swift
+++ b/app/AgentHubTests/WorktreeCreationTests.swift
@@ -1,0 +1,330 @@
+import Combine
+import Foundation
+import Testing
+@testable import AgentHubCore
+
+// MARK: - Minimal mocks for CLISessionsViewModel dependencies
+
+private final class MockMonitorService: SessionMonitorServiceProtocol, @unchecked Sendable {
+  private let subject = PassthroughSubject<[SelectedRepository], Never>()
+  var repositoriesPublisher: AnyPublisher<[SelectedRepository], Never> { subject.eraseToAnyPublisher() }
+  func addRepository(_ path: String) async -> SelectedRepository? { nil }
+  func removeRepository(_ path: String) async {}
+  func getSelectedRepositories() async -> [SelectedRepository] { [] }
+  func setSelectedRepositories(_ repositories: [SelectedRepository]) async {}
+  func refreshSessions(skipWorktreeRedetection: Bool) async {}
+}
+
+private final class MockFileWatcher: SessionFileWatcherProtocol, @unchecked Sendable {
+  private let subject = PassthroughSubject<SessionFileWatcher.StateUpdate, Never>()
+  var statePublisher: AnyPublisher<SessionFileWatcher.StateUpdate, Never> { subject.eraseToAnyPublisher() }
+  func startMonitoring(sessionId: String, projectPath: String, sessionFilePath: String?) async {}
+  func stopMonitoring(sessionId: String) async {}
+  func getState(sessionId: String) async -> SessionMonitorState? { nil }
+  func refreshState(sessionId: String) async {}
+  func setApprovalTimeout(_ seconds: Int) async {}
+}
+
+@MainActor
+private func makeViewModel() -> MultiSessionLaunchViewModel {
+  let claudeVM = CLISessionsViewModel(
+    monitorService: MockMonitorService(),
+    fileWatcher: MockFileWatcher(),
+    searchService: nil,
+    cliConfiguration: .claudeDefault,
+    providerKind: .claude
+  )
+  let codexVM = CLISessionsViewModel(
+    monitorService: MockMonitorService(),
+    fileWatcher: MockFileWatcher(),
+    searchService: nil,
+    cliConfiguration: .codexDefault,
+    providerKind: .codex
+  )
+  return MultiSessionLaunchViewModel(claudeViewModel: claudeVM, codexViewModel: codexVM)
+}
+
+// MARK: - CLICommandConfiguration --worktree flag tests
+
+@Suite("CLICommandConfiguration.argumentsForSession — worktree flag")
+struct CLICommandConfigurationWorktreeTests {
+
+  private let config = CLICommandConfiguration.claudeDefault
+
+  @Test("No --worktree flag when worktreeName is nil")
+  func noWorktreeFlagWhenNil() {
+    let args = config.argumentsForSession(sessionId: nil, prompt: nil, worktreeName: nil)
+    #expect(!args.contains("--worktree"))
+  }
+
+  @Test("Emits bare --worktree when name is empty")
+  func bareWorktreeFlagForEmptyName() {
+    let args = config.argumentsForSession(sessionId: nil, prompt: nil, worktreeName: "")
+    #expect(args.contains("--worktree"))
+    // No branch-name value should follow
+    if let idx = args.firstIndex(of: "--worktree") {
+      let next = args.index(after: idx)
+      if next < args.endIndex {
+        #expect(args[next].hasPrefix("-"), "Expected no branch-name argument after bare --worktree")
+      }
+    }
+  }
+
+  @Test("Bare --worktree appears before prompt")
+  func bareWorktreeFlagBeforePrompt() {
+    let args = config.argumentsForSession(sessionId: nil, prompt: "do something", worktreeName: "")
+    #expect(args.contains("--worktree"))
+    #expect(args.last == "do something")
+  }
+
+  @Test("Emits --worktree <name> for non-empty name")
+  func namedWorktreeFlag() {
+    let args = config.argumentsForSession(sessionId: nil, prompt: nil, worktreeName: "my-branch")
+    guard let idx = args.firstIndex(of: "--worktree") else {
+      Issue.record("Expected --worktree flag")
+      return
+    }
+    let nameIdx = args.index(after: idx)
+    #expect(nameIdx < args.endIndex)
+    #expect(args[nameIdx] == "my-branch")
+  }
+
+  @Test("--worktree <name> appears before prompt")
+  func namedWorktreeFlagBeforePrompt() {
+    let args = config.argumentsForSession(sessionId: nil, prompt: "run tests", worktreeName: "feat-login")
+    guard let idx = args.firstIndex(of: "--worktree") else {
+      Issue.record("Expected --worktree flag")
+      return
+    }
+    #expect(args[idx + 1] == "feat-login")
+    #expect(args.last == "run tests")
+  }
+
+  @Test("--worktree not appended when resuming a real session")
+  func noWorktreeFlagOnResume() {
+    let args = config.argumentsForSession(
+      sessionId: "abc-123",
+      prompt: nil,
+      worktreeName: "feat-login"
+    )
+    #expect(!args.contains("--worktree"))
+    #expect(args.contains("-r"))
+    #expect(args.contains("abc-123"))
+  }
+
+  @Test("--worktree not appended when resuming with prompt")
+  func noWorktreeFlagOnResumeWithPrompt() {
+    let args = config.argumentsForSession(
+      sessionId: "real-session-id",
+      prompt: "continue",
+      worktreeName: "some-branch"
+    )
+    #expect(!args.contains("--worktree"))
+  }
+
+  @Test("--worktree appended for pending- session IDs (treated as new)")
+  func worktreeFlagForPendingSession() {
+    let args = config.argumentsForSession(
+      sessionId: "pending-42",
+      prompt: nil,
+      worktreeName: "feat-x"
+    )
+    #expect(args.contains("--worktree"))
+  }
+
+  @Test("--worktree appended when sessionId is empty string")
+  func worktreeFlagForEmptySessionId() {
+    let args = config.argumentsForSession(
+      sessionId: "",
+      prompt: nil,
+      worktreeName: "feat-x"
+    )
+    #expect(args.contains("--worktree"))
+  }
+
+  @Test("Both --dangerously-skip-permissions and --worktree emitted for new session")
+  func dangerouslyAndWorktreeTogether() {
+    let args = config.argumentsForSession(
+      sessionId: nil,
+      prompt: nil,
+      dangerouslySkipPermissions: true,
+      worktreeName: "safe-branch"
+    )
+    #expect(args.contains("--dangerously-skip-permissions"))
+    #expect(args.contains("--worktree"))
+    if let idx = args.firstIndex(of: "--worktree") {
+      #expect(args[idx + 1] == "safe-branch")
+    }
+  }
+
+  @Test("Codex mode never emits --worktree")
+  func codexIgnoresWorktreeName() {
+    let codex = CLICommandConfiguration.codexDefault
+    let args = codex.argumentsForSession(sessionId: nil, prompt: nil, worktreeName: "some-branch")
+    #expect(!args.contains("--worktree"))
+  }
+}
+
+// MARK: - MultiSessionLaunchViewModel claudeWorktreeOption tests
+
+@Suite("MultiSessionLaunchViewModel — claudeWorktreeOption")
+struct MultiSessionLaunchViewModelWorktreeOptionTests {
+
+  @Test("Returns nil when Claude is disabled")
+  @MainActor
+  func nilWhenClaudeDisabled() {
+    let vm = makeViewModel()
+    vm.claudeMode = .disabled
+    vm.claudeUseWorktree = true
+    vm.claudeWorktreeName = "branch"
+    #expect(vm.claudeWorktreeOption == nil)
+  }
+
+  @Test("Returns nil when claudeUseWorktree is false")
+  @MainActor
+  func nilWhenFlagOff() {
+    let vm = makeViewModel()
+    vm.claudeMode = .enabled
+    vm.claudeUseWorktree = false
+    vm.claudeWorktreeName = "branch"
+    #expect(vm.claudeWorktreeOption == nil)
+  }
+
+  @Test("Returns empty string for auto-generated name")
+  @MainActor
+  func emptyStringForAutoName() {
+    let vm = makeViewModel()
+    vm.claudeMode = .enabled
+    vm.claudeUseWorktree = true
+    vm.claudeWorktreeName = ""
+    #expect(vm.claudeWorktreeOption == "")
+  }
+
+  @Test("Returns branch name when set")
+  @MainActor
+  func returnsBranchName() {
+    let vm = makeViewModel()
+    vm.claudeMode = .enabled
+    vm.claudeUseWorktree = true
+    vm.claudeWorktreeName = "feat-new-ui"
+    #expect(vm.claudeWorktreeOption == "feat-new-ui")
+  }
+
+  @Test("Returns non-nil for enabledDangerously mode")
+  @MainActor
+  func worksWithDangerousMode() {
+    let vm = makeViewModel()
+    vm.claudeMode = .enabledDangerously
+    vm.claudeUseWorktree = true
+    vm.claudeWorktreeName = "hotfix"
+    #expect(vm.claudeWorktreeOption == "hotfix")
+  }
+}
+
+// MARK: - MultiSessionLaunchViewModel reset() tests
+
+@Suite("MultiSessionLaunchViewModel — reset clears worktree state")
+struct MultiSessionLaunchViewModelResetTests {
+
+  @Test("reset() sets claudeUseWorktree to false")
+  @MainActor
+  func resetClearsUseWorktree() {
+    let vm = makeViewModel()
+    vm.claudeMode = .enabled
+    vm.claudeUseWorktree = true
+    vm.reset()
+    #expect(vm.claudeUseWorktree == false)
+  }
+
+  @Test("reset() clears claudeWorktreeName")
+  @MainActor
+  func resetClearsWorktreeName() {
+    let vm = makeViewModel()
+    vm.claudeUseWorktree = true
+    vm.claudeWorktreeName = "some-branch"
+    vm.reset()
+    #expect(vm.claudeWorktreeName == "")
+  }
+
+  @Test("reset() leaves claudeWorktreeOption as nil")
+  @MainActor
+  func resetLeavesOptionNil() {
+    let vm = makeViewModel()
+    vm.claudeMode = .enabled
+    vm.claudeUseWorktree = true
+    vm.claudeWorktreeName = "branch"
+    vm.reset()
+    #expect(vm.claudeWorktreeOption == nil)
+  }
+}
+
+// MARK: - worktreeRow visibility condition (logic mirroring the View)
+
+@Suite("worktreeRow visibility condition")
+struct WorktreeRowVisibilityTests {
+
+  /// Mirrors the condition in MultiSessionLaunchView:
+  ///   selectedRepository != nil && isClaudeSelected && !isCodexSelected && workMode == .local
+  @MainActor
+  private func isWorktreeRowVisible(_ vm: MultiSessionLaunchViewModel) -> Bool {
+    vm.selectedRepository != nil
+      && vm.isClaudeSelected
+      && !vm.isCodexSelected
+      && vm.workMode == .local
+  }
+
+  @Test("Hidden when no repository selected")
+  @MainActor
+  func hiddenWithoutRepo() {
+    let vm = makeViewModel()
+    vm.claudeMode = .enabled
+    vm.isCodexSelected = false
+    vm.workMode = .local
+    vm.selectedRepository = nil
+    #expect(isWorktreeRowVisible(vm) == false)
+  }
+
+  @Test("Hidden when Claude is not selected")
+  @MainActor
+  func hiddenWhenClaudeDisabled() {
+    let vm = makeViewModel()
+    vm.claudeMode = .disabled
+    vm.isCodexSelected = false
+    vm.workMode = .local
+    vm.selectedRepository = SelectedRepository(path: "/repo", name: "repo")
+    #expect(isWorktreeRowVisible(vm) == false)
+  }
+
+  @Test("Hidden when Codex is also selected")
+  @MainActor
+  func hiddenWhenCodexAlsoSelected() {
+    let vm = makeViewModel()
+    vm.claudeMode = .enabled
+    vm.isCodexSelected = true
+    vm.workMode = .local
+    vm.selectedRepository = SelectedRepository(path: "/repo", name: "repo")
+    #expect(isWorktreeRowVisible(vm) == false)
+  }
+
+  @Test("Hidden when workMode is .worktree")
+  @MainActor
+  func hiddenInWorktreeMode() {
+    let vm = makeViewModel()
+    vm.claudeMode = .enabled
+    vm.isCodexSelected = false
+    vm.workMode = .worktree
+    vm.selectedRepository = SelectedRepository(path: "/repo", name: "repo")
+    #expect(isWorktreeRowVisible(vm) == false)
+  }
+
+  @Test("Visible when repo selected, Claude only, local mode")
+  @MainActor
+  func visibleForValidCondition() {
+    let vm = makeViewModel()
+    vm.claudeMode = .enabled
+    vm.isCodexSelected = false
+    vm.workMode = .local
+    vm.selectedRepository = SelectedRepository(path: "/repo", name: "repo")
+    #expect(isWorktreeRowVisible(vm) == true)
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/Configuration/CLICommandConfiguration.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Configuration/CLICommandConfiguration.swift
@@ -50,7 +50,8 @@ public struct CLICommandConfiguration: Codable, Sendable {
   public func argumentsForSession(
     sessionId: String?,
     prompt: String?,
-    dangerouslySkipPermissions: Bool = false
+    dangerouslySkipPermissions: Bool = false,
+    worktreeName: String? = nil
   ) -> [String] {
     let prefix = subcommandArgs
 
@@ -58,9 +59,20 @@ public struct CLICommandConfiguration: Codable, Sendable {
     case .claude:
       var args: [String] = []
 
-      // Add flag only for NEW sessions (not resume)
-      if dangerouslySkipPermissions && (sessionId == nil || sessionId?.isEmpty == true || sessionId?.hasPrefix("pending-") == true) {
-        args.append("--dangerously-skip-permissions")
+      let isNewSession = sessionId == nil || sessionId?.isEmpty == true || sessionId?.hasPrefix("pending-") == true
+
+      // Add flags only for NEW sessions (not resume)
+      if isNewSession {
+        if dangerouslySkipPermissions {
+          args.append("--dangerously-skip-permissions")
+        }
+        if let name = worktreeName {
+          if name.isEmpty {
+            args.append("--worktree")
+          } else {
+            args += ["--worktree", name]
+          }
+        }
       }
 
       if let sessionId, !sessionId.isEmpty, !sessionId.hasPrefix("pending-") {

--- a/app/modules/AgentHubCore/Sources/AgentHub/Models/PendingHubSession.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Models/PendingHubSession.swift
@@ -16,12 +16,15 @@ public struct PendingHubSession: Identifiable {
   public let initialPrompt: String?
   public let initialInputText: String?
   public let dangerouslySkipPermissions: Bool
+  /// nil = no worktree flag; "" = --worktree (auto-name); non-empty = --worktree <name>
+  public let worktreeName: String?
 
   public init(
     worktree: WorktreeBranch,
     initialPrompt: String? = nil,
     initialInputText: String? = nil,
-    dangerouslySkipPermissions: Bool = false
+    dangerouslySkipPermissions: Bool = false,
+    worktreeName: String? = nil
   ) {
     self.id = UUID()
     self.worktree = worktree
@@ -29,6 +32,7 @@ public struct PendingHubSession: Identifiable {
     self.initialPrompt = initialPrompt
     self.initialInputText = initialInputText
     self.dangerouslySkipPermissions = dangerouslySkipPermissions
+    self.worktreeName = worktreeName
   }
 
   /// Creates a placeholder CLISession for use with MonitoringCardView

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/TerminalLauncher.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/TerminalLauncher.swift
@@ -224,7 +224,8 @@ public struct TerminalLauncher {
     skipCheckout: Bool = false,
     claudeClient: ClaudeCode,
     initialPrompt: String? = nil,
-    dangerouslySkipPermissions: Bool = false
+    dangerouslySkipPermissions: Bool = false,
+    worktreeName: String? = nil
   ) -> Error? {
     let claudeCommand = claudeClient.configuration.command
 
@@ -256,17 +257,33 @@ public struct TerminalLauncher {
     // Build the dangerous flag if needed (hardcoded literal, safe to append)
     let dangerousFlag = dangerouslySkipPermissions ? " --dangerously-skip-permissions" : ""
 
+    // Build the --worktree flag if needed (name is validated via shellEscapeSingleQuoted)
+    let worktreeFlag: String
+    if let name = worktreeName {
+      if name.isEmpty {
+        worktreeFlag = " --worktree"
+      } else if let escapedName = shellEscapeSingleQuoted(name) {
+        worktreeFlag = " --worktree \(escapedName)"
+      } else {
+        worktreeFlag = " --worktree"
+      }
+    } else {
+      worktreeFlag = ""
+    }
+
+    let flags = "\(dangerousFlag)\(worktreeFlag)"
+
     // Build the command - for worktrees or when skipCheckout is true, just cd and run claude
     // Otherwise, checkout the branch first
     let command: String
     if isWorktree || skipCheckout {
       if let prompt = escapedPrompt {
-        command = "cd \(escapedPath) && \(escapedClaudePath)\(dangerousFlag) \(prompt)"
+        command = "cd \(escapedPath) && \(escapedClaudePath)\(flags) \(prompt)"
       } else {
-        command = "cd \(escapedPath) && \(escapedClaudePath)\(dangerousFlag)"
+        command = "cd \(escapedPath) && \(escapedClaudePath)\(flags)"
       }
     } else {
-      command = "cd \(escapedPath) && git checkout \(escapedBranch) && \(escapedClaudePath)\(dangerousFlag)"
+      command = "cd \(escapedPath) && git checkout \(escapedBranch) && \(escapedClaudePath)\(flags)"
     }
 
     return launchTerminalScript(command: command, scriptPrefix: "claude_open")

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/EmbeddedTerminalView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/EmbeddedTerminalView.swift
@@ -53,6 +53,7 @@ public struct EmbeddedTerminalView: NSViewRepresentable {
   let initialInputText: String?  // Optional: text to prefill terminal input without Enter
   let viewModel: CLISessionsViewModel?  // For shared terminal storage
   let dangerouslySkipPermissions: Bool  // One-shot flag for new sessions
+  let worktreeName: String?  // nil = no --worktree; "" = auto-name; non-empty = named
   let onUserInteraction: (() -> Void)?
 
   public init(
@@ -64,6 +65,7 @@ public struct EmbeddedTerminalView: NSViewRepresentable {
     initialInputText: String? = nil,
     viewModel: CLISessionsViewModel? = nil,
     dangerouslySkipPermissions: Bool = false,
+    worktreeName: String? = nil,
     onUserInteraction: (() -> Void)? = nil
   ) {
     self.terminalKey = terminalKey
@@ -74,6 +76,7 @@ public struct EmbeddedTerminalView: NSViewRepresentable {
     self.initialInputText = initialInputText
     self.viewModel = viewModel
     self.dangerouslySkipPermissions = dangerouslySkipPermissions
+    self.worktreeName = worktreeName
     self.onUserInteraction = onUserInteraction
   }
 
@@ -90,7 +93,8 @@ public struct EmbeddedTerminalView: NSViewRepresentable {
         initialPrompt: initialPrompt,
         initialInputText: initialInputText,
         isDark: isDark,
-        dangerouslySkipPermissions: dangerouslySkipPermissions
+        dangerouslySkipPermissions: dangerouslySkipPermissions,
+        worktreeName: worktreeName
       )
       terminalContainer.onUserInteraction = onUserInteraction
       return terminalContainer
@@ -105,7 +109,8 @@ public struct EmbeddedTerminalView: NSViewRepresentable {
       initialPrompt: initialPrompt,
       initialInputText: initialInputText,
       isDark: isDark,
-      dangerouslySkipPermissions: dangerouslySkipPermissions
+      dangerouslySkipPermissions: dangerouslySkipPermissions,
+      worktreeName: worktreeName
     )
     containerView.onUserInteraction = onUserInteraction
     return containerView
@@ -188,7 +193,8 @@ public class TerminalContainerView: NSView, ManagedLocalProcessTerminalViewDeleg
     initialPrompt: String? = nil,
     initialInputText: String? = nil,
     isDark: Bool = true,
-    dangerouslySkipPermissions: Bool = false
+    dangerouslySkipPermissions: Bool = false,
+    worktreeName: String? = nil
   ) {
     guard !isConfigured else { return }
     isConfigured = true
@@ -220,7 +226,8 @@ public class TerminalContainerView: NSView, ManagedLocalProcessTerminalViewDeleg
       projectPath: projectPath,
       cliConfiguration: cliConfiguration,
       initialPrompt: initialPrompt,
-      dangerouslySkipPermissions: dangerouslySkipPermissions
+      dangerouslySkipPermissions: dangerouslySkipPermissions,
+      worktreeName: worktreeName
     )
     registerProcessIfNeeded(for: terminal)
 
@@ -361,7 +368,8 @@ public class TerminalContainerView: NSView, ManagedLocalProcessTerminalViewDeleg
     projectPath: String,
     cliConfiguration: CLICommandConfiguration,
     initialPrompt: String? = nil,
-    dangerouslySkipPermissions: Bool = false
+    dangerouslySkipPermissions: Bool = false,
+    worktreeName: String? = nil
   ) {
     // Find the CLI executable using just the executable name (first word of command)
     let command = cliConfiguration.command
@@ -434,7 +442,8 @@ public class TerminalContainerView: NSView, ManagedLocalProcessTerminalViewDeleg
     let args = cliConfiguration.argumentsForSession(
       sessionId: sessionId,
       prompt: initialPrompt,
-      dangerouslySkipPermissions: dangerouslySkipPermissions
+      dangerouslySkipPermissions: dangerouslySkipPermissions,
+      worktreeName: worktreeName
     )
     let escapedArgs = args.map { $0.replacingOccurrences(of: "'", with: "'\\''") }
     let joinedArgs = escapedArgs.map { "'\($0)'" }.joined(separator: " ")

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringCardView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringCardView.swift
@@ -59,6 +59,7 @@ public struct MonitoringCardView: View {
   let terminalKey: String?  // Key for terminal storage (session ID or "pending-{pendingId}")
   let viewModel: CLISessionsViewModel?
   var dangerouslySkipPermissions: Bool = false
+  let worktreeName: String?
   let onToggleTerminal: (Bool) -> Void
   let onStopMonitoring: () -> Void
   let onConnect: () -> Void
@@ -101,6 +102,7 @@ public struct MonitoringCardView: View {
     terminalKey: String? = nil,
     viewModel: CLISessionsViewModel? = nil,
     dangerouslySkipPermissions: Bool = false,
+    worktreeName: String? = nil,
     onToggleTerminal: @escaping (Bool) -> Void,
     onStopMonitoring: @escaping () -> Void,
     onConnect: @escaping () -> Void,
@@ -131,6 +133,7 @@ public struct MonitoringCardView: View {
     self.terminalKey = terminalKey
     self.viewModel = viewModel
     self.dangerouslySkipPermissions = dangerouslySkipPermissions
+    self.worktreeName = worktreeName
     self.onToggleTerminal = onToggleTerminal
     self.onStopMonitoring = onStopMonitoring
     self.onConnect = onConnect
@@ -698,6 +701,7 @@ public struct MonitoringCardView: View {
           initialInputText: initialInputText,
           viewModel: viewModel,
           dangerouslySkipPermissions: dangerouslySkipPermissions,
+          worktreeName: worktreeName,
           onUserInteraction: onTerminalInteraction
         )
         .frame(minHeight: 300)

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringPanelView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringPanelView.swift
@@ -342,6 +342,7 @@ public struct MonitoringPanelView: View {
         terminalKey: "pending-\(pending.id.uuidString)",
         viewModel: viewModel,
         dangerouslySkipPermissions: pending.dangerouslySkipPermissions,
+        worktreeName: pending.worktreeName,
         onToggleTerminal: { _ in },
         onStopMonitoring: {
           viewModel.cancelPendingSession(pending)
@@ -469,6 +470,7 @@ public struct MonitoringPanelView: View {
           terminalKey: pendingId,
           viewModel: viewModel,
           dangerouslySkipPermissions: pending.dangerouslySkipPermissions,
+        worktreeName: pending.worktreeName,
           onToggleTerminal: { _ in },
           onStopMonitoring: {
             viewModel.cancelPendingSession(pending)
@@ -561,6 +563,7 @@ public struct MonitoringPanelView: View {
         terminalKey: pendingId,
         viewModel: viewModel,
         dangerouslySkipPermissions: pending.dangerouslySkipPermissions,
+        worktreeName: pending.worktreeName,
         onToggleTerminal: { _ in },
         onStopMonitoring: {
           viewModel.cancelPendingSession(pending)
@@ -669,6 +672,7 @@ public struct MonitoringPanelView: View {
               terminalKey: pendingId,
               viewModel: viewModel,
               dangerouslySkipPermissions: pending.dangerouslySkipPermissions,
+        worktreeName: pending.worktreeName,
               onToggleTerminal: { _ in },
               onStopMonitoring: {
                 viewModel.cancelPendingSession(pending)

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderMonitoringPanelView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderMonitoringPanelView.swift
@@ -470,6 +470,7 @@ public struct MultiProviderMonitoringPanelView: View {
           terminalKey: pendingId,
           viewModel: viewModel,
           dangerouslySkipPermissions: pending.dangerouslySkipPermissions,
+          worktreeName: pending.worktreeName,
           onToggleTerminal: { _ in },
           onStopMonitoring: { viewModel.cancelPendingSession(pending) },
           onConnect: { },
@@ -613,6 +614,7 @@ public struct MultiProviderMonitoringPanelView: View {
               terminalKey: "pending-\(pending.id.uuidString)",
               viewModel: viewModel,
               dangerouslySkipPermissions: pending.dangerouslySkipPermissions,
+          worktreeName: pending.worktreeName,
               onToggleTerminal: { _ in },
               onStopMonitoring: { viewModel.cancelPendingSession(pending) },
               onConnect: { },
@@ -748,6 +750,7 @@ public struct MultiProviderMonitoringPanelView: View {
           terminalKey: "pending-\(pending.id.uuidString)",
           viewModel: viewModel,
           dangerouslySkipPermissions: pending.dangerouslySkipPermissions,
+          worktreeName: pending.worktreeName,
           onToggleTerminal: { _ in },
           onStopMonitoring: {
             viewModel.cancelPendingSession(pending)

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiSessionLaunchView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiSessionLaunchView.swift
@@ -54,6 +54,10 @@ public struct MultiSessionLaunchView: View {
 
           providerPills
 
+          if viewModel.selectedRepository != nil && viewModel.isClaudeSelected && !viewModel.isCodexSelected && viewModel.workMode == .local {
+            worktreeRow
+          }
+
           if viewModel.isLaunching && viewModel.workMode == .worktree {
             progressSection
           }
@@ -619,6 +623,74 @@ public struct MultiSessionLaunchView: View {
       return colorScheme == .dark
         ? Color(nsColor: NSColor(srgbRed: 0.96, green: 0.64, blue: 0.64, alpha: 1))
         : Color(nsColor: NSColor(srgbRed: 0.91, green: 0.54, blue: 0.54, alpha: 1))
+    }
+  }
+
+  // MARK: - Worktree Row
+
+  private var worktreeRow: some View {
+    VStack(alignment: .leading, spacing: 4) {
+      HStack(spacing: 8) {
+        Button(action: {
+          withAnimation(.easeInOut(duration: 0.2)) {
+            viewModel.claudeUseWorktree.toggle()
+            if !viewModel.claudeUseWorktree {
+              viewModel.claudeWorktreeName = ""
+            }
+          }
+        }) {
+          HStack(spacing: 4) {
+            Image(systemName: "arrow.triangle.branch")
+              .font(.system(size: 9))
+            Text("--worktree")
+              .font(.system(size: 11, weight: .medium))
+          }
+          .foregroundColor(viewModel.claudeUseWorktree ? (colorScheme == .dark ? .black : .white) : .secondary)
+          .padding(.horizontal, 10)
+          .padding(.vertical, 5)
+          .background(
+            Capsule()
+              .fill(
+                viewModel.claudeUseWorktree
+                  ? (colorScheme == .dark ? Color.white : Color.black)
+                  : Color.primary.opacity(0.06)
+              )
+          )
+        }
+        .buttonStyle(.plain)
+
+        if viewModel.claudeUseWorktree {
+          TextField("auto-generated name", text: $viewModel.claudeWorktreeName)
+            .font(.system(size: 11))
+            .textFieldStyle(.plain)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 5)
+            .background(
+              RoundedRectangle(cornerRadius: 6)
+                .fill(Color.primary.opacity(0.05))
+            )
+            .frame(maxWidth: 200)
+            .transition(.opacity.combined(with: .move(edge: .leading)))
+        }
+
+        Spacer()
+      }
+
+      if viewModel.claudeUseWorktree {
+        Text(worktreeCommandCaption)
+          .font(.system(size: 10, design: .monospaced))
+          .foregroundColor(.secondary.opacity(0.6))
+          .transition(.opacity)
+      }
+    }
+  }
+
+  private var worktreeCommandCaption: String {
+    let name = viewModel.claudeWorktreeName
+    if name.isEmpty {
+      return "claude --worktree  ← name will be auto-generated"
+    } else {
+      return "claude --worktree \(name)"
     }
   }
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/Utils/String+ClaudePath.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Utils/String+ClaudePath.swift
@@ -10,13 +10,15 @@ import Foundation
 extension String {
   /// Encodes a file path for Claude's project directory naming convention.
   ///
-  /// Claude CLI replaces both "/" and "_" with "-" when creating project directories.
+  /// Claude CLI replaces "/", ".", and "_" with "-" when creating project directories.
   /// For example: `/Users/james/Desktop/git/new_hub` becomes `-Users-james-Desktop-git-new-hub`
+  /// And: `/Users/james/repo/.claude/worktrees/feat` becomes `-Users-james-repo--claude-worktrees-feat`
   ///
   /// This must match the encoding used by Claude CLI to correctly locate session files.
   var claudeProjectPathEncoded: String {
     self
       .replacingOccurrences(of: "/", with: "-")
+      .replacingOccurrences(of: ".", with: "-")
       .replacingOccurrences(of: "_", with: "-")
   }
 }

--- a/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/CLISessionsViewModel.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/CLISessionsViewModel.swift
@@ -247,7 +247,8 @@ public final class CLISessionsViewModel {
     initialPrompt: String?,
     initialInputText: String? = nil,
     isDark: Bool = true,
-    dangerouslySkipPermissions: Bool = false
+    dangerouslySkipPermissions: Bool = false,
+    worktreeName: String? = nil
   ) -> TerminalContainerView {
     if let existing = activeTerminals[key] {
       #if DEBUG
@@ -278,7 +279,8 @@ public final class CLISessionsViewModel {
       initialPrompt: initialPrompt,
       initialInputText: initialInputText,
       isDark: isDark,
-      dangerouslySkipPermissions: dangerouslySkipPermissions
+      dangerouslySkipPermissions: dangerouslySkipPermissions,
+      worktreeName: worktreeName
     )
     activeTerminals[key] = terminal
     return terminal
@@ -1248,7 +1250,8 @@ public final class CLISessionsViewModel {
     _ worktree: WorktreeBranch,
     initialPrompt: String? = nil,
     initialInputText: String? = nil,
-    dangerouslySkipPermissions: Bool = false
+    dangerouslySkipPermissions: Bool = false,
+    worktreeName: String? = nil
   ) {
     // Each pending session gets a unique ID, so no need to clear existing terminals
     // Terminals are now keyed by session ID, not worktree path
@@ -1256,7 +1259,8 @@ public final class CLISessionsViewModel {
       worktree: worktree,
       initialPrompt: initialPrompt,
       initialInputText: initialInputText,
-      dangerouslySkipPermissions: dangerouslySkipPermissions
+      dangerouslySkipPermissions: dangerouslySkipPermissions,
+      worktreeName: worktreeName
     )
     pendingHubSessions.append(pending)
     lastCreatedPendingId = pending.id
@@ -1296,8 +1300,20 @@ public final class CLISessionsViewModel {
   /// Watches the Claude project directory for a new session file
   @MainActor
   private func watchForNewClaudeSession(pending: PendingHubSession, worktree: WorktreeBranch) async {
+    // Auto-named --worktree: we don't know the path ahead of time, poll history.jsonl instead
+    if let worktreeName = pending.worktreeName, worktreeName.isEmpty {
+      await pollForWorktreeHistoryEntry(pending: pending, repoPath: worktree.path)
+      return
+    }
+
     let claudeDataPath = FileManager.default.homeDirectoryForCurrentUser.path + "/.claude"
-    let encodedPath = worktree.path.claudeProjectPathEncoded
+    let watchPath: String
+    if let worktreeName = pending.worktreeName, !worktreeName.isEmpty {
+      watchPath = worktree.path + "/.claude/worktrees/" + worktreeName
+    } else {
+      watchPath = worktree.path
+    }
+    let encodedPath = watchPath.claudeProjectPathEncoded
     let projectDir = "\(claudeDataPath)/projects/\(encodedPath)"
 #if DEBUG
     AppLogger.watcher.debug(
@@ -1480,26 +1496,26 @@ public final class CLISessionsViewModel {
           }
         }
 
-        // Third fallback: check session file directly for new worktrees
-        // This handles the case where history.jsonl hasn't been updated yet
-        // TODO: Review - only triggers for worktrees with zero sessions
-        let currentSessions = selectedRepositories
-          .flatMap { $0.worktrees }
-          .first { $0.path == worktree.path }?
-          .sessions ?? []
-
+        // Third fallback: check session file directly
+        // This handles new worktrees where history.jsonl hasn't been updated yet,
+        // and ensures pending sessions always resolve even after retry exhaustion.
         let claudeDataPath = FileManager.default.homeDirectoryForCurrentUser.path + "/.claude"
-        let encodedPath = worktree.path.claudeProjectPathEncoded
+        let effectivePath: String
+        if let worktreeName = pending.worktreeName, !worktreeName.isEmpty {
+          effectivePath = worktree.path + "/.claude/worktrees/" + worktreeName
+        } else {
+          effectivePath = worktree.path
+        }
+        let encodedPath = effectivePath.claudeProjectPathEncoded
         let fallbackSessionFilePath = "\(claudeDataPath)/projects/\(encodedPath)/\(sessionId).jsonl"
         if providerKind == .claude,
-           currentSessions.isEmpty,
            FileManager.default.fileExists(atPath: fallbackSessionFilePath) {
           // Session file exists but not in history.jsonl yet - create directly
           let newSession = CLISession(
             id: sessionId,
-            projectPath: worktree.path,
-            branchName: worktree.name,
-            isWorktree: worktree.isWorktree,
+            projectPath: effectivePath,
+            branchName: pending.worktreeName ?? worktree.name,
+            isWorktree: pending.worktreeName != nil,
             lastActivityAt: Date(),
             messageCount: 0,
             isActive: true,
@@ -1508,7 +1524,9 @@ public final class CLISessionsViewModel {
           )
 
           for repoIndex in selectedRepositories.indices {
-            if let wtIndex = selectedRepositories[repoIndex].worktrees.firstIndex(where: { $0.path == worktree.path }) {
+            if let wtIndex = selectedRepositories[repoIndex].worktrees.firstIndex(where: {
+              $0.path == effectivePath || $0.path == worktree.path
+            }) {
               selectedRepositories[repoIndex].worktrees[wtIndex].sessions.insert(newSession, at: 0)
               break
             }
@@ -1527,6 +1545,11 @@ public final class CLISessionsViewModel {
 #endif
           return
         }
+
+        let currentSessions = selectedRepositories
+          .flatMap { $0.worktrees }
+          .first { $0.path == worktree.path }?
+          .sessions ?? []
 
         if providerKind == .codex,
            currentSessions.isEmpty,
@@ -1621,6 +1644,60 @@ public final class CLISessionsViewModel {
 #endif
         // Directory exists now - restart watching
         await watchForNewClaudeSession(pending: pending, worktree: worktree)
+        return
+      }
+    }
+  }
+
+  /// Polls ~/.claude/history.jsonl for a new entry whose project path starts with
+  /// `repoPath/.claude/worktrees/`. Used for auto-named `--worktree` sessions where
+  /// the exact worktree path isn't known until Claude CLI creates it.
+  @MainActor
+  private func pollForWorktreeHistoryEntry(pending: PendingHubSession, repoPath: String) async {
+    let claudeDataPath = FileManager.default.homeDirectoryForCurrentUser.path + "/.claude"
+    let historyPath = "\(claudeDataPath)/history.jsonl"
+    let worktreePrefix = repoPath + "/.claude/worktrees/"
+
+#if DEBUG
+    AppLogger.watcher.debug(
+      "[PollWorktreeHistory] pendingId=\(pending.id.uuidString, privacy: .public) prefix=\(worktreePrefix, privacy: .public)"
+    )
+#endif
+
+    while true {
+      try? await Task.sleep(for: .seconds(1))
+
+      if !pendingHubSessions.contains(where: { $0.id == pending.id }) { return }
+
+      guard let contents = try? String(contentsOfFile: historyPath, encoding: .utf8) else { continue }
+
+      // Parse history.jsonl lines for entries with matching project path after pending.startedAt
+      let lines = contents.components(separatedBy: "\n").filter { !$0.isEmpty }
+      for line in lines.reversed() {
+        guard let data = line.data(using: .utf8),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let sessionId = json["sessionId"] as? String,
+              let projectPath = json["project"] as? String,
+              projectPath.hasPrefix(worktreePrefix) else { continue }
+
+        // Only consider entries created after this pending session started
+        var entryDate: Date?
+        if let ts = json["timestamp"] as? String {
+          entryDate = ISO8601DateFormatter().date(from: ts)
+        }
+        if let date = entryDate, date < pending.startedAt { continue }
+
+#if DEBUG
+        AppLogger.watcher.debug(
+          "[PollWorktreeHistory] pendingId=\(pending.id.uuidString, privacy: .public) found sessionId=\(sessionId, privacy: .public) at \(projectPath, privacy: .public)"
+        )
+#endif
+        let resolvedWorktree = WorktreeBranch(
+          name: URL(fileURLWithPath: projectPath).lastPathComponent,
+          path: projectPath,
+          isWorktree: true
+        )
+        handleNewSessionFound(sessionId: sessionId, pending: pending, worktree: resolvedWorktree)
         return
       }
     }

--- a/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/MultiSessionLaunchViewModel.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/MultiSessionLaunchViewModel.swift
@@ -109,6 +109,8 @@ public final class MultiSessionLaunchViewModel {
   public var launchMode: LaunchMode = .manual
   public var workMode: WorkMode = .local
   public var claudeMode: ClaudeMode = .disabled
+  public var claudeUseWorktree: Bool = false
+  public var claudeWorktreeName: String = ""
   public var isCodexSelected: Bool = false
   public var sharedPrompt: String = ""
   public var attachedFiles: [AttachedFile] = []
@@ -146,6 +148,13 @@ public final class MultiSessionLaunchViewModel {
   // MARK: - Computed
 
   public var isClaudeSelected: Bool { claudeMode.isSelected }
+
+  /// Returns the --worktree name option when Claude is enabled and worktree mode is on.
+  /// nil = no --worktree flag; "" = auto-generated name; non-empty = named worktree
+  public var claudeWorktreeOption: String? {
+    guard claudeMode.isSelected && claudeUseWorktree else { return nil }
+    return claudeWorktreeName
+  }
 
   public var selectedProviders: [SessionProviderKind] {
     var providers: [SessionProviderKind] = []
@@ -656,6 +665,8 @@ public final class MultiSessionLaunchViewModel {
     launchMode = .manual
     workMode = .local
     claudeMode = .disabled
+    claudeUseWorktree = false
+    claudeWorktreeName = ""
     isCodexSelected = false
     claudeProgress = .idle
     codexProgress = .idle
@@ -679,10 +690,14 @@ public final class MultiSessionLaunchViewModel {
 
     try? await Task.sleep(for: .milliseconds(300))
 
+    let worktreeBranchName: String = {
+      if let name = claudeWorktreeOption, !name.isEmpty { return name }
+      return currentBranchName.isEmpty ? "main" : currentBranchName
+    }()
     let worktree = WorktreeBranch(
-      name: currentBranchName.isEmpty ? "main" : currentBranchName,
+      name: worktreeBranchName,
       path: repoPath,
-      isWorktree: false
+      isWorktree: claudeWorktreeOption != nil
     )
 
     if providers.contains(.claude) {
@@ -692,7 +707,8 @@ public final class MultiSessionLaunchViewModel {
         worktree,
         initialPrompt: initialPrompt,
         initialInputText: initialInputText,
-        dangerouslySkipPermissions: claudeMode.dangerouslySkipPermissions
+        dangerouslySkipPermissions: claudeMode.dangerouslySkipPermissions,
+        worktreeName: claudeWorktreeOption
       )
     }
 


### PR DESCRIPTION
## Summary

- **`--worktree` toggle in launch UI** — new `worktreeRow` in `MultiSessionLaunchView` lets users opt into `--worktree` (auto-named) or `--worktree <name>` when starting a Claude session in Local mode
- **Row placement & visibility fix** — `worktreeRow` is now positioned below `providerPills` and only shown when a repository is selected, Claude is the sole provider, and work mode is Local (prevents confusion with the `[Local] [Worktree]` tab row)
- **`--worktree` flag plumbed end-to-end** — `PendingHubSession`, `EmbeddedTerminalView`, `TerminalContainerView`, `TerminalLauncher`, `CLICommandConfiguration.argumentsForSession`, `CLISessionsViewModel`, and `MultiSessionLaunchViewModel` all gain a `worktreeName: String?` parameter (nil = no flag, `""` = auto-name, non-empty = named branch)
- **Auto-named worktree detection** — when `worktreeName == ""`, Claude picks the branch name at runtime; `pollForWorktreeHistoryEntry` polls `~/.claude/history.jsonl` for a new entry under `<repo>/.claude/worktrees/` instead of watching a predetermined path
- **Named worktree path resolution** — watches `<repo>/.claude/worktrees/<name>` encoded as a Claude project path; the fallback session-file check and `handleNewSessionFound` use the resolved path so the session appears in the sidebar
- **`claudeProjectPathEncoded` fix** — `.` is now replaced with `-` to match Claude CLI's encoding of paths like `<repo>/.claude/worktrees/<name>`
- **`reset()` clears worktree state** — `claudeUseWorktree` and `claudeWorktreeName` reset to defaults on form clear

## Test plan

- [x] 26 new tests in `WorktreeCreationTests.swift` — all passing
  - `CLICommandConfigurationWorktreeTests` (10 tests): flag absent/bare/named, resume guard, pending-session pass-through, Codex ignored, combined with `--dangerously-skip-permissions`
  - `MultiSessionLaunchViewModelWorktreeOptionTests` (5 tests): nil/false/empty/named/dangerous-mode
  - `MultiSessionLaunchViewModelResetTests` (3 tests): `claudeUseWorktree`, `claudeWorktreeName`, `claudeWorktreeOption` after reset
  - `WorktreeRowVisibilityTests` (5 tests): all conditions from the visibility table (no repo, Claude disabled, Codex also selected, worktree mode, all-valid)
- [ ] Manually verify: `worktreeRow` hidden with no repo selected, visible with repo + Claude + local
- [ ] Manually verify: launching with bare `--worktree` auto-resolves to a new session card
- [ ] Manually verify: launching with `--worktree my-branch` resolves at the named path