### PR TITLE
fix: accumulate URLs across requests and extract from tool calls

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/SessionFileWatcher.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/SessionFileWatcher.swift
@@ -125,6 +125,9 @@ public actor SessionFileWatcher {
         // Parse new lines
         SessionJSONLParser.parseNewLines(newLines, into: &parseResult, approvalTimeoutSeconds: timeout)
 
+        // Keep watchedSessions in sync with the mutated parseResult
+        Task { await self.updateStoredParseResult(sessionId: sessionId, parseResult: parseResult) }
+
         // Keep lastEmittedStatus in sync to prevent redundant emissions from status timer
         lastEmittedStatus = parseResult.currentStatus
 
@@ -168,6 +171,9 @@ public actor SessionFileWatcher {
 
           if !newLines.isEmpty {
             SessionJSONLParser.parseNewLines(newLines, into: &parseResult, approvalTimeoutSeconds: timeout)
+
+            // Keep watchedSessions in sync with the mutated parseResult
+            Task { await self.updateStoredParseResult(sessionId: sessionId, parseResult: parseResult) }
 
             // Update tracking
             lastKnownFileSize = tempPosition
@@ -262,6 +268,10 @@ public actor SessionFileWatcher {
   }
 
   // MARK: - Private Helpers
+
+  private func updateStoredParseResult(sessionId: String, parseResult: SessionJSONLParser.ParseResult) {
+    watchedSessions[sessionId]?.parseResult = parseResult
+  }
 
   private func findSessionFile(sessionId: String, projectPath: String) -> String? {
     // Session files are in: ~/.claude/projects/{encoded-path}/{sessionId}.jsonl

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/SessionJSONLParser.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/SessionJSONLParser.swift
@@ -259,6 +259,17 @@ public struct SessionJSONLParser {
             codeChangeInput: codeChangeInput,
             to: &result
           )
+
+          // Extract URL from tool_use input (e.g., WebFetch url parameter)
+          if let dict = block.input?.value as? [String: Any],
+             let urlString = dict["url"] as? String {
+            let links = extractResourceLinks(from: urlString, timestamp: timestamp)
+            for link in links {
+              if !result.detectedResourceLinks.contains(where: { $0.url == link.url }) {
+                result.detectedResourceLinks.append(link)
+              }
+            }
+          }
         }
 
       case "tool_result":
@@ -276,6 +287,24 @@ public struct SessionJSONLParser {
             timestamp: timestamp,
             to: &result
           )
+
+          // Extract URLs from tool result content
+          if let content = block.content {
+            var textToScan = ""
+            if let str = content.value as? String {
+              textToScan = str
+            } else if let arr = content.value as? [[String: Any]] {
+              textToScan = arr.compactMap { $0["text"] as? String }.joined(separator: " ")
+            }
+            if !textToScan.isEmpty {
+              let links = extractResourceLinks(from: textToScan, timestamp: timestamp)
+              for link in links {
+                if !result.detectedResourceLinks.contains(where: { $0.url == link.url }) {
+                  result.detectedResourceLinks.append(link)
+                }
+              }
+            }
+          }
         }
 
       case "thinking":

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/SessionJSONLParserURLTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/SessionJSONLParserURLTests.swift
@@ -1,0 +1,127 @@
+import Foundation
+import Testing
+
+@testable import AgentHubCore
+
+@Suite("SessionJSONLParser URL extraction")
+struct SessionJSONLParserURLTests {
+
+  // MARK: - tool_use input URL extraction
+
+  @Test("Extracts URL from WebFetch tool_use input")
+  func extractsURLFromToolUseInput() {
+    let line = """
+      {"type":"assistant","timestamp":"2026-01-01T00:00:00Z","message":{"role":"assistant","content":[{"type":"tool_use","id":"tu1","name":"WebFetch","input":{"url":"https://example.com/page","prompt":"summarize"}}]}}
+      """
+    var result = SessionJSONLParser.ParseResult()
+    SessionJSONLParser.parseNewLines([line], into: &result)
+
+    #expect(result.detectedResourceLinks.count == 1)
+    #expect(result.detectedResourceLinks[0].url == "https://example.com/page")
+  }
+
+  @Test("Does not duplicate URL already seen in tool_use")
+  func noDuplicateFromToolUse() {
+    let line = """
+      {"type":"assistant","timestamp":"2026-01-01T00:00:00Z","message":{"role":"assistant","content":[{"type":"tool_use","id":"tu1","name":"WebFetch","input":{"url":"https://example.com"}},{"type":"tool_use","id":"tu2","name":"WebFetch","input":{"url":"https://example.com"}}]}}
+      """
+    var result = SessionJSONLParser.ParseResult()
+    SessionJSONLParser.parseNewLines([line], into: &result)
+
+    #expect(result.detectedResourceLinks.count == 1)
+  }
+
+  @Test("Ignores tool_use with no url key in input")
+  func ignoresToolUseWithNoURL() {
+    let line = """
+      {"type":"assistant","timestamp":"2026-01-01T00:00:00Z","message":{"role":"assistant","content":[{"type":"tool_use","id":"tu1","name":"Bash","input":{"command":"ls -la"}}]}}
+      """
+    var result = SessionJSONLParser.ParseResult()
+    SessionJSONLParser.parseNewLines([line], into: &result)
+
+    #expect(result.detectedResourceLinks.isEmpty)
+  }
+
+  // MARK: - tool_result content URL extraction
+
+  @Test("Extracts URL from tool_result with String content")
+  func extractsURLFromToolResultStringContent() {
+    let assistantLine = """
+      {"type":"assistant","timestamp":"2026-01-01T00:00:00Z","message":{"role":"assistant","content":[{"type":"tool_use","id":"tu1","name":"WebFetch","input":{"url":"https://example.com"}}]}}
+      """
+    let userLine = """
+      {"type":"user","timestamp":"2026-01-01T00:00:01Z","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"tu1","content":"Fetched https://docs.example.com/api successfully"}]}}
+      """
+    var result = SessionJSONLParser.ParseResult()
+    SessionJSONLParser.parseNewLines([assistantLine, userLine], into: &result)
+
+    let urls = result.detectedResourceLinks.map { $0.url }
+    #expect(urls.contains("https://example.com"))
+    #expect(urls.contains("https://docs.example.com/api"))
+  }
+
+  @Test("Extracts URL from tool_result with array content")
+  func extractsURLFromToolResultArrayContent() {
+    let assistantLine = """
+      {"type":"assistant","timestamp":"2026-01-01T00:00:00Z","message":{"role":"assistant","content":[{"type":"tool_use","id":"tu1","name":"web_search","input":{"query":"swift concurrency"}}]}}
+      """
+    let userLine = """
+      {"type":"user","timestamp":"2026-01-01T00:00:01Z","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"tu1","content":[{"type":"text","text":"Result: https://swift.org/concurrency and https://developer.apple.com/swift"}]}]}}
+      """
+    var result = SessionJSONLParser.ParseResult()
+    SessionJSONLParser.parseNewLines([assistantLine, userLine], into: &result)
+
+    let urls = result.detectedResourceLinks.map { $0.url }
+    #expect(urls.contains("https://swift.org/concurrency"))
+    #expect(urls.contains("https://developer.apple.com/swift"))
+  }
+
+  @Test("Does not duplicate URL seen in both tool_use and tool_result")
+  func noDuplicateAcrossToolUseAndResult() {
+    let assistantLine = """
+      {"type":"assistant","timestamp":"2026-01-01T00:00:00Z","message":{"role":"assistant","content":[{"type":"tool_use","id":"tu1","name":"WebFetch","input":{"url":"https://example.com"}}]}}
+      """
+    let userLine = """
+      {"type":"user","timestamp":"2026-01-01T00:00:01Z","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"tu1","content":"Fetched https://example.com successfully"}]}}
+      """
+    var result = SessionJSONLParser.ParseResult()
+    SessionJSONLParser.parseNewLines([assistantLine, userLine], into: &result)
+
+    let count = result.detectedResourceLinks.filter { $0.url == "https://example.com" }.count
+    #expect(count == 1)
+  }
+
+  // MARK: - URL accumulation across multiple messages
+
+  @Test("Accumulates URLs across multiple incremental parse calls")
+  func accumulatesURLsAcrossIncrementalCalls() {
+    let line1 = """
+      {"type":"assistant","timestamp":"2026-01-01T00:00:00Z","message":{"role":"assistant","content":[{"type":"tool_use","id":"tu1","name":"WebFetch","input":{"url":"https://first.com"}}]}}
+      """
+    let line2 = """
+      {"type":"assistant","timestamp":"2026-01-01T00:00:01Z","message":{"role":"assistant","content":[{"type":"tool_use","id":"tu2","name":"WebFetch","input":{"url":"https://second.com"}}]}}
+      """
+    var result = SessionJSONLParser.ParseResult()
+    SessionJSONLParser.parseNewLines([line1], into: &result)
+    SessionJSONLParser.parseNewLines([line2], into: &result)
+
+    let urls = result.detectedResourceLinks.map { $0.url }
+    #expect(urls.contains("https://first.com"))
+    #expect(urls.contains("https://second.com"))
+    #expect(result.detectedResourceLinks.count == 2)
+  }
+
+  // MARK: - Existing text block extraction still works
+
+  @Test("Still extracts URLs from assistant text blocks")
+  func stillExtractsURLsFromTextBlocks() {
+    let line = """
+      {"type":"assistant","timestamp":"2026-01-01T00:00:00Z","message":{"role":"assistant","content":[{"type":"text","text":"Check out https://example.com for more info"}]}}
+      """
+    var result = SessionJSONLParser.ParseResult()
+    SessionJSONLParser.parseNewLines([line], into: &result)
+
+    #expect(result.detectedResourceLinks.count == 1)
+    #expect(result.detectedResourceLinks[0].url == "https://example.com")
+  }
+}


### PR DESCRIPTION
## Summary

- **Bug 1 — Stale `watchedSessions` state**: `watchedSessions[sessionId].parseResult` was never updated after incremental parses, so navigating away and back to a session re-emitted a stale state with no accumulated URLs. Fixed by adding `updateStoredParseResult` actor method called after every `parseNewLines` invocation.
- **Bug 2 — Missing URL sources**: URL extraction only happened in `text` content blocks. Now also extracts from `tool_use` input (`url` key, covers `WebFetch` etc.) and `tool_result` content (both `String` and `[[String: Any]]` array forms).

## Test plan

- [ ] Unit tests added in `SessionJSONLParserURLTests.swift` covering all new extraction paths, deduplication, and incremental accumulation — all passing
- [ ] Ask Claude to fetch a URL → verify it appears in `ResourceLinksPanel`
- [ ] Ask Claude to fetch a second URL → verify it is **added** (not replacing) the first
- [ ] Navigate away from the session and back → verify all URLs are still shown
- [ ] App restart → URLs gone (expected, in-memory only)