### PR TITLE
Add resource link detection and display panel to sessions

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/Models/SessionMonitorState.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Models/SessionMonitorState.swift
@@ -40,6 +40,9 @@ public struct SessionMonitorState: Equatable, Sendable {
   // Mermaid diagram detection
   public var hasMermaidContent: Bool
 
+  // Resource links detected in session responses
+  public var detectedResourceLinks: [ResourceLink]
+
   public init(
     status: SessionStatus = .idle,
     currentTool: String? = nil,
@@ -56,7 +59,8 @@ public struct SessionMonitorState: Equatable, Sendable {
     gitBranch: String? = nil,
     pendingToolUse: PendingToolUse? = nil,
     recentActivities: [ActivityEntry] = [],
-    hasMermaidContent: Bool = false
+    hasMermaidContent: Bool = false,
+    detectedResourceLinks: [ResourceLink] = []
   ) {
     self.status = status
     self.currentTool = currentTool
@@ -74,6 +78,7 @@ public struct SessionMonitorState: Equatable, Sendable {
     self.pendingToolUse = pendingToolUse
     self.recentActivities = recentActivities
     self.hasMermaidContent = hasMermaidContent
+    self.detectedResourceLinks = detectedResourceLinks
   }
 
   // MARK: - Computed Properties
@@ -469,7 +474,9 @@ public struct CostCalculator {
     )
   }
 
-  private static func getPrices(for model: String?) -> (input: Decimal, output: Decimal, cacheRead: Decimal, cacheCreation: Decimal) {
+  private static func getPrices(
+    for model: String?
+  ) -> (input: Decimal, output: Decimal, cacheRead: Decimal, cacheCreation: Decimal) {
     guard let model = model?.lowercased() else {
       // Default to Opus pricing
       return (opusInputPrice, opusOutputPrice, opusCacheReadPrice, opusCacheCreationPrice)
@@ -485,5 +492,48 @@ public struct CostCalculator {
       // Default to Opus pricing for unknown models
       return (opusInputPrice, opusOutputPrice, opusCacheReadPrice, opusCacheCreationPrice)
     }
+  }
+}
+
+// MARK: - ResourceLink
+
+/// A URL resource detected in session assistant responses
+public struct ResourceLink: Identifiable, Equatable, Sendable, Hashable {
+  public let id: UUID
+  public let url: String
+  public let timestamp: Date
+
+  public init(
+    id: UUID = UUID(),
+    url: String,
+    timestamp: Date = Date()
+  ) {
+    self.id = id
+    self.url = url
+    self.timestamp = timestamp
+  }
+
+  /// Extract display-friendly domain from the URL
+  public var displayDomain: String {
+    guard let urlObj = URL(string: url),
+          let host = urlObj.host else {
+      return url
+    }
+    return host
+  }
+
+  /// Extract a short display title from the URL path
+  public var displayTitle: String {
+    guard let urlObj = URL(string: url) else { return url }
+    let path = urlObj.path
+    if path.isEmpty || path == "/" {
+      return displayDomain
+    }
+    // Use last meaningful path component
+    let components = path.split(separator: "/").filter { !$0.isEmpty }
+    if let last = components.last {
+      return String(last)
+    }
+    return displayDomain
   }
 }

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/CodexSessionFileWatcher.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/CodexSessionFileWatcher.swift
@@ -219,7 +219,8 @@ public actor CodexSessionFileWatcher {
       gitBranch: nil,
       pendingToolUse: nil,
       recentActivities: result.recentActivities,
-      hasMermaidContent: result.hasMermaidContent
+      hasMermaidContent: result.hasMermaidContent,
+      detectedResourceLinks: result.detectedResourceLinks
     )
   }
 }

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/CodexSessionJSONLParser.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/CodexSessionJSONLParser.swift
@@ -41,6 +41,7 @@ public struct CodexSessionJSONLParser {
     public var sessionStartedAt: Date?
     public var currentStatus: SessionStatus = .idle
     public var hasMermaidContent: Bool = false
+    public var detectedResourceLinks: [ResourceLink] = []
 
     public init() {}
   }
@@ -198,6 +199,12 @@ public struct CodexSessionJSONLParser {
       result.messageCount += 1
       if let message = payload["message"] as? String, !message.isEmpty {
         if message.contains("```mermaid") { result.hasMermaidContent = true }
+        let links = extractResourceLinks(from: message, timestamp: timestamp)
+        for link in links {
+          if !result.detectedResourceLinks.contains(where: { $0.url == link.url }) {
+            result.detectedResourceLinks.append(link)
+          }
+        }
         addActivity(type: .assistantMessage, description: String(message.prefix(80)), timestamp: timestamp, to: &result)
       }
 
@@ -313,6 +320,27 @@ public struct CodexSessionJSONLParser {
     if result.recentActivities.count > 100 {
       result.recentActivities.removeFirst(result.recentActivities.count - 100)
     }
+  }
+
+  private static func extractResourceLinks(from text: String, timestamp: Date?) -> [ResourceLink] {
+    guard let regex = try? NSRegularExpression(
+      pattern: "https?://[^\\s)\\]>\"'`]+",
+      options: []
+    ) else { return [] }
+
+    let range = NSRange(text.startIndex..., in: text)
+    let matches = regex.matches(in: text, options: [], range: range)
+
+    var links: [ResourceLink] = []
+    for match in matches {
+      guard let matchRange = Range(match.range, in: text) else { continue }
+      var urlString = String(text[matchRange])
+      while let last = urlString.last, [".", ",", ";", ":"].contains(String(last)) {
+        urlString.removeLast()
+      }
+      links.append(ResourceLink(url: urlString, timestamp: timestamp ?? Date()))
+    }
+    return links
   }
 
   private static func parseTimestamp(_ string: String?) -> Date? {

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/SessionFileWatcher.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/SessionFileWatcher.swift
@@ -358,7 +358,8 @@ public actor SessionFileWatcher {
       gitBranch: result.gitBranch,
       pendingToolUse: pendingToolUse,
       recentActivities: result.recentActivities,
-      hasMermaidContent: result.hasMermaidContent
+      hasMermaidContent: result.hasMermaidContent,
+      detectedResourceLinks: result.detectedResourceLinks
     )
   }
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/SessionJSONLParser.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/SessionJSONLParser.swift
@@ -85,6 +85,7 @@ public struct SessionJSONLParser {
     public var currentStatus: SessionStatus = .idle
     public var gitBranch: String?
     public var hasMermaidContent: Bool = false
+    public var detectedResourceLinks: [ResourceLink] = []
 
     public init() {}
   }
@@ -286,8 +287,16 @@ public struct SessionJSONLParser {
         )
 
       case "text":
-        if let text = block.text, text.contains("```mermaid") {
-          result.hasMermaidContent = true
+        if let text = block.text {
+          if text.contains("```mermaid") {
+            result.hasMermaidContent = true
+          }
+          let links = extractResourceLinks(from: text, timestamp: timestamp)
+          for link in links {
+            if !result.detectedResourceLinks.contains(where: { $0.url == link.url }) {
+              result.detectedResourceLinks.append(link)
+            }
+          }
         }
         addActivity(
           type: .assistantMessage,
@@ -482,6 +491,30 @@ public struct SessionJSONLParser {
     }
 
     return nil
+  }
+
+  /// Extract URLs from text content and return as ResourceLink instances
+  private static func extractResourceLinks(from text: String, timestamp: Date?) -> [ResourceLink] {
+    // Match http:// and https:// URLs
+    guard let regex = try? NSRegularExpression(
+      pattern: "https?://[^\\s)\\]>\"'`]+",
+      options: []
+    ) else { return [] }
+
+    let range = NSRange(text.startIndex..., in: text)
+    let matches = regex.matches(in: text, options: [], range: range)
+
+    var links: [ResourceLink] = []
+    for match in matches {
+      guard let matchRange = Range(match.range, in: text) else { continue }
+      var urlString = String(text[matchRange])
+      // Strip trailing punctuation that's likely not part of the URL
+      while let last = urlString.last, [".", ",", ";", ":"].contains(String(last)) {
+        urlString.removeLast()
+      }
+      links.append(ResourceLink(url: urlString, timestamp: timestamp ?? Date()))
+    }
+    return links
   }
 
   private static func isErrorResult(_ content: AnyCodable?) -> Bool {

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringCardView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringCardView.swift
@@ -225,6 +225,11 @@ public struct MonitoringCardView: View {
       monitorContent
         .padding(.horizontal, 12)
         .padding(.vertical, 8)
+
+      // Resource links panel (shown when URLs are detected in session responses)
+      if let links = state?.detectedResourceLinks, !links.isEmpty {
+        ResourceLinksPanel(links: links, providerKind: providerKind)
+      }
     }
     .background(colorScheme == .dark ? Color(white: 0.07) : Color(white: 0.92))
     .clipShape(RoundedRectangle(cornerRadius: 8))

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/ResourceLinksPanel.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/ResourceLinksPanel.swift
@@ -1,0 +1,152 @@
+//
+//  ResourceLinksPanel.swift
+//  AgentHub
+//
+//  Created by Assistant on 3/11/26.
+//
+
+import SwiftUI
+
+// MARK: - ResourceLinksPanel
+
+/// A compact bottom panel that displays clickable resource links detected in session responses
+struct ResourceLinksPanel: View {
+  let links: [ResourceLink]
+  let providerKind: SessionProviderKind
+  @State private var isExpanded = false
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 0) {
+      Divider()
+
+      // Header bar - always visible, toggles expand/collapse
+      Button(action: { withAnimation(.easeInOut(duration: 0.2)) { isExpanded.toggle() } }) {
+        HStack(spacing: 6) {
+          Image(systemName: "link")
+            .font(.caption2)
+            .foregroundColor(.brandPrimary(for: providerKind))
+
+          Text("Resources")
+            .font(.caption)
+            .fontWeight(.medium)
+            .foregroundColor(.primary)
+
+          Text("\(links.count)")
+            .font(.caption2)
+            .foregroundColor(.secondary)
+            .padding(.horizontal, 5)
+            .padding(.vertical, 1)
+            .background(Color.secondary.opacity(0.15))
+            .clipShape(Capsule())
+
+          Spacer()
+
+          Image(systemName: isExpanded ? "chevron.down" : "chevron.up")
+            .font(.caption2)
+            .foregroundColor(.secondary)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 6)
+        .contentShape(Rectangle())
+      }
+      .buttonStyle(.plain)
+
+      if isExpanded {
+        Divider()
+
+        // Scrollable link list
+        ScrollView(.horizontal, showsIndicators: false) {
+          HStack(spacing: 8) {
+            ForEach(links) { link in
+              ResourceLinkChip(link: link, providerKind: providerKind)
+            }
+          }
+          .padding(.horizontal, 12)
+          .padding(.vertical, 8)
+        }
+      }
+    }
+    .background(Color.primary.opacity(0.03))
+  }
+}
+
+// MARK: - ResourceLinkChip
+
+/// A compact clickable chip for a single resource link
+private struct ResourceLinkChip: View {
+  let link: ResourceLink
+  let providerKind: SessionProviderKind
+  @State private var isHovering = false
+
+  var body: some View {
+    Button(action: openLink) {
+      HStack(spacing: 4) {
+        Image(systemName: iconForURL(link.url))
+          .font(.caption2)
+
+        VStack(alignment: .leading, spacing: 0) {
+          Text(link.displayTitle)
+            .font(.caption2)
+            .fontWeight(.medium)
+            .lineLimit(1)
+          Text(link.displayDomain)
+            .font(.system(size: 9))
+            .foregroundColor(.secondary)
+            .lineLimit(1)
+        }
+      }
+      .padding(.horizontal, 8)
+      .padding(.vertical, 5)
+      .background(
+        isHovering
+          ? Color.brandPrimary(for: providerKind).opacity(0.12)
+          : Color.secondary.opacity(0.08)
+      )
+      .clipShape(RoundedRectangle(cornerRadius: 6))
+      .overlay(
+        RoundedRectangle(cornerRadius: 6)
+          .stroke(Color.secondary.opacity(0.15), lineWidth: 0.5)
+      )
+    }
+    .buttonStyle(.plain)
+    .onHover { hovering in isHovering = hovering }
+    .help(link.url)
+  }
+
+  private func openLink() {
+    guard let url = URL(string: link.url) else { return }
+    NSWorkspace.shared.open(url)
+  }
+
+  private func iconForURL(_ urlString: String) -> String {
+    let lowered = urlString.lowercased()
+    if lowered.contains("github.com") {
+      return "curlybraces"
+    } else if lowered.contains("docs.") || lowered.contains("documentation") {
+      return "doc.text"
+    } else if lowered.contains("stackoverflow.com") {
+      return "questionmark.circle"
+    } else if lowered.contains("npm") || lowered.contains("pypi") || lowered.contains("crates.io") {
+      return "shippingbox"
+    } else {
+      return "globe"
+    }
+  }
+}
+
+// MARK: - Preview
+
+#Preview {
+  VStack {
+    ResourceLinksPanel(
+      links: [
+        ResourceLink(url: "https://github.com/anthropics/claude-code/issues/123"),
+        ResourceLink(url: "https://docs.swift.org/swift-book/documentation/the-swift-programming-language"),
+        ResourceLink(url: "https://stackoverflow.com/questions/12345/some-question"),
+        ResourceLink(url: "https://example.com/api/v2/endpoint"),
+      ],
+      providerKind: .claude
+    )
+  }
+  .frame(width: 400)
+}


### PR DESCRIPTION
## Summary
This PR adds automatic detection and display of resource links (URLs) found in session assistant responses. A new collapsible panel shows detected links with provider-specific styling and allows users to quickly open them.

## Key Changes

- **New `ResourceLink` model** (`SessionMonitorState.swift`): A public struct that represents a detected URL with metadata including display title and domain extraction from the URL
- **New `ResourceLinksPanel` UI component** (`ResourceLinksPanel.swift`): A compact bottom panel that displays detected links as interactive chips with:
  - Collapsible header showing link count
  - Horizontal scrollable list of resource chips
  - Context-aware icons (GitHub, documentation, Stack Overflow, package registries, etc.)
  - Hover effects and click-to-open functionality
  - Provider-specific color theming
- **URL extraction logic**: Added `extractResourceLinks()` method to both `SessionJSONLParser` and `CodexSessionJSONLParser` that:
  - Uses regex to find http/https URLs in text content
  - Strips trailing punctuation to avoid including sentence-ending periods
  - Deduplicates URLs to avoid showing the same link multiple times
- **State management**: Updated `SessionMonitorState` to track `detectedResourceLinks` array
- **Integration**: Connected the panel to `MonitoringCardView` to display when links are detected
- **File watchers**: Updated both `SessionFileWatcher` and `CodexSessionFileWatcher` to pass detected links to the state

## Implementation Details

- URL detection uses a regex pattern `https?://[^\s)\]>"'\`]+` to match common URL formats
- The `ResourceLinkChip` component provides visual feedback with hover states and tooltips
- Icons are intelligently selected based on URL domain patterns (GitHub, docs, Stack Overflow, package managers)
- Links are deduplicated by URL string to prevent duplicates in the panel
- The panel uses smooth animations for expand/collapse transitions

https://claude.ai/code/session_01JDZtsP9NQaNQsk5djxU1Ku