### PR TITLE
feat: make theme picker dynamic, show all YAML themes from Themes folder

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/SettingsView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/SettingsView.swift
@@ -38,7 +38,6 @@ public struct SettingsView: View {
   @Environment(ThemeManager.self) private var themeManager
   @AppStorage(AgentHubDefaults.selectedTheme) private var selectedThemeId: String = "claude"
   private let defaultThemeId = "claude"
-  private let sentryThemeFileId = "sentry.yaml"
 
   public init() {}
 
@@ -163,7 +162,9 @@ public struct SettingsView: View {
       Section {
         Picker("Theme", selection: themeSelectionBinding) {
           Text("Default").tag(defaultThemeId)
-          Text("Sentry").tag(sentryThemeFileId)
+          ForEach(themeManager.availableYAMLThemes) { theme in
+            Text(theme.name).tag(theme.id)
+          }
         }
 
         HStack(spacing: 8) {
@@ -186,6 +187,7 @@ public struct SettingsView: View {
     .formStyle(.grouped)
     .frame(width: 300, height: 500)
     .task {
+      await themeManager.discoverThemes()
       await ensureSupportedThemeSelection()
     }
   }
@@ -193,26 +195,29 @@ public struct SettingsView: View {
   private var themeSelectionBinding: Binding<String> {
     Binding(
       get: {
-        isSentryThemeId(selectedThemeId) ? sentryThemeFileId : defaultThemeId
+        let yamlIds = themeManager.availableYAMLThemes.map(\.id)
+        return yamlIds.contains(selectedThemeId) ? selectedThemeId : defaultThemeId
       },
       set: { newValue in
-        Task {
-          await applyThemeSelection(newValue)
-        }
+        Task { await applyThemeSelection(newValue) }
       }
     )
   }
 
   private func ensureSupportedThemeSelection() async {
-    if isSentryThemeId(selectedThemeId) {
-      await applyThemeSelection(sentryThemeFileId)
+    if selectedThemeId == defaultThemeId {
+      themeManager.loadBuiltInTheme(.claude)
       return
     }
 
-    if selectedThemeId != defaultThemeId {
-      selectedThemeId = defaultThemeId
-      themeManager.loadBuiltInTheme(.claude)
+    if let theme = themeManager.availableYAMLThemes.first(where: { $0.id == selectedThemeId }),
+       let fileURL = theme.fileURL {
+      try? await themeManager.loadTheme(fileURL: fileURL)
+      return
     }
+
+    selectedThemeId = defaultThemeId
+    themeManager.loadBuiltInTheme(.claude)
   }
 
   private func applyThemeSelection(_ selection: String) async {
@@ -224,30 +229,14 @@ public struct SettingsView: View {
 
     await themeManager.discoverThemes()
 
-    if let sentryTheme = themeManager.availableYAMLThemes.first(where: isSentryTheme),
-       let fileURL = sentryTheme.fileURL {
+    if let theme = themeManager.availableYAMLThemes.first(where: { $0.id == selection }),
+       let fileURL = theme.fileURL {
       try? await themeManager.loadTheme(fileURL: fileURL)
-      selectedThemeId = sentryTheme.id
-      return
-    }
-
-    let sentryURL = ThemeManager.themesDirectory().appendingPathComponent(sentryThemeFileId)
-    if FileManager.default.fileExists(atPath: sentryURL.path) {
-      try? await themeManager.loadTheme(fileURL: sentryURL)
-      selectedThemeId = sentryThemeFileId
+      selectedThemeId = theme.id
       return
     }
 
     selectedThemeId = defaultThemeId
     themeManager.loadBuiltInTheme(.claude)
-  }
-
-  private func isSentryTheme(_ metadata: ThemeManager.ThemeMetadata) -> Bool {
-    isSentryThemeId(metadata.id) || metadata.name.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "sentry"
-  }
-
-  private func isSentryThemeId(_ value: String) -> Bool {
-    let normalized = value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-    return normalized == "sentry" || normalized == "sentry.yaml" || normalized == "sentry.yml"
   }
 }


### PR DESCRIPTION
Theme picker in Settings now discovers and lists all .yaml files from ~/Library/Application Support/AgentHub/Themes/ dynamically, instead of hardcoding only the Sentry option.