### PR TITLE
Animate flat session layout toggle with opacity cross-fade

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringPanelView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringPanelView.swift
@@ -106,6 +106,8 @@ public struct MonitoringPanelView: View {
   private var layoutModeRawValue: Int = LayoutMode.single.rawValue
   @AppStorage(AgentHubDefaults.hubPreviousLayoutMode)
   private var previousLayoutModeRawValue: Int = -1
+  @AppStorage(AgentHubDefaults.flatSessionLayout)
+  private var flatSessionLayout: Bool = false
   @Environment(\.colorScheme) private var colorScheme
   @Environment(\.runtimeTheme) private var runtimeTheme
 
@@ -179,6 +181,10 @@ public struct MonitoringPanelView: View {
         // Sort by timestamp descending (newest first)
         timestamp(for: item1) > timestamp(for: item2)
       })}
+  }
+
+  private var flatSortedItems: [MonitoringItem] {
+    groupedMonitoredSessions.flatMap { $0.items }
   }
 
   /// Helper to get timestamp for sorting MonitoringItems
@@ -434,19 +440,42 @@ public struct MonitoringPanelView: View {
     } else {
       ScrollView {
         if layoutMode == .list {
-          LazyVStack(spacing: 12, pinnedViews: [.sectionHeaders]) {
-            monitoredSessionsGroupedContent
+          if flatSessionLayout {
+            LazyVStack(spacing: 12) {
+              ForEach(flatSortedItems) { item in
+                itemCardView(for: item)
+              }
+            }
+            .padding(12)
+            .transition(.opacity)
+          } else {
+            LazyVStack(spacing: 12, pinnedViews: [.sectionHeaders]) {
+              monitoredSessionsGroupedContent
+            }
+            .padding(12)
+            .transition(.opacity)
           }
-          .padding(12)
         } else {
           let columns = Array(repeating: GridItem(.flexible(), alignment: .top), count: layoutMode.columnCount)
-          LazyVGrid(columns: columns, spacing: 12, pinnedViews: [.sectionHeaders]) {
-            monitoredSessionsGroupedContent
+          if flatSessionLayout {
+            LazyVGrid(columns: columns, spacing: 12) {
+              ForEach(flatSortedItems) { item in
+                itemCardView(for: item)
+              }
+            }
+            .padding(12)
+            .transition(.opacity)
+          } else {
+            LazyVGrid(columns: columns, spacing: 12, pinnedViews: [.sectionHeaders]) {
+              monitoredSessionsGroupedContent
+            }
+            .padding(12)
+            .transition(.opacity)
           }
-          .padding(12)
         }
       }
       .animation(.easeInOut(duration: 0.2), value: layoutMode)
+      .animation(.easeInOut(duration: 0.25), value: flatSessionLayout)
     }
   }
 
@@ -645,110 +674,116 @@ public struct MonitoringPanelView: View {
     }
   }
 
+  // MARK: - Single Card View
+
+  @ViewBuilder
+  private func itemCardView(for item: MonitoringItem) -> some View {
+    switch item {
+    case .pending(let pending):
+      let pendingId = "pending-\(pending.id.uuidString)"
+      let isPrimary = pendingId == effectivePrimarySessionId
+      MonitoringCardView(
+        session: pending.placeholderSession,
+        state: nil,
+        claudeClient: claudeClient,
+        cliConfiguration: viewModel.cliConfiguration,
+        providerKind: viewModel.providerKind,
+        showTerminal: true,
+        initialPrompt: pending.initialPrompt,
+        initialInputText: pending.initialInputText,
+        terminalKey: pendingId,
+        viewModel: viewModel,
+        dangerouslySkipPermissions: pending.dangerouslySkipPermissions,
+        worktreeName: pending.worktreeName,
+        onToggleTerminal: { _ in },
+        onStopMonitoring: {
+          viewModel.cancelPendingSession(pending)
+        },
+        onConnect: { },
+        onCopySessionId: { },
+        onOpenSessionFile: { },
+        onRefreshTerminal: { },
+        onTerminalInteraction: { setPrimarySessionIfNeeded(pendingId) },
+        isMaximized: maximizedSessionId == pendingId,
+        onToggleMaximize: {
+          withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) {
+            maximizedSessionId = maximizedSessionId == pendingId ? nil : pendingId
+          }
+        },
+        isPrimarySession: isPrimary,
+        showPrimaryIndicator: layoutMode != .single
+      )
+
+    case .monitored(let session, let state):
+      let isPrimary = session.id == effectivePrimarySessionId
+      let planState = state.flatMap {
+        PlanState.from(activities: $0.recentActivities)
+      }
+      let initialPrompt = viewModel.pendingPrompt(for: session.id)
+
+      MonitoringCardView(
+        session: session,
+        state: state,
+        planState: planState,
+        claudeClient: claudeClient,
+        cliConfiguration: viewModel.cliConfiguration,
+        providerKind: viewModel.providerKind,
+        showTerminal: viewModel.sessionsWithTerminalView.contains(session.id),
+        initialPrompt: initialPrompt,
+        terminalKey: session.id,
+        viewModel: viewModel,
+        onToggleTerminal: { show in
+          viewModel.setTerminalView(for: session.id, show: show)
+        },
+        onStopMonitoring: {
+          viewModel.stopMonitoring(session: session)
+        },
+        onConnect: {
+          _ = viewModel.connectToSession(session)
+        },
+        onCopySessionId: {
+          viewModel.copySessionId(session)
+        },
+        onOpenSessionFile: {
+          openSessionFile(for: session)
+        },
+        onRefreshTerminal: {
+          viewModel.refreshTerminal(
+            forKey: session.id,
+            sessionId: session.id,
+            projectPath: session.projectPath
+          )
+        },
+        onInlineRequestSubmit: { prompt, sess in
+          viewModel.showTerminalWithPrompt(for: sess, prompt: prompt)
+        },
+        onPromptConsumed: {
+          viewModel.clearPendingPrompt(for: session.id)
+        },
+        onTerminalInteraction: { setPrimarySessionIfNeeded(session.id) },
+        isMaximized: maximizedSessionId == session.id,
+        onToggleMaximize: {
+          withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) {
+            maximizedSessionId = maximizedSessionId == session.id ? nil : session.id
+          }
+        },
+        isPrimarySession: isPrimary,
+        showPrimaryIndicator: layoutMode != .single
+      )
+    }
+  }
+
   // MARK: - Grouped Content by Module
 
   @ViewBuilder
   private var monitoredSessionsGroupedContent: some View {
-    // All sessions grouped by module (pending + monitored combined)
     ForEach(groupedMonitoredSessions, id: \.modulePath) { group in
       Section(header: ModuleSectionHeader(
         name: URL(fileURLWithPath: group.modulePath).lastPathComponent,
         sessionCount: group.items.count
       )) {
         ForEach(group.items) { item in
-          switch item {
-          case .pending(let pending):
-            let pendingId = "pending-\(pending.id.uuidString)"
-            let isPrimary = pendingId == effectivePrimarySessionId
-            MonitoringCardView(
-              session: pending.placeholderSession,
-              state: nil,
-              claudeClient: claudeClient,
-              cliConfiguration: viewModel.cliConfiguration,
-              providerKind: viewModel.providerKind,
-              showTerminal: true,
-              initialPrompt: pending.initialPrompt,
-              initialInputText: pending.initialInputText,
-              terminalKey: pendingId,
-              viewModel: viewModel,
-              dangerouslySkipPermissions: pending.dangerouslySkipPermissions,
-        worktreeName: pending.worktreeName,
-              onToggleTerminal: { _ in },
-              onStopMonitoring: {
-                viewModel.cancelPendingSession(pending)
-              },
-              onConnect: { },
-              onCopySessionId: { },
-              onOpenSessionFile: { },
-              onRefreshTerminal: { },
-              onTerminalInteraction: { setPrimarySessionIfNeeded(pendingId) },
-              isMaximized: maximizedSessionId == pendingId,
-              onToggleMaximize: {
-                withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) {
-                  maximizedSessionId = maximizedSessionId == pendingId ? nil : pendingId
-                }
-              },
-              isPrimarySession: isPrimary,
-              showPrimaryIndicator: layoutMode != .single
-            )
-
-          case .monitored(let session, let state):
-            let isPrimary = session.id == effectivePrimarySessionId
-            let planState = state.flatMap {
-              PlanState.from(activities: $0.recentActivities)
-            }
-            let initialPrompt = viewModel.pendingPrompt(for: session.id)
-
-            MonitoringCardView(
-              session: session,
-              state: state,
-              planState: planState,
-              claudeClient: claudeClient,
-              cliConfiguration: viewModel.cliConfiguration,
-              providerKind: viewModel.providerKind,
-              showTerminal: viewModel.sessionsWithTerminalView.contains(session.id),
-              initialPrompt: initialPrompt,
-              terminalKey: session.id,
-              viewModel: viewModel,
-              onToggleTerminal: { show in
-                viewModel.setTerminalView(for: session.id, show: show)
-              },
-              onStopMonitoring: {
-                viewModel.stopMonitoring(session: session)
-              },
-              onConnect: {
-                _ = viewModel.connectToSession(session)
-              },
-              onCopySessionId: {
-                viewModel.copySessionId(session)
-              },
-              onOpenSessionFile: {
-                openSessionFile(for: session)
-              },
-              onRefreshTerminal: {
-                viewModel.refreshTerminal(
-                  forKey: session.id,
-                  sessionId: session.id,
-                  projectPath: session.projectPath
-                )
-              },
-              onInlineRequestSubmit: { prompt, sess in
-                viewModel.showTerminalWithPrompt(for: sess, prompt: prompt)
-              },
-              onPromptConsumed: {
-                viewModel.clearPendingPrompt(for: session.id)
-              },
-              onTerminalInteraction: { setPrimarySessionIfNeeded(session.id) },
-              isMaximized: maximizedSessionId == session.id,
-              onToggleMaximize: {
-                withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) {
-                  maximizedSessionId = maximizedSessionId == session.id ? nil : session.id
-                }
-              },
-              isPrimarySession: isPrimary,
-              showPrimaryIndicator: layoutMode != .single
-            )
-          }
+          itemCardView(for: item)
         }
       }
     }

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderMonitoringPanelView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderMonitoringPanelView.swift
@@ -223,6 +223,8 @@ public struct MultiProviderMonitoringPanelView: View {
   private var layoutModeRawValue: Int = LayoutMode.single.rawValue
   @AppStorage(AgentHubDefaults.hubPreviousLayoutMode)
   private var previousLayoutModeRawValue: Int = -1
+  @AppStorage(AgentHubDefaults.flatSessionLayout)
+  private var flatSessionLayout: Bool = false
   @Environment(\.colorScheme) private var colorScheme
   @Environment(\.runtimeTheme) private var runtimeTheme
 
@@ -427,19 +429,42 @@ public struct MultiProviderMonitoringPanelView: View {
       ScrollViewReader { proxy in
         ScrollView {
           if layoutMode == .list {
-            LazyVStack(spacing: 12, pinnedViews: [.sectionHeaders]) {
-              monitoredSessionsGroupedContent
+            if flatSessionLayout {
+              LazyVStack(spacing: 12) {
+                ForEach(flatSortedItems) { item in
+                  itemCardView(for: item)
+                }
+              }
+              .padding(12)
+              .transition(.opacity)
+            } else {
+              LazyVStack(spacing: 12, pinnedViews: [.sectionHeaders]) {
+                monitoredSessionsGroupedContent
+              }
+              .padding(12)
+              .transition(.opacity)
             }
-            .padding(12)
           } else {
             let columns = Array(repeating: GridItem(.flexible(), alignment: .top), count: layoutMode.columnCount)
-            LazyVGrid(columns: columns, spacing: 12, pinnedViews: [.sectionHeaders]) {
-              monitoredSessionsGroupedContent
+            if flatSessionLayout {
+              LazyVGrid(columns: columns, spacing: 12) {
+                ForEach(flatSortedItems) { item in
+                  itemCardView(for: item)
+                }
+              }
+              .padding(12)
+              .transition(.opacity)
+            } else {
+              LazyVGrid(columns: columns, spacing: 12, pinnedViews: [.sectionHeaders]) {
+                monitoredSessionsGroupedContent
+              }
+              .padding(12)
+              .transition(.opacity)
             }
-            .padding(12)
           }
         }
         .animation(.easeInOut(duration: 0.2), value: layoutMode)
+        .animation(.easeInOut(duration: 0.25), value: flatSessionLayout)
         .onChange(of: primarySessionId) { _, newId in
           guard let newId else { return }
           withAnimation(.easeInOut(duration: 0.25)) {
@@ -591,6 +616,103 @@ public struct MultiProviderMonitoringPanelView: View {
     }
   }
 
+  // MARK: - Single Card View
+
+  @ViewBuilder
+  private func itemCardView(for item: ProviderMonitoringItem) -> some View {
+    let isPrimary = item.id == effectivePrimarySessionId
+    switch item {
+    case .pending(_, let viewModel, let pending):
+      MonitoringCardView(
+        session: pending.placeholderSession,
+        state: nil,
+        claudeClient: viewModel.claudeClient,
+        cliConfiguration: viewModel.cliConfiguration,
+        providerKind: item.providerKind,
+        showTerminal: true,
+        initialPrompt: pending.initialPrompt,
+        initialInputText: pending.initialInputText,
+        terminalKey: "pending-\(pending.id.uuidString)",
+        viewModel: viewModel,
+        dangerouslySkipPermissions: pending.dangerouslySkipPermissions,
+        worktreeName: pending.worktreeName,
+        onToggleTerminal: { _ in },
+        onStopMonitoring: { viewModel.cancelPendingSession(pending) },
+        onConnect: { },
+        onCopySessionId: { },
+        onOpenSessionFile: { },
+        onRefreshTerminal: { },
+        onTerminalInteraction: { setPrimarySessionIfNeeded(item.id) },
+        isMaximized: maximizedSessionId == item.id,
+        onToggleMaximize: {
+          withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) {
+            maximizedSessionId = maximizedSessionId == item.id ? nil : item.id
+          }
+        },
+        isPrimarySession: isPrimary,
+        showPrimaryIndicator: layoutMode != .single
+      )
+      .id(item.id)
+
+    case .monitored(_, let viewModel, let session, let state):
+      let planState = state.flatMap { PlanState.from(activities: $0.recentActivities) }
+      let initialPrompt = viewModel.pendingPrompt(for: session.id)
+
+      MonitoringCardView(
+        session: session,
+        state: state,
+        planState: planState,
+        claudeClient: viewModel.claudeClient,
+        cliConfiguration: viewModel.cliConfiguration,
+        providerKind: item.providerKind,
+        showTerminal: viewModel.sessionsWithTerminalView.contains(session.id),
+        initialPrompt: initialPrompt,
+        terminalKey: session.id,
+        viewModel: viewModel,
+        onToggleTerminal: { show in
+          viewModel.setTerminalView(for: session.id, show: show)
+        },
+        onStopMonitoring: {
+          viewModel.stopMonitoring(session: session)
+        },
+        onConnect: {
+          _ = viewModel.connectToSession(session)
+        },
+        onCopySessionId: {
+          viewModel.copySessionId(session)
+        },
+        onOpenSessionFile: {
+          openSessionFile(for: session, viewModel: viewModel)
+        },
+        onRefreshTerminal: {
+          viewModel.refreshTerminal(
+            forKey: session.id,
+            sessionId: session.id,
+            projectPath: session.projectPath
+          )
+        },
+        onInlineRequestSubmit: { prompt, sess in
+          viewModel.showTerminalWithPrompt(for: sess, prompt: prompt)
+        },
+        onPromptConsumed: {
+          viewModel.clearPendingPrompt(for: session.id)
+        },
+        onTerminalInteraction: { setPrimarySessionIfNeeded(item.id) },
+        isMaximized: maximizedSessionId == item.id,
+        onToggleMaximize: {
+          withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) {
+            maximizedSessionId = maximizedSessionId == item.id ? nil : item.id
+          }
+        },
+        isPrimarySession: isPrimary,
+        showPrimaryIndicator: layoutMode != .single
+      )
+      .id(item.id)
+    }
+  }
+
+  // MARK: - Grouped Content by Module
+
   @ViewBuilder
   private var monitoredSessionsGroupedContent: some View {
     ForEach(groupedMonitoredSessions, id: \.modulePath) { group in
@@ -599,95 +721,7 @@ public struct MultiProviderMonitoringPanelView: View {
         sessionCount: group.items.count
       )) {
         ForEach(group.items) { item in
-          let isPrimary = item.id == effectivePrimarySessionId
-          switch item {
-          case .pending(_, let viewModel, let pending):
-            MonitoringCardView(
-              session: pending.placeholderSession,
-              state: nil,
-              claudeClient: viewModel.claudeClient,
-              cliConfiguration: viewModel.cliConfiguration,
-              providerKind: item.providerKind,
-              showTerminal: true,
-              initialPrompt: pending.initialPrompt,
-              initialInputText: pending.initialInputText,
-              terminalKey: "pending-\(pending.id.uuidString)",
-              viewModel: viewModel,
-              dangerouslySkipPermissions: pending.dangerouslySkipPermissions,
-          worktreeName: pending.worktreeName,
-              onToggleTerminal: { _ in },
-              onStopMonitoring: { viewModel.cancelPendingSession(pending) },
-              onConnect: { },
-              onCopySessionId: { },
-              onOpenSessionFile: { },
-              onRefreshTerminal: { },
-              onTerminalInteraction: { setPrimarySessionIfNeeded(item.id) },
-              isMaximized: maximizedSessionId == item.id,
-              onToggleMaximize: {
-                withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) {
-                  maximizedSessionId = maximizedSessionId == item.id ? nil : item.id
-                }
-              },
-              isPrimarySession: isPrimary,
-              showPrimaryIndicator: layoutMode != .single
-            )
-            .id(item.id)
-
-          case .monitored(_, let viewModel, let session, let state):
-            let planState = state.flatMap { PlanState.from(activities: $0.recentActivities) }
-            let initialPrompt = viewModel.pendingPrompt(for: session.id)
-
-            MonitoringCardView(
-              session: session,
-              state: state,
-              planState: planState,
-              claudeClient: viewModel.claudeClient,
-              cliConfiguration: viewModel.cliConfiguration,
-              providerKind: item.providerKind,
-              showTerminal: viewModel.sessionsWithTerminalView.contains(session.id),
-              initialPrompt: initialPrompt,
-              terminalKey: session.id,
-              viewModel: viewModel,
-              onToggleTerminal: { show in
-                viewModel.setTerminalView(for: session.id, show: show)
-              },
-              onStopMonitoring: {
-                viewModel.stopMonitoring(session: session)
-              },
-              onConnect: {
-                _ = viewModel.connectToSession(session)
-              },
-              onCopySessionId: {
-                viewModel.copySessionId(session)
-              },
-              onOpenSessionFile: {
-                openSessionFile(for: session, viewModel: viewModel)
-              },
-              onRefreshTerminal: {
-                viewModel.refreshTerminal(
-                  forKey: session.id,
-                  sessionId: session.id,
-                  projectPath: session.projectPath
-                )
-              },
-              onInlineRequestSubmit: { prompt, sess in
-                viewModel.showTerminalWithPrompt(for: sess, prompt: prompt)
-              },
-              onPromptConsumed: {
-                viewModel.clearPendingPrompt(for: session.id)
-              },
-              onTerminalInteraction: { setPrimarySessionIfNeeded(item.id) },
-              isMaximized: maximizedSessionId == item.id,
-              onToggleMaximize: {
-                withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) {
-                  maximizedSessionId = maximizedSessionId == item.id ? nil : item.id
-                }
-              },
-              isPrimarySession: isPrimary,
-              showPrimaryIndicator: layoutMode != .single
-            )
-            .id(item.id)
-          }
+          itemCardView(for: item)
         }
       }
     }
@@ -860,6 +894,10 @@ public struct MultiProviderMonitoringPanelView: View {
     let grouped = Dictionary(grouping: visibleItems) { findModulePath(for: $0) }
     return grouped.sorted { $0.key < $1.key }
       .map { (modulePath: $0.key, items: $0.value.sorted { $0.timestamp > $1.timestamp }) }
+  }
+
+  private var flatSortedItems: [ProviderMonitoringItem] {
+    groupedMonitoredSessions.flatMap { $0.items }
   }
 
   private var allSelectedRepositories: [SelectedRepository] {


### PR DESCRIPTION
## Summary

- Adds `.transition(.opacity)` to both branches of the `flatSessionLayout` conditional (list and grid modes) in `MonitoringPanelView` and `MultiProviderMonitoringPanelView`
- Drives the transition with `.animation(.easeInOut(duration: 0.25), value: flatSessionLayout)` on the `ScrollView`, alongside the existing `layoutMode` animation

## Test plan

- [ ] Monitor two or more repos with multiple sessions
- [ ] Switch to list or grid layout mode (not single)
- [ ] Toggle "Flat session layout" in Settings → Features — section headers should cross-fade smoothly into the flat list
- [ ] Toggle back — flat list cross-fades back to sections
- [ ] Confirm layout-mode switching still animates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)