### PR TITLE
fix: validate URLs before storing to prevent malformed entries in UI

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/SessionJSONLParser.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/SessionJSONLParser.swift
@@ -541,6 +541,7 @@ public struct SessionJSONLParser {
       while let last = urlString.last, [".", ",", ";", ":"].contains(String(last)) {
         urlString.removeLast()
       }
+      guard URL(string: urlString) != nil else { continue }
       links.append(ResourceLink(url: urlString, timestamp: timestamp ?? Date()))
     }
     return links


### PR DESCRIPTION
## Summary
- Adds `URL(string:)` validation in `extractResourceLinks` before creating a `ResourceLink`
- Invalid/malformed regex matches (e.g. bare `https://`, truncated URLs) are now dropped at extraction time and never reach `ResourceLinksPanel`
- Previously, validation only happened at click time — malformed strings could still appear in the UI

## Test plan
- [ ] Existing `SessionJSONLParserURLTests` pass (all use well-formed URLs, should be unaffected)
- [ ] Verify malformed strings like `https://` or `https://[broken` no longer appear in the resource links panel