### PR TITLE
Add flat session layout toggle to defaults and settings

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubDefaults.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubDefaults.swift
@@ -124,6 +124,10 @@ public enum AgentHubDefaults {
   /// Type: Bool (default: false)
   public static let smartModeEnabled = "\(keyPrefix)features.smartModeEnabled"
 
+  /// Whether to show sessions in a flat list without per-repository section headers
+  /// Type: Bool (default: false)
+  public static let flatSessionLayout = "\(keyPrefix)hub.flatSessionLayout"
+
   // MARK: - Theme Settings
 
   /// Selected color theme name

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/SettingsView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/SettingsView.swift
@@ -11,6 +11,9 @@ public struct SettingsView: View {
   @AppStorage(AgentHubDefaults.smartModeEnabled)
   private var smartModeEnabled: Bool = false
 
+  @AppStorage(AgentHubDefaults.flatSessionLayout)
+  private var flatSessionLayout: Bool = false
+
   @AppStorage(AgentHubDefaults.terminalFontSize)
   private var terminalFontSize: Double = 12
 
@@ -131,6 +134,14 @@ public struct SettingsView: View {
           VStack(alignment: .leading, spacing: 2) {
             Text("Smart mode")
             Text("Use AI to plan and orchestrate multi-session launches")
+              .font(.caption)
+              .foregroundColor(.secondary)
+          }
+        }
+        Toggle(isOn: $flatSessionLayout) {
+          VStack(alignment: .leading, spacing: 2) {
+            Text("Flat session layout")
+            Text("Show all sessions without per-repository sections")
               .font(.caption)
               .foregroundColor(.secondary)
           }


### PR DESCRIPTION
## Summary

- Adds `flatSessionLayout` UserDefaults key to `AgentHubDefaults`
- Wires up a Settings toggle to show all sessions without per-repository section headers

## Test plan

- [ ] Build and confirm no compile errors
- [ ] Toggle "Flat session layout" in Settings → Features
- [ ] Verify sessions display flat (no section headers) when enabled, grouped when disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)