### PR TITLE
feat: unified skills picker for Claude and Codex slash commands

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubDefaults.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubDefaults.swift
@@ -137,6 +137,10 @@ public enum AgentHubDefaults {
   /// Type: Bool (default: false)
   public static let fileExplorerAlwaysModal = "\(keyPrefix)features.fileExplorerAlwaysModal"
 
+  /// Whether the skills/slash-command picker is enabled in the prompt editor
+  /// Type: Bool (default: false)
+  public static let skillsPickerEnabled = "\(keyPrefix)features.skillsPickerEnabled"
+
   /// Width of the side panel (diff, plan, web preview, file explorer) in the single-session layout
   /// Type: Double (default: 700)
   public static let sidePanelWidth = "\(keyPrefix)ui.sidePanelWidth"

--- a/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubProvider.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubProvider.swift
@@ -101,6 +101,13 @@ public final class AgentHubProvider {
     }
   }()
 
+  // MARK: - Skills
+
+  /// Skills service for discovering and merging Claude and Codex skills/commands
+  public private(set) lazy var skillsService: SkillsService = {
+    SkillsService()
+  }()
+
   // MARK: - Theme Management
 
   /// Theme manager for YAML and built-in themes

--- a/app/modules/AgentHubCore/Sources/AgentHub/Models/HubSkill.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Models/HubSkill.swift
@@ -1,0 +1,73 @@
+//
+//  HubSkill.swift
+//  AgentHub
+//
+//  Unified model representing a skill or custom command from Claude or Codex.
+//
+
+import Foundation
+
+/// A unified skill or custom slash command discovered from Claude or Codex data directories.
+public struct HubSkill: Identifiable, Sendable {
+
+  public var id: String { "\(source.storageKey):\(name)" }
+
+  /// The skill name (used as the slash command trigger, e.g. `/swiftui-animation`)
+  public let name: String
+
+  /// Human-readable description from the skill's frontmatter
+  public let description: String
+
+  /// Where the skill was discovered
+  public let source: Source
+
+  /// Argument hint from Claude command frontmatter (e.g. `[message]`)
+  public let argumentHint: String?
+
+  public enum Source: Sendable {
+    case claudeGlobal   // ~/.claude/commands/*.md or ~/.claude/skills/*/SKILL.md
+    case claudeProject  // {project}/.claude/commands/*.md or {project}/.claude/skills/*/SKILL.md
+    case codexGlobal    // ~/.codex/skills/*/SKILL.md
+    case codexSystem    // ~/.codex/skills/.system/*/SKILL.md
+
+    /// Short label shown in the picker badge
+    public var displayLabel: String {
+      switch self {
+      case .claudeGlobal:  "Global"
+      case .claudeProject: "Project"
+      case .codexGlobal:   "Global"
+      case .codexSystem:   "System"
+      }
+    }
+
+    /// Unique key used to build `id` (avoids collisions between providers)
+    var storageKey: String {
+      switch self {
+      case .claudeGlobal:  "claude-global"
+      case .claudeProject: "claude-project"
+      case .codexGlobal:   "codex-global"
+      case .codexSystem:   "codex-system"
+      }
+    }
+
+    /// The CLI provider this skill belongs to
+    public var provider: Provider {
+      switch self {
+      case .claudeGlobal, .claudeProject: .claude
+      case .codexGlobal, .codexSystem:    .codex
+      }
+    }
+  }
+
+  public enum Provider: String, Sendable {
+    case claude
+    case codex
+  }
+
+  public init(name: String, description: String, source: Source, argumentHint: String? = nil) {
+    self.name = name
+    self.description = description
+    self.source = source
+    self.argumentHint = argumentHint
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/SkillsService.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/SkillsService.swift
@@ -1,0 +1,134 @@
+//
+//  SkillsService.swift
+//  AgentHub
+//
+//  Discovers and merges skills/custom commands from Claude and Codex data directories.
+//
+
+import Foundation
+
+/// Reads skills and custom commands from the file system and merges them into a unified list.
+///
+/// Scans:
+/// - `~/.claude/commands/*.md` (Claude global commands)
+/// - `~/.claude/skills/*/SKILL.md` (Claude global skills)
+/// - `{project}/.claude/commands/*.md` (Claude project commands)
+/// - `{project}/.claude/skills/*/SKILL.md` (Claude project skills)
+/// - `~/.codex/skills/*/SKILL.md` (Codex global skills, hidden dirs skipped)
+/// - `~/.codex/skills/.system/*/SKILL.md` (Codex system skills)
+public actor SkillsService {
+
+  public init() {}
+
+  /// Loads and merges all available skills.
+  /// - Parameters:
+  ///   - claudeDataPath: Path to the Claude data directory (default `~/.claude`)
+  ///   - codexDataPath: Path to the Codex data directory (default `~/.codex`)
+  ///   - projectPath: Optional project root path for project-scoped skills
+  /// - Returns: Deduplicated, merged array of skills
+  public func load(
+    claudeDataPath: String,
+    codexDataPath: String,
+    projectPath: String?
+  ) async -> [HubSkill] {
+    var skills: [HubSkill] = []
+
+    // Claude global commands
+    skills += loadCommands(from: claudeDataPath + "/commands", source: .claudeGlobal)
+
+    // Claude global skills
+    skills += loadSkillDirectories(from: claudeDataPath + "/skills", source: .claudeGlobal)
+
+    // Claude project-level commands and skills
+    if let projectPath {
+      let projectClaude = projectPath + "/.claude"
+      skills += loadCommands(from: projectClaude + "/commands", source: .claudeProject)
+      skills += loadSkillDirectories(from: projectClaude + "/skills", source: .claudeProject)
+    }
+
+    // Codex global skills (skip hidden directories like .system)
+    skills += loadSkillDirectories(from: codexDataPath + "/skills", source: .codexGlobal, skipHidden: true)
+
+    // Codex system skills
+    skills += loadSkillDirectories(from: codexDataPath + "/skills/.system", source: .codexSystem)
+
+    // Deduplicate by id, preserving order
+    var seen = Set<String>()
+    return skills.filter { seen.insert($0.id).inserted }
+  }
+
+  // MARK: - Private helpers
+
+  /// Loads `*.md` files from a flat commands directory (Claude slash commands).
+  private func loadCommands(from dir: String, source: HubSkill.Source) -> [HubSkill] {
+    let fm = FileManager.default
+    guard fm.fileExists(atPath: dir),
+          let entries = try? fm.contentsOfDirectory(atPath: dir) else { return [] }
+
+    return entries.compactMap { filename -> HubSkill? in
+      guard filename.hasSuffix(".md") else { return nil }
+      let filePath = dir + "/" + filename
+      guard let content = try? String(contentsOfFile: filePath, encoding: .utf8) else { return nil }
+      let fm = parseFrontmatter(content)
+      let name = String(filename.dropLast(3)) // strip ".md"
+      let description = fm["description"] ?? ""
+      let hint = fm["argument-hint"]
+      return HubSkill(name: name, description: description, source: source, argumentHint: hint)
+    }
+  }
+
+  /// Loads `{name}/SKILL.md` entries from a skills directory.
+  private func loadSkillDirectories(
+    from dir: String,
+    source: HubSkill.Source,
+    skipHidden: Bool = false
+  ) -> [HubSkill] {
+    let fm = FileManager.default
+    guard fm.fileExists(atPath: dir),
+          let entries = try? fm.contentsOfDirectory(atPath: dir) else { return [] }
+
+    return entries.compactMap { skillName -> HubSkill? in
+      if skipHidden && skillName.hasPrefix(".") { return nil }
+      let skillFile = dir + "/" + skillName + "/SKILL.md"
+      guard fm.fileExists(atPath: skillFile),
+            let content = try? String(contentsOfFile: skillFile, encoding: .utf8) else { return nil }
+      let fm = parseFrontmatter(content)
+      let name = fm["name"] ?? skillName
+      let description = fm["description"] ?? ""
+      return HubSkill(name: name, description: description, source: source)
+    }
+  }
+
+  /// Parses the YAML frontmatter block (between `---` delimiters) into a key-value dictionary.
+  private func parseFrontmatter(_ content: String) -> [String: String] {
+    var result: [String: String] = [:]
+    var inBlock = false
+    var started = false
+
+    for line in content.components(separatedBy: "\n") {
+      let trimmed = line.trimmingCharacters(in: .whitespaces)
+      if trimmed == "---" {
+        if !started {
+          started = true
+          inBlock = true
+        } else if inBlock {
+          break
+        }
+        continue
+      }
+      guard inBlock else { continue }
+      // Split only on the first colon to handle values containing colons
+      if let colonRange = trimmed.range(of: ":") {
+        let key = String(trimmed[trimmed.startIndex..<colonRange.lowerBound])
+          .trimmingCharacters(in: .whitespaces)
+        let value = String(trimmed[colonRange.upperBound...])
+          .trimmingCharacters(in: .whitespaces)
+          .trimmingCharacters(in: CharacterSet(charactersIn: "\"'"))
+        if !key.isEmpty {
+          result[key] = value
+        }
+      }
+    }
+    return result
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiSessionLaunchView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiSessionLaunchView.swift
@@ -20,7 +20,9 @@ public struct MultiSessionLaunchView: View {
   var expandRequestID: Int = 0
 
   @AppStorage(AgentHubDefaults.smartModeEnabled) private var smartModeEnabled: Bool = false
+  @AppStorage(AgentHubDefaults.skillsPickerEnabled) private var skillsPickerEnabled: Bool = false
 
+  @Environment(\.agentHub) private var agentHub
   @Environment(\.colorScheme) private var colorScheme
   @State private var isExpanded = false
   @State private var isDragging = false
@@ -42,6 +44,19 @@ public struct MultiSessionLaunchView: View {
         repositorySection
 
         promptEditor
+
+        if skillsPickerEnabled, let query = viewModel.skillQuery {
+          SkillPickerView(
+            query: query,
+            skills: viewModel.skills,
+            selectedIndex: viewModel.skillSelectedIndex,
+            onSelect: { viewModel.applySkill($0) },
+            onDismiss: { viewModel.skillQuery = nil }
+          )
+          .padding(.top, -6)
+          .zIndex(10)
+          .transition(.opacity.combined(with: .move(edge: .top)))
+        }
 
         if viewModel.isPlanModeEnabled {
           planModeHint
@@ -145,6 +160,17 @@ public struct MultiSessionLaunchView: View {
     .onChange(of: expandRequestID) { _, _ in
       withAnimation(.easeInOut(duration: 0.2)) {
         isExpanded = true
+      }
+    }
+    .task(id: viewModel.selectedRepository?.path) {
+      guard skillsPickerEnabled, let service = agentHub?.skillsService else { return }
+      await viewModel.loadSkills(service: service, projectPath: viewModel.selectedRepository?.path)
+    }
+    .onChange(of: skillsPickerEnabled) { _, enabled in
+      if enabled, let service = agentHub?.skillsService {
+        Task { await viewModel.loadSkills(service: service, projectPath: viewModel.selectedRepository?.path) }
+      } else if !enabled {
+        viewModel.skillQuery = nil
       }
     }
   }
@@ -337,7 +363,34 @@ public struct MultiSessionLaunchView: View {
             viewModel.isPlanModeEnabled.toggle()
             return .handled
           }
+          // Skill picker keyboard navigation
+          if skillsPickerEnabled, viewModel.skillQuery != nil {
+            let filtered = filteredSkills
+            switch press.key {
+            case .upArrow:
+              viewModel.skillSelectedIndex = max(0, viewModel.skillSelectedIndex - 1)
+              return .handled
+            case .downArrow:
+              viewModel.skillSelectedIndex = min(filtered.count - 1, viewModel.skillSelectedIndex + 1)
+              return .handled
+            case .return, .tab:
+              if viewModel.skillSelectedIndex < filtered.count {
+                viewModel.applySkill(filtered[viewModel.skillSelectedIndex])
+              }
+              return .handled
+            case .escape:
+              viewModel.skillQuery = nil
+              return .handled
+            default:
+              break
+            }
+          }
           return .ignored
+        }
+        .onChange(of: viewModel.sharedPrompt) { _, _ in
+          if skillsPickerEnabled {
+            viewModel.updateSkillQuery()
+          }
         }
     }
     .frame(minHeight: 60, maxHeight: 120)
@@ -350,6 +403,17 @@ public struct MultiSessionLaunchView: View {
       RoundedRectangle(cornerRadius: DesignTokens.Radius.sm)
         .stroke(Color.borderSubtle, lineWidth: 1)
     )
+  }
+
+  private var filteredSkills: [HubSkill] {
+    let query = viewModel.skillQuery ?? ""
+    let trimmed = query.trimmingCharacters(in: .whitespaces)
+    guard !trimmed.isEmpty else { return Array(viewModel.skills.prefix(6)) }
+    let lower = trimmed.lowercased()
+    return Array(viewModel.skills.filter {
+      $0.name.lowercased().contains(lower) ||
+      $0.description.lowercased().contains(lower)
+    }.prefix(6))
   }
 
   private var promptPlaceholder: String {

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/SettingsView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/SettingsView.swift
@@ -17,6 +17,9 @@ public struct SettingsView: View {
   @AppStorage(AgentHubDefaults.fileExplorerAlwaysModal)
   private var fileExplorerAlwaysModal: Bool = false
 
+  @AppStorage(AgentHubDefaults.skillsPickerEnabled)
+  private var skillsPickerEnabled: Bool = false
+
   @AppStorage(AgentHubDefaults.terminalFontSize)
   private var terminalFontSize: Double = 12
 
@@ -156,6 +159,14 @@ public struct SettingsView: View {
           VStack(alignment: .leading, spacing: 2) {
             Text("File explorer always modal")
             Text("Open file explorer as a floating window instead of a side panel")
+              .font(.caption)
+              .foregroundColor(.secondary)
+          }
+        }
+        Toggle(isOn: $skillsPickerEnabled) {
+          VStack(alignment: .leading, spacing: 2) {
+            Text("Skills picker")
+            Text("Type / in the prompt to browse and insert Claude and Codex skills")
               .font(.caption)
               .foregroundColor(.secondary)
           }

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/SkillPickerView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/SkillPickerView.swift
@@ -1,0 +1,126 @@
+//
+//  SkillPickerView.swift
+//  AgentHub
+//
+//  Slash-command picker overlay shown in the prompt editor when the user types "/".
+//
+
+import SwiftUI
+
+// MARK: - SkillPickerView
+
+struct SkillPickerView: View {
+
+  let query: String
+  let skills: [HubSkill]
+  let selectedIndex: Int
+  let onSelect: (HubSkill) -> Void
+  let onDismiss: () -> Void
+
+  private var filtered: [HubSkill] {
+    let trimmed = query.trimmingCharacters(in: .whitespaces)
+    guard !trimmed.isEmpty else { return Array(skills.prefix(6)) }
+    let lower = trimmed.lowercased()
+    let matches = skills.filter {
+      $0.name.lowercased().contains(lower) ||
+      $0.description.lowercased().contains(lower)
+    }
+    return Array(matches.prefix(6))
+  }
+
+  var body: some View {
+    if filtered.isEmpty { return AnyView(EmptyView()) }
+    return AnyView(content)
+  }
+
+  private var content: some View {
+    VStack(spacing: 0) {
+      ForEach(Array(filtered.enumerated()), id: \.element.id) { index, skill in
+        SkillPickerRow(
+          skill: skill,
+          isSelected: index == selectedIndex
+        )
+        .contentShape(Rectangle())
+        .onTapGesture { onSelect(skill) }
+
+        if index < filtered.count - 1 {
+          Divider()
+            .opacity(0.5)
+        }
+      }
+    }
+    .background(
+      RoundedRectangle(cornerRadius: DesignTokens.Radius.sm)
+        .fill(Color(NSColor.controlBackgroundColor))
+    )
+    .overlay(
+      RoundedRectangle(cornerRadius: DesignTokens.Radius.sm)
+        .stroke(Color.borderSubtle, lineWidth: 1)
+    )
+    .shadow(color: .black.opacity(0.12), radius: 8, y: -4)
+  }
+}
+
+// MARK: - SkillPickerRow
+
+private struct SkillPickerRow: View {
+  let skill: HubSkill
+  let isSelected: Bool
+
+  var body: some View {
+    HStack(spacing: 8) {
+      VStack(alignment: .leading, spacing: 2) {
+        Text("/\(skill.name)")
+          .font(.system(size: 12, weight: .medium, design: .monospaced))
+          .foregroundColor(.primary)
+          .lineLimit(1)
+        if !skill.description.isEmpty {
+          Text(skill.description)
+            .font(.system(size: 10))
+            .foregroundColor(.secondary)
+            .lineLimit(1)
+        }
+      }
+      Spacer()
+      skillBadge
+    }
+    .padding(.horizontal, 10)
+    .padding(.vertical, 6)
+    .background(
+      isSelected
+        ? Color.accentColor.opacity(0.12)
+        : Color.clear
+    )
+  }
+
+  private var skillBadge: some View {
+    HStack(spacing: 4) {
+      Circle()
+        .fill(providerColor)
+        .frame(width: 5, height: 5)
+      Text("\(providerLabel) · \(skill.source.displayLabel)")
+        .font(.system(size: 9, weight: .medium))
+        .foregroundColor(.secondary)
+    }
+    .padding(.horizontal, 6)
+    .padding(.vertical, 3)
+    .background(
+      Capsule()
+        .fill(Color.primary.opacity(0.06))
+    )
+  }
+
+  private var providerLabel: String {
+    switch skill.source.provider {
+    case .claude: "Claude"
+    case .codex:  "Codex"
+    }
+  }
+
+  private var providerColor: Color {
+    switch skill.source.provider {
+    case .claude: Color.brandPrimary(for: SessionProviderKind.claude)
+    case .codex:  Color.brandPrimary(for: SessionProviderKind.codex)
+    }
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/MultiSessionLaunchViewModel.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/MultiSessionLaunchViewModel.swift
@@ -142,6 +142,18 @@ public final class MultiSessionLaunchViewModel {
   public var smartPlanText: String = ""
   public var smartOrchestrationPlan: OrchestrationPlan?
 
+  // MARK: - Skills State
+
+  /// All loaded skills from Claude and Codex data directories
+  public var skills: [HubSkill] = []
+
+  /// Active slash-command query, non-nil while the picker is open
+  /// Set to the string after "/" when the prompt begins with "/"
+  public var skillQuery: String? = nil
+
+  /// Highlighted row index inside the skill picker
+  public var skillSelectedIndex: Int = 0
+
   // MARK: - Callbacks
 
   public var onLaunchCompleted: (() -> Void)?
@@ -199,6 +211,56 @@ public final class MultiSessionLaunchViewModel {
     self.codexViewModel = codexViewModel
     self.worktreeService = worktreeService
     self.intelligenceViewModel = intelligenceViewModel
+  }
+
+  // MARK: - Skills
+
+  /// Loads skills from Claude and Codex directories for the given project path.
+  public func loadSkills(service: SkillsService, projectPath: String?) async {
+    let home = NSHomeDirectory()
+    let loaded = await service.load(
+      claudeDataPath: home + "/.claude",
+      codexDataPath: home + "/.codex",
+      projectPath: projectPath
+    )
+    skills = loaded
+  }
+
+  /// Updates `skillQuery` based on the current prompt text.
+  /// Call this from the view's `onChange(of: viewModel.sharedPrompt)`.
+  public func updateSkillQuery() {
+    guard sharedPrompt.hasPrefix("/") else {
+      if skillQuery != nil { skillQuery = nil }
+      return
+    }
+    let afterSlash = String(sharedPrompt.dropFirst())
+    // Once the user adds a space the skill name is committed — dismiss picker
+    if afterSlash.contains(" ") || afterSlash.contains("\n") {
+      if skillQuery != nil { skillQuery = nil }
+    } else {
+      skillQuery = afterSlash
+      // Reset selection when query changes
+      skillSelectedIndex = 0
+    }
+  }
+
+  /// Replaces the current "/query" prefix with "/skill-name " and dismisses the picker.
+  public func applySkill(_ skill: HubSkill) {
+    let rest: String
+    if sharedPrompt.hasPrefix("/") {
+      let afterSlash = String(sharedPrompt.dropFirst())
+      if let idx = afterSlash.firstIndex(where: { $0 == " " || $0 == "\n" }) {
+        rest = String(afterSlash[idx...])
+      } else {
+        rest = ""
+      }
+    } else {
+      rest = ""
+    }
+    sharedPrompt = "/\(skill.name) \(rest)".trimmingCharacters(in: .init(charactersIn: " "))
+    sharedPrompt += " "
+    skillQuery = nil
+    skillSelectedIndex = 0
   }
 
   // MARK: - Attachments


### PR DESCRIPTION
## Summary

- Adds a unified `HubSkill` model abstracting both Claude commands/skills and Codex skills across global, project, and system sources
- New `SkillsService` actor reads and merges all six directory sources, parses YAML frontmatter, and deduplicates by id
- Typing `/` in the session-start prompt editor triggers a picker dropdown (opt-in via Settings → Features → Skills picker)
- Each row shows `/name`, description, and a provider+source badge (e.g. `Claude · Project`, `Codex · System`)
- Keyboard navigation: ↑↓ to move, Return/Tab to confirm, Escape to dismiss
- Skills reload automatically when the selected repository changes (for project-scoped skills)
- Also removes a stale untracked `main.swift` that was silently conflicting with `@main` on `AgentHubApp`

## Test plan

- [ ] Enable "Skills picker" in Settings → Features
- [ ] Open Start Session panel, type `/` — picker appears listing discovered skills with provider/source badges
- [ ] Type `/sw` — list filters to skills matching "sw"
- [ ] Press ↑↓ to navigate, Return to confirm — `/skill-name ` inserted into prompt
- [ ] Press Escape — picker dismisses without inserting
- [ ] Switch to a repo with `.claude/commands/` — project-scoped commands appear with "Project" badge
- [ ] Disable toggle in Settings — typing `/` no longer triggers picker
- [ ] No `~/.claude/commands` or `~/.codex/skills` dirs — no crash, empty list handled gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)