### PR TITLE
[transport] Filter link previews to user/assistant messages only

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/SessionJSONLParser.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/SessionJSONLParser.swift
@@ -264,11 +264,8 @@ public struct SessionJSONLParser {
             to: &result
           )
 
-          // Extract URL from tool_use input (e.g., WebFetch url parameter)
-          if let dict = block.input?.value as? [String: Any],
-             let urlString = dict["url"] as? String {
-            appendResourceLinks(extractResourceLinks(from: urlString, timestamp: timestamp), to: &result)
-          }
+          // Note: URL extraction from tool_use inputs is intentionally skipped
+          // to reduce noise — only user/assistant text links are shown
         }
 
       case "tool_result":
@@ -287,18 +284,8 @@ public struct SessionJSONLParser {
             to: &result
           )
 
-          // Extract URLs from tool result content
-          if let content = block.content {
-            var textToScan = ""
-            if let str = content.value as? String {
-              textToScan = str
-            } else if let arr = content.value as? [[String: Any]] {
-              textToScan = arr.compactMap { $0["text"] as? String }.joined(separator: " ")
-            }
-            if !textToScan.isEmpty {
-              appendResourceLinks(extractResourceLinks(from: textToScan, timestamp: timestamp), to: &result)
-            }
-          }
+          // Note: URL extraction from tool results is intentionally skipped
+          // to reduce noise — only user/assistant text links are shown
         }
 
       case "thinking":


### PR DESCRIPTION
## Summary
- Removed URL extraction from `tool_use` inputs (e.g., WebFetch url parameters) and `tool_result` content in `SessionJSONLParser`
- Links are now only collected from user and assistant text blocks, significantly reducing noise in the ResourceLinksPanel
- Users reported that tool-generated URLs (documentation links, dependency URLs, stack traces) were cluttering the link panel

## Test plan
- [ ] Verify links from assistant text messages still appear in ResourceLinksPanel
- [ ] Verify links from tool outputs (Bash results, Read results, WebFetch) no longer appear
- [ ] Confirm the link panel is noticeably less noisy during active sessions