### PR TITLE
Add setting to always show diff in modal window instead of side panel

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubDefaults.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubDefaults.swift
@@ -128,6 +128,10 @@ public enum AgentHubDefaults {
   /// Type: Bool (default: false)
   public static let flatSessionLayout = "\(keyPrefix)hub.flatSessionLayout"
 
+  /// Whether to always show diff in a modal window instead of side panel
+  /// Type: Bool (default: false)
+  public static let diffAlwaysModal = "\(keyPrefix)hub.diffAlwaysModal"
+
   // MARK: - Theme Settings
 
   /// Selected color theme name

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderMonitoringPanelView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderMonitoringPanelView.swift
@@ -228,6 +228,8 @@ public struct MultiProviderMonitoringPanelView: View {
   private var previousLayoutModeRawValue: Int = -1
   @AppStorage(AgentHubDefaults.flatSessionLayout)
   private var flatSessionLayout: Bool = false
+  @AppStorage(AgentHubDefaults.diffAlwaysModal)
+  private var diffAlwaysModal: Bool = false
   @Environment(\.colorScheme) private var colorScheme
   @Environment(\.runtimeTheme) private var runtimeTheme
 
@@ -556,7 +558,7 @@ public struct MultiProviderMonitoringPanelView: View {
             onInlineRequestSubmit: { prompt, sess in
               viewModel.showTerminalWithPrompt(for: sess, prompt: prompt)
             },
-            onShowDiff: canShowSidePanel ? { session, projectPath in
+            onShowDiff: (canShowSidePanel && !diffAlwaysModal) ? { session, projectPath in
               sidePanelContent = .diff(sessionId: session.id, session: session, projectPath: projectPath)
             } : nil,
             onShowPlan: canShowSidePanel ? { session, planState in

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/SettingsView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/SettingsView.swift
@@ -14,6 +14,9 @@ public struct SettingsView: View {
   @AppStorage(AgentHubDefaults.flatSessionLayout)
   private var flatSessionLayout: Bool = false
 
+  @AppStorage(AgentHubDefaults.diffAlwaysModal)
+  private var diffAlwaysModal: Bool = false
+
   @AppStorage(AgentHubDefaults.terminalFontSize)
   private var terminalFontSize: Double = 12
 
@@ -142,6 +145,14 @@ public struct SettingsView: View {
           VStack(alignment: .leading, spacing: 2) {
             Text("Flat session layout")
             Text("Show all sessions without per-repository sections")
+              .font(.caption)
+              .foregroundColor(.secondary)
+          }
+        }
+        Toggle(isOn: $diffAlwaysModal) {
+          VStack(alignment: .leading, spacing: 2) {
+            Text("Diff in modal window")
+            Text("Always open diff in a popup window instead of the side panel")
               .font(.caption)
               .foregroundColor(.secondary)
           }


### PR DESCRIPTION
When enabled, the diff view opens as a popup sheet even in single-layout mode where it would otherwise slide out as an embedded side panel.