### PR TITLE
Add interactive plan review mode with batch feedback to Claude

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ https://github.com/user-attachments/assets/ee453a78-e417-488a-96c7-20732d1d1f60
 - **Multi-session launcher** — Launch parallel sessions across Claude and Codex with manual prompts or AI-planned orchestration (Smart mode)
 - **Mermaid diagrams** — Detects Mermaid diagram syntax in session output and renders it natively; diagrams can be exported as images
 - **Web preview** — Auto-detects project type, starts dev servers for framework projects, and live-reloads static HTML
-- **Plan view** — Renders Claude-generated plan files with markdown and syntax highlighting
+- **Plan view** — Renders Claude-generated plan files with markdown and syntax highlighting; switch to Review mode to annotate individual lines and send batch feedback directly to Claude's interactive plan prompt
 - **Global search** — Search across all session files with ranked results
 - **Usage stats** — Track token counts, costs, and daily activity per provider (menu bar or popover)
 - **Command palette** — Quick access to sessions, repositories, and actions via Cmd+K
@@ -42,6 +42,10 @@ https://github.com/user-attachments/assets/ee453a78-e417-488a-96c7-20732d1d1f60
 Parallel execution with Claude Code and Codex
 
 https://github.com/user-attachments/assets/c20c1f3e-745d-4a39-8599-37ad242b3ae6
+
+Plan view with inline review and batch feedback
+
+https://github.com/user-attachments/assets/b7661b65-dc58-4f8e-a4c5-df1e17a4076d
 
 Mermaid diagram rendering with image export
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/EmbeddedTerminalView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/EmbeddedTerminalView.swift
@@ -251,11 +251,31 @@ public class TerminalContainerView: NSView, ManagedLocalProcessTerminalViewDeleg
     guard !hasDeliveredInitialPrompt else { return }
     hasDeliveredInitialPrompt = true
 
-    // Send the prompt text first
-    terminal.send(txt: prompt)
+    // Detect plan-feedback prefix: 3 down-arrows + Enter marks step-by-step delivery
+    let planFeedbackPrefix = "\u{1B}[B\u{1B}[B\u{1B}[B\r"
+    if prompt.hasPrefix(planFeedbackPrefix) {
+      let feedback = String(prompt.dropFirst(planFeedbackPrefix.count))
+      Task { @MainActor [weak terminal] in
+        let down: [UInt8] = [0x1B, 0x5B, 0x42]  // ESC [ B = down arrow
+        terminal?.send(down)
+        try? await Task.sleep(for: .milliseconds(80))
+        terminal?.send(down)
+        try? await Task.sleep(for: .milliseconds(80))
+        terminal?.send(down)
+        try? await Task.sleep(for: .milliseconds(80))
+        terminal?.send([13])                            // select option 4
+        try? await Task.sleep(for: .milliseconds(150)) // wait for text input to open
+        if !feedback.isEmpty {
+          terminal?.send(txt: feedback)
+          try? await Task.sleep(for: .milliseconds(100))
+        }
+        terminal?.send([13])                            // submit
+      }
+      return
+    }
 
-    // Small delay before sending Enter to ensure the terminal's input buffer
-    // processes the text before receiving the carriage return
+    // Normal prompt: send text then Enter
+    terminal.send(txt: prompt)
     Task { @MainActor [weak terminal] in
       try? await Task.sleep(for: .milliseconds(100))
       terminal?.send([13])  // ASCII 13 = carriage return (Enter key)

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringCardView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringCardView.swift
@@ -230,7 +230,11 @@ public struct MonitoringCardView: View {
       PlanView(
         session: item.session,
         planState: item.planState,
-        onDismiss: { planSheetItem = nil }
+        onDismiss: { planSheetItem = nil },
+        providerKind: providerKind,
+        onSendFeedback: { feedback, sess in
+          viewModel?.showTerminalWithPrompt(for: sess, prompt: feedback)
+        }
       )
     }
     .sheet(item: $pendingChangesSheetItem) { item in

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderMonitoringPanelView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderMonitoringPanelView.swift
@@ -610,7 +610,11 @@ public struct MultiProviderMonitoringPanelView: View {
         session: session,
         planState: planState,
         onDismiss: { withAnimation(.easeInOut(duration: 0.25)) { sidePanelContent = nil } },
-        isEmbedded: true
+        isEmbedded: true,
+        providerKind: visibleItems.first?.providerKind ?? .claude,
+        onSendFeedback: { feedback, sess in
+          viewModel.showTerminalWithPrompt(for: sess, prompt: feedback)
+        }
       )
     case .webPreview(_, let session, let projectPath):
       WebPreviewView(

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/PlanView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/PlanView.swift
@@ -17,26 +17,37 @@ import SwiftUI
 ///
 /// Shows a header with file information and session context, followed by
 /// the rendered markdown content. Handles async loading and error states.
+/// Supports a review mode where users can annotate individual lines and
+/// send batch feedback back to the terminal (option 4).
 public struct PlanView: View {
   let session: CLISession
   let planState: PlanState
   let onDismiss: () -> Void
   var isEmbedded: Bool = false
+  var providerKind: SessionProviderKind = .claude
+  var onSendFeedback: ((String, CLISession) -> Void)?
 
   @State private var content: String?
   @State private var isLoading = true
   @State private var errorMessage: String?
+  @State private var commentsState = DiffCommentsState()
+  @State private var activeLineIndex: Int?
+  @State private var isReviewMode: Bool = false
 
   public init(
     session: CLISession,
     planState: PlanState,
     onDismiss: @escaping () -> Void,
-    isEmbedded: Bool = false
+    isEmbedded: Bool = false,
+    providerKind: SessionProviderKind = .claude,
+    onSendFeedback: ((String, CLISession) -> Void)? = nil
   ) {
     self.session = session
     self.planState = planState
     self.onDismiss = onDismiss
     self.isEmbedded = isEmbedded
+    self.providerKind = providerKind
+    self.onSendFeedback = onSendFeedback
   }
 
   public var body: some View {
@@ -52,7 +63,11 @@ public struct PlanView: View {
       } else if let error = errorMessage {
         errorState(error)
       } else if let content = content {
-        markdownContent(content)
+        if isReviewMode {
+          reviewContent(content)
+        } else {
+          markdownContent(content)
+        }
       }
 
       Divider()
@@ -89,17 +104,6 @@ public struct PlanView: View {
       .buttonStyle(.bordered)
       .disabled(content == nil)
       .help("Copy plan to clipboard")
-
-      // TODO: Revisit "Run in Codex" button when UX is defined
-      // Button(action: runInCodex) {
-      //   HStack(spacing: 4) {
-      //     Image(systemName: "play.fill")
-      //     Text("Run in Codex")
-      //   }
-      // }
-      // .buttonStyle(.borderedProminent)
-      // .disabled(content == nil)
-      // .help("Start Codex session with this plan")
     }
     .padding()
     .background(Color.surfaceElevated)
@@ -138,6 +142,35 @@ public struct PlanView: View {
       }
 
       Spacer()
+
+      // Review mode toggle (only when feedback is supported)
+      if onSendFeedback != nil {
+        Button {
+          withAnimation(.easeInOut(duration: 0.2)) {
+            isReviewMode.toggle()
+            if !isReviewMode {
+              activeLineIndex = nil
+            }
+          }
+        } label: {
+          HStack(spacing: 4) {
+            Image(systemName: isReviewMode ? "doc.text.fill" : "pencil.and.list.clipboard")
+              .font(.caption)
+            Text(isReviewMode ? "Preview" : "Review")
+              .font(.caption)
+          }
+          .overlay(alignment: .topTrailing) {
+            if commentsState.hasComments && !isReviewMode {
+              Circle()
+                .fill(Color.brandPrimary(for: providerKind))
+                .frame(width: 8, height: 8)
+                .offset(x: 4, y: -4)
+            }
+          }
+        }
+        .buttonStyle(.bordered)
+        .help(isReviewMode ? "Switch to rendered preview" : "Switch to review mode to annotate lines")
+      }
 
       Button("Close") {
         onDismiss()
@@ -214,6 +247,145 @@ public struct PlanView: View {
     colorScheme == .dark ? Color.black.opacity(0.3) : Color.black.opacity(0.08)
   }
 
+  // MARK: - Review Content
+
+  private func reviewContent(_ text: String) -> some View {
+    let lines = text.components(separatedBy: "\n")
+    return VStack(spacing: 0) {
+      ScrollView {
+        LazyVStack(alignment: .leading, spacing: 0) {
+          ForEach(Array(lines.enumerated()), id: \.offset) { idx, line in
+            planLineRow(index: idx, line: line, planFilePath: planState.filePath)
+          }
+        }
+        .padding(DesignTokens.Spacing.md)
+      }
+      .background(Color.surfaceCanvas)
+
+      if commentsState.hasComments {
+        DiffCommentsPanelView(
+          commentsState: commentsState,
+          providerKind: providerKind,
+          onSendToCloud: sendFeedbackToTerminal
+        )
+      }
+    }
+  }
+
+  // MARK: - Plan Line Row
+
+  @ViewBuilder
+  private func planLineRow(index: Int, line: String, planFilePath: String) -> some View {
+    let lineNumber = index + 1
+    let hasComment = commentsState.hasComment(
+      filePath: planFilePath,
+      lineNumber: lineNumber,
+      side: "plan"
+    )
+
+    VStack(alignment: .leading, spacing: 0) {
+      // Clickable line row
+      Button {
+        withAnimation(.easeInOut(duration: 0.15)) {
+          activeLineIndex = (activeLineIndex == index ? nil : index)
+        }
+      } label: {
+        HStack(spacing: 8) {
+          // Line number
+          Text("\(lineNumber)")
+            .font(.system(.caption2, design: .monospaced))
+            .foregroundStyle(.tertiary)
+            .frame(minWidth: 32, alignment: .trailing)
+
+          // Comment indicator dot
+          Circle()
+            .fill(hasComment ? Color.brandPrimary(for: providerKind) : Color.clear)
+            .frame(width: 6, height: 6)
+
+          // Line content
+          Text(line.isEmpty ? " " : line)
+            .font(.system(.body, design: .monospaced))
+            .foregroundColor(.primary)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .lineLimit(1)
+        }
+        .padding(.vertical, 2)
+        .padding(.horizontal, 8)
+        .background(
+          activeLineIndex == index
+            ? Color.brandPrimary(for: providerKind).opacity(0.08)
+            : Color.clear
+        )
+        .contentShape(Rectangle())
+      }
+      .buttonStyle(.plain)
+
+      // Inline editor — expands below the clicked line
+      if activeLineIndex == index {
+        InlineEditorView(
+          lineNumber: lineNumber,
+          side: "plan",
+          fileName: planFilePath,
+          errorMessage: nil,
+          providerKind: providerKind,
+          onSubmit: { message in
+            let feedback = "Feedback on line \(lineNumber): \(message)"
+            onSendFeedback?("\u{1B}[B\u{1B}[B\u{1B}[B\r\(feedback)", session)
+            withAnimation { activeLineIndex = nil }
+          },
+          onAddComment: { message in
+            commentsState.addComment(
+              filePath: planFilePath,
+              lineNumber: lineNumber,
+              side: "plan",
+              lineContent: line,
+              text: message
+            )
+            if commentsState.commentCount == 1 {
+              commentsState.isPanelExpanded = true
+            }
+            withAnimation { activeLineIndex = nil }
+          },
+          onDeleteComment: hasComment ? {
+            commentsState.removeComment(
+              filePath: planFilePath,
+              lineNumber: lineNumber,
+              side: "plan"
+            )
+            withAnimation { activeLineIndex = nil }
+          } : nil,
+          onDismiss: { withAnimation { activeLineIndex = nil } },
+          initialText: commentsState.getComment(
+            filePath: planFilePath,
+            lineNumber: lineNumber,
+            side: "plan"
+          )?.text ?? "",
+          isEditMode: hasComment
+        )
+        .padding(.leading, 48)
+        .transition(.opacity.combined(with: .move(edge: .top)))
+      }
+    }
+  }
+
+  // MARK: - Send Feedback to Terminal
+
+  private func sendFeedbackToTerminal() {
+    let comments = commentsState.orderedComments
+    guard !comments.isEmpty else { return }
+
+    var feedback = "Here is my feedback on the plan:\n"
+    for comment in comments {
+      feedback += "\n**Line \(comment.lineNumber)**: `\(comment.lineContent)`\n"
+      feedback += "Feedback: \(comment.text)\n"
+    }
+    feedback += "\nPlease revise the plan based on this feedback."
+
+    onSendFeedback?("\u{1B}[B\u{1B}[B\u{1B}[B\r\(feedback)", session)
+    commentsState.clearAll()
+    onDismiss()
+  }
+
   // MARK: - Load Content
 
   private func loadPlanContent() async {
@@ -256,50 +428,6 @@ public struct PlanView: View {
   private var sessionTranscriptPath: String {
     let sanitizedPath = session.projectPath.claudeProjectPathEncoded
     return "~/.claude/projects/\(sanitizedPath)/\(session.id).jsonl"
-  }
-
-  // MARK: - Run in Codex
-
-  private func runInCodex() {
-    guard let planContent = content else { return }
-
-    // Append transcript context (like Claude Code does internally)
-    let transcriptContext = """
-
-
-    If you need specific details from before exiting plan mode (like exact code snippets, error messages, or content you generated), read the full transcript at: \(sessionTranscriptPath)
-    """
-    let fullContent = planContent + transcriptContext
-
-    // Write full content to a temp file
-    let tempDir = FileManager.default.temporaryDirectory
-    let tempFile = tempDir.appendingPathComponent("plan-\(UUID().uuidString).md")
-
-    do {
-      try fullContent.write(to: tempFile, atomically: true, encoding: .utf8)
-    } catch {
-      return
-    }
-
-    // Build the command to run interactive codex in Terminal
-    let escapedPath = session.projectPath.replacingOccurrences(of: "'", with: "'\\''")
-    let escapedTempFile = tempFile.path.replacingOccurrences(of: "'", with: "'\\''")
-    let command = "cd '\(escapedPath)' && codex \"$(cat '\(escapedTempFile)')\""
-
-    // Use AppleScript to open Terminal and run the command
-    let script = """
-      tell application "Terminal"
-        activate
-        do script "\(command.replacingOccurrences(of: "\\", with: "\\\\").replacingOccurrences(of: "\"", with: "\\\""))"
-      end tell
-      """
-
-    Task.detached {
-      let process = Process()
-      process.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
-      process.arguments = ["-e", script]
-      try? process.run()
-    }
   }
 }
 


### PR DESCRIPTION
## Summary

- **PlanView**: new Review mode lets users annotate individual plan lines with inline comments; a "Send N to Claude" button collects all annotations into a single feedback message and routes it to the active session terminal
- **EmbeddedTerminalView**: step-by-step keystroke delivery for plan-feedback prompts — each down-arrow and the subsequent text input are sent as separate writes with explicit delays (80ms between arrows, 150ms before typing feedback), preventing ESC-timing races and Inquirer.js mode-transition data loss
- **MonitoringCardView / MultiProviderMonitoringPanelView**: wire up `onSendFeedback` callback so PlanView can trigger `showTerminalWithPrompt`
- **README**: documents the new feature and embeds demo video

## Test plan

- [ ] Open a Claude Code session and run `/plan` to enter plan mode
- [ ] Open PlanView from the side panel or sheet
- [ ] Switch to Review mode (pencil icon)
- [ ] Annotate one or more lines with inline comments
- [ ] Click "Send N to Claude" — verify the terminal navigates to option 4, types the collected feedback into the text input, and submits
- [ ] Confirm no accidental plan approval (options 1–3) and no Escape cancellation
- [ ] Verify normal (non-plan) prompts still deliver correctly