### PR TITLE
Revert notification window fix

### DIFF
--- a/app/AgentHub/AgentHubApp.swift
+++ b/app/AgentHub/AgentHubApp.swift
@@ -42,36 +42,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
     withCompletionHandler completionHandler: @escaping () -> Void
   ) {
     Task { @MainActor in
-      Self.activateExistingWindow()
+      NSApp.activate(ignoringOtherApps: true)
     }
     completionHandler()
-  }
-
-  func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
-    if !flag {
-      Self.activateExistingWindow()
-      return false
-    }
-    return true
-  }
-
-  /// Finds and surfaces the existing app window instead of allowing a new one to be created.
-  private static func activateExistingWindow() {
-    // Look for the main app window (exclude panels, status bar windows, etc.)
-    let appWindow = NSApp.windows.first(where: { window in
-      !(window is NSPanel)
-        && window.className != "NSStatusBarWindow"
-        && window.className != "_NSAlertPanel"
-    })
-
-    if let window = appWindow {
-      if window.isMiniaturized {
-        window.deminiaturize(nil)
-      }
-      window.makeKeyAndOrderFront(nil)
-    }
-
-    NSApp.activate(ignoringOtherApps: true)
   }
 
   nonisolated func userNotificationCenter(


### PR DESCRIPTION
Reverts bfdcda676f4d24e7bc8b2ca77eacea98d24846f5

Removes `activateExistingWindow()` and `applicationShouldHandleReopen` added in the original fix.