### PR TITLE
Add Mermaid diagram viewer with native rendering

### DIFF
--- a/app/AgentHub.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/app/AgentHub.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -11,12 +11,30 @@
       }
     },
     {
+      "identity" : "beautiful-mermaid-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/lukilabs/beautiful-mermaid-swift",
+      "state" : {
+        "revision" : "c6a63655285c5e479d6641c774acb0a8739f8ad7",
+        "version" : "0.1.1"
+      }
+    },
+    {
       "identity" : "claudecodesdk",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/jamesrochabrun/ClaudeCodeSDK",
       "state" : {
         "revision" : "f626d1d1eab3bf43a1eef2f70b2a493903f7e5e8",
         "version" : "1.2.4"
+      }
+    },
+    {
+      "identity" : "dagre-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/lukilabs/dagre-swift",
+      "state" : {
+        "revision" : "92efb78b73a8b665ee74bacfb0f1f5b17bbe1b38",
+        "version" : "0.1.0"
       }
     },
     {

--- a/app/modules/AgentHubCore/Package.swift
+++ b/app/modules/AgentHubCore/Package.swift
@@ -21,6 +21,7 @@ let package = Package(
     .package(url: "https://github.com/groue/GRDB.swift", from: "6.24.0"),
     .package(url: "https://github.com/appstefan/HighlightSwift", from: "1.1.0"),
     .package(url: "https://github.com/jpsim/Yams", from: "5.0.0"),
+    .package(url: "https://github.com/lukilabs/beautiful-mermaid-swift", from: "0.1.0"),
   ],
   targets: [
     .target(
@@ -33,6 +34,7 @@ let package = Package(
         .product(name: "GRDB", package: "GRDB.swift"),
         .product(name: "HighlightSwift", package: "HighlightSwift"),
         .product(name: "Yams", package: "Yams"),
+        .product(name: "BeautifulMermaid", package: "beautiful-mermaid-swift"),
       ],
       path: "Sources/AgentHub",
       resources: [

--- a/app/modules/AgentHubCore/Sources/AgentHub/Models/SessionMonitorState.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Models/SessionMonitorState.swift
@@ -37,6 +37,9 @@ public struct SessionMonitorState: Equatable, Sendable {
   // Recent activity log
   public var recentActivities: [ActivityEntry]
 
+  // Mermaid diagram detection
+  public var hasMermaidContent: Bool
+
   public init(
     status: SessionStatus = .idle,
     currentTool: String? = nil,
@@ -52,7 +55,8 @@ public struct SessionMonitorState: Equatable, Sendable {
     model: String? = nil,
     gitBranch: String? = nil,
     pendingToolUse: PendingToolUse? = nil,
-    recentActivities: [ActivityEntry] = []
+    recentActivities: [ActivityEntry] = [],
+    hasMermaidContent: Bool = false
   ) {
     self.status = status
     self.currentTool = currentTool
@@ -69,6 +73,7 @@ public struct SessionMonitorState: Equatable, Sendable {
     self.gitBranch = gitBranch
     self.pendingToolUse = pendingToolUse
     self.recentActivities = recentActivities
+    self.hasMermaidContent = hasMermaidContent
   }
 
   // MARK: - Computed Properties

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/CodexSessionFileWatcher.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/CodexSessionFileWatcher.swift
@@ -218,7 +218,8 @@ public actor CodexSessionFileWatcher {
       model: result.model,
       gitBranch: nil,
       pendingToolUse: nil,
-      recentActivities: result.recentActivities
+      recentActivities: result.recentActivities,
+      hasMermaidContent: result.hasMermaidContent
     )
   }
 }

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/CodexSessionJSONLParser.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/CodexSessionJSONLParser.swift
@@ -40,6 +40,7 @@ public struct CodexSessionJSONLParser {
     public var lastActivityAt: Date?
     public var sessionStartedAt: Date?
     public var currentStatus: SessionStatus = .idle
+    public var hasMermaidContent: Bool = false
 
     public init() {}
   }
@@ -196,6 +197,7 @@ public struct CodexSessionJSONLParser {
     case "agent_message":
       result.messageCount += 1
       if let message = payload["message"] as? String, !message.isEmpty {
+        if message.contains("```mermaid") { result.hasMermaidContent = true }
         addActivity(type: .assistantMessage, description: String(message.prefix(80)), timestamp: timestamp, to: &result)
       }
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/MermaidRenderHelper.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/MermaidRenderHelper.swift
@@ -1,0 +1,17 @@
+//
+//  MermaidRenderHelper.swift
+//  AgentHub
+//
+//  Thin wrapper that isolates the BeautifulMermaid import so its `State` type
+//  doesn't pollute SwiftUI view files and cause @State ambiguity.
+//
+
+import AppKit
+import BeautifulMermaid
+
+enum MermaidRenderHelper {
+  /// Renders a Mermaid diagram source string to an NSImage.
+  static func renderImage(source: String) throws -> NSImage? {
+    try MermaidRenderer.renderImage(source: source)
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/SessionFileWatcher.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/SessionFileWatcher.swift
@@ -357,7 +357,8 @@ public actor SessionFileWatcher {
       model: result.model,
       gitBranch: result.gitBranch,
       pendingToolUse: pendingToolUse,
-      recentActivities: result.recentActivities
+      recentActivities: result.recentActivities,
+      hasMermaidContent: result.hasMermaidContent
     )
   }
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/SessionJSONLParser.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/SessionJSONLParser.swift
@@ -84,6 +84,7 @@ public struct SessionJSONLParser {
     public var sessionStartedAt: Date?
     public var currentStatus: SessionStatus = .idle
     public var gitBranch: String?
+    public var hasMermaidContent: Bool = false
 
     public init() {}
   }
@@ -285,6 +286,9 @@ public struct SessionJSONLParser {
         )
 
       case "text":
+        if let text = block.text, text.contains("```mermaid") {
+          result.hasMermaidContent = true
+        }
         addActivity(
           type: .assistantMessage,
           description: block.text?.prefix(50).description ?? "",

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MermaidDiagramView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MermaidDiagramView.swift
@@ -1,0 +1,370 @@
+//
+//  MermaidDiagramView.swift
+//  AgentHub
+//
+//  Renders Mermaid diagrams extracted from a Claude Code session's JSONL file.
+//
+
+import AppKit
+import SwiftUI
+
+// MARK: - MermaidDiagramView
+
+/// Side panel / sheet view that extracts and renders all Mermaid diagrams
+/// from a session's JSONL file using native rendering (no WebView/JS).
+public struct MermaidDiagramView: View {
+  let session: CLISession
+  let onDismiss: () -> Void
+  var isEmbedded: Bool = false
+
+  @State private var diagrams: [String] = []
+  @State private var isLoading = true
+  @State private var errorMessage: String?
+
+  public init(
+    session: CLISession,
+    onDismiss: @escaping () -> Void,
+    isEmbedded: Bool = false
+  ) {
+    self.session = session
+    self.onDismiss = onDismiss
+    self.isEmbedded = isEmbedded
+  }
+
+  public var body: some View {
+    VStack(spacing: 0) {
+      header
+
+      if isLoading {
+        loadingState
+      } else if let error = errorMessage {
+        errorState(error)
+      } else if diagrams.isEmpty {
+        emptyState
+      } else {
+        diagramList
+      }
+    }
+    .frame(
+      minWidth: isEmbedded ? 300 : 700, idealWidth: isEmbedded ? .infinity : 900, maxWidth: .infinity,
+      minHeight: isEmbedded ? 300 : 550, idealHeight: isEmbedded ? .infinity : 750, maxHeight: .infinity
+    )
+    .onKeyPress(.escape) {
+      onDismiss()
+      return .handled
+    }
+    .task {
+      await loadDiagrams()
+    }
+  }
+
+  // MARK: - Header
+
+  private var header: some View {
+    HStack {
+      Spacer()
+      Button("Close") {
+        onDismiss()
+      }
+    }
+    .padding(.horizontal, 12)
+    .padding(.vertical, 6)
+  }
+
+  // MARK: - Content
+
+  private var loadingState: some View {
+    VStack(spacing: 12) {
+      ProgressView()
+      Text("Extracting diagrams...")
+        .font(.caption)
+        .foregroundColor(.secondary)
+    }
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+  }
+
+  private func errorState(_ message: String) -> some View {
+    VStack(spacing: 8) {
+      Image(systemName: "exclamationmark.triangle")
+        .font(.title2)
+        .foregroundColor(.secondary)
+      Text(message)
+        .font(.caption)
+        .foregroundColor(.secondary)
+        .multilineTextAlignment(.center)
+        .padding(.horizontal)
+    }
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+  }
+
+  private var emptyState: some View {
+    VStack(spacing: 8) {
+      Image(systemName: "chart.xyaxis.line")
+        .font(.title2)
+        .foregroundColor(.secondary)
+      Text("No Mermaid diagrams found")
+        .font(.caption)
+        .foregroundColor(.secondary)
+    }
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+  }
+
+  private var diagramList: some View {
+    ScrollView {
+      LazyVStack(spacing: 24) {
+        ForEach(Array(diagrams.enumerated()), id: \.offset) { index, source in
+          DiagramCard(index: index + 1, source: source)
+        }
+      }
+      .padding(16)
+    }
+  }
+
+  // MARK: - Loading
+
+  private func loadDiagrams() async {
+    let filePath = session.sessionFilePath ?? Self.resolveFilePath(for: session)
+    do {
+      diagrams = try await Self.extractMermaidBlocks(from: filePath)
+    } catch {
+      errorMessage = "Failed to read session: \(error.localizedDescription)"
+    }
+    isLoading = false
+  }
+
+  /// Constructs the session JSONL path using the same encoding as CLISessionMonitorService.
+  private static func resolveFilePath(for session: CLISession) -> String {
+    let claudeDataPath = NSHomeDirectory() + "/.claude"
+    let encodedPath = session.projectPath.claudeProjectPathEncoded
+    return "\(claudeDataPath)/projects/\(encodedPath)/\(session.id).jsonl"
+  }
+
+  // MARK: - JSONL Extraction
+
+  /// Reads a session JSONL file and returns all Mermaid source blocks found in assistant text content.
+  /// Handles both Claude (assistant/text blocks) and Codex (event_msg/agent_message) formats.
+  public static func extractMermaidBlocks(from filePath: String) async throws -> [String] {
+    return try await Task.detached(priority: .userInitiated) {
+      guard let data = FileManager.default.contents(atPath: filePath),
+            let content = String(data: data, encoding: .utf8) else {
+        throw CocoaError(.fileReadNoSuchFile)
+      }
+
+      var blocks: [String] = []
+      let lines = content.components(separatedBy: .newlines)
+      let decoder = JSONDecoder()
+
+      for line in lines where !line.isEmpty {
+        guard let lineData = line.data(using: .utf8) else { continue }
+
+        // Try Claude format first
+        if let entry = try? decoder.decode(SessionJSONLParser.SessionEntry.self, from: lineData),
+           entry.type == "assistant",
+           let contentBlocks = entry.message?.content {
+          for block in contentBlocks where block.type == "text" {
+            guard let text = block.text else { continue }
+            blocks.append(contentsOf: extractMermaidSections(from: text))
+          }
+          continue
+        }
+
+        // Try Codex format: {"type":"event_msg","payload":{"type":"agent_message","message":"..."}}
+        if let json = (try? JSONSerialization.jsonObject(with: lineData)) as? [String: Any],
+           let type = json["type"] as? String, type == "event_msg",
+           let payload = json["payload"] as? [String: Any],
+           let eventType = payload["type"] as? String, eventType == "agent_message",
+           let message = payload["message"] as? String {
+          blocks.append(contentsOf: extractMermaidSections(from: message))
+        }
+      }
+      return blocks
+    }.value
+  }
+
+  /// Extracts all ```mermaid ... ``` sections from a text string.
+  private static func extractMermaidSections(from text: String) -> [String] {
+    var results: [String] = []
+    var searchRange = text.startIndex..<text.endIndex
+
+    let openTag = "```mermaid"
+    let closeTag = "```"
+
+    while let openRange = text.range(of: openTag, range: searchRange) {
+      let afterOpen = openRange.upperBound
+      // Skip the newline right after the opening tag
+      let contentStart = text[afterOpen...].first == "\n"
+        ? text.index(after: afterOpen)
+        : afterOpen
+
+      guard contentStart < text.endIndex,
+            let closeRange = text.range(of: closeTag, range: contentStart..<text.endIndex) else {
+        break
+      }
+
+      let source = String(text[contentStart..<closeRange.lowerBound])
+        .trimmingCharacters(in: .whitespacesAndNewlines)
+      if !source.isEmpty {
+        results.append(source)
+      }
+      searchRange = closeRange.upperBound..<text.endIndex
+    }
+    return results
+  }
+}
+
+// MARK: - DiagramCard
+
+/// Renders a single Mermaid diagram asynchronously with zoom and download support.
+private struct DiagramCard: View {
+  let index: Int
+  let source: String
+
+  @State private var renderedImage: NSImage?
+  @State private var isRendering = true
+  @State private var renderError: String?
+  @State private var scale: CGFloat = 1.0
+  @State private var baseScale: CGFloat = 1.0
+
+  private let scaleStep: CGFloat = 0.25
+  private let minScale: CGFloat = 0.25
+  private let maxScale: CGFloat = 4.0
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      // Label row + controls
+      HStack {
+        Text("Diagram \(index)")
+          .font(.caption)
+          .fontWeight(.medium)
+          .foregroundColor(.secondary)
+
+        Spacer()
+
+        if renderedImage != nil {
+          // Zoom controls
+          HStack(spacing: 2) {
+            Button(action: { scale = max(minScale, scale - scaleStep) }) {
+              Image(systemName: "minus")
+                .font(.caption2)
+            }
+            .buttonStyle(.plain)
+            .help("Zoom out")
+
+            Text("\(Int(scale * 100))%")
+              .font(.caption2)
+              .foregroundColor(.secondary)
+              .frame(minWidth: 36)
+
+            Button(action: { scale = min(maxScale, scale + scaleStep) }) {
+              Image(systemName: "plus")
+                .font(.caption2)
+            }
+            .buttonStyle(.plain)
+            .help("Zoom in")
+
+            Button(action: { scale = 1.0; baseScale = 1.0 }) {
+              Image(systemName: "arrow.uturn.backward")
+                .font(.caption2)
+            }
+            .buttonStyle(.plain)
+            .help("Reset zoom")
+          }
+          .padding(.horizontal, 6)
+          .padding(.vertical, 3)
+          .background(Color.secondary.opacity(0.08))
+          .clipShape(RoundedRectangle(cornerRadius: 4))
+
+          // Download button
+          Button(action: saveImage) {
+            Image(systemName: "arrow.down.circle")
+              .font(.caption2)
+          }
+          .buttonStyle(.plain)
+          .help("Save as PNG")
+        }
+      }
+
+      // Diagram canvas
+      ZStack {
+        if isRendering {
+          HStack(spacing: 8) {
+            ProgressView()
+              .scaleEffect(0.7)
+            Text("Rendering...")
+              .font(.caption)
+              .foregroundColor(.secondary)
+          }
+          .frame(height: 120)
+          .frame(maxWidth: .infinity)
+        } else if let error = renderError {
+          VStack(spacing: 6) {
+            Image(systemName: "exclamationmark.triangle")
+              .foregroundColor(.secondary)
+            Text(error)
+              .font(.caption)
+              .foregroundColor(.secondary)
+              .multilineTextAlignment(.center)
+          }
+          .frame(height: 80)
+          .frame(maxWidth: .infinity)
+        } else if let image = renderedImage {
+          let aspect = image.size.height / max(image.size.width, 1)
+          let baseWidth: CGFloat = 560
+          ScrollView([.horizontal, .vertical]) {
+            Image(nsImage: image)
+              .resizable()
+              .frame(
+                width: baseWidth * scale,
+                height: baseWidth * aspect * scale
+              )
+          }
+        }
+      }
+      .padding(12)
+      .background(Color(NSColor.textBackgroundColor))
+      .clipShape(RoundedRectangle(cornerRadius: 8))
+      .overlay(
+        RoundedRectangle(cornerRadius: 8)
+          .stroke(Color.secondary.opacity(0.2), lineWidth: 1)
+      )
+      .gesture(
+        MagnifyGesture()
+          .onChanged { value in
+            scale = min(maxScale, max(minScale, baseScale * value.magnification))
+          }
+          .onEnded { value in
+            baseScale = scale
+          }
+      )
+    }
+    .task {
+      await render()
+    }
+  }
+
+  private func render() async {
+    do {
+      let image = try await Task.detached(priority: .userInitiated) {
+        try MermaidRenderHelper.renderImage(source: source)
+      }.value
+      renderedImage = image
+    } catch {
+      renderError = "Render failed: \(error.localizedDescription)"
+    }
+    isRendering = false
+  }
+
+  private func saveImage() {
+    guard let image = renderedImage else { return }
+    let panel = NSSavePanel()
+    panel.allowedContentTypes = [.png]
+    panel.nameFieldStringValue = "diagram-\(index).png"
+    panel.begin { response in
+      guard response == .OK, let url = panel.url else { return }
+      guard let tiffData = image.tiffRepresentation,
+            let bitmap = NSBitmapImageRep(data: tiffData),
+            let png = bitmap.representation(using: .png, properties: [:]) else { return }
+      try? png.write(to: url)
+    }
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringCardView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringCardView.swift
@@ -70,6 +70,7 @@ public struct MonitoringCardView: View {
   let onShowDiff: ((CLISession, String) -> Void)?
   let onShowPlan: ((CLISession, PlanState) -> Void)?
   let onShowWebPreview: ((CLISession, String) -> Void)?
+  let onShowMermaid: ((CLISession) -> Void)?
   let onPromptConsumed: (() -> Void)?
   let onTerminalInteraction: (() -> Void)?
   let isMaximized: Bool
@@ -82,6 +83,7 @@ public struct MonitoringCardView: View {
   @State private var planSheetItem: PlanSheetItem?
   @State private var pendingChangesSheetItem: PendingChangesSheetItem?
   @State private var webPreviewSheetItem: WebPreviewSheetItem?
+  @State private var mermaidSheetSession: CLISession?
   @State private var isDragging = false
   @State private var showingActionsPopover = false
   @State private var showingFilePicker = false
@@ -113,6 +115,7 @@ public struct MonitoringCardView: View {
     onShowDiff: ((CLISession, String) -> Void)? = nil,
     onShowPlan: ((CLISession, PlanState) -> Void)? = nil,
     onShowWebPreview: ((CLISession, String) -> Void)? = nil,
+    onShowMermaid: ((CLISession) -> Void)? = nil,
     onPromptConsumed: (() -> Void)? = nil,
     onTerminalInteraction: (() -> Void)? = nil,
     isMaximized: Bool = false,
@@ -144,6 +147,7 @@ public struct MonitoringCardView: View {
     self.onShowDiff = onShowDiff
     self.onShowPlan = onShowPlan
     self.onShowWebPreview = onShowWebPreview
+    self.onShowMermaid = onShowMermaid
     self.onPromptConsumed = onPromptConsumed
     self.onTerminalInteraction = onTerminalInteraction
     self.isMaximized = isMaximized
@@ -245,6 +249,12 @@ public struct MonitoringCardView: View {
         session: item.session,
         projectPath: item.projectPath,
         onDismiss: { webPreviewSheetItem = nil }
+      )
+    }
+    .sheet(item: $mermaidSheetSession) { session in
+      MermaidDiagramView(
+        session: session,
+        onDismiss: { mermaidSheetSession = nil }
       )
     }
     .sheet(isPresented: $showingNameSheet) {
@@ -663,6 +673,31 @@ public struct MonitoringCardView: View {
         }
         .buttonStyle(.plain)
         .help("Preview localhost web app")
+      }
+
+      // Mermaid diagram button (only visible when mermaid content is detected)
+      if state?.hasMermaidContent == true {
+        Button(action: {
+          if let onShowMermaid {
+            onShowMermaid(session)
+          } else {
+            mermaidSheetSession = session
+          }
+        }) {
+          HStack(spacing: 4) {
+            Image(systemName: "chart.xyaxis.line")
+              .font(.caption2)
+            Text("Diagram")
+              .font(.caption2)
+          }
+          .foregroundColor(.secondary)
+          .padding(.horizontal, 8)
+          .padding(.vertical, 4)
+          .background(Color.secondary.opacity(0.1))
+          .clipShape(RoundedRectangle(cornerRadius: 4))
+        }
+        .buttonStyle(.plain)
+        .help("View Mermaid diagrams")
       }
 
       // Terminal refresh button (only visible when terminal is shown)

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderMonitoringPanelView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderMonitoringPanelView.swift
@@ -16,6 +16,7 @@ private enum SidePanelContent: Equatable {
   case diff(sessionId: String, session: CLISession, projectPath: String)
   case plan(sessionId: String, session: CLISession, planState: PlanState)
   case webPreview(sessionId: String, session: CLISession, projectPath: String)
+  case mermaid(sessionId: String, session: CLISession)
 
   static func == (lhs: SidePanelContent, rhs: SidePanelContent) -> Bool {
     switch (lhs, rhs) {
@@ -25,6 +26,8 @@ private enum SidePanelContent: Equatable {
       return id1 == id2
     case (.webPreview(let id1, _, let p1), .webPreview(let id2, _, let p2)):
       return id1 == id2 && p1 == p2
+    case (.mermaid(let id1, _), .mermaid(let id2, _)):
+      return id1 == id2
     default: return false
     }
   }
@@ -562,6 +565,9 @@ public struct MultiProviderMonitoringPanelView: View {
             onShowWebPreview: canShowSidePanel ? { session, projectPath in
               sidePanelContent = .webPreview(sessionId: session.id, session: session, projectPath: projectPath)
             } : nil,
+            onShowMermaid: canShowSidePanel ? { session in
+              sidePanelContent = .mermaid(sessionId: session.id, session: session)
+            } : nil,
             onPromptConsumed: {
               viewModel.clearPendingPrompt(for: session.id)
             },
@@ -610,6 +616,12 @@ public struct MultiProviderMonitoringPanelView: View {
       WebPreviewView(
         session: session,
         projectPath: projectPath,
+        onDismiss: { withAnimation(.easeInOut(duration: 0.25)) { sidePanelContent = nil } },
+        isEmbedded: true
+      )
+    case .mermaid(_, let session):
+      MermaidDiagramView(
+        session: session,
         onDismiss: { withAnimation(.easeInOut(duration: 0.25)) { sidePanelContent = nil } },
         isEmbedded: true
       )


### PR DESCRIPTION
## Summary

- Adds `beautiful-mermaid-swift` package for native Mermaid rendering (no WebView/JS)
- Detects ` ```mermaid ` blocks in session JSONL for both Claude and Codex formats and surfaces a **Diagram** button in the monitoring card path row
- Opens a `MermaidDiagramView` side panel (or sheet fallback) showing all diagrams from the session with zoom (+/−, pinch), pan, and PNG export
- Fixes zoom: replaces `GeometryReader` with a `baseWidth × scale` layout so `ScrollView` correctly tracks content size and enables panning when zoomed

## Test plan

- [ ] Open a Claude Code session that contains a Mermaid code block — **Diagram** button appears in card path row
- [ ] Click **Diagram** in Single layout (≥900px wide) → side panel opens with rendered diagram
- [ ] Click **Diagram** in List/2-Column/3-Column layout → sheet opens
- [ ] Zoom in/out with +/− buttons and pinch gesture — diagram scales and ScrollView pans correctly
- [ ] Click save icon → NSSavePanel prompts for PNG location
- [ ] Sessions without Mermaid content show no **Diagram** button
- [ ] Codex sessions with agent_message mermaid blocks also detected