### PR TITLE
Improve app window activation and reopen handling

### DIFF
--- a/app/AgentHub/AgentHubApp.swift
+++ b/app/AgentHub/AgentHubApp.swift
@@ -42,9 +42,36 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
     withCompletionHandler completionHandler: @escaping () -> Void
   ) {
     Task { @MainActor in
-      NSApp.activate(ignoringOtherApps: true)
+      Self.activateExistingWindow()
     }
     completionHandler()
+  }
+
+  func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
+    if !flag {
+      Self.activateExistingWindow()
+      return false
+    }
+    return true
+  }
+
+  /// Finds and surfaces the existing app window instead of allowing a new one to be created.
+  private static func activateExistingWindow() {
+    // Look for the main app window (exclude panels, status bar windows, etc.)
+    let appWindow = NSApp.windows.first(where: { window in
+      !(window is NSPanel)
+        && window.className != "NSStatusBarWindow"
+        && window.className != "_NSAlertPanel"
+    })
+
+    if let window = appWindow {
+      if window.isMiniaturized {
+        window.deminiaturize(nil)
+      }
+      window.makeKeyAndOrderFront(nil)
+    }
+
+    NSApp.activate(ignoringOtherApps: true)
   }
 
   nonisolated func userNotificationCenter(


### PR DESCRIPTION
## Summary
Refactored the app window activation logic to properly handle window restoration when the app is reopened or activated from notifications. This prevents creating duplicate windows and ensures existing windows are properly surfaced.

## Key Changes
- Extracted window activation logic into a new `activateExistingWindow()` helper method that intelligently finds and restores the main app window
- Implemented `applicationShouldHandleReopen(_:hasVisibleWindows:)` delegate method to handle app reopen events (e.g., clicking the dock icon)
- Updated notification handling to use the new activation method instead of directly calling `NSApp.activate()`
- Added window filtering to exclude system windows (panels, status bar windows, alert panels) when finding the main app window
- Added logic to restore minimized windows when the app is activated

## Implementation Details
- The `activateExistingWindow()` method searches through `NSApp.windows` to find the first valid app window, filtering out system UI elements
- If the found window is minimized, it's restored via `deminiaturize(nil)` before being brought to the foreground
- The `applicationShouldHandleReopen` method returns `false` when no windows are visible after activation, preventing the system from creating a new window

https://claude.ai/code/session_013xWLwqcyMZmq1zWqvG99u2