### PR TITLE
feat: drag-and-drop session reordering in Focused Sessions sidebar

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubDefaults.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubDefaults.swift
@@ -53,6 +53,11 @@ public enum AgentHubDefaults {
   /// Type: Data (JSON-encoded [String])
   public static let monitoredSessionIds = "\(keyPrefix)sessions.monitoredSessionIds"
 
+  /// Persisted manual ordering of monitored session IDs (JSON-encoded array of session IDs)
+  /// Type: Data (JSON-encoded [String])
+  /// Note: Provider-suffixed at runtime (e.g., `.claude` or `.codex`)
+  public static let monitoredSessionOrder = "\(keyPrefix)sessions.monitoredSessionOrder"
+
   /// Persisted session IDs that have terminal view enabled
   /// Type: Data (JSON-encoded [String])
   public static let sessionsWithTerminalView = "\(keyPrefix)sessions.sessionsWithTerminalView"

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/CollapsibleSelectedSessionsPanel.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/CollapsibleSelectedSessionsPanel.swift
@@ -21,6 +21,8 @@ public struct CollapsibleSelectedSessionsPanel: View {
 
   @State private var showDeleteWorktreeAlert = false
   @State private var sessionToDeleteWorktree: CLISession? = nil
+  @State private var draggedItemId: String?
+  @State private var dropTargetId: String?
 
   private let headerHeight: CGFloat = 40
 
@@ -141,35 +143,56 @@ public struct CollapsibleSelectedSessionsPanel: View {
     ScrollView(showsIndicators: false) {
       LazyVStack(spacing: 6) {
         ForEach(items) { item in
-          CollapsibleSessionRow(
-            session: item.session,
-            providerKind: item.providerKind,
-            timestamp: item.timestamp,
-            isPending: item.isPending,
-            isPrimary: item.id == primarySessionId,
-            customName: customName(for: item),
-            sessionStatus: item.sessionStatus,
-            colorScheme: colorScheme,
-            onArchive: item.isPending ? nil : {
-              switch item.providerKind {
-              case .claude: claudeViewModel.stopMonitoring(session: item.session)
-              case .codex: codexViewModel.stopMonitoring(session: item.session)
-              }
-            },
-            onDeleteWorktree: (!item.isPending && item.session.isWorktree) ? {
-              sessionToDeleteWorktree = item.session
-              showDeleteWorktreeAlert = true
-            } : nil,
-            isDeletingWorktree: item.session.isWorktree && {
-              switch item.providerKind {
-              case .claude: return claudeViewModel.deletingWorktreePath == item.session.projectPath
-              case .codex: return codexViewModel.deletingWorktreePath == item.session.projectPath
-              }
-            }(),
-            onSelect: {
-              primarySessionId = item.id
+          VStack(spacing: 0) {
+            if dropTargetId == item.id {
+              Rectangle()
+                .fill(Color.accentColor)
+                .frame(height: 2)
+                .padding(.horizontal, 4)
             }
-          )
+
+            CollapsibleSessionRow(
+              session: item.session,
+              providerKind: item.providerKind,
+              timestamp: item.timestamp,
+              isPending: item.isPending,
+              isPrimary: item.id == primarySessionId,
+              customName: customName(for: item),
+              sessionStatus: item.sessionStatus,
+              colorScheme: colorScheme,
+              onArchive: item.isPending ? nil : {
+                switch item.providerKind {
+                case .claude: claudeViewModel.stopMonitoring(session: item.session)
+                case .codex: codexViewModel.stopMonitoring(session: item.session)
+                }
+              },
+              onDeleteWorktree: (!item.isPending && item.session.isWorktree) ? {
+                sessionToDeleteWorktree = item.session
+                showDeleteWorktreeAlert = true
+              } : nil,
+              isDeletingWorktree: item.session.isWorktree && {
+                switch item.providerKind {
+                case .claude: return claudeViewModel.deletingWorktreePath == item.session.projectPath
+                case .codex: return codexViewModel.deletingWorktreePath == item.session.projectPath
+                }
+              }(),
+              onSelect: { primarySessionId = item.id },
+              dragProvider: item.isPending ? nil : {
+                draggedItemId = item.id
+                return NSItemProvider(object: NSString(string: item.id))
+              }
+            )
+          }
+          .opacity(draggedItemId == item.id ? 0.4 : 1.0)
+          .contentShape(Rectangle())
+          .onDrop(of: [.utf8PlainText], isTargeted: Binding(
+            get: { dropTargetId == item.id },
+            set: { isTargeted in dropTargetId = isTargeted ? item.id : nil }
+          )) { _ in
+            guard let dragId = draggedItemId else { return false }
+            handleDrop(itemId: dragId, targetItemId: item.id)
+            return true
+          }
         }
       }
       .padding(.horizontal, 4)
@@ -189,53 +212,53 @@ public struct CollapsibleSelectedSessionsPanel: View {
   }
 
   private var items: [SelectedSessionItem] {
-    var results: [SelectedSessionItem] = []
-
-    for pending in claudeViewModel.pendingHubSessions {
-      results.append(SelectedSessionItem(
+    let pendingClaude: [SelectedSessionItem] = claudeViewModel.pendingHubSessions.map { pending in
+      SelectedSessionItem(
         id: "pending-claude-\(pending.id.uuidString)",
         session: pending.placeholderSession,
         providerKind: .claude,
         timestamp: pending.startedAt,
         isPending: true,
         sessionStatus: nil
-      ))
+      )
     }
 
-    for pending in codexViewModel.pendingHubSessions {
-      results.append(SelectedSessionItem(
+    let pendingCodex: [SelectedSessionItem] = codexViewModel.pendingHubSessions.map { pending in
+      SelectedSessionItem(
         id: "pending-codex-\(pending.id.uuidString)",
         session: pending.placeholderSession,
         providerKind: .codex,
         timestamp: pending.startedAt,
         isPending: true,
         sessionStatus: nil
-      ))
+      )
     }
 
-    for item in claudeViewModel.monitoredSessions {
-      results.append(SelectedSessionItem(
+    let monitoredClaude: [SelectedSessionItem] = claudeViewModel.monitoredSessions.map { item in
+      SelectedSessionItem(
         id: "claude-\(item.session.id)",
         session: item.session,
         providerKind: .claude,
         timestamp: item.session.lastActivityAt,
         isPending: false,
         sessionStatus: item.state?.status
-      ))
+      )
     }
 
-    for item in codexViewModel.monitoredSessions {
-      results.append(SelectedSessionItem(
+    let monitoredCodex: [SelectedSessionItem] = codexViewModel.monitoredSessions.map { item in
+      SelectedSessionItem(
         id: "codex-\(item.session.id)",
         session: item.session,
         providerKind: .codex,
         timestamp: item.session.lastActivityAt,
         isPending: false,
         sessionStatus: item.state?.status
-      ))
+      )
     }
 
-    return results.sorted { $0.timestamp > $1.timestamp }
+    let pending = (pendingClaude + pendingCodex).sorted { $0.timestamp > $1.timestamp }
+    let monitored = monitoredClaude + monitoredCodex
+    return pending + monitored
   }
 
   private func customName(for item: SelectedSessionItem) -> String? {
@@ -244,6 +267,41 @@ public struct CollapsibleSelectedSessionsPanel: View {
       return claudeViewModel.sessionCustomNames[item.session.id]
     case .codex:
       return codexViewModel.sessionCustomNames[item.session.id]
+    }
+  }
+
+  private func handleDrop(itemId: String, targetItemId: String) {
+    draggedItemId = nil
+    dropTargetId = nil
+    guard itemId != targetItemId, !itemId.hasPrefix("pending-") else { return }
+
+    // If dropping onto a pending item, move the session to front of its provider list
+    if targetItemId.hasPrefix("pending-") {
+      if itemId.hasPrefix("claude-") {
+        let sessionId = String(itemId.dropFirst(7))
+        claudeViewModel.reorderMonitoredSession(id: sessionId, toAfter: nil)
+      } else if itemId.hasPrefix("codex-") {
+        let sessionId = String(itemId.dropFirst(6))
+        codexViewModel.reorderMonitoredSession(id: sessionId, toAfter: nil)
+      }
+      return
+    }
+
+    // Reject cross-provider drops
+    let isClaude = itemId.hasPrefix("claude-")
+    let isCodex = itemId.hasPrefix("codex-")
+    let targetIsClaude = targetItemId.hasPrefix("claude-")
+    let targetIsCodex = targetItemId.hasPrefix("codex-")
+    guard (isClaude && targetIsClaude) || (isCodex && targetIsCodex) else { return }
+
+    if isClaude {
+      let sessionId = String(itemId.dropFirst(7))
+      let targetSessionId = String(targetItemId.dropFirst(7))
+      claudeViewModel.reorderMonitoredSession(id: sessionId, toAfter: targetSessionId)
+    } else if isCodex {
+      let sessionId = String(itemId.dropFirst(6))
+      let targetSessionId = String(targetItemId.dropFirst(6))
+      codexViewModel.reorderMonitoredSession(id: sessionId, toAfter: targetSessionId)
     }
   }
 
@@ -274,6 +332,8 @@ public struct SingleProviderCollapsibleSelectedSessionsPanel: View {
 
   @State private var showDeleteWorktreeAlert = false
   @State private var sessionToDeleteWorktree: CLISession? = nil
+  @State private var draggedItemId: String?
+  @State private var dropTargetId: String?
 
   private let headerHeight: CGFloat = 40
 
@@ -381,28 +441,49 @@ public struct SingleProviderCollapsibleSelectedSessionsPanel: View {
     ScrollView(showsIndicators: false) {
       LazyVStack(spacing: 6) {
         ForEach(items) { item in
-          CollapsibleSessionRow(
-            session: item.session,
-            providerKind: viewModel.providerKind,
-            timestamp: item.timestamp,
-            isPending: item.isPending,
-            isPrimary: item.id == primarySessionId,
-            customName: viewModel.sessionCustomNames[item.session.id],
-            sessionStatus: item.sessionStatus,
-            colorScheme: colorScheme,
-            onArchive: item.isPending ? nil : {
-              viewModel.stopMonitoring(session: item.session)
-            },
-            onDeleteWorktree: (!item.isPending && item.session.isWorktree) ? {
-              sessionToDeleteWorktree = item.session
-              showDeleteWorktreeAlert = true
-            } : nil,
-            isDeletingWorktree: item.session.isWorktree
-              && viewModel.deletingWorktreePath == item.session.projectPath,
-            onSelect: {
-              primarySessionId = item.id
+          VStack(spacing: 0) {
+            if dropTargetId == item.id {
+              Rectangle()
+                .fill(Color.accentColor)
+                .frame(height: 2)
+                .padding(.horizontal, 4)
             }
-          )
+
+            CollapsibleSessionRow(
+              session: item.session,
+              providerKind: viewModel.providerKind,
+              timestamp: item.timestamp,
+              isPending: item.isPending,
+              isPrimary: item.id == primarySessionId,
+              customName: viewModel.sessionCustomNames[item.session.id],
+              sessionStatus: item.sessionStatus,
+              colorScheme: colorScheme,
+              onArchive: item.isPending ? nil : {
+                viewModel.stopMonitoring(session: item.session)
+              },
+              onDeleteWorktree: (!item.isPending && item.session.isWorktree) ? {
+                sessionToDeleteWorktree = item.session
+                showDeleteWorktreeAlert = true
+              } : nil,
+              isDeletingWorktree: item.session.isWorktree
+                && viewModel.deletingWorktreePath == item.session.projectPath,
+              onSelect: { primarySessionId = item.id },
+              dragProvider: item.isPending ? nil : {
+                draggedItemId = item.id
+                return NSItemProvider(object: NSString(string: item.id))
+              }
+            )
+          }
+          .opacity(draggedItemId == item.id ? 0.4 : 1.0)
+          .contentShape(Rectangle())
+          .onDrop(of: [.utf8PlainText], isTargeted: Binding(
+            get: { dropTargetId == item.id },
+            set: { isTargeted in dropTargetId = isTargeted ? item.id : nil }
+          )) { _ in
+            guard let dragId = draggedItemId else { return false }
+            handleDrop(itemId: dragId, targetItemId: item.id)
+            return true
+          }
         }
       }
       .padding(.horizontal, 4)
@@ -421,29 +502,27 @@ public struct SingleProviderCollapsibleSelectedSessionsPanel: View {
   }
 
   private var items: [SelectedSessionItem] {
-    var results: [SelectedSessionItem] = []
-
-    for pending in viewModel.pendingHubSessions {
-      results.append(SelectedSessionItem(
+    let pending: [SelectedSessionItem] = viewModel.pendingHubSessions.map { pending in
+      SelectedSessionItem(
         id: "pending-\(pending.id.uuidString)",
         session: pending.placeholderSession,
         timestamp: pending.startedAt,
         isPending: true,
         sessionStatus: nil
-      ))
-    }
+      )
+    }.sorted { $0.timestamp > $1.timestamp }
 
-    for item in viewModel.monitoredSessions {
-      results.append(SelectedSessionItem(
+    let monitored: [SelectedSessionItem] = viewModel.monitoredSessions.map { item in
+      SelectedSessionItem(
         id: item.session.id,
         session: item.session,
         timestamp: item.session.lastActivityAt,
         isPending: false,
         sessionStatus: item.state?.status
-      ))
+      )
     }
 
-    return results.sorted { $0.timestamp > $1.timestamp }
+    return pending + monitored
   }
 
   private func ensurePrimarySelection() {
@@ -457,6 +536,14 @@ public struct SingleProviderCollapsibleSelectedSessionsPanel: View {
     }
 
     primarySessionId = items.first?.id
+  }
+
+  private func handleDrop(itemId: String, targetItemId: String) {
+    draggedItemId = nil
+    dropTargetId = nil
+    guard itemId != targetItemId, !itemId.hasPrefix("pending-") else { return }
+    let targetId: String? = targetItemId.hasPrefix("pending-") ? nil : targetItemId
+    viewModel.reorderMonitoredSession(id: itemId, toAfter: targetId)
   }
 }
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/CollapsibleSessionRow.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/CollapsibleSessionRow.swift
@@ -15,6 +15,7 @@ struct CollapsibleSessionRow: View {
   let onDeleteWorktree: (() -> Void)?
   var isDeletingWorktree: Bool = false
   let onSelect: () -> Void
+  var dragProvider: (() -> NSItemProvider)? = nil
 
   @State private var gradientProgress: CGFloat = 0
   @State private var showArchiveConfirm = false
@@ -76,55 +77,26 @@ struct CollapsibleSessionRow: View {
   var body: some View {
     VStack(alignment: .leading, spacing: 6) {
       // Path + branch header bar
-      HStack(spacing: 5) {
-        Image(systemName: "folder")
-          .font(.system(size: 9))
-          .foregroundColor(.secondary.opacity(0.6))
-
-        Text(tildeProjectPath)
-          .font(.system(size: 10, design: .monospaced))
-          .foregroundColor(.secondary.opacity(0.9))
-          .lineLimit(1)
-          .truncationMode(.middle)
-
-        if let branch = session.branchName {
-          Spacer(minLength: 4)
-
-          Image(systemName: "arrow.triangle.branch")
-            .font(.system(size: 9))
-            .foregroundColor(.secondary.opacity(0.6))
-
-          Text(branch)
-            .font(.system(size: 10, design: .monospaced))
-            .foregroundColor(.secondary.opacity(0.9))
-            .lineLimit(1)
+      Group {
+        if let provider = dragProvider {
+          headerBar
+            .onDrag {
+              provider()
+            } preview: {
+              Text(customName ?? session.slug ?? session.shortId)
+                .font(.caption.monospaced())
+                .padding(.horizontal, 8)
+                .padding(.vertical, 4)
+                .background(Color.secondary.opacity(0.2))
+                .clipShape(Capsule())
+            }
+            .onHover { hovering in
+              if hovering { NSCursor.openHand.push() } else { NSCursor.pop() }
+            }
+        } else {
+          headerBar
         }
       }
-      .padding(.horizontal, 8)
-      .padding(.vertical, 4)
-      .frame(maxWidth: .infinity, alignment: .leading)
-      .background(
-        ZStack {
-          UnevenRoundedRectangle(topLeadingRadius: 6, bottomLeadingRadius: 2, bottomTrailingRadius: 2, topTrailingRadius: 6)
-            .fill(colorScheme == .dark ? Color.white.opacity(0.06) : Color.black.opacity(0.06))
-          UnevenRoundedRectangle(topLeadingRadius: 6, bottomLeadingRadius: 2, bottomTrailingRadius: 2, topTrailingRadius: 6)
-            .fill(LinearGradient(
-              colors: [
-                Color.brandPrimary(for: providerKind).opacity(colorScheme == .dark ? 0.45 : 0.35),
-                colorScheme == .dark ? Color.white.opacity(0.06) : Color.black.opacity(0.06)
-              ],
-              startPoint: .trailing,
-              endPoint: .leading
-            ))
-            .mask(
-              GeometryReader { geo in
-                Rectangle()
-                  .frame(width: geo.size.width * gradientProgress)
-                  .frame(maxWidth: .infinity, alignment: .leading)
-              }
-            )
-        }
-      )
 
       // Content area
       VStack(alignment: .leading, spacing: 8) {
@@ -301,6 +273,62 @@ struct CollapsibleSessionRow: View {
       // Restart pulse animation if status changed
       startPulseAnimation()
     }
+  }
+
+  // MARK: - Header Bar
+
+  @ViewBuilder
+  private var headerBar: some View {
+    HStack(spacing: 5) {
+      Image(systemName: "folder")
+        .font(.system(size: 9))
+        .foregroundColor(.secondary.opacity(0.6))
+
+      Text(tildeProjectPath)
+        .font(.system(size: 10, design: .monospaced))
+        .foregroundColor(.secondary.opacity(0.9))
+        .lineLimit(1)
+        .truncationMode(.middle)
+
+      if let branch = session.branchName {
+        Spacer(minLength: 4)
+
+        Image(systemName: "arrow.triangle.branch")
+          .font(.system(size: 9))
+          .foregroundColor(.secondary.opacity(0.6))
+
+        Text(branch)
+          .font(.system(size: 10, design: .monospaced))
+          .foregroundColor(.secondary.opacity(0.9))
+          .lineLimit(1)
+      }
+    }
+    .padding(.horizontal, 8)
+    .padding(.vertical, 4)
+    .frame(maxWidth: .infinity, alignment: .leading)
+    .contentShape(Rectangle())
+    .background(
+      ZStack {
+        UnevenRoundedRectangle(topLeadingRadius: 6, bottomLeadingRadius: 2, bottomTrailingRadius: 2, topTrailingRadius: 6)
+          .fill(colorScheme == .dark ? Color.white.opacity(0.06) : Color.black.opacity(0.06))
+        UnevenRoundedRectangle(topLeadingRadius: 6, bottomLeadingRadius: 2, bottomTrailingRadius: 2, topTrailingRadius: 6)
+          .fill(LinearGradient(
+            colors: [
+              Color.brandPrimary(for: providerKind).opacity(colorScheme == .dark ? 0.45 : 0.35),
+              colorScheme == .dark ? Color.white.opacity(0.06) : Color.black.opacity(0.06)
+            ],
+            startPoint: .trailing,
+            endPoint: .leading
+          ))
+          .mask(
+            GeometryReader { geo in
+              Rectangle()
+                .frame(width: geo.size.width * gradientProgress)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+          )
+      }
+    )
   }
 
   // MARK: - Animations

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
@@ -9,6 +9,7 @@ import AppKit
 import Foundation
 import PierreDiffsSwift
 import SwiftUI
+import UniformTypeIdentifiers
 
 // MARK: - SessionFileSheetItem
 
@@ -39,6 +40,8 @@ public struct MultiProviderSessionsListView: View {
   @State private var primarySessionId: String?
   @State private var showDeleteWorktreeAlert = false
   @State private var sessionToDeleteWorktree: CLISession? = nil
+  @State private var dropTargetId: String?
+  @State private var draggedItemId: String?
   @State private var showCommandPalette = false
   @State private var hubFilterMode: HubFilterMode = .all
   @State private var scrollToSessionId: String?
@@ -603,7 +606,10 @@ public struct MultiProviderSessionsListView: View {
       ))
     }
 
-    return results.sorted { $0.timestamp > $1.timestamp }
+    // Pending sessions sorted by timestamp; monitored sessions preserve ViewModel order
+    let pending = results.filter { $0.isPending }.sorted { $0.timestamp > $1.timestamp }
+    let monitored = results.filter { !$0.isPending }
+    return pending + monitored
   }
 
   private var filteredSelectedSessionItems: [SelectedSessionItem] {
@@ -648,45 +654,137 @@ public struct MultiProviderSessionsListView: View {
         .padding(.vertical, 6)
 
         ForEach(items) { item in
-          CollapsibleSessionRow(
-            session: item.session,
-            providerKind: item.providerKind,
-            timestamp: item.timestamp,
-            isPending: item.isPending,
-            isPrimary: item.id == primarySessionId,
-            customName: selectedSessionCustomName(for: item),
-            sessionStatus: item.sessionStatus,
-            colorScheme: colorScheme,
-            onArchive: item.isPending ? nil : {
-              withAnimation(.easeInOut(duration: 0.25)) {
-                switch item.providerKind {
-                case .claude: claudeViewModel.stopMonitoring(session: item.session)
-                case .codex: codexViewModel.stopMonitoring(session: item.session)
-                }
-              }
-            },
-            onDeleteWorktree: (!item.isPending && item.session.isWorktree) ? {
-              sessionToDeleteWorktree = item.session
-              showDeleteWorktreeAlert = true
-            } : nil,
-            isDeletingWorktree: item.session.isWorktree && {
-              switch item.providerKind {
-              case .claude: return claudeViewModel.deletingWorktreePath == item.session.projectPath
-              case .codex: return codexViewModel.deletingWorktreePath == item.session.projectPath
-              }
-            }(),
-            onSelect: {
-              primarySessionId = item.id
+          let draggedIdx = items.firstIndex(where: { $0.id == draggedItemId })
+          let targetIdx = items.firstIndex(where: { $0.id == item.id })
+          let isTargeted = dropTargetId == item.id
+          let isDraggingDown = isTargeted && draggedIdx != nil && targetIdx != nil && draggedIdx! < targetIdx!
+          let isDraggingUp = isTargeted && draggedIdx != nil && targetIdx != nil && draggedIdx! > targetIdx!
+
+          VStack(spacing: 0) {
+            // Top indicator: dragging UP onto this item
+            if isDraggingUp {
+              Rectangle()
+                .fill(Color.accentColor)
+                .frame(height: 2)
             }
-          )
-          .transition(.asymmetric(
-            insertion: .opacity,
-            removal: .move(edge: .trailing).combined(with: .opacity)
-          ))
-          .id(item.id)
+
+            CollapsibleSessionRow(
+              session: item.session,
+              providerKind: item.providerKind,
+              timestamp: item.timestamp,
+              isPending: item.isPending,
+              isPrimary: item.id == primarySessionId,
+              customName: selectedSessionCustomName(for: item),
+              sessionStatus: item.sessionStatus,
+              colorScheme: colorScheme,
+              onArchive: item.isPending ? nil : {
+                withAnimation(.easeInOut(duration: 0.25)) {
+                  switch item.providerKind {
+                  case .claude: claudeViewModel.stopMonitoring(session: item.session)
+                  case .codex: codexViewModel.stopMonitoring(session: item.session)
+                  }
+                }
+              },
+              onDeleteWorktree: (!item.isPending && item.session.isWorktree) ? {
+                sessionToDeleteWorktree = item.session
+                showDeleteWorktreeAlert = true
+              } : nil,
+              isDeletingWorktree: item.session.isWorktree && {
+                switch item.providerKind {
+                case .claude: return claudeViewModel.deletingWorktreePath == item.session.projectPath
+                case .codex: return codexViewModel.deletingWorktreePath == item.session.projectPath
+                }
+              }(),
+              onSelect: { primarySessionId = item.id },
+              dragProvider: item.isPending ? nil : {
+                draggedItemId = item.id
+                return NSItemProvider(object: NSString(string: item.id))
+              }
+            )
+            .transition(.asymmetric(
+              insertion: .opacity,
+              removal: .move(edge: .trailing).combined(with: .opacity)
+            ))
+            .id(item.id)
+
+            // Bottom indicator: dragging DOWN onto this item
+            if isDraggingDown {
+              Rectangle()
+                .fill(Color.accentColor)
+                .frame(height: 2)
+            }
+          }
+          .contentShape(Rectangle())
+          .onDrop(of: [.utf8PlainText], isTargeted: Binding(
+            get: { dropTargetId == item.id },
+            set: { isTargeted in dropTargetId = isTargeted ? item.id : nil }
+          )) { providers in
+            let targetId = item.id
+            guard let provider = providers.first else { return false }
+            provider.loadDataRepresentation(forTypeIdentifier: UTType.utf8PlainText.identifier) { data, _ in
+              guard let data, let dragId = String(data: data, encoding: .utf8) else { return }
+              DispatchQueue.main.async {
+                handleFocusedSessionDrop(itemId: dragId, targetItemId: targetId, in: items)
+              }
+            }
+            return true
+          }
         }
       }
       .padding(.bottom, 8)
+    }
+  }
+
+  private func handleFocusedSessionDrop(itemId: String, targetItemId: String, in items: [SelectedSessionItem]) {
+    dropTargetId = nil
+    draggedItemId = nil
+    guard itemId != targetItemId, !itemId.hasPrefix("pending-") else { return }
+
+    // Move to front (drop on a pending item)
+    if targetItemId.hasPrefix("pending-") {
+      if itemId.hasPrefix("claude-") {
+        claudeViewModel.reorderMonitoredSession(id: String(itemId.dropFirst(7)), toAfter: nil)
+      } else if itemId.hasPrefix("codex-") {
+        codexViewModel.reorderMonitoredSession(id: String(itemId.dropFirst(6)), toAfter: nil)
+      }
+      return
+    }
+
+    let isClaude = itemId.hasPrefix("claude-")
+    let isCodex = itemId.hasPrefix("codex-")
+    guard (isClaude && targetItemId.hasPrefix("claude-")) || (isCodex && targetItemId.hasPrefix("codex-")) else { return }
+
+    // Determine drag direction from displayed order
+    let draggedIdx = items.firstIndex(where: { $0.id == itemId })
+    let targetIdx = items.firstIndex(where: { $0.id == targetItemId })
+    let isDraggingDown = draggedIdx != nil && targetIdx != nil && draggedIdx! < targetIdx!
+
+    if isClaude {
+      let rawItemId = String(itemId.dropFirst(7))
+      let rawTargetId = String(targetItemId.dropFirst(7))
+      if isDraggingDown {
+        // Indicator at bottom → insert AFTER target
+        claudeViewModel.reorderMonitoredSession(id: rawItemId, toAfter: rawTargetId)
+      } else {
+        // Indicator at top → insert BEFORE target = AFTER predecessor
+        let orderWithoutDragged = claudeViewModel.monitoredSessionOrder.filter { $0 != rawItemId }
+        let predecessorId = orderWithoutDragged.firstIndex(of: rawTargetId).flatMap { idx in
+          idx > 0 ? orderWithoutDragged[idx - 1] : nil
+        }
+        claudeViewModel.reorderMonitoredSession(id: rawItemId, toAfter: predecessorId)
+      }
+    } else if isCodex {
+      let rawItemId = String(itemId.dropFirst(6))
+      let rawTargetId = String(targetItemId.dropFirst(6))
+      if isDraggingDown {
+        codexViewModel.reorderMonitoredSession(id: rawItemId, toAfter: rawTargetId)
+      } else {
+        let orderWithoutDragged = codexViewModel.monitoredSessionOrder.filter { $0 != rawItemId }
+        let predecessorId = orderWithoutDragged.firstIndex(of: rawTargetId).flatMap { idx in
+          idx > 0 ? orderWithoutDragged[idx - 1] : nil
+        }
+        codexViewModel.reorderMonitoredSession(id: rawItemId, toAfter: predecessorId)
+      }
     }
   }
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/CLISessionsViewModel.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/CLISessionsViewModel.swift
@@ -348,6 +348,10 @@ public final class CLISessionsViewModel {
   /// Set of session IDs currently being monitored
   public private(set) var monitoredSessionIds: Set<String> = []
 
+  /// Ordered list of monitored session IDs (user-defined via drag-reorder)
+  /// Parallel to monitoredSessionIds — contains same IDs in display order
+  public private(set) var monitoredSessionOrder: [String] = []
+
   /// Current monitoring states keyed by session ID
   public private(set) var monitorStates: [String: SessionMonitorState] = [:]
 
@@ -390,6 +394,9 @@ public final class CLISessionsViewModel {
   }
   private var monitoredSessionsKey: String {
     AgentHubDefaults.monitoredSessionIds + "." + providerDefaultsSuffix
+  }
+  private var monitoredSessionOrderKey: String {
+    AgentHubDefaults.monitoredSessionOrder + "." + providerDefaultsSuffix
   }
   private var terminalViewKey: String {
     AgentHubDefaults.sessionsWithTerminalView + "." + providerDefaultsSuffix
@@ -579,6 +586,7 @@ public final class CLISessionsViewModel {
       let persistedSessionIds = loadPersistedSessionIds()
       if !persistedSessionIds.isEmpty {
         pendingRestorationSessionIds = persistedSessionIds
+        loadMonitoredSessionOrder()
         // Load terminal view state for restoration decisions
         if let tvData = UserDefaults.standard.data(forKey: terminalViewKey),
            let tvIds = try? JSONDecoder().decode([String].self, from: tvData) {
@@ -640,6 +648,17 @@ public final class CLISessionsViewModel {
       pendingRestorationSessionIds.subtract(restoredIds)
       expandItemsContainingMonitoredSessions()
       loadCustomNames()
+
+      // Only prune stale order entries once all pending restorations are complete
+      if pendingRestorationSessionIds.isEmpty {
+        let validIds = monitoredSessionIds
+        monitoredSessionOrder.removeAll { !validIds.contains($0) }
+        // Ensure all restored sessions appear in the order (first-time or migrated installs)
+        for sessionId in validIds where !monitoredSessionOrder.contains(sessionId) {
+          monitoredSessionOrder.append(sessionId)
+        }
+        persistMonitoredSessionOrder()
+      }
     }
   }
 
@@ -688,6 +707,20 @@ public final class CLISessionsViewModel {
     if let data = try? JSONEncoder().encode(sessionIds) {
       UserDefaults.standard.set(data, forKey: monitoredSessionsKey)
     }
+  }
+
+  private func persistMonitoredSessionOrder() {
+    if let data = try? JSONEncoder().encode(monitoredSessionOrder) {
+      UserDefaults.standard.set(data, forKey: monitoredSessionOrderKey)
+    }
+  }
+
+  private func loadMonitoredSessionOrder() {
+    guard let data = UserDefaults.standard.data(forKey: monitoredSessionOrderKey),
+          let order = try? JSONDecoder().decode([String].self, from: data) else {
+      return
+    }
+    monitoredSessionOrder = order
   }
 
   /// Persists which sessions have terminal view enabled
@@ -1853,6 +1886,16 @@ public final class CLISessionsViewModel {
 
   // MARK: - Monitoring Management
 
+  /// Resolves the main repository path for a session (handles worktrees)
+  private func mainRepoPath(for session: CLISession) -> String {
+    for repo in selectedRepositories {
+      for worktree in repo.worktrees where worktree.path == session.projectPath {
+        return repo.path
+      }
+    }
+    return session.projectPath
+  }
+
   /// Toggle monitoring for a session
   public func toggleMonitoring(for session: CLISession) {
     if monitoredSessionIds.contains(session.id) {
@@ -1871,10 +1914,22 @@ public final class CLISessionsViewModel {
     monitoredSessionBackup[session.id] = session
     sessionsWithTerminalView.insert(session.id)  // Default to terminal view
 
-    persistMonitoredSessions()
-    persistSessionsWithTerminalView()
+    // Insert near same-project sessions (worktrees share mainRepoPath)
+    let newRepoPath = mainRepoPath(for: session)
+    if let insertAfterIndex = monitoredSessionOrder.indices.reversed().first(where: { idx in
+      let id = monitoredSessionOrder[idx]
+      guard let existing = allSessions.first(where: { $0.id == id })
+              ?? monitoredSessionBackup[id] else { return false }
+      return mainRepoPath(for: existing) == newRepoPath
+    }) {
+      monitoredSessionOrder.insert(session.id, at: insertAfterIndex + 1)
+    } else {
+      monitoredSessionOrder.append(session.id)
+    }
 
-    // Start polling for Preview/Plan buttons (works in both terminal and monitor modes)
+    persistMonitoredSessions()
+    persistMonitoredSessionOrder()
+
     startPolling(session: session)
   }
 
@@ -1886,6 +1941,7 @@ public final class CLISessionsViewModel {
   /// Stop monitoring by session ID
   public func stopMonitoring(sessionId: String) {
     monitoredSessionIds.remove(sessionId)
+    monitoredSessionOrder.removeAll { $0 == sessionId }
     monitoredSessionBackup.removeValue(forKey: sessionId)
     sessionsWithTerminalView.remove(sessionId)
     monitorStates.removeValue(forKey: sessionId)
@@ -1895,11 +1951,36 @@ public final class CLISessionsViewModel {
     removeTerminal(forKey: sessionId)
 
     persistMonitoredSessions()
+    persistMonitoredSessionOrder()
     persistSessionsWithTerminalView()
 
     Task {
       await fileWatcher.stopMonitoring(sessionId: sessionId)
     }
+  }
+
+  /// Moves a session to immediately after the target session in the display order.
+  /// Pass nil for targetId to move the session to the beginning.
+  public func reorderMonitoredSession(id: String, toAfter targetId: String?) {
+    guard monitoredSessionIds.contains(id) else { return }
+
+    // Sync any monitored sessions not yet in order (migration / race-condition safety)
+    for sessionId in monitoredSessionIds where !monitoredSessionOrder.contains(sessionId) {
+      monitoredSessionOrder.append(sessionId)
+    }
+
+    // If targetId is specified, verify it exists in the order before mutating
+    if let targetId, !monitoredSessionOrder.contains(targetId) { return }
+
+    monitoredSessionOrder.removeAll { $0 == id }
+
+    if let targetId, let toIndex = monitoredSessionOrder.firstIndex(of: targetId) {
+      monitoredSessionOrder.insert(id, at: toIndex + 1)
+    } else {
+      monitoredSessionOrder.insert(id, at: 0)
+    }
+
+    persistMonitoredSessionOrder()
   }
 
   /// Check if a session is being monitored
@@ -1910,18 +1991,30 @@ public final class CLISessionsViewModel {
   /// Get all currently monitored sessions with their states.
   /// Uses a backup store to preserve sessions that may not yet be in history.jsonl.
   public var monitoredSessions: [(session: CLISession, state: SessionMonitorState?)] {
-    monitoredSessionIds.compactMap { sessionId in
-      // First try to get from allSessions (authoritative source if available)
-      if let session = allSessions.first(where: { $0.id == sessionId }) {
-        return (session: session, state: monitorStates[sessionId])
-      }
-      // Fallback to backup if not in allSessions (race condition during refresh)
-      if let backupSession = monitoredSessionBackup[sessionId] {
-        return (session: backupSession, state: monitorStates[sessionId])
-      }
-      // Session not found anywhere - should not happen, but handle gracefully
-      return nil
+    let sessionLookup = Dictionary(uniqueKeysWithValues: allSessions.map { ($0.id, $0) })
+    var result: [(session: CLISession, state: SessionMonitorState?)] = []
+    var seen = Set<String>()
+
+    // Sessions in user-defined order first
+    for sessionId in monitoredSessionOrder where monitoredSessionIds.contains(sessionId) {
+      if let session = sessionLookup[sessionId] {
+        result.append((session: session, state: monitorStates[sessionId]))
+      } else if let backup = monitoredSessionBackup[sessionId] {
+        result.append((session: backup, state: monitorStates[sessionId]))
+      } else { continue }
+      seen.insert(sessionId)
     }
+
+    // Any monitored sessions not yet in order (race condition fallback)
+    for sessionId in monitoredSessionIds where !seen.contains(sessionId) {
+      if let session = sessionLookup[sessionId] {
+        result.append((session: session, state: monitorStates[sessionId]))
+      } else if let backup = monitoredSessionBackup[sessionId] {
+        result.append((session: backup, state: monitorStates[sessionId]))
+      }
+    }
+
+    return result
   }
 
   // MARK: - Search


### PR DESCRIPTION
 ## Summary

  - Full header bar of each session card is draggable
  - Direction-aware drop indicator: appears **above** target when dragging up, **below** when dragging down
  - Correct insertion semantics per direction — no off-by-one positioning
  - Session order persisted via UserDefaults and restored on app restart
  - Sync safety net keeps monitoredSessionOrder in sync with monitoredSessionIds

  ## Test plan

  - [ ] Drag session up — blue line above target, correct position
  - [ ] Drag session down — blue line below target, correct position
  - [ ] Position 0 (before first item) reachable
  - [ ] Last position reachable by hovering over last item
  - [ ] Order persists after restart
  - [ ] No indicator on self-hover