### PR TITLE
Optimize file explorer performance

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/FileIndexService.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/FileIndexService.swift
@@ -9,6 +9,12 @@ import Foundation
 
 // MARK: - FileIndexService
 
+public enum FileSearchIndexStatus: Sendable {
+  case idle
+  case building
+  case ready
+}
+
 /// Scans project directories, respects .gitignore, caches the index, and provides fuzzy search.
 public actor FileIndexService {
 
@@ -57,7 +63,27 @@ public actor FileIndexService {
     let date: Date
   }
 
-  private var cache: [String: CacheEntry] = [:]
+  private struct IndexedFile: Sendable {
+    let name: String
+    let relativePath: String
+    let absolutePath: String
+  }
+
+  private struct SearchCacheEntry: Sendable {
+    let files: [IndexedFile]
+    let date: Date
+  }
+
+  private struct DirectoryEntry: Sendable {
+    let name: String
+    let path: String
+    let isDirectory: Bool
+  }
+
+  private var directoryCache: [String: CacheEntry] = [:]
+  private var directoryLoadTasks: [String: Task<[FileTreeNode], Never>] = [:]
+  private var searchCache: [String: SearchCacheEntry] = [:]
+  private var searchBuildTasks: [String: Task<SearchCacheEntry, Never>] = [:]
   private var recentPaths: [String] = []
   private static let maxRecentFiles = 20
 
@@ -94,14 +120,42 @@ public actor FileIndexService {
       }
   }
 
-  /// Returns the cached file tree for `projectPath`, or scans it fresh if the cache is stale.
+  /// Legacy entry point kept for compatibility. Returns the lazily loaded root nodes.
   public func index(projectPath: String) async -> [FileTreeNode] {
-    if let entry = cache[projectPath], !isCacheStale(entry.date) {
-      return entry.nodes
+    await rootNodes(projectPath: projectPath)
+  }
+
+  public func rootNodes(projectPath: String) async -> [FileTreeNode] {
+    let resolvedProjectPath = Self.resolvedURL(for: projectPath).path
+    return await cachedDirectoryNodes(at: resolvedProjectPath, rootPath: resolvedProjectPath)
+  }
+
+  public func children(of directoryPath: String, in projectPath: String) async -> [FileTreeNode] {
+    let resolvedProjectPath = Self.resolvedURL(for: projectPath).path
+    let resolvedDirectoryPath = Self.resolvedURL(for: directoryPath).path
+    guard Self.isPath(resolvedDirectoryPath, within: resolvedProjectPath) else {
+      return []
     }
-    let nodes = await scanDirectory(at: projectPath)
-    cache[projectPath] = CacheEntry(nodes: nodes, date: Date())
-    return nodes
+    return await cachedDirectoryNodes(at: resolvedDirectoryPath, rootPath: resolvedProjectPath)
+  }
+
+  public func prepareSearchIndex(projectPath: String) async {
+    let resolvedProjectPath = Self.resolvedURL(for: projectPath).path
+    guard searchCache[resolvedProjectPath].map({ !isCacheStale($0.date) }) != true else { return }
+    if searchBuildTasks[resolvedProjectPath] == nil {
+      searchBuildTasks[resolvedProjectPath] = makeSearchBuildTask(projectPath: resolvedProjectPath)
+    }
+  }
+
+  public func searchIndexStatus(projectPath: String) async -> FileSearchIndexStatus {
+    let resolvedProjectPath = Self.resolvedURL(for: projectPath).path
+    if let entry = searchCache[resolvedProjectPath], !isCacheStale(entry.date) {
+      return .ready
+    }
+    if searchBuildTasks[resolvedProjectPath] != nil {
+      return .building
+    }
+    return .idle
   }
 
   /// Searches files using a strict 3-tier approach:
@@ -111,8 +165,8 @@ public actor FileIndexService {
   /// All matching is case-insensitive substring, no fuzzy.
   public func search(query: String, in projectPath: String) async -> [FileSearchResult] {
     guard !query.isEmpty, query.count < 200 else { return [] }
-    let nodes = await index(projectPath: projectPath)
-    let allFiles = flattenFiles(nodes, projectPath: projectPath)
+    let resolvedProjectPath = Self.resolvedURL(for: projectPath).path
+    let allFiles = await searchIndex(projectPath: resolvedProjectPath)
     let q = query.lowercased()
 
     var scored: [FileSearchResult] = []
@@ -143,7 +197,7 @@ public actor FileIndexService {
 
       guard score > 0 else { continue }
       scored.append(FileSearchResult(
-        id: file.id, name: file.name, relativePath: file.relativePath,
+        id: file.absolutePath, name: file.name, relativePath: file.relativePath,
         absolutePath: file.absolutePath, score: score
       ))
     }
@@ -157,7 +211,19 @@ public actor FileIndexService {
 
   /// Removes the cache entry for `projectPath`.
   public func invalidate(projectPath: String) {
-    cache.removeValue(forKey: projectPath)
+    let resolvedProjectPath = Self.resolvedURL(for: projectPath).path
+    directoryCache.keys
+      .filter { Self.isPath($0, within: resolvedProjectPath) }
+      .forEach { directoryCache.removeValue(forKey: $0) }
+    directoryLoadTasks.keys
+      .filter { Self.isPath($0, within: resolvedProjectPath) }
+      .forEach { path in
+        directoryLoadTasks[path]?.cancel()
+        directoryLoadTasks.removeValue(forKey: path)
+      }
+    searchCache.removeValue(forKey: resolvedProjectPath)
+    searchBuildTasks[resolvedProjectPath]?.cancel()
+    searchBuildTasks.removeValue(forKey: resolvedProjectPath)
   }
 
   /// Reads a file at `path` as a UTF-8 string.
@@ -171,10 +237,10 @@ public actor FileIndexService {
   /// `projectPath` is required so the write is validated to stay within the project root.
   public func writeFile(at path: String, content: String, projectPath: String) throws {
     let validatedURL = try validatePath(path, within: projectPath, forWrite: true)
+    let didExist = FileManager.default.fileExists(atPath: validatedURL.path)
     try content.write(to: validatedURL, atomically: true, encoding: .utf8)
-    // Invalidate the cache for any project whose path is a prefix of the written file
-    for key in cache.keys where Self.isPath(validatedURL.path, within: key) {
-      cache.removeValue(forKey: key)
+    if !didExist {
+      invalidate(projectPath: projectPath)
     }
   }
 
@@ -212,96 +278,192 @@ public actor FileIndexService {
 
   // MARK: - Scanning
 
-  private func scanDirectory(at path: String) async -> [FileTreeNode] {
-    await Task.detached(priority: .utility) {
-      let rootPatterns = FileIndexService.parseGitignore(at: path, relativeTo: path)
-      return FileIndexService.scanDirectorySync(
-        at: path, relativeTo: path, depth: 0, inheritedRules: rootPatterns
+  private func cachedDirectoryNodes(at directoryPath: String, rootPath: String) async -> [FileTreeNode] {
+    if let entry = directoryCache[directoryPath], !isCacheStale(entry.date) {
+      return entry.nodes
+    }
+    if let task = directoryLoadTasks[directoryPath] {
+      return await task.value
+    }
+
+    let task = Task.detached(priority: .utility) {
+      let rules = FileIndexService.ignoreRules(forDirectoryAt: directoryPath, rootPath: rootPath)
+      return FileIndexService.scanDirectoryContentsSync(
+        at: directoryPath,
+        rootPath: rootPath,
+        rules: rules
       )
-    }.value
+    }
+    directoryLoadTasks[directoryPath] = task
+
+    let nodes = await task.value
+    directoryLoadTasks.removeValue(forKey: directoryPath)
+    directoryCache[directoryPath] = CacheEntry(nodes: nodes, date: Date())
+    return nodes
   }
 
-  private static func scanDirectorySync(
+  private func searchIndex(projectPath: String) async -> [IndexedFile] {
+    if let entry = searchCache[projectPath], !isCacheStale(entry.date) {
+      return entry.files
+    }
+
+    let task: Task<SearchCacheEntry, Never>
+    if let existingTask = searchBuildTasks[projectPath] {
+      task = existingTask
+    } else {
+      let newTask = makeSearchBuildTask(projectPath: projectPath)
+      searchBuildTasks[projectPath] = newTask
+      task = newTask
+    }
+
+    let entry = await task.value
+    searchBuildTasks.removeValue(forKey: projectPath)
+    searchCache[projectPath] = entry
+    return entry.files
+  }
+
+  private func makeSearchBuildTask(projectPath: String) -> Task<SearchCacheEntry, Never> {
+    Task.detached(priority: .utility) {
+      let files = FileIndexService.buildSearchIndexSync(projectPath: projectPath)
+      return SearchCacheEntry(files: files, date: Date())
+    }
+  }
+
+  private static func scanDirectoryContentsSync(
     at path: String,
-    relativeTo rootPath: String,
-    depth: Int,
-    inheritedRules: [IgnoreRule]
+    rootPath: String,
+    rules: [IgnoreRule]
   ) -> [FileTreeNode] {
-    guard depth < maxDepth else { return [] }
+    filteredDirectoryEntries(at: path, rootPath: rootPath, rules: rules).map { entry in
+      FileTreeNode(
+        id: entry.path,
+        name: entry.name,
+        path: entry.path,
+        isDirectory: entry.isDirectory
+      )
+    }
+  }
 
-    let fm = FileManager.default
+  private static func buildSearchIndexSync(projectPath: String) -> [IndexedFile] {
+    var files: [IndexedFile] = []
+    collectSearchEntriesSync(
+      at: projectPath,
+      rootPath: projectPath,
+      depth: 0,
+      inheritedRules: [],
+      into: &files
+    )
+    return files
+  }
 
-    guard let rawEntries = try? fm.contentsOfDirectory(atPath: path) else {
+  private static func collectSearchEntriesSync(
+    at path: String,
+    rootPath: String,
+    depth: Int,
+    inheritedRules: [IgnoreRule],
+    into results: inout [IndexedFile]
+  ) {
+    guard depth < maxDepth else { return }
+
+    let allRules = inheritedRules + parseGitignore(at: path, relativeTo: rootPath)
+    let entries = filteredDirectoryEntries(at: path, rootPath: rootPath, rules: allRules)
+
+    for entry in entries {
+      if entry.isDirectory {
+        collectSearchEntriesSync(
+          at: entry.path,
+          rootPath: rootPath,
+          depth: depth + 1,
+          inheritedRules: allRules,
+          into: &results
+        )
+      } else {
+        let relativePath = projectRelativePath(for: entry.path, relativeTo: rootPath)
+        results.append(IndexedFile(
+          name: entry.name,
+          relativePath: relativePath,
+          absolutePath: entry.path
+        ))
+      }
+    }
+  }
+
+  private static func ignoreRules(forDirectoryAt directoryPath: String, rootPath: String) -> [IgnoreRule] {
+    let resolvedRootPath = resolvedURL(for: rootPath).path
+    let resolvedDirectoryPath = resolvedURL(for: directoryPath).path
+    guard isPath(resolvedDirectoryPath, within: resolvedRootPath) else { return [] }
+
+    var rules: [IgnoreRule] = []
+    var currentPath = resolvedRootPath
+    rules += parseGitignore(at: currentPath, relativeTo: resolvedRootPath)
+
+    guard resolvedDirectoryPath != resolvedRootPath else { return rules }
+
+    let relativePath = String(resolvedDirectoryPath.dropFirst(resolvedRootPath.count + 1))
+    for component in relativePath.split(separator: "/") {
+      currentPath = (currentPath as NSString).appendingPathComponent(String(component))
+      rules += parseGitignore(at: currentPath, relativeTo: resolvedRootPath)
+    }
+
+    return rules
+  }
+
+  private static func filteredDirectoryEntries(
+    at path: String,
+    rootPath: String,
+    rules: [IgnoreRule]
+  ) -> [DirectoryEntry] {
+    rawDirectoryEntries(at: path)
+      .filter { entry in
+        shouldIncludeEntry(entry, rootPath: rootPath, rules: rules)
+      }
+      .sorted { lhs, rhs in
+        if lhs.isDirectory != rhs.isDirectory {
+          return lhs.isDirectory
+        }
+        return lhs.name.localizedStandardCompare(rhs.name) == .orderedAscending
+      }
+  }
+
+  private static func rawDirectoryEntries(at path: String) -> [DirectoryEntry] {
+    let resourceKeys: Set<URLResourceKey> = [.isDirectoryKey, .isSymbolicLinkKey]
+    let directoryURL = URL(fileURLWithPath: path)
+
+    guard let rawURLs = try? FileManager.default.contentsOfDirectory(
+      at: directoryURL,
+      includingPropertiesForKeys: Array(resourceKeys),
+      options: [.skipsPackageDescendants]
+    ) else {
       return []
     }
 
-    // Merge inherited rules with this directory's own .gitignore rules.
-    let localRules = depth == 0 ? [] : parseGitignore(at: path, relativeTo: rootPath)
-    let allRules = inheritedRules + localRules
-
-    var nodes: [FileTreeNode] = []
-
-    for name in rawEntries {
-      // Hard-exclude check
-      if hardExcludedNames.contains(name) { continue }
-
-      // Hidden file filtering
-      if name.hasPrefix(".") {
-        guard allowedHiddenNames.contains(name) else { continue }
+    return rawURLs.compactMap { url in
+      guard let values = try? url.resourceValues(forKeys: resourceKeys),
+            values.isSymbolicLink != true else {
+        return nil
       }
 
-      let fullPath = (path as NSString).appendingPathComponent(name)
-      let relativePath = fullPath.hasPrefix(rootPath + "/")
-        ? String(fullPath.dropFirst(rootPath.count + 1))
-        : name
+      return DirectoryEntry(
+        name: url.lastPathComponent,
+        path: url.path,
+        isDirectory: values.isDirectory == true
+      )
+    }
+  }
 
-      // Skip symlinks to prevent traversal outside the project root
-      if let attrs = try? fm.attributesOfItem(atPath: fullPath),
-         attrs[.type] as? FileAttributeType == .typeSymbolicLink {
-        continue
-      }
+  private static func shouldIncludeEntry(
+    _ entry: DirectoryEntry,
+    rootPath: String,
+    rules: [IgnoreRule]
+  ) -> Bool {
+    if hardExcludedNames.contains(entry.name) { return false }
 
-      // Gitignore check
-      var isDirectory: ObjCBool = false
-      fm.fileExists(atPath: fullPath, isDirectory: &isDirectory)
-
-      if isIgnored(relativePath: relativePath, isDirectory: isDirectory.boolValue, rules: allRules) {
-        continue
-      }
-
-      if isDirectory.boolValue {
-        let children = scanDirectorySync(
-          at: fullPath, relativeTo: rootPath, depth: depth + 1,
-          inheritedRules: allRules
-        )
-        let node = FileTreeNode(
-          id: fullPath,
-          name: name,
-          path: fullPath,
-          isDirectory: true,
-          children: children
-        )
-        nodes.append(node)
-      } else {
-        let node = FileTreeNode(
-          id: fullPath,
-          name: name,
-          path: fullPath,
-          isDirectory: false
-        )
-        nodes.append(node)
-      }
+    if entry.name.hasPrefix(".") && !allowedHiddenNames.contains(entry.name) {
+      return false
     }
 
-    // Sort: directories first (alphabetical), then files (alphabetical)
-    nodes.sort { lhs, rhs in
-      if lhs.isDirectory != rhs.isDirectory {
-        return lhs.isDirectory
-      }
-      return lhs.name.localizedStandardCompare(rhs.name) == .orderedAscending
-    }
-
-    return nodes
+    let relativePath = projectRelativePath(for: entry.path, relativeTo: rootPath)
+    return !isIgnored(relativePath: relativePath, isDirectory: entry.isDirectory, rules: rules)
   }
 
   // MARK: - Gitignore Parsing
@@ -467,35 +629,4 @@ public actor FileIndexService {
 
   // MARK: - Search Helpers
 
-  /// Recursively flattens all leaf file nodes into `FileSearchResult` objects.
-  private func flattenFiles(_ nodes: [FileTreeNode], projectPath: String) -> [FileSearchResult] {
-    var results: [FileSearchResult] = []
-    flattenFilesInto(&results, nodes: nodes, projectPath: projectPath)
-    return results
-  }
-
-  private func flattenFilesInto(
-    _ results: inout [FileSearchResult],
-    nodes: [FileTreeNode],
-    projectPath: String
-  ) {
-    for node in nodes {
-      if node.isDirectory {
-        if let children = node.children {
-          flattenFilesInto(&results, nodes: children, projectPath: projectPath)
-        }
-      } else {
-        let relativePath = node.path.hasPrefix(projectPath + "/")
-          ? String(node.path.dropFirst(projectPath.count + 1))
-          : node.name
-        results.append(FileSearchResult(
-          id: node.path,
-          name: node.name,
-          relativePath: relativePath,
-          absolutePath: node.path,
-          score: 0
-        ))
-      }
-    }
-  }
 }

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/FileExplorerView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/FileExplorerView.swift
@@ -13,6 +13,24 @@ import HighlightSwift
 
 // MARK: - FileExplorerView
 
+enum EditorDisplayMode: Equatable {
+  case highlighted
+  case plainText
+
+  var badgeLabel: String? {
+    switch self {
+    case .highlighted:
+      nil
+    case .plainText:
+      "Fast Mode"
+    }
+  }
+
+  var highlightsSyntax: Bool {
+    self == .highlighted
+  }
+}
+
 /// A panel that lets the user browse and edit files in a project directory.
 ///
 /// - Shows a hierarchical file tree in a collapsible sidebar (240 pt wide).
@@ -43,7 +61,11 @@ public struct FileExplorerView: View {
   @State private var showSidebar = true
   @State private var showDiscardAlert = false
   @State private var expandedPaths: Set<String> = []
+  @State private var loadingDirectories: Set<String> = []
   @State private var scrollToPath: String?
+  @State private var hasLoadedTreeRoot = false
+  @State private var editorDisplayMode: EditorDisplayMode = .highlighted
+  @State private var editorDocumentID = UUID()
 
 
   // MARK: - Init
@@ -60,6 +82,14 @@ public struct FileExplorerView: View {
     self.onDismiss = onDismiss
     self.isEmbedded = isEmbedded
     self.initialFilePath = initialFilePath
+  }
+
+  private var normalizedProjectPath: String {
+    URL(fileURLWithPath: projectPath).standardizedFileURL.resolvingSymlinksInPath().path
+  }
+
+  private var loadTaskID: String {
+    normalizedProjectPath + "::" + (initialFilePath ?? "")
   }
 
   // MARK: - Body
@@ -102,14 +132,18 @@ public struct FileExplorerView: View {
       minHeight: isEmbedded ? 400 : nil,
       maxHeight: .infinity
     )
-    .task {
+    .task(id: loadTaskID) {
       await loadFileTree()
       if let initial = initialFilePath {
-        expandToFile(initial)
+        let resolvedInitialPath = URL(fileURLWithPath: initial)
+          .standardizedFileURL
+          .resolvingSymlinksInPath()
+          .path
+        await expandToFile(initial)
         await openFile(at: initial)
         // Delay scroll to let the expanded tree render
         try? await Task.sleep(for: .milliseconds(100))
-        scrollToPath = initial
+        scrollToPath = resolvedInitialPath
       }
     }
     .onKeyPress(.escape) {
@@ -157,8 +191,8 @@ public struct FileExplorerView: View {
 
       // File path breadcrumb or project name
       if let path = selectedFilePath {
-        let relPath = path.hasPrefix(projectPath + "/")
-          ? String(path.dropFirst(projectPath.count + 1))
+        let relPath = path.hasPrefix(normalizedProjectPath + "/")
+          ? String(path.dropFirst(normalizedProjectPath.count + 1))
           : (path as NSString).lastPathComponent
         HStack(spacing: 4) {
           Text(relPath)
@@ -166,6 +200,17 @@ public struct FileExplorerView: View {
             .foregroundColor(.secondary)
             .lineLimit(1)
             .truncationMode(.middle)
+          if let badgeLabel = editorDisplayMode.badgeLabel, fileError == nil {
+            Text(badgeLabel)
+              .font(.system(size: 10, weight: .medium))
+              .foregroundColor(.secondary)
+              .padding(.horizontal, 5)
+              .padding(.vertical, 1)
+              .background(
+                Capsule()
+                  .fill(Color.secondary.opacity(0.12))
+              )
+          }
           if hasUnsavedChanges {
             Text("Modified")
               .font(.system(size: 10, weight: .medium))
@@ -251,8 +296,12 @@ public struct FileExplorerView: View {
                 depth: 0,
                 selectedFilePath: $selectedFilePath,
                 expandedPaths: $expandedPaths,
+                loadingPaths: loadingDirectories,
                 onSelectFile: { path in
                   Task { await openFile(at: path) }
+                },
+                onToggleDirectory: { directory in
+                  Task { await toggleDirectory(directory) }
                 }
               )
             }
@@ -314,8 +363,16 @@ public struct FileExplorerView: View {
       CETextViewRepresentable(
         text: $fileContent,
         fileName: selectedFilePath.map { URL(fileURLWithPath: $0).lastPathComponent } ?? "",
+        documentID: editorDocumentID,
+        displayMode: editorDisplayMode,
         onTextChange: { updatedText in
-          hasUnsavedChanges = updatedText != savedFileContent
+          if updatedText != savedFileContent {
+            hasUnsavedChanges = true
+          }
+        },
+        onIdleTextSnapshot: { idleText in
+          guard editorDisplayMode == .highlighted else { return }
+          hasUnsavedChanges = idleText != savedFileContent
         }
       )
       .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -326,23 +383,29 @@ public struct FileExplorerView: View {
 
   private func loadFileTree() async {
     isLoading = true
-    treeNodes = await FileIndexService.shared.index(projectPath: projectPath)
+    loadingDirectories.removeAll()
+    expandedPaths.removeAll()
+    treeNodes = await FileIndexService.shared.rootNodes(projectPath: normalizedProjectPath)
+    hasLoadedTreeRoot = true
     isLoading = false
   }
 
   private func openFile(at path: String) async {
+    let resolvedPath = URL(fileURLWithPath: path).standardizedFileURL.resolvingSymlinksInPath().path
     let ext = URL(fileURLWithPath: path).pathExtension.lowercased()
     let binaryExts: Set<String> = [
       "png", "jpg", "jpeg", "gif", "pdf", "zip", "tar", "gz",
       "exe", "dylib", "a", "o", "mp3", "mp4", "mov", "woff", "ttf"
     ]
-    selectedFilePath = path
+    selectedFilePath = resolvedPath
     fileError = nil
     saveError = nil
     isLoadingFile = false
     fileContent = ""
     savedFileContent = ""
     hasUnsavedChanges = false
+    editorDisplayMode = .highlighted
+    editorDocumentID = UUID()
 
     guard !binaryExts.contains(ext) else {
       fileError = "Binary files cannot be displayed."
@@ -351,7 +414,7 @@ public struct FileExplorerView: View {
 
     // Guard against loading very large files that would exhaust memory
     let fm = FileManager.default
-    if let attrs = try? fm.attributesOfItem(atPath: path),
+    if let attrs = try? fm.attributesOfItem(atPath: resolvedPath),
        let fileSize = attrs[.size] as? UInt64, fileSize > 10_000_000 {
       fileError = "File is too large to display (>10 MB)."
       return
@@ -360,11 +423,13 @@ public struct FileExplorerView: View {
     isLoadingFile = true
 
     do {
-      let content = try await FileIndexService.shared.readFile(at: path, projectPath: projectPath)
+      let content = try await FileIndexService.shared.readFile(at: resolvedPath, projectPath: normalizedProjectPath)
       fileContent = content
       savedFileContent = content
       hasUnsavedChanges = false
-      await FileIndexService.shared.addToRecent(path)
+      editorDisplayMode = Self.displayMode(for: content)
+      editorDocumentID = UUID()
+      await FileIndexService.shared.addToRecent(resolvedPath)
     } catch {
       fileContent = ""
       savedFileContent = ""
@@ -381,7 +446,7 @@ public struct FileExplorerView: View {
     let content = fileContent
     Task {
       do {
-        try await FileIndexService.shared.writeFile(at: path, content: content, projectPath: projectPath)
+        try await FileIndexService.shared.writeFile(at: path, content: content, projectPath: normalizedProjectPath)
         await MainActor.run {
           savedFileContent = content
           hasUnsavedChanges = false
@@ -396,13 +461,109 @@ public struct FileExplorerView: View {
     }
   }
 
-  private func expandToFile(_ filePath: String) {
-    let relative = filePath.replacingOccurrences(of: projectPath + "/", with: "")
+  private func toggleDirectory(_ directory: FileTreeNode) async {
+    if expandedPaths.contains(directory.path) {
+      expandedPaths.remove(directory.path)
+      return
+    }
+
+    expandedPaths.insert(directory.path)
+    guard directory.isDirectory,
+          directory.children == nil,
+          !loadingDirectories.contains(directory.path) else {
+      return
+    }
+
+    await loadChildren(for: directory.path)
+  }
+
+  private func loadChildren(for directoryPath: String) async {
+    guard !loadingDirectories.contains(directoryPath) else { return }
+    loadingDirectories.insert(directoryPath)
+    let children = await FileIndexService.shared.children(of: directoryPath, in: normalizedProjectPath)
+    treeNodes = updatingChildren(
+      in: treeNodes,
+      for: directoryPath,
+      children: children
+    )
+    loadingDirectories.remove(directoryPath)
+  }
+
+  private func expandToFile(_ filePath: String) async {
+    let resolvedPath = URL(fileURLWithPath: filePath).standardizedFileURL.resolvingSymlinksInPath().path
+    let relative = resolvedPath.replacingOccurrences(of: normalizedProjectPath + "/", with: "")
     let parts = relative.components(separatedBy: "/")
-    var accumulated = projectPath
+    var accumulated = normalizedProjectPath
     for part in parts.dropLast() {
       accumulated += "/" + part
       expandedPaths.insert(accumulated)
+      await ensureDirectoryLoaded(accumulated)
+    }
+  }
+
+  private func ensureDirectoryLoaded(_ directoryPath: String) async {
+    if directoryPath == normalizedProjectPath {
+      if !hasLoadedTreeRoot {
+        await loadFileTree()
+      }
+      return
+    }
+
+    guard let node = findNode(at: directoryPath, in: treeNodes), node.children == nil else {
+      return
+    }
+    await loadChildren(for: directoryPath)
+  }
+
+  private func findNode(at path: String, in nodes: [FileTreeNode]) -> FileTreeNode? {
+    for node in nodes {
+      if node.path == path {
+        return node
+      }
+      if let children = node.children, let found = findNode(at: path, in: children) {
+        return found
+      }
+    }
+    return nil
+  }
+
+  private func updatingChildren(
+    in nodes: [FileTreeNode],
+    for targetPath: String,
+    children: [FileTreeNode]
+  ) -> [FileTreeNode] {
+    nodes.map { node in
+      var updated = node
+      if node.path == targetPath {
+        updated.children = children
+        return updated
+      }
+      if let existingChildren = node.children {
+        updated.children = updatingChildren(
+          in: existingChildren,
+          for: targetPath,
+          children: children
+        )
+      }
+      return updated
+    }
+  }
+
+  private static func displayMode(for content: String) -> EditorDisplayMode {
+    let byteCount = content.utf8.count
+    let lineCount = Self.lineCount(for: content)
+    if byteCount <= 300_000 && lineCount <= 5_000 {
+      return .highlighted
+    }
+    return .plainText
+  }
+
+  private static func lineCount(for content: String) -> Int {
+    guard !content.isEmpty else { return 0 }
+    return content.utf8.reduce(into: 1) { count, byte in
+      if byte == 0x0A {
+        count += 1
+      }
     }
   }
 }
@@ -415,7 +576,9 @@ private struct FileTreeNodeView: View {
   let depth: Int
   @Binding var selectedFilePath: String?
   @Binding var expandedPaths: Set<String>
+  let loadingPaths: Set<String>
   let onSelectFile: (String) -> Void
+  let onToggleDirectory: (FileTreeNode) -> Void
 
   @State private var isHovered = false
 
@@ -482,15 +645,30 @@ private struct FileTreeNodeView: View {
       .id(node.path)
 
       // Children
-      if node.isDirectory && isExpanded, let children = node.children {
-        ForEach(children) { child in
-          FileTreeNodeView(
-            node: child,
-            depth: depth + 1,
-            selectedFilePath: $selectedFilePath,
-            expandedPaths: $expandedPaths,
-            onSelectFile: onSelectFile
-          )
+      if node.isDirectory && isExpanded {
+        if loadingPaths.contains(node.path) {
+          HStack(spacing: 8) {
+            Spacer()
+              .frame(width: CGFloat(depth + 1) * 12 + 28)
+            ProgressView()
+              .controlSize(.small)
+            Text("Loading…")
+              .font(.system(size: 11))
+              .foregroundColor(.secondary)
+          }
+          .padding(.vertical, 4)
+        } else if let children = node.children {
+          ForEach(children) { child in
+            FileTreeNodeView(
+              node: child,
+              depth: depth + 1,
+              selectedFilePath: $selectedFilePath,
+              expandedPaths: $expandedPaths,
+              loadingPaths: loadingPaths,
+              onSelectFile: onSelectFile,
+              onToggleDirectory: onToggleDirectory
+            )
+          }
         }
       }
     }
@@ -498,11 +676,7 @@ private struct FileTreeNodeView: View {
 
   private func handleTap() {
     if node.isDirectory {
-      if isExpanded {
-        expandedPaths.remove(node.path)
-      } else {
-        expandedPaths.insert(node.path)
-      }
+      onToggleDirectory(node)
     } else {
       onSelectFile(node.path)
     }
@@ -556,7 +730,10 @@ public struct CETextViewRepresentable: NSViewRepresentable {
 
   @Binding var text: String
   let fileName: String
+  let documentID: UUID
+  let displayMode: EditorDisplayMode
   let onTextChange: (String) -> Void
+  let onIdleTextSnapshot: (String) -> Void
   @Environment(\.colorScheme) private var colorScheme
 
   public func makeCoordinator() -> Coordinator {
@@ -566,7 +743,7 @@ public struct CETextViewRepresentable: NSViewRepresentable {
   public func makeNSView(context: Context) -> NSScrollView {
     let scrollView = NSScrollView()
     scrollView.hasVerticalScroller = true
-    scrollView.hasHorizontalScroller = false
+    scrollView.hasHorizontalScroller = true
     scrollView.autohidesScrollers = true
     scrollView.borderType = .noBorder
     scrollView.contentView.postsFrameChangedNotifications = true
@@ -577,7 +754,7 @@ public struct CETextViewRepresentable: NSViewRepresentable {
       font: .monospacedSystemFont(ofSize: 12, weight: .regular),
       textColor: .labelColor,
       lineHeightMultiplier: 1.3,
-      wrapLines: true,
+      wrapLines: false,
       isEditable: true,
       isSelectable: true,
       letterSpacing: 1.0,
@@ -589,29 +766,55 @@ public struct CETextViewRepresentable: NSViewRepresentable {
     scrollView.documentView = textView
     textView.updateFrameIfNeeded()
     context.coordinator.textView = textView
-    context.coordinator.applySyntaxHighlighting(
-      text: text, fileName: fileName, colorScheme: colorScheme
+    context.coordinator.loadDocument(
+      text: text,
+      fileName: fileName,
+      documentID: documentID,
+      displayMode: displayMode,
+      colorScheme: colorScheme
     )
     return scrollView
   }
 
   public func updateNSView(_ scrollView: NSScrollView, context: Context) {
-    guard let textView = context.coordinator.textView else { return }
-    if textView.string != text {
-      context.coordinator.isUpdatingFromBinding = true
-      textView.string = text
-      textView.updateFrameIfNeeded()
-      context.coordinator.isUpdatingFromBinding = false
-      context.coordinator.applySyntaxHighlighting(
-        text: text, fileName: fileName, colorScheme: colorScheme
+    context.coordinator.parent = self
+    guard context.coordinator.textView != nil else { return }
+
+    if context.coordinator.currentDocumentID != documentID {
+      context.coordinator.loadDocument(
+        text: text,
+        fileName: fileName,
+        documentID: documentID,
+        displayMode: displayMode,
+        colorScheme: colorScheme
       )
+      return
     }
-    // Update highlighting if colorScheme changed
+
+    if context.coordinator.currentDisplayMode != displayMode {
+      context.coordinator.currentDisplayMode = displayMode
+      if displayMode.highlightsSyntax {
+        context.coordinator.applySyntaxHighlighting(
+          text: text,
+          fileName: fileName,
+          colorScheme: colorScheme
+        )
+      } else {
+        context.coordinator.applyPlainTextAppearance()
+      }
+    }
+
     if context.coordinator.lastColorScheme != colorScheme {
       context.coordinator.lastColorScheme = colorScheme
-      context.coordinator.applySyntaxHighlighting(
-        text: text, fileName: fileName, colorScheme: colorScheme
-      )
+      if displayMode.highlightsSyntax {
+        context.coordinator.applySyntaxHighlighting(
+          text: text,
+          fileName: fileName,
+          colorScheme: colorScheme
+        )
+      } else {
+        context.coordinator.applyPlainTextAppearance()
+      }
     }
   }
 
@@ -621,12 +824,43 @@ public struct CETextViewRepresentable: NSViewRepresentable {
     var parent: CETextViewRepresentable
     weak var textView: TextView?
     var isUpdatingFromBinding = false
-    var lastColorScheme: ColorScheme = .dark
+    var currentDocumentID: UUID?
+    var currentDisplayMode: EditorDisplayMode = .highlighted
+    var lastColorScheme: ColorScheme?
     private var highlightTask: Task<Void, Never>?
+    private var idleTask: Task<Void, Never>?
     private let highlighter = Highlight()
 
     init(parent: CETextViewRepresentable) {
       self.parent = parent
+    }
+
+    func loadDocument(
+      text: String,
+      fileName: String,
+      documentID: UUID,
+      displayMode: EditorDisplayMode,
+      colorScheme: ColorScheme
+    ) {
+      guard let textView else { return }
+      highlightTask?.cancel()
+      idleTask?.cancel()
+      currentDocumentID = documentID
+      currentDisplayMode = displayMode
+      lastColorScheme = colorScheme
+
+      isUpdatingFromBinding = true
+      textView.string = text
+      textView.textColor = .labelColor
+      textView.wrapLines = false
+      textView.updateFrameIfNeeded()
+      isUpdatingFromBinding = false
+
+      if displayMode.highlightsSyntax {
+        applySyntaxHighlighting(text: text, fileName: fileName, colorScheme: colorScheme)
+      } else {
+        applyPlainTextAppearance()
+      }
     }
 
     public func textView(
@@ -641,14 +875,16 @@ public struct CETextViewRepresentable: NSViewRepresentable {
         self.parent.text = newText
         self.parent.onTextChange(newText)
       }
-      // Re-highlight after edit with debounce
-      scheduleRehighlight(text: textView.string)
+      schedulePostEditWork(text: newText)
     }
 
     func applySyntaxHighlighting(text: String, fileName: String, colorScheme: ColorScheme) {
       highlightTask?.cancel()
+      guard currentDisplayMode.highlightsSyntax else {
+        applyPlainTextAppearance()
+        return
+      }
       guard !text.isEmpty else { return }
-      guard text.utf8.count < 500_000 else { return }
 
       let lang = Self.languageForFile(fileName)
       let colors: HighlightColors = colorScheme == .dark ? .dark(.github) : .light(.github)
@@ -691,14 +927,18 @@ public struct CETextViewRepresentable: NSViewRepresentable {
       }
     }
 
-    private func scheduleRehighlight(text: String) {
-      highlightTask?.cancel()
-      guard text.utf8.count < 500_000 else { return }
+    private func schedulePostEditWork(text: String) {
+      idleTask?.cancel()
       let fileName = parent.fileName
-      let colorScheme = lastColorScheme
-      highlightTask = Task { [weak self] in
-        try? await Task.sleep(for: .milliseconds(500))
+      let colorScheme = lastColorScheme ?? .light
+      let displayMode = currentDisplayMode
+      idleTask = Task { [weak self] in
+        try? await Task.sleep(for: .milliseconds(650))
         guard !Task.isCancelled else { return }
+        await MainActor.run { [weak self] in
+          self?.parent.onIdleTextSnapshot(text)
+        }
+        guard !Task.isCancelled, displayMode.highlightsSyntax else { return }
         self?.applySyntaxHighlighting(text: text, fileName: fileName, colorScheme: colorScheme)
       }
     }
@@ -709,6 +949,9 @@ public struct CETextViewRepresentable: NSViewRepresentable {
       guard storageLen > 0 else { return }
 
       storage.beginEditing()
+      let fullRange = NSRange(location: 0, length: storageLen)
+      storage.removeAttribute(.foregroundColor, range: fullRange)
+      storage.addAttribute(.foregroundColor, value: textView.textColor, range: fullRange)
       for (range, color) in colorRanges {
         let adjusted = NSRange(location: range.location + leadingOffset, length: range.length)
         if adjusted.location >= 0, adjusted.location + adjusted.length <= storageLen {
@@ -718,6 +961,22 @@ public struct CETextViewRepresentable: NSViewRepresentable {
       storage.endEditing()
 
       // Force CodeEditTextView to re-layout with new attributes
+      textView.layoutManager?.setNeedsLayout()
+      textView.needsLayout = true
+      textView.needsDisplay = true
+    }
+
+    func applyPlainTextAppearance() {
+      highlightTask?.cancel()
+      guard let textView, let storage = textView.textStorage else { return }
+      let storageLen = storage.length
+      guard storageLen > 0 else { return }
+
+      let fullRange = NSRange(location: 0, length: storageLen)
+      storage.beginEditing()
+      storage.removeAttribute(.foregroundColor, range: fullRange)
+      storage.addAttribute(.foregroundColor, value: textView.textColor, range: fullRange)
+      storage.endEditing()
       textView.layoutManager?.setNeedsLayout()
       textView.needsLayout = true
       textView.needsDisplay = true

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/QuickFilePickerView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/QuickFilePickerView.swift
@@ -18,6 +18,7 @@ public struct QuickFilePickerView: View {
   @State private var results: [FileSearchResult] = []
   @State private var selectedIndex = 0
   @State private var showingRecent = true
+  @State private var isIndexing = false
   @FocusState private var isSearchFocused: Bool
 
   public init(
@@ -98,6 +99,21 @@ public struct QuickFilePickerView: View {
             withAnimation { proxy.scrollTo(newIndex, anchor: .center) }
           }
         }
+      } else if isIndexing && !searchQuery.isEmpty {
+        Divider()
+        VStack(spacing: 8) {
+          ProgressView()
+            .controlSize(.small)
+          Text("Indexing files…")
+            .font(.caption)
+            .foregroundColor(.secondary)
+          Text("Large repositories are indexed in the background the first time you search.")
+            .font(.caption2)
+            .foregroundColor(.secondary.opacity(0.7))
+            .multilineTextAlignment(.center)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 20)
       } else if !searchQuery.isEmpty {
         Divider()
         VStack(spacing: 6) {
@@ -161,6 +177,7 @@ public struct QuickFilePickerView: View {
     .task(id: searchQuery) {
       // Automatically cancels previous task when searchQuery changes
       if searchQuery.isEmpty {
+        isIndexing = false
         let recent = await FileIndexService.shared.recentFiles(in: projectPath)
         results = recent
         showingRecent = true
@@ -171,10 +188,17 @@ public struct QuickFilePickerView: View {
       // Debounce — but clear results immediately to avoid showing stale data
       results = []
       selectedIndex = 0
+      isIndexing = false
       try? await Task.sleep(for: .milliseconds(150))
       guard !Task.isCancelled else { return }
+      let status = await FileIndexService.shared.searchIndexStatus(projectPath: projectPath)
+      if status != .ready {
+        isIndexing = true
+        await FileIndexService.shared.prepareSearchIndex(projectPath: projectPath)
+      }
       let found = await FileIndexService.shared.search(query: searchQuery, in: projectPath)
       guard !Task.isCancelled else { return }
+      isIndexing = false
       results = found
       selectedIndex = 0
     }

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/FileIndexServiceTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/FileIndexServiceTests.swift
@@ -158,4 +158,99 @@ struct FileIndexServicePrivacyTests {
     #expect(secretsResults.isEmpty)
     #expect(swiftlintResults.contains { $0.relativePath == ".swiftlint.yml" })
   }
+
+  @Test("Loads only root nodes until a directory is expanded")
+  func loadsRootNodesLazily() async throws {
+    let fixture = try FileIndexFixture.create()
+    defer { fixture.cleanup() }
+
+    try fixture.writeProjectFile("Sources/App.swift", content: "struct App {}")
+    try fixture.writeProjectFile("Sources/Feature/Detail.swift", content: "struct Detail {}")
+    try fixture.writeProjectFile("README.md", content: "# AgentHub")
+
+    let service = FileIndexService()
+    let rootNodes = await service.rootNodes(projectPath: fixture.projectPath)
+
+    #expect(rootNodes.map(\.name) == ["Sources", "README.md"])
+    #expect(rootNodes.first(where: { $0.name == "Sources" })?.children == nil)
+
+    let sourceChildren = await service.children(
+      of: fixture.projectPath + "/Sources",
+      in: fixture.projectPath
+    )
+
+    #expect(sourceChildren.map(\.name) == ["Feature", "App.swift"])
+    #expect(sourceChildren.first(where: { $0.name == "Feature" })?.children == nil)
+  }
+
+  @Test("Keeps tree loading and search indexing aligned with ignore rules")
+  func keepsTreeAndSearchRulesInSync() async throws {
+    let fixture = try FileIndexFixture.create()
+    defer { fixture.cleanup() }
+
+    try fixture.writeProjectFile(".gitignore", content: "Generated/\n")
+    try fixture.writeProjectFile("Generated/tmp.swift", content: "let generated = true")
+    try fixture.writeProjectFile("Sources/App.swift", content: "struct App {}")
+
+    let service = FileIndexService()
+    let rootNodes = await service.rootNodes(projectPath: fixture.projectPath)
+    let searchResults = await service.search(query: "tmp", in: fixture.projectPath)
+
+    #expect(rootNodes.contains { $0.name == "Sources" })
+    #expect(!rootNodes.contains { $0.name == "Generated" })
+    #expect(searchResults.isEmpty)
+  }
+
+  @Test("Content-only writes keep the search index warm")
+  func contentOnlyWritesKeepSearchIndexReady() async throws {
+    let fixture = try FileIndexFixture.create()
+    defer { fixture.cleanup() }
+
+    try fixture.writeProjectFile("Sources/App.swift", content: "struct App {}")
+
+    let service = FileIndexService()
+    let initialResults = await service.search(query: "app", in: fixture.projectPath)
+    let initialStatus = await service.searchIndexStatus(projectPath: fixture.projectPath)
+
+    try await service.writeFile(
+      at: fixture.projectPath + "/Sources/App.swift",
+      content: "struct App { let version = 2 }",
+      projectPath: fixture.projectPath
+    )
+
+    let statusAfterWrite = await service.searchIndexStatus(projectPath: fixture.projectPath)
+    let resultsAfterWrite = await service.search(query: "app", in: fixture.projectPath)
+
+    #expect(initialResults.map(\.absolutePath) == resultsAfterWrite.map(\.absolutePath))
+    #expect(initialStatus == .ready)
+    #expect(statusAfterWrite == .ready)
+  }
+
+  @Test("Creating a new file invalidates cached directory listings")
+  func creatingNewFileInvalidatesDirectoryCache() async throws {
+    let fixture = try FileIndexFixture.create()
+    defer { fixture.cleanup() }
+
+    try fixture.writeProjectFile("Sources/App.swift", content: "struct App {}")
+
+    let service = FileIndexService()
+    let initialChildren = await service.children(
+      of: fixture.projectPath + "/Sources",
+      in: fixture.projectPath
+    )
+
+    try await service.writeFile(
+      at: fixture.projectPath + "/Sources/NewFile.swift",
+      content: "struct NewFile {}",
+      projectPath: fixture.projectPath
+    )
+
+    let refreshedChildren = await service.children(
+      of: fixture.projectPath + "/Sources",
+      in: fixture.projectPath
+    )
+
+    #expect(initialChildren.map(\.name) == ["App.swift"])
+    #expect(refreshedChildren.map(\.name) == ["App.swift", "NewFile.swift"])
+  }
 }


### PR DESCRIPTION
## Summary
- lazy-load the file tree instead of recursively indexing the full repo up front
- move quick file search onto a separate cached background index with an indexing state
- keep large files editable in a fast plain-text mode and disable wrapped layout by default
- add coverage for lazy loading, cache behavior, and ignore-rule parity

## Testing
- xcodebuild -workspace app/AgentHub.xcodeproj/project.xcworkspace -scheme AgentHub build CODE_SIGNING_ALLOWED=NO

## Notes
- attempted focused `swift test --package-path app/modules/AgentHubCore --filter FileIndexService`, but the local SwiftPM path repeatedly rebuilt package checkouts and timed out in this environment