### PR TITLE
Add plan mode to multi-session launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,19 @@ In list mode, cards can be resized with a drag preview that commits on release.
 | Waiting for User | Awaiting input |
 | Idle | Session inactive |
 
+## Plan Mode
+
+Plan mode lets Claude read and analyze your codebase without executing any changes.
+Toggle it on or off with **Shift+Tab** inside the prompt editor in the multi-session launcher.
+When active, a teal indicator appears below the prompt.
+
+| Provider | Behavior |
+|---|---|
+| **Claude** | Launched with `--permission-mode plan`; reads files and plans but does not write or execute |
+| **Codex** | Not available — the Codex CLI has no flag to start in plan mode |
+
+> **Why isn't Codex supported?** Codex's plan mode (`ModeKind::Plan`) is a TUI-only collaboration mode that can only be toggled interactively inside the running terminal. The CLI always starts in Default mode with no override flag. When plan mode is active in AgentHub, the Codex provider pill is disabled to avoid confusion. Track upstream support at [openai/codex #12738](https://github.com/openai/codex/issues/12738).
+
 ## Configuration
 
 ### Display Mode

--- a/app/AgentHubTests/WorktreeCreationTests.swift
+++ b/app/AgentHubTests/WorktreeCreationTests.swift
@@ -328,3 +328,138 @@ struct WorktreeRowVisibilityTests {
     #expect(isWorktreeRowVisible(vm) == true)
   }
 }
+
+// MARK: - CLICommandConfiguration plan mode tests
+
+@Suite("CLICommandConfiguration.argumentsForSession — plan mode")
+struct CLICommandConfigurationPlanModeTests {
+
+  private let claude = CLICommandConfiguration.claudeDefault
+  private let codex  = CLICommandConfiguration.codexDefault
+
+  // MARK: Claude
+
+  @Test("Claude emits --permission-mode plan when permissionModePlan is true")
+  func claudePlanModeFlag() {
+    let args = claude.argumentsForSession(sessionId: nil, prompt: nil, permissionModePlan: true)
+    guard let idx = args.firstIndex(of: "--permission-mode") else {
+      Issue.record("Expected --permission-mode flag")
+      return
+    }
+    let valueIdx = args.index(after: idx)
+    #expect(valueIdx < args.endIndex)
+    #expect(args[valueIdx] == "plan")
+  }
+
+  @Test("Claude plan mode takes precedence over dangerouslySkipPermissions")
+  func claudePlanModePrecedence() {
+    let args = claude.argumentsForSession(
+      sessionId: nil,
+      prompt: nil,
+      dangerouslySkipPermissions: true,
+      permissionModePlan: true
+    )
+    #expect(args.contains("--permission-mode"))
+    #expect(!args.contains("--dangerously-skip-permissions"))
+  }
+
+  @Test("Claude does not emit --permission-mode when plan mode is off")
+  func claudeNoPlanModeByDefault() {
+    let args = claude.argumentsForSession(sessionId: nil, prompt: nil, permissionModePlan: false)
+    #expect(!args.contains("--permission-mode"))
+  }
+
+  @Test("Claude plan mode flag appears before prompt")
+  func claudePlanModeFlagBeforePrompt() {
+    let args = claude.argumentsForSession(sessionId: nil, prompt: "fix bug", permissionModePlan: true)
+    #expect(args.last == "fix bug")
+    #expect(args.contains("--permission-mode"))
+  }
+
+  // MARK: Codex
+
+  @Test("Codex emits no --ask-for-approval flag when permissionModePlan is true")
+  func codexNoApprovalFlagInPlanMode() {
+    let args = codex.argumentsForSession(sessionId: nil, prompt: nil, permissionModePlan: true)
+    #expect(!args.contains("--ask-for-approval"))
+  }
+
+  @Test("Codex with plan mode true and a prompt emits only the prompt")
+  func codexPlanModeWithPrompt() {
+    let args = codex.argumentsForSession(sessionId: nil, prompt: "do work", permissionModePlan: true)
+    #expect(args == ["do work"])
+  }
+
+  @Test("Codex with plan mode true and no prompt emits empty args")
+  func codexPlanModeNoPrompt() {
+    let args = codex.argumentsForSession(sessionId: nil, prompt: nil, permissionModePlan: true)
+    #expect(args.isEmpty)
+  }
+
+  @Test("Codex resume ignores permissionModePlan")
+  func codexResumeIgnoresPlanMode() {
+    let args = codex.argumentsForSession(
+      sessionId: "abc-123",
+      prompt: nil,
+      permissionModePlan: true
+    )
+    #expect(args.contains("resume"))
+    #expect(args.contains("abc-123"))
+    #expect(!args.contains("--ask-for-approval"))
+  }
+}
+
+// MARK: - MultiSessionLaunchViewModel plan mode tests
+
+@Suite("MultiSessionLaunchViewModel — plan mode")
+struct MultiSessionLaunchViewModelPlanModeTests {
+
+  /// Mirrors the condition in MultiSessionLaunchView:
+  ///   disabled: viewModel.isPlanModeEnabled
+  @MainActor
+  private func isCodexPillDisabled(_ vm: MultiSessionLaunchViewModel) -> Bool {
+    vm.isPlanModeEnabled
+  }
+
+  @Test("isPlanModeEnabled defaults to false")
+  @MainActor
+  func defaultsToFalse() {
+    let vm = makeViewModel()
+    #expect(vm.isPlanModeEnabled == false)
+  }
+
+  @Test("reset() clears isPlanModeEnabled")
+  @MainActor
+  func resetClearsPlanMode() {
+    let vm = makeViewModel()
+    vm.isPlanModeEnabled = true
+    vm.reset()
+    #expect(vm.isPlanModeEnabled == false)
+  }
+
+  @Test("Codex pill is not disabled when plan mode is off")
+  @MainActor
+  func codexPillEnabledByDefault() {
+    let vm = makeViewModel()
+    #expect(isCodexPillDisabled(vm) == false)
+  }
+
+  @Test("Codex pill is disabled when plan mode is on")
+  @MainActor
+  func codexPillDisabledInPlanMode() {
+    let vm = makeViewModel()
+    vm.isPlanModeEnabled = true
+    #expect(isCodexPillDisabled(vm) == true)
+  }
+
+  @Test("selectedProviders excludes Codex when Codex is deselected in plan mode")
+  @MainActor
+  func selectedProvidersExcludesCodexInPlanMode() {
+    let vm = makeViewModel()
+    vm.isPlanModeEnabled = true
+    vm.isCodexSelected = false   // UI enforces this via .onChange
+    vm.claudeMode = .enabled
+    #expect(!vm.selectedProviders.contains(.codex))
+    #expect(vm.selectedProviders.contains(.claude))
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/Configuration/CLICommandConfiguration.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Configuration/CLICommandConfiguration.swift
@@ -51,7 +51,8 @@ public struct CLICommandConfiguration: Codable, Sendable {
     sessionId: String?,
     prompt: String?,
     dangerouslySkipPermissions: Bool = false,
-    worktreeName: String? = nil
+    worktreeName: String? = nil,
+    permissionModePlan: Bool = false
   ) -> [String] {
     let prefix = subcommandArgs
 
@@ -63,7 +64,10 @@ public struct CLICommandConfiguration: Codable, Sendable {
 
       // Add flags only for NEW sessions (not resume)
       if isNewSession {
-        if dangerouslySkipPermissions {
+        if permissionModePlan {
+          // --permission-mode plan takes precedence; mutually exclusive with dangerously-skip-permissions
+          args += ["--permission-mode", "plan"]
+        } else if dangerouslySkipPermissions {
           args.append("--dangerously-skip-permissions")
         }
         if let name = worktreeName {
@@ -87,12 +91,13 @@ public struct CLICommandConfiguration: Codable, Sendable {
       return prefix + args
 
     case .codex:
-      // Codex doesn't support this flag
       if let sessionId, !sessionId.isEmpty, !sessionId.hasPrefix("pending-") {
         // Codex CLI resume: codex resume <SESSION_ID>
         return prefix + ["resume", sessionId]
       }
-      // Start a new Codex session with optional prompt as positional argument
+      // Start a new Codex session.
+      // NOTE: Codex plan mode (ModeKind::Plan) is TUI-only and cannot be activated
+      // via CLI flags. The UI layer disables the Codex pill when plan mode is on.
       if let prompt, !prompt.isEmpty {
         return prefix + [prompt]
       }

--- a/app/modules/AgentHubCore/Sources/AgentHub/Models/PendingHubSession.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Models/PendingHubSession.swift
@@ -16,6 +16,7 @@ public struct PendingHubSession: Identifiable {
   public let initialPrompt: String?
   public let initialInputText: String?
   public let dangerouslySkipPermissions: Bool
+  public let permissionModePlan: Bool
   /// nil = no worktree flag; "" = --worktree (auto-name); non-empty = --worktree <name>
   public let worktreeName: String?
 
@@ -24,6 +25,7 @@ public struct PendingHubSession: Identifiable {
     initialPrompt: String? = nil,
     initialInputText: String? = nil,
     dangerouslySkipPermissions: Bool = false,
+    permissionModePlan: Bool = false,
     worktreeName: String? = nil
   ) {
     self.id = UUID()
@@ -32,6 +34,7 @@ public struct PendingHubSession: Identifiable {
     self.initialPrompt = initialPrompt
     self.initialInputText = initialInputText
     self.dangerouslySkipPermissions = dangerouslySkipPermissions
+    self.permissionModePlan = permissionModePlan
     self.worktreeName = worktreeName
   }
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/EmbeddedTerminalView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/EmbeddedTerminalView.swift
@@ -53,6 +53,7 @@ public struct EmbeddedTerminalView: NSViewRepresentable {
   let initialInputText: String?  // Optional: text to prefill terminal input without Enter
   let viewModel: CLISessionsViewModel?  // For shared terminal storage
   let dangerouslySkipPermissions: Bool  // One-shot flag for new sessions
+  let permissionModePlan: Bool  // One-shot flag: start session in plan mode
   let worktreeName: String?  // nil = no --worktree; "" = auto-name; non-empty = named
   let onUserInteraction: (() -> Void)?
 
@@ -65,6 +66,7 @@ public struct EmbeddedTerminalView: NSViewRepresentable {
     initialInputText: String? = nil,
     viewModel: CLISessionsViewModel? = nil,
     dangerouslySkipPermissions: Bool = false,
+    permissionModePlan: Bool = false,
     worktreeName: String? = nil,
     onUserInteraction: (() -> Void)? = nil
   ) {
@@ -76,6 +78,7 @@ public struct EmbeddedTerminalView: NSViewRepresentable {
     self.initialInputText = initialInputText
     self.viewModel = viewModel
     self.dangerouslySkipPermissions = dangerouslySkipPermissions
+    self.permissionModePlan = permissionModePlan
     self.worktreeName = worktreeName
     self.onUserInteraction = onUserInteraction
   }
@@ -94,6 +97,7 @@ public struct EmbeddedTerminalView: NSViewRepresentable {
         initialInputText: initialInputText,
         isDark: isDark,
         dangerouslySkipPermissions: dangerouslySkipPermissions,
+        permissionModePlan: permissionModePlan,
         worktreeName: worktreeName
       )
       terminalContainer.onUserInteraction = onUserInteraction
@@ -110,6 +114,7 @@ public struct EmbeddedTerminalView: NSViewRepresentable {
       initialInputText: initialInputText,
       isDark: isDark,
       dangerouslySkipPermissions: dangerouslySkipPermissions,
+      permissionModePlan: permissionModePlan,
       worktreeName: worktreeName
     )
     containerView.onUserInteraction = onUserInteraction
@@ -194,6 +199,7 @@ public class TerminalContainerView: NSView, ManagedLocalProcessTerminalViewDeleg
     initialInputText: String? = nil,
     isDark: Bool = true,
     dangerouslySkipPermissions: Bool = false,
+    permissionModePlan: Bool = false,
     worktreeName: String? = nil
   ) {
     guard !isConfigured else { return }
@@ -227,6 +233,7 @@ public class TerminalContainerView: NSView, ManagedLocalProcessTerminalViewDeleg
       cliConfiguration: cliConfiguration,
       initialPrompt: initialPrompt,
       dangerouslySkipPermissions: dangerouslySkipPermissions,
+      permissionModePlan: permissionModePlan,
       worktreeName: worktreeName
     )
     registerProcessIfNeeded(for: terminal)
@@ -407,6 +414,7 @@ public class TerminalContainerView: NSView, ManagedLocalProcessTerminalViewDeleg
     cliConfiguration: CLICommandConfiguration,
     initialPrompt: String? = nil,
     dangerouslySkipPermissions: Bool = false,
+    permissionModePlan: Bool = false,
     worktreeName: String? = nil
   ) {
     // Find the CLI executable using just the executable name (first word of command)
@@ -481,7 +489,8 @@ public class TerminalContainerView: NSView, ManagedLocalProcessTerminalViewDeleg
       sessionId: sessionId,
       prompt: initialPrompt,
       dangerouslySkipPermissions: dangerouslySkipPermissions,
-      worktreeName: worktreeName
+      worktreeName: worktreeName,
+      permissionModePlan: permissionModePlan
     )
     let escapedArgs = args.map { $0.replacingOccurrences(of: "'", with: "'\\''") }
     let joinedArgs = escapedArgs.map { "'\($0)'" }.joined(separator: " ")

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringCardView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringCardView.swift
@@ -59,6 +59,7 @@ public struct MonitoringCardView: View {
   let terminalKey: String?  // Key for terminal storage (session ID or "pending-{pendingId}")
   let viewModel: CLISessionsViewModel?
   var dangerouslySkipPermissions: Bool = false
+  var permissionModePlan: Bool = false
   let worktreeName: String?
   let onToggleTerminal: (Bool) -> Void
   let onStopMonitoring: () -> Void
@@ -106,6 +107,7 @@ public struct MonitoringCardView: View {
     terminalKey: String? = nil,
     viewModel: CLISessionsViewModel? = nil,
     dangerouslySkipPermissions: Bool = false,
+    permissionModePlan: Bool = false,
     worktreeName: String? = nil,
     onToggleTerminal: @escaping (Bool) -> Void,
     onStopMonitoring: @escaping () -> Void,
@@ -139,6 +141,7 @@ public struct MonitoringCardView: View {
     self.terminalKey = terminalKey
     self.viewModel = viewModel
     self.dangerouslySkipPermissions = dangerouslySkipPermissions
+    self.permissionModePlan = permissionModePlan
     self.worktreeName = worktreeName
     self.onToggleTerminal = onToggleTerminal
     self.onStopMonitoring = onStopMonitoring
@@ -809,6 +812,7 @@ public struct MonitoringCardView: View {
           initialInputText: initialInputText,
           viewModel: viewModel,
           dangerouslySkipPermissions: dangerouslySkipPermissions,
+          permissionModePlan: permissionModePlan,
           worktreeName: worktreeName,
           onUserInteraction: onTerminalInteraction
         )

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringPanelView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringPanelView.swift
@@ -349,6 +349,7 @@ public struct MonitoringPanelView: View {
         terminalKey: "pending-\(pending.id.uuidString)",
         viewModel: viewModel,
         dangerouslySkipPermissions: pending.dangerouslySkipPermissions,
+        permissionModePlan: pending.permissionModePlan,
         worktreeName: pending.worktreeName,
         onToggleTerminal: { _ in },
         onStopMonitoring: {
@@ -501,6 +502,7 @@ public struct MonitoringPanelView: View {
           terminalKey: pendingId,
           viewModel: viewModel,
           dangerouslySkipPermissions: pending.dangerouslySkipPermissions,
+          permissionModePlan: pending.permissionModePlan,
           worktreeName: pending.worktreeName,
           onToggleTerminal: { _ in },
           onStopMonitoring: {
@@ -596,6 +598,7 @@ public struct MonitoringPanelView: View {
         terminalKey: pendingId,
         viewModel: viewModel,
         dangerouslySkipPermissions: pending.dangerouslySkipPermissions,
+        permissionModePlan: pending.permissionModePlan,
         worktreeName: pending.worktreeName,
         onToggleTerminal: { _ in },
         onStopMonitoring: {

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderMonitoringPanelView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderMonitoringPanelView.swift
@@ -503,6 +503,7 @@ public struct MultiProviderMonitoringPanelView: View {
           terminalKey: pendingId,
           viewModel: viewModel,
           dangerouslySkipPermissions: pending.dangerouslySkipPermissions,
+          permissionModePlan: pending.permissionModePlan,
           worktreeName: pending.worktreeName,
           onToggleTerminal: { _ in },
           onStopMonitoring: { viewModel.cancelPendingSession(pending) },
@@ -665,6 +666,7 @@ public struct MultiProviderMonitoringPanelView: View {
         terminalKey: "pending-\(pending.id.uuidString)",
         viewModel: viewModel,
         dangerouslySkipPermissions: pending.dangerouslySkipPermissions,
+        permissionModePlan: pending.permissionModePlan,
         worktreeName: pending.worktreeName,
         onToggleTerminal: { _ in },
         onStopMonitoring: { viewModel.cancelPendingSession(pending) },
@@ -832,6 +834,7 @@ public struct MultiProviderMonitoringPanelView: View {
           terminalKey: "pending-\(pending.id.uuidString)",
           viewModel: viewModel,
           dangerouslySkipPermissions: pending.dangerouslySkipPermissions,
+          permissionModePlan: pending.permissionModePlan,
           worktreeName: pending.worktreeName,
           onToggleTerminal: { _ in },
           onStopMonitoring: {

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiSessionLaunchView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiSessionLaunchView.swift
@@ -43,6 +43,14 @@ public struct MultiSessionLaunchView: View {
 
         promptEditor
 
+        if viewModel.isPlanModeEnabled {
+          planModeHint
+            .transition(.asymmetric(
+              insertion: .move(edge: .top).combined(with: .opacity),
+              removal: .move(edge: .top).combined(with: .opacity)
+            ))
+        }
+
         if !viewModel.attachedFiles.isEmpty {
           attachedFilesSection
         }
@@ -86,6 +94,10 @@ public struct MultiSessionLaunchView: View {
 
         actionButtons
       }
+    }
+    .animation(.easeInOut(duration: 0.2), value: viewModel.isPlanModeEnabled)
+    .onChange(of: viewModel.isPlanModeEnabled) { _, enabled in
+      if enabled { viewModel.isCodexSelected = false }
     }
     .padding(DesignTokens.Spacing.md)
     .background(
@@ -320,6 +332,13 @@ public struct MultiSessionLaunchView: View {
         .font(.system(size: 12))
         .scrollContentBackground(.hidden)
         .padding(2)
+        .onKeyPress { press in
+          if press.key == KeyEquivalent("\u{19}") {
+            viewModel.isPlanModeEnabled.toggle()
+            return .handled
+          }
+          return .ignored
+        }
     }
     .frame(minHeight: 60, maxHeight: 120)
     .padding(4)
@@ -577,8 +596,24 @@ public struct MultiSessionLaunchView: View {
       claudePill
       providerPill(
         label: "Codex",
-        isSelected: $viewModel.isCodexSelected
+        isSelected: $viewModel.isCodexSelected,
+        disabled: viewModel.isPlanModeEnabled
       )
+      Spacer()
+    }
+  }
+
+  private var planModeHint: some View {
+    HStack(spacing: 5) {
+      Image(systemName: "pause.fill")
+        .font(.system(size: 8))
+        .foregroundStyle(Color(nsColor: .systemTeal))
+      Text("plan mode on")
+        .font(.system(size: 11, weight: .medium))
+        .foregroundStyle(Color(nsColor: .systemTeal))
+      Text("(shift+tab to cycle)")
+        .font(.system(size: 11))
+        .foregroundColor(.secondary)
       Spacer()
     }
   }
@@ -694,19 +729,31 @@ public struct MultiSessionLaunchView: View {
     }
   }
 
-  private func providerPill(label: String, isSelected: Binding<Bool>) -> some View {
-    Button(action: { isSelected.wrappedValue.toggle() }) {
+  private func providerPill(label: String, isSelected: Binding<Bool>, disabled: Bool = false) -> some View {
+    Button(action: {
+      guard !disabled else { return }
+      isSelected.wrappedValue.toggle()
+    }) {
       Text(label)
         .font(.system(size: 11, weight: .medium))
-        .foregroundColor(isSelected.wrappedValue ? (colorScheme == .dark ? .black : .white) : .secondary)
+        .foregroundColor(
+          disabled ? .secondary.opacity(0.4)
+            : isSelected.wrappedValue ? (colorScheme == .dark ? .black : .white)
+            : .secondary
+        )
         .padding(.horizontal, 14)
         .padding(.vertical, 5)
         .background(
           Capsule()
-            .fill(isSelected.wrappedValue ? (colorScheme == .dark ? Color.white : Color.black) : Color.primary.opacity(0.06))
+            .fill(
+              disabled ? Color.primary.opacity(0.03)
+                : isSelected.wrappedValue ? (colorScheme == .dark ? Color.white : Color.black)
+                : Color.primary.opacity(0.06)
+            )
         )
     }
     .buttonStyle(.plain)
+    .disabled(disabled)
   }
 
   // MARK: - Progress

--- a/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/CLISessionsViewModel.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/CLISessionsViewModel.swift
@@ -248,6 +248,7 @@ public final class CLISessionsViewModel {
     initialInputText: String? = nil,
     isDark: Bool = true,
     dangerouslySkipPermissions: Bool = false,
+    permissionModePlan: Bool = false,
     worktreeName: String? = nil
   ) -> TerminalContainerView {
     if let existing = activeTerminals[key] {
@@ -280,6 +281,7 @@ public final class CLISessionsViewModel {
       initialInputText: initialInputText,
       isDark: isDark,
       dangerouslySkipPermissions: dangerouslySkipPermissions,
+      permissionModePlan: permissionModePlan,
       worktreeName: worktreeName
     )
     activeTerminals[key] = terminal
@@ -1251,6 +1253,7 @@ public final class CLISessionsViewModel {
     initialPrompt: String? = nil,
     initialInputText: String? = nil,
     dangerouslySkipPermissions: Bool = false,
+    permissionModePlan: Bool = false,
     worktreeName: String? = nil
   ) {
     // Each pending session gets a unique ID, so no need to clear existing terminals
@@ -1260,6 +1263,7 @@ public final class CLISessionsViewModel {
       initialPrompt: initialPrompt,
       initialInputText: initialInputText,
       dangerouslySkipPermissions: dangerouslySkipPermissions,
+      permissionModePlan: permissionModePlan,
       worktreeName: worktreeName
     )
     pendingHubSessions.append(pending)

--- a/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/MultiSessionLaunchViewModel.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/MultiSessionLaunchViewModel.swift
@@ -112,6 +112,7 @@ public final class MultiSessionLaunchViewModel {
   public var claudeUseWorktree: Bool = false
   public var claudeWorktreeName: String = ""
   public var isCodexSelected: Bool = false
+  public var isPlanModeEnabled: Bool = false
   public var sharedPrompt: String = ""
   public var attachedFiles: [AttachedFile] = []
   public var claudeBranchName: String = ""
@@ -393,6 +394,7 @@ public final class MultiSessionLaunchViewModel {
             branchName: singleBranchName,
             viewModel: claudeViewModel,
             dangerouslySkipPermissions: claudeMode.dangerouslySkipPermissions,
+            permissionModePlan: isPlanModeEnabled,
             progressSetter: { self.claudeProgress = $0 }
           )
         case .codex:
@@ -402,6 +404,7 @@ public final class MultiSessionLaunchViewModel {
             repoPath: repoPath,
             branchName: singleBranchName,
             viewModel: codexViewModel,
+            permissionModePlan: isPlanModeEnabled,
             progressSetter: { self.codexProgress = $0 }
           )
         }
@@ -509,7 +512,8 @@ public final class MultiSessionLaunchViewModel {
         plan: plan,
         repoPath: repoPath,
         viewModel: viewModel,
-        dangerouslySkipPermissions: dangerously
+        dangerouslySkipPermissions: dangerously,
+        permissionModePlan: isPlanModeEnabled
       )
     } else {
       // Fallback: single session with the full plan text (not the original prompt)
@@ -517,7 +521,8 @@ public final class MultiSessionLaunchViewModel {
         repoPath: repoPath,
         repoName: repo.name,
         viewModel: viewModel,
-        dangerouslySkipPermissions: dangerously
+        dangerouslySkipPermissions: dangerously,
+        permissionModePlan: isPlanModeEnabled
       )
     }
   }
@@ -527,7 +532,8 @@ public final class MultiSessionLaunchViewModel {
     plan: OrchestrationPlan,
     repoPath: String,
     viewModel: CLISessionsViewModel,
-    dangerouslySkipPermissions: Bool
+    dangerouslySkipPermissions: Bool,
+    permissionModePlan: Bool = false
   ) async {
     var errors: [String] = []
 
@@ -558,7 +564,8 @@ public final class MultiSessionLaunchViewModel {
         viewModel.startNewSessionInHub(
           worktree,
           initialPrompt: session.prompt,
-          dangerouslySkipPermissions: dangerouslySkipPermissions
+          dangerouslySkipPermissions: dangerouslySkipPermissions,
+          permissionModePlan: permissionModePlan
         )
         viewModel.refresh()
 
@@ -589,7 +596,8 @@ public final class MultiSessionLaunchViewModel {
     repoPath: String,
     repoName: String,
     viewModel: CLISessionsViewModel,
-    dangerouslySkipPermissions: Bool
+    dangerouslySkipPermissions: Bool,
+    permissionModePlan: Bool = false
   ) async {
     // Auto-generate branch name from prompt
     let promptSeed = sharedPrompt.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -624,7 +632,8 @@ public final class MultiSessionLaunchViewModel {
       viewModel.startNewSessionInHub(
         worktree,
         initialPrompt: initialPrompt,
-        dangerouslySkipPermissions: dangerouslySkipPermissions
+        dangerouslySkipPermissions: dangerouslySkipPermissions,
+        permissionModePlan: permissionModePlan
       )
       viewModel.refresh()
 
@@ -668,6 +677,7 @@ public final class MultiSessionLaunchViewModel {
     claudeUseWorktree = false
     claudeWorktreeName = ""
     isCodexSelected = false
+    isPlanModeEnabled = false
     claudeProgress = .idle
     codexProgress = .idle
     launchError = nil
@@ -708,6 +718,7 @@ public final class MultiSessionLaunchViewModel {
         initialPrompt: initialPrompt,
         initialInputText: initialInputText,
         dangerouslySkipPermissions: claudeMode.dangerouslySkipPermissions,
+        permissionModePlan: isPlanModeEnabled,
         worktreeName: claudeWorktreeOption
       )
     }
@@ -719,7 +730,8 @@ public final class MultiSessionLaunchViewModel {
       codexViewModel.startNewSessionInHub(
         worktree,
         initialPrompt: initialPrompt,
-        initialInputText: initialInputText
+        initialInputText: initialInputText,
+        permissionModePlan: isPlanModeEnabled
       )
     }
 
@@ -785,7 +797,8 @@ public final class MultiSessionLaunchViewModel {
         worktree,
         initialPrompt: initialPrompt,
         initialInputText: initialInputText,
-        dangerouslySkipPermissions: claudeMode.dangerouslySkipPermissions
+        dangerouslySkipPermissions: claudeMode.dangerouslySkipPermissions,
+        permissionModePlan: isPlanModeEnabled
       )
     }
 
@@ -796,7 +809,8 @@ public final class MultiSessionLaunchViewModel {
       codexViewModel.startNewSessionInHub(
         worktree,
         initialPrompt: initialPrompt,
-        initialInputText: initialInputText
+        initialInputText: initialInputText,
+        permissionModePlan: isPlanModeEnabled
       )
     }
 
@@ -811,6 +825,7 @@ public final class MultiSessionLaunchViewModel {
     branchName: String,
     viewModel: CLISessionsViewModel,
     dangerouslySkipPermissions: Bool = false,
+    permissionModePlan: Bool = false,
     progressSetter: @escaping (WorktreeCreationProgress) -> Void
   ) async {
     viewModel.addRepository(at: repoPath)
@@ -845,7 +860,8 @@ public final class MultiSessionLaunchViewModel {
       worktree,
       initialPrompt: initialPrompt,
       initialInputText: initialInputText,
-      dangerouslySkipPermissions: dangerouslySkipPermissions
+      dangerouslySkipPermissions: dangerouslySkipPermissions,
+      permissionModePlan: permissionModePlan
     )
     viewModel.refresh()
   }


### PR DESCRIPTION
## Summary

- Adds **plan mode** to the multi-session launcher: toggle with **Shift+Tab** in the prompt editor
- A teal `pause.fill` indicator animates in/out below the prompt when active
- **Claude** launches with `--permission-mode plan` (reads files, plans, does not execute)
- **Codex pill is disabled** in plan mode — the Codex CLI has no flag to activate plan mode; `ModeKind::Plan` is a TUI-only collaboration mode hardcoded to start in Default mode
- Removes the incorrect `--ask-for-approval untrusted` flag that was previously (and silently) passed to Codex in plan mode
- Auto-deselects Codex when plan mode toggles on
- 13 new unit tests covering `CLICommandConfiguration` plan mode args and `MultiSessionLaunchViewModel` plan mode state
- README documents the feature and Codex limitation with a link to [openai/codex #12738](https://github.com/openai/codex/issues/12738)

## Changes

| File | Change |
|---|---|
| `MultiSessionLaunchView.swift` | Shift+Tab toggles plan mode; animated hint label; Codex pill disabled + `.onChange` auto-deselect |
| `MultiSessionLaunchViewModel.swift` | `isPlanModeEnabled` property; reset clears it; passed through all launch paths |
| `CLICommandConfiguration.swift` | Claude: `--permission-mode plan`; Codex: removed `--ask-for-approval untrusted` |
| `PendingHubSession.swift` / `MonitoringCardView.swift` / `EmbeddedTerminalView.swift` / `MonitoringPanelView.swift` / `MultiProviderMonitoringPanelView.swift` / `CLISessionsViewModel.swift` | Thread `permissionModePlan` through the full pending→terminal pipeline |
| `WorktreeCreationTests.swift` | 13 new tests: plan mode flags for Claude/Codex, ViewModel state |
| `README.md` | New Plan Mode section |

## Test plan

- [ ] Shift+Tab in launcher prompt → teal `pause.fill` label slides in; again → slides out
- [ ] Launch Claude in plan mode → terminal runs `claude --permission-mode plan`
- [ ] Codex pill is dimmed and unclickable when plan mode is on
- [ ] Select Codex, then toggle plan mode on → Codex auto-deselects
- [ ] Disable plan mode → Codex pill is interactive again
- [ ] All 13 new unit tests pass