### PR TITLE
feat: configurable newline shortcut for embedded terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Updates are delivered automatically via [Sparkle](https://sparkle-project.org/) 
 | **Cmd+C** | Copy selected text |
 | **Cmd+V** | Paste |
 | **Cmd+A** | Select all |
+| **⌥↩ / ⌘↩ / ⇧↩** | Insert newline (configurable in Settings → Terminal) |
 
 ### Command Palette
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubDefaults.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubDefaults.swift
@@ -98,6 +98,11 @@ public enum AgentHubDefaults {
   /// Type: Double (default: 12.0)
   public static let terminalFontSize = "\(keyPrefix)terminal.fontSize"
 
+  /// Preferred newline shortcut in the embedded terminal
+  /// Type: Int (default: 0 = system/default)
+  /// See: NewlineShortcut enum in EmbeddedTerminalView.swift
+  public static let terminalNewlineShortcut = "\(keyPrefix)terminal.newlineShortcut"
+
   /// Monitoring panel layout mode (list, 2-column, 3-column grid)
   /// Type: Int (default: 0 = list)
   public static let monitoringPanelLayoutMode = "\(keyPrefix)ui.monitoringPanelLayoutMode"

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/EmbeddedTerminalView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/EmbeddedTerminalView.swift
@@ -9,6 +9,26 @@ import AppKit
 import SwiftTerm
 import SwiftUI
 
+// MARK: - NewlineShortcut
+
+/// Controls which key combination inserts a newline in the embedded Claude Code terminal.
+public enum NewlineShortcut: Int, CaseIterable {
+  /// System default: option+return inserts newline (SwiftTerm native behavior, no interception)
+  case system = 0
+  /// cmd+return inserts newline; option+return submits like plain Enter
+  case cmdReturn = 1
+  /// shift+return inserts newline; option+return submits like plain Enter
+  case shiftReturn = 2
+
+  public var label: String {
+    switch self {
+    case .system: return "Default (⌥↩)"
+    case .cmdReturn: return "⌘↩ Newline"
+    case .shiftReturn: return "⇧↩ Newline"
+    }
+  }
+}
+
 // MARK: - SafeLocalProcessTerminalView
 
 /// A ManagedLocalProcessTerminalView subclass that safely handles cleanup by stopping
@@ -371,9 +391,43 @@ public class TerminalContainerView: NSView, ManagedLocalProcessTerminalViewDeleg
 
       switch event.type {
       case .keyDown:
-        if let window = terminal.window,
-           event.window === window,
-           isTerminalResponderActive(window: window, terminal: terminal) {
+        guard let window = terminal.window,
+              event.window === window,
+              isTerminalResponderActive(window: window, terminal: terminal) else { break }
+
+        let shortcut = NewlineShortcut(
+          rawValue: UserDefaults.standard.integer(forKey: AgentHubDefaults.terminalNewlineShortcut)
+        ) ?? .system
+
+        let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+        let isReturn = event.keyCode == 36
+
+        switch shortcut {
+        case .system:
+          self.onUserInteraction?()
+
+        case .cmdReturn:
+          if isReturn && flags == .command {
+            terminal.send([0x1B, 0x0D])  // newline
+            self.onUserInteraction?()
+            return nil
+          } else if isReturn && flags == .option {
+            terminal.send([0x0D])  // suppress ESC+CR, submit instead
+            self.onUserInteraction?()
+            return nil
+          }
+          self.onUserInteraction?()
+
+        case .shiftReturn:
+          if isReturn && flags == .shift {
+            terminal.send([0x1B, 0x0D])  // newline
+            self.onUserInteraction?()
+            return nil
+          } else if isReturn && (flags == .option || flags == .command) {
+            terminal.send([0x0D])  // submit
+            self.onUserInteraction?()
+            return nil
+          }
           self.onUserInteraction?()
         }
       case .leftMouseUp:

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/SettingsView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/SettingsView.swift
@@ -20,6 +20,9 @@ public struct SettingsView: View {
   @AppStorage(AgentHubDefaults.terminalFontSize)
   private var terminalFontSize: Double = 12
 
+  @AppStorage(AgentHubDefaults.terminalNewlineShortcut)
+  private var newlineShortcutRawValue: Int = NewlineShortcut.system.rawValue
+
   @AppStorage(AgentHubDefaults.notificationSoundsEnabled)
   private var notificationSoundsEnabled: Bool = true
 
@@ -167,6 +170,11 @@ public struct SettingsView: View {
             Text("\(Int(terminalFontSize)) pt")
               .foregroundColor(.secondary)
               .monospacedDigit()
+          }
+        }
+        Picker("Newline shortcut", selection: $newlineShortcutRawValue) {
+          ForEach(NewlineShortcut.allCases, id: \.rawValue) { shortcut in
+            Text(shortcut.label).tag(shortcut.rawValue)
           }
         }
       }

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/NewlineShortcutTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/NewlineShortcutTests.swift
@@ -1,0 +1,35 @@
+import Testing
+@testable import AgentHub
+
+@Suite("NewlineShortcut")
+struct NewlineShortcutTests {
+
+  @Test("Raw values are stable")
+  func rawValues() {
+    #expect(NewlineShortcut.system.rawValue == 0)
+    #expect(NewlineShortcut.cmdReturn.rawValue == 1)
+    #expect(NewlineShortcut.shiftReturn.rawValue == 2)
+  }
+
+  @Test("Default raw value resolves to .system")
+  func defaultIsSystem() {
+    #expect(NewlineShortcut(rawValue: 0) == .system)
+  }
+
+  @Test("Unknown raw value falls back to nil")
+  func unknownRawValue() {
+    #expect(NewlineShortcut(rawValue: 99) == nil)
+  }
+
+  @Test("All cases covered by CaseIterable")
+  func allCases() {
+    #expect(NewlineShortcut.allCases.count == 3)
+  }
+
+  @Test("Labels are non-empty")
+  func labels() {
+    for shortcut in NewlineShortcut.allCases {
+      #expect(!shortcut.label.isEmpty)
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `NewlineShortcut` enum (`system`, `cmdReturn`, `shiftReturn`) to `EmbeddedTerminalView.swift`
- Rewrites the `NSEvent` local monitor to read the user's preference on each keydown and send the correct PTY byte sequences (`[ESC+CR]` for newline, `[CR]` for submit)
- In `⇧↩` mode, both `⌥↩` and `⌘↩` submit (so cmd+return isn't silently swallowed)
- Adds `terminalNewlineShortcut` key to `AgentHubDefaults`
- Adds a `Picker` in Settings → Terminal after the font size stepper
- Adds `NewlineShortcutTests` covering raw value stability, default resolution, unknown fallback, `CaseIterable` count, and non-empty labels

## Test plan

- [ ] Build succeeds with no errors
- [ ] Settings → Terminal shows "Newline shortcut" picker with 3 options
- [ ] **Default (⌥↩):** `option+return` inserts newline; no interception of other combos
- [ ] **⌘↩ Newline:** `cmd+return` inserts newline; `option+return` submits
- [ ] **⇧↩ Newline:** `shift+return` inserts newline; `option+return` and `cmd+return` both submit
- [ ] `NewlineShortcutTests` all pass