### PR TITLE
feat: add terminal font family picker in settings

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubDefaults.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubDefaults.swift
@@ -98,6 +98,10 @@ public enum AgentHubDefaults {
   /// Type: Double (default: 12.0)
   public static let terminalFontSize = "\(keyPrefix)terminal.fontSize"
 
+  /// Terminal font family name
+  /// Type: String (default: "SF Mono")
+  public static let terminalFontName = "\(keyPrefix)terminal.fontName"
+
   /// Monitoring panel layout mode (list, 2-column, 3-column grid)
   /// Type: Int (default: 0 = list)
   public static let monitoringPanelLayoutMode = "\(keyPrefix)ui.monitoringPanelLayoutMode"

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/EmbeddedTerminalView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/EmbeddedTerminalView.swift
@@ -44,6 +44,7 @@ class SafeLocalProcessTerminalView: ManagedLocalProcessTerminalView {
 public struct EmbeddedTerminalView: NSViewRepresentable {
   @Environment(\.colorScheme) private var colorScheme
   @AppStorage(AgentHubDefaults.terminalFontSize) private var terminalFontSize: Double = 12
+  @AppStorage(AgentHubDefaults.terminalFontName) private var terminalFontName: String = "SF Mono"
 
   let terminalKey: String  // Key for terminal storage (session ID or "pending-{pendingId}")
   let sessionId: String?  // Optional: nil for new sessions, set for resume
@@ -120,7 +121,7 @@ public struct EmbeddedTerminalView: NSViewRepresentable {
     // Update colors when color scheme changes
     nsView.updateColors(isDark: colorScheme == .dark)
     nsView.onUserInteraction = onUserInteraction
-    nsView.updateFont(size: CGFloat(terminalFontSize))
+    nsView.updateFont(name: terminalFontName, size: CGFloat(terminalFontSize))
 
     // If there's a pending prompt in the viewModel, send it (and clear it)
     // Use terminalKey (not sessionId) since it works for both pending and real sessions
@@ -140,6 +141,8 @@ public class TerminalContainerView: NSView, ManagedLocalProcessTerminalViewDeleg
   private var isConfigured = false
   private var hasDeliveredInitialPrompt = false
   private var hasPrefilledInitialInputText = false
+  private var appliedFontName: String = ""
+  private var appliedFontSize: CGFloat = 0
   private var terminalPidMap: [ObjectIdentifier: pid_t] = [:]
   private var localEventMonitor: Any?
   public var onUserInteraction: (() -> Void)?
@@ -277,13 +280,15 @@ public class TerminalContainerView: NSView, ManagedLocalProcessTerminalViewDeleg
     typeText(text)
   }
 
-  /// Updates terminal font size.
-  public func updateFont(size: CGFloat) {
+  /// Updates terminal font and size.
+  public func updateFont(name: String, size: CGFloat) {
     guard let terminal = terminalView else { return }
-    let font = NSFont(name: "SF Mono", size: size)
+    guard name != appliedFontName || size != appliedFontSize else { return }
+    appliedFontName = name
+    appliedFontSize = size
+    terminal.font = NSFont(name: name, size: size)
       ?? NSFont(name: "Menlo", size: size)
       ?? NSFont.monospacedSystemFont(ofSize: size, weight: .regular)
-    terminal.font = font
   }
 
   /// Updates terminal colors based on color scheme.
@@ -343,11 +348,12 @@ public class TerminalContainerView: NSView, ManagedLocalProcessTerminalViewDeleg
 
   private func configureTerminalAppearance(_ terminal: TerminalView, isDark: Bool) {
     // Use a monospace font that looks good in terminals
-    let fontSize: CGFloat = 12
-    let font = NSFont(name: "SF Mono", size: fontSize)
+    let storedSize = UserDefaults.standard.double(forKey: AgentHubDefaults.terminalFontSize)
+    let fontSize = storedSize > 0 ? CGFloat(storedSize) : 12
+    let fontName = UserDefaults.standard.string(forKey: AgentHubDefaults.terminalFontName) ?? "SF Mono"
+    terminal.font = NSFont(name: fontName, size: fontSize)
       ?? NSFont(name: "Menlo", size: fontSize)
       ?? NSFont.monospacedSystemFont(ofSize: fontSize, weight: .regular)
-    terminal.font = font
 
     // Configure colors based on color scheme
     if isDark {

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/SettingsView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/SettingsView.swift
@@ -17,6 +17,9 @@ public struct SettingsView: View {
   @AppStorage(AgentHubDefaults.terminalFontSize)
   private var terminalFontSize: Double = 12
 
+  @AppStorage(AgentHubDefaults.terminalFontName)
+  private var terminalFontName: String = "SF Mono"
+
   @AppStorage(AgentHubDefaults.notificationSoundsEnabled)
   private var notificationSoundsEnabled: Bool = true
 
@@ -39,6 +42,12 @@ public struct SettingsView: View {
   @AppStorage(AgentHubDefaults.selectedTheme) private var selectedThemeId: String = "claude"
   private let defaultThemeId = "claude"
   private let sentryThemeFileId = "sentry.yaml"
+
+  private var availableFonts: [String] {
+    NSFontManager.shared.availableFontFamilies
+      .filter { NSFont(name: $0, size: 12)?.isFixedPitch == true }
+      .sorted()
+  }
 
   public init() {}
 
@@ -149,6 +158,17 @@ public struct SettingsView: View {
       }
 
       Section("Terminal") {
+        Picker("Font", selection: $terminalFontName) {
+          ForEach(availableFonts, id: \.self) { name in
+            Text(name).tag(name)
+          }
+        }
+        .onChange(of: terminalFontName) { _, newValue in
+          if !availableFonts.contains(newValue), let first = availableFonts.first {
+            terminalFontName = first
+          }
+        }
+
         Stepper(value: $terminalFontSize, in: 8...24, step: 1) {
           HStack {
             Text("Font size")
@@ -158,6 +178,7 @@ public struct SettingsView: View {
               .monospacedDigit()
           }
         }
+
       }
 
       Section {
@@ -187,6 +208,9 @@ public struct SettingsView: View {
     .frame(width: 300, height: 500)
     .task {
       await ensureSupportedThemeSelection()
+      if !availableFonts.contains(terminalFontName), let first = availableFonts.first {
+        terminalFontName = first
+      }
     }
   }
 


### PR DESCRIPTION
Let users choose any monospace font installed on the system from Settings → Terminal. Font list is populated dynamically via NSFontManager filtered by isFixedPitch. Font name persists via UserDefaults and is applied to SwiftTerm on every settings change, with caching to avoid redundant resetFont/SIGWINCH calls.

<img width="368" height="600" alt="Screenshot 2026-03-01 at 01 08 51" src="https://github.com/user-attachments/assets/68c53d5c-3042-4f44-9c58-8bdb3d13db78" />