### PR TITLE
Fix Codex double-message, narrow terminal, and add Cmd+Return launch shortcut

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/EmbeddedTerminalView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/EmbeddedTerminalView.swift
@@ -205,8 +205,13 @@ public class TerminalContainerView: NSView, ManagedLocalProcessTerminalViewDeleg
     guard !isConfigured else { return }
     isConfigured = true
 
-    // Create and configure terminal view
-    let terminal = SafeLocalProcessTerminalView(frame: bounds)
+    // Create and configure terminal view.
+    // Use a sensible fallback frame when bounds is zero (view not yet laid out by SwiftUI).
+    // SwiftTerm calculates column/row count from the initial frame — a zero frame produces a
+    // ~2-column terminal that wraps every character. Auto Layout will correct the size on the
+    // next layout pass and SwiftTerm's setFrameSize override sends SIGWINCH to the process.
+    let initialFrame = bounds.isEmpty ? CGRect(x: 0, y: 0, width: 800, height: 600) : bounds
+    let terminal = SafeLocalProcessTerminalView(frame: initialFrame)
     terminal.translatesAutoresizingMaskIntoConstraints = false
     terminal.processDelegate = self
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiSessionLaunchView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiSessionLaunchView.swift
@@ -1310,11 +1310,17 @@ public struct MultiSessionLaunchView: View {
                 .scaleEffect(0.7)
             }
             Text(launchButtonTitle)
+            if !viewModel.isLaunching {
+              Text("⌘↵")
+                .font(.system(size: 11, weight: .regular))
+                .opacity(0.7)
+            }
           }
         }
         .buttonStyle(.borderedProminent)
         .tint(.primary)
         .disabled(!viewModel.isValid || viewModel.isLaunching)
+        .keyboardShortcut(.return, modifiers: .command)
       }
     }
   }

--- a/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/CLISessionsViewModel.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/CLISessionsViewModel.swift
@@ -257,9 +257,12 @@ public final class CLISessionsViewModel {
       #endif
       // Send prompt to existing terminal if provided
       if let prompt = initialPrompt {
-        // Reset the delivery flag so this new prompt can be sent
-        existing.resetPromptDeliveryFlag()
-        existing.sendPromptIfNeeded(prompt)
+        if !key.hasPrefix("pending-") {
+          // Resume scenario: send prompt to existing terminal (e.g., inline edit).
+          // For pending sessions, the prompt is already embedded in CLI args — don't re-send.
+          existing.resetPromptDeliveryFlag()
+          existing.sendPromptIfNeeded(prompt)
+        }
         clearPendingPrompt(for: key)  // Clear after sending
       }
       if let inputText = initialInputText, !inputText.isEmpty {


### PR DESCRIPTION
## Summary

- **Codex double-message fix**: In `getOrCreateTerminal`, skip `sendPromptIfNeeded` for `pending-` keyed terminals. The prompt is already embedded in the CLI args (`codex 'prompt'`), so calling `sendPromptIfNeeded` on a re-render was submitting it a second time — only affected Codex since it auto-submits from CLI args immediately.
- **Narrow terminal fix**: `SafeLocalProcessTerminalView` was initialised with `frame: bounds`, but `bounds` is zero when SwiftUI calls `configure()` before layout. This caused SwiftTerm to report a ~2-column terminal width to the process, wrapping every character onto its own line. Now uses an 800×600 fallback when `bounds.isEmpty`; Auto Layout + `SIGWINCH` correct the size after the first layout pass.
- **Cmd+Return launch shortcut**: The launch button in the multi-session launcher now responds to `⌘↵`. A small `⌘↵` hint is shown inside the button label (hidden while launching).

## Test plan

- [ ] Launch a new Codex session in Hub with a prompt — confirm the message is submitted **once**
- [ ] Launch a new Codex session — confirm the terminal renders at full width (no per-character line wrapping)
- [ ] Open the session launcher, type a prompt, press `⌘↵` — confirm launch triggers
- [ ] Verify Claude sessions are unaffected (single prompt submit, full-width terminal)
- [ ] Verify inline edit requests (GitDiffView) still correctly send prompts to existing sessions