### PR TITLE
Remove monitor/watching mode — always show terminal

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubDefaults.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubDefaults.swift
@@ -53,10 +53,6 @@ public enum AgentHubDefaults {
   /// Type: Data (JSON-encoded [String])
   public static let monitoredSessionIds = "\(keyPrefix)sessions.monitoredSessionIds"
 
-  /// Persisted session IDs that have terminal view enabled
-  /// Type: Data (JSON-encoded [String])
-  public static let sessionsWithTerminalView = "\(keyPrefix)sessions.sessionsWithTerminalView"
-
   // MARK: - Provider Settings
 
   /// Base key for enabled providers

--- a/app/modules/AgentHubCore/Sources/AgentHub/Models/SessionMonitorState.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Models/SessionMonitorState.swift
@@ -26,7 +26,6 @@ public struct SessionMonitorState: Equatable, Sendable {
 
   // Metrics
   public var messageCount: Int
-  public var toolCalls: [String: Int]  // Tool name -> count
   public var sessionStartedAt: Date?
   public var model: String?
   public var gitBranch: String?
@@ -53,7 +52,6 @@ public struct SessionMonitorState: Equatable, Sendable {
     cacheReadTokens: Int = 0,
     cacheCreationTokens: Int = 0,
     messageCount: Int = 0,
-    toolCalls: [String: Int] = [:],
     sessionStartedAt: Date? = nil,
     model: String? = nil,
     gitBranch: String? = nil,
@@ -71,7 +69,6 @@ public struct SessionMonitorState: Equatable, Sendable {
     self.cacheReadTokens = cacheReadTokens
     self.cacheCreationTokens = cacheCreationTokens
     self.messageCount = messageCount
-    self.toolCalls = toolCalls
     self.sessionStartedAt = sessionStartedAt
     self.model = model
     self.gitBranch = gitBranch

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/CodexSessionFileWatcher.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/CodexSessionFileWatcher.swift
@@ -269,7 +269,6 @@ public actor CodexSessionFileWatcher {
       cacheReadTokens: result.cacheReadTokens,
       cacheCreationTokens: result.cacheCreationTokens,
       messageCount: result.messageCount,
-      toolCalls: result.toolCalls,
       sessionStartedAt: result.sessionStartedAt,
       model: result.model,
       gitBranch: nil,

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/CodexSessionJSONLParser.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/CodexSessionJSONLParser.swift
@@ -37,7 +37,6 @@ public struct CodexSessionJSONLParser {
     public var cacheReadTokens: Int = 0
     public var cacheCreationTokens: Int = 0
     public var messageCount: Int = 0
-    public var toolCalls: [String: Int] = [:]
     public var pendingToolUses: [String: PendingToolInfo] = [:]
     public var recentActivities: [ActivityEntry] = []
     public var lastActivityAt: Date?
@@ -245,7 +244,6 @@ public struct CodexSessionJSONLParser {
     case "function_call":
       guard let name = payload["name"] as? String,
             let callId = payload["call_id"] as? String else { return }
-      result.toolCalls[name, default: 0] += 1
       result.pendingToolUses[callId] = PendingToolInfo(toolName: name, toolUseId: callId, timestamp: timestamp ?? Date())
       addActivity(type: .toolUse(name: name), description: name, timestamp: timestamp, to: &result)
 
@@ -259,7 +257,6 @@ public struct CodexSessionJSONLParser {
     case "custom_tool_call":
       guard let name = payload["name"] as? String else { return }
       let status = payload["status"] as? String
-      result.toolCalls[name, default: 0] += 1
       addActivity(type: .toolUse(name: name), description: name, timestamp: timestamp, to: &result)
       if status == "completed" {
         addActivity(type: .toolResult(name: name, success: true), description: "Completed", timestamp: timestamp, to: &result)

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/SessionFileWatcher.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/SessionFileWatcher.swift
@@ -418,7 +418,6 @@ public actor SessionFileWatcher {
       cacheReadTokens: result.cacheReadTokens,
       cacheCreationTokens: result.cacheCreationTokens,
       messageCount: result.messageCount,
-      toolCalls: result.toolCalls,
       sessionStartedAt: result.sessionStartedAt,
       model: result.model,
       gitBranch: result.gitBranch,

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/SessionJSONLParser.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/SessionJSONLParser.swift
@@ -81,7 +81,6 @@ public struct SessionJSONLParser {
     public var cacheReadTokens: Int = 0
     public var cacheCreationTokens: Int = 0
     public var messageCount: Int = 0
-    public var toolCalls: [String: Int] = [:]
     public var pendingToolUses: [String: PendingToolInfo] = [:]  // toolUseId -> info
     public var recentActivities: [ActivityEntry] = []
     public var lastActivityAt: Date?
@@ -239,9 +238,6 @@ public struct SessionJSONLParser {
       switch block.type {
       case "tool_use":
         if let name = block.name, let id = block.id {
-          // Track tool call count
-          result.toolCalls[name, default: 0] += 1
-
           // Add to pending (will be removed when we see tool_result)
           let inputPreview = extractInputPreview(block.input)
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringCardView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringCardView.swift
@@ -61,7 +61,6 @@ public struct MonitoringCardView: View {
   let claudeClient: (any ClaudeCode)?
   let cliConfiguration: CLICommandConfiguration?
   let providerKind: SessionProviderKind
-  let showTerminal: Bool
   let initialPrompt: String?
   let initialInputText: String?
   let terminalKey: String?  // Key for terminal storage (session ID or "pending-{pendingId}")
@@ -69,7 +68,6 @@ public struct MonitoringCardView: View {
   var dangerouslySkipPermissions: Bool = false
   var permissionModePlan: Bool = false
   let worktreeName: String?
-  let onToggleTerminal: (Bool) -> Void
   let onStopMonitoring: () -> Void
   let onConnect: () -> Void
   let onCopySessionId: () -> Void
@@ -111,7 +109,6 @@ public struct MonitoringCardView: View {
     claudeClient: (any ClaudeCode)? = nil,
     cliConfiguration: CLICommandConfiguration? = nil,
     providerKind: SessionProviderKind = .claude,
-    showTerminal: Bool = false,
     initialPrompt: String? = nil,
     initialInputText: String? = nil,
     terminalKey: String? = nil,
@@ -119,7 +116,6 @@ public struct MonitoringCardView: View {
     dangerouslySkipPermissions: Bool = false,
     permissionModePlan: Bool = false,
     worktreeName: String? = nil,
-    onToggleTerminal: @escaping (Bool) -> Void,
     onStopMonitoring: @escaping () -> Void,
     onConnect: @escaping () -> Void,
     onCopySessionId: @escaping () -> Void,
@@ -146,7 +142,6 @@ public struct MonitoringCardView: View {
     self.claudeClient = claudeClient
     self.cliConfiguration = cliConfiguration
     self.providerKind = providerKind
-    self.showTerminal = showTerminal
     self.initialPrompt = initialPrompt
     self.initialInputText = initialInputText
     self.terminalKey = terminalKey
@@ -154,7 +149,6 @@ public struct MonitoringCardView: View {
     self.dangerouslySkipPermissions = dangerouslySkipPermissions
     self.permissionModePlan = permissionModePlan
     self.worktreeName = worktreeName
-    self.onToggleTerminal = onToggleTerminal
     self.onStopMonitoring = onStopMonitoring
     self.onConnect = onConnect
     self.onCopySessionId = onCopySessionId
@@ -178,18 +172,9 @@ public struct MonitoringCardView: View {
 
   static func listHeightMetrics(
     providerKind: SessionProviderKind,
-    state: SessionMonitorState?,
-    showTerminal: Bool
+    state: SessionMonitorState?
   ) -> ResizableCardMetrics {
-    if showTerminal {
-      return ResizableCardMetrics(defaultHeight: 520, minHeight: 400)
-    }
-
-    let showsContextBar = providerKind == .claude && (state?.inputTokens ?? 0) > 0
-    return ResizableCardMetrics(
-      defaultHeight: showsContextBar ? 340 : 300,
-      minHeight: showsContextBar ? 240 : 210
-    )
+    return ResizableCardMetrics(defaultHeight: 520, minHeight: 400)
   }
 
   public var body: some View {
@@ -206,20 +191,7 @@ public struct MonitoringCardView: View {
         .padding(.horizontal, 12)
         .padding(.vertical, 8)
 
-      // Context bar (only in monitor/list mode, not terminal mode, Claude only)
-      if !showTerminal, providerKind == .claude, let state = state, state.inputTokens > 0 {
-        Divider()
-
-        ContextWindowBar(
-          percentage: state.contextWindowUsagePercentage,
-          formattedUsage: state.formattedContextUsage,
-          model: state.model
-        )
-        .padding(.horizontal, 12)
-        .padding(.vertical, 8)
-      }
-
-      // Recent activity (with status) or terminal
+      // Terminal content
       Divider()
 
       monitorContent
@@ -249,9 +221,8 @@ public struct MonitoringCardView: View {
     .animation(.easeInOut(duration: 0.2), value: isDragging)
     .onDrop(
       of: [.fileURL, .png, .tiff, .image, .pdf],
-      isTargeted: showTerminal ? $isDragging : .constant(false)
+      isTargeted: $isDragging
     ) { providers in
-      guard showTerminal else { return false }
       handleDroppedFiles(providers)
       return true
     }
@@ -365,7 +336,7 @@ public struct MonitoringCardView: View {
 
   /// Handles dropped file providers by extracting paths and typing them into terminal
   private func handleDroppedFiles(_ providers: [NSItemProvider]) {
-    guard showTerminal, let key = terminalKey, let viewModel = viewModel else { return }
+    guard let key = terminalKey, let viewModel = viewModel else { return }
 
     for provider in providers {
       // Handle file URLs (files dragged from Finder)
@@ -459,7 +430,7 @@ public struct MonitoringCardView: View {
 
   /// Handles files selected from the file picker by typing their paths into terminal
   private func handlePickedFiles(_ result: Result<[URL], Error>) {
-    guard showTerminal, let key = terminalKey, let viewModel = viewModel else { return }
+    guard let key = terminalKey, let viewModel = viewModel else { return }
 
     switch result {
     case .success(let urls):
@@ -522,37 +493,6 @@ public struct MonitoringCardView: View {
 
       Spacer()
 
-      // Terminal/List segmented control (hidden when maximized)
-      if !isMaximized {
-        HStack(spacing: 4) {
-          // Terminal button (left - default)
-          Button(action: { withAnimation(.easeInOut(duration: 0.2)) { onToggleTerminal(true) } }) {
-            Image(systemName: "terminal")
-              .font(.caption)
-              .frame(width: 28, height: 22)
-              .foregroundColor(showTerminal ? .primary : .secondary)
-              .contentShape(Rectangle())
-          }
-          .buttonStyle(.plain)
-
-          // Monitor button (right)
-          Button(action: { withAnimation(.easeInOut(duration: 0.2)) { onToggleTerminal(false) } }) {
-            Image(systemName: "waveform.circle")
-              .font(.caption)
-              .frame(width: 28, height: 22)
-              .foregroundColor(!showTerminal ? .primary : .secondary)
-              .contentShape(Rectangle())
-          }
-          .buttonStyle(.plain)
-        }
-        .padding(4)
-        .background(Color.secondary.opacity(0.12))
-        .clipShape(RoundedRectangle(cornerRadius: 6))
-        .animation(.easeInOut(duration: 0.2), value: showTerminal)
-        .fixedSize()
-        .layoutPriority(2)
-      }
-
       // TODO: Consider removing later
       // Maximize/Minimize button
 //      Button(action: onToggleMaximize) {
@@ -599,16 +539,13 @@ public struct MonitoringCardView: View {
         showingRemixProviderPicker = true
       }
 
-      // Media actions (only in terminal mode)
-      if showTerminal {
-        Divider()
-          .padding(.vertical, 4)
+      Divider()
+        .padding(.vertical, 4)
 
-        PopoverButton(icon: "plus.rectangle.on.folder", title: "Add Files") {
-          showingActionsPopover = false
-          DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-            showingFilePicker = true
-          }
+      PopoverButton(icon: "plus.rectangle.on.folder", title: "Add Files") {
+        showingActionsPopover = false
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+          showingFilePicker = true
         }
       }
     }
@@ -834,24 +771,21 @@ public struct MonitoringCardView: View {
           .help("Manage iOS Simulators")
         }
 
-        // Terminal refresh button (only visible when terminal is shown)
-        if showTerminal {
-          Button(action: onRefreshTerminal) {
-            HStack(spacing: 4) {
-              Image(systemName: "arrow.clockwise")
-                .font(.caption2)
-              Text("Refresh terminal")
-                .font(.caption2)
-            }
-            .foregroundColor(.secondary)
-            .padding(.horizontal, 8)
-            .padding(.vertical, 4)
-            .background(Color.secondary.opacity(0.1))
-            .clipShape(RoundedRectangle(cornerRadius: 4))
+        Button(action: onRefreshTerminal) {
+          HStack(spacing: 4) {
+            Image(systemName: "arrow.clockwise")
+              .font(.caption2)
+            Text("Refresh terminal")
+              .font(.caption2)
           }
-          .buttonStyle(.plain)
-          .help("Refresh terminal (reload session history)")
+          .foregroundColor(.secondary)
+          .padding(.horizontal, 8)
+          .padding(.vertical, 4)
+          .background(Color.secondary.opacity(0.1))
+          .clipShape(RoundedRectangle(cornerRadius: 4))
         }
+        .buttonStyle(.plain)
+        .help("Refresh terminal (reload session history)")
       }
       .fixedSize()
       .layoutPriority(2)
@@ -863,46 +797,22 @@ public struct MonitoringCardView: View {
   @ViewBuilder
   private var monitorContent: some View {
     ZStack(alignment: .bottomTrailing) {
-      if showTerminal {
-        EmbeddedTerminalView(
-          terminalKey: terminalKey ?? session.id,
-          sessionId: session.id,
-          projectPath: session.projectPath,
-          cliConfiguration: viewModel?.cliConfiguration ?? .claudeDefault,
-          initialPrompt: initialPrompt,
-          initialInputText: initialInputText,
-          viewModel: viewModel,
-          dangerouslySkipPermissions: dangerouslySkipPermissions,
-          permissionModePlan: permissionModePlan,
-          worktreeName: worktreeName,
-          onUserInteraction: onTerminalInteraction
-        )
-        .frame(minHeight: 300)
-      } else {
-        VStack(alignment: .leading, spacing: 12) {
-          Text("Recent Activity")
-            .font(.system(.subheadline, design: .monospaced))
-            .foregroundColor(.secondary)
+      EmbeddedTerminalView(
+        terminalKey: terminalKey ?? session.id,
+        sessionId: session.id,
+        projectPath: session.projectPath,
+        cliConfiguration: viewModel?.cliConfiguration ?? .claudeDefault,
+        initialPrompt: initialPrompt,
+        initialInputText: initialInputText,
+        viewModel: viewModel,
+        dangerouslySkipPermissions: dangerouslySkipPermissions,
+        permissionModePlan: permissionModePlan,
+        worktreeName: worktreeName,
+        onUserInteraction: onTerminalInteraction
+      )
+      .frame(minHeight: 300)
 
-          VStack(alignment: .leading, spacing: 16) {
-            // Show recent activities (older first)
-            if let state = state {
-              ForEach(state.recentActivities.suffix(2).reversed()) { activity in
-                FlatActivityRow(activity: activity)
-              }
-            }
-
-            // Current status as the most recent item
-            StatusActivityRow(
-              status: state?.status ?? .idle,
-              timestamp: state?.lastActivityAt ?? Date()
-            )
-          }
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-      }
-
-      // Plus button for actions popover - visible in both modes
+      // Plus button for actions popover
       Button {
         showingActionsPopover = true
       } label: {
@@ -918,109 +828,6 @@ public struct MonitoringCardView: View {
       }
       .help("Session actions")
     }
-  }
-}
-
-// MARK: - Flat Activity Row
-
-private struct FlatActivityRow: View {
-  let activity: ActivityEntry
-
-  private var iconColor: Color {
-    switch activity.type {
-    case .toolUse:
-      return .orange
-    case .toolResult(_, let success):
-      return success ? .green : .red
-    case .userMessage:
-      return .blue
-    case .assistantMessage:
-      return .purple
-    case .thinking:
-      return .gray
-    }
-  }
-
-  var body: some View {
-    HStack(spacing: 12) {
-      Text(formatTime(activity.timestamp))
-        .font(.system(.subheadline, design: .monospaced))
-        .foregroundColor(.secondary)
-        .monospacedDigit()
-
-      Image(systemName: activity.type.icon)
-        .font(.subheadline)
-        .foregroundColor(iconColor)
-        .frame(width: 18)
-
-      Text(activity.description)
-        .font(.subheadline)
-        .lineLimit(1)
-        .foregroundColor(.primary)
-    }
-  }
-
-  private func formatTime(_ date: Date) -> String {
-    let formatter = DateFormatter()
-    formatter.dateFormat = "HH:mm:ss"
-    return formatter.string(from: date)
-  }
-}
-
-// MARK: - Status Activity Row
-
-/// Shows the current session status as an activity row
-private struct StatusActivityRow: View {
-  let status: SessionStatus
-  let timestamp: Date
-
-  private var statusColor: Color {
-    switch status.color {
-    case "blue": return .blue
-    case "orange": return .orange
-    case "yellow": return .yellow
-    case "red": return .red
-    default: return .gray
-    }
-  }
-
-  private var statusIcon: String {
-    switch status {
-    case .idle:
-      return "circle.fill"
-    case .thinking:
-      return "sparkles"
-    case .executingTool:
-      return "gearshape.fill"
-    case .awaitingApproval:
-      return "exclamationmark.circle.fill"
-    case .waitingForUser:
-      return "circle.fill"
-    }
-  }
-
-  var body: some View {
-    HStack(spacing: 12) {
-      Text(formatTime(timestamp))
-        .font(.system(.subheadline, design: .monospaced))
-        .foregroundColor(.secondary)
-        .monospacedDigit()
-
-      Image(systemName: statusIcon)
-        .font(.subheadline)
-        .foregroundColor(statusColor)
-        .frame(width: 18)
-
-      Text(status.displayName)
-        .font(.subheadline)
-        .foregroundColor(.primary)
-    }
-  }
-
-  private func formatTime(_ date: Date) -> String {
-    let formatter = DateFormatter()
-    formatter.dateFormat = "HH:mm:ss"
-    return formatter.string(from: date)
   }
 }
 
@@ -1110,7 +917,6 @@ struct AnimatedCopyButton: View {
           ActivityEntry(timestamp: Date(), type: .toolUse(name: "Bash"), description: "swift build")
         ]
       ),
-      onToggleTerminal: { _ in },
       onStopMonitoring: {},
       onConnect: {},
       onCopySessionId: {},
@@ -1136,7 +942,6 @@ struct AnimatedCopyButton: View {
         model: "claude-sonnet-4-20250514",
         recentActivities: []
       ),
-      onToggleTerminal: { _ in },
       onStopMonitoring: {},
       onConnect: {},
       onCopySessionId: {},
@@ -1156,7 +961,6 @@ struct AnimatedCopyButton: View {
         isActive: false
       ),
       state: nil,
-      onToggleTerminal: { _ in },
       onStopMonitoring: {},
       onConnect: {},
       onCopySessionId: {},

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringPanelView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringPanelView.swift
@@ -343,7 +343,7 @@ public struct MonitoringPanelView: View {
         claudeClient: claudeClient,
         cliConfiguration: viewModel.cliConfiguration,
         providerKind: viewModel.providerKind,
-        showTerminal: true,
+
         initialPrompt: pending.initialPrompt,
         initialInputText: pending.initialInputText,
         terminalKey: "pending-\(pending.id.uuidString)",
@@ -351,7 +351,7 @@ public struct MonitoringPanelView: View {
         dangerouslySkipPermissions: pending.dangerouslySkipPermissions,
         permissionModePlan: pending.permissionModePlan,
         worktreeName: pending.worktreeName,
-        onToggleTerminal: { _ in },
+
         onStopMonitoring: {
           viewModel.cancelPendingSession(pending)
           withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) {
@@ -385,13 +385,9 @@ public struct MonitoringPanelView: View {
         claudeClient: claudeClient,
         cliConfiguration: viewModel.cliConfiguration,
         providerKind: viewModel.providerKind,
-        showTerminal: viewModel.sessionsWithTerminalView.contains(item.session.id),
         initialPrompt: initialPrompt,
         terminalKey: item.session.id,
         viewModel: viewModel,
-        onToggleTerminal: { show in
-          viewModel.setTerminalView(for: item.session.id, show: show)
-        },
         onStopMonitoring: {
           viewModel.stopMonitoring(session: item.session)
           withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) {
@@ -496,7 +492,7 @@ public struct MonitoringPanelView: View {
           claudeClient: claudeClient,
           cliConfiguration: viewModel.cliConfiguration,
           providerKind: viewModel.providerKind,
-          showTerminal: true,
+  
           initialPrompt: pending.initialPrompt,
           initialInputText: pending.initialInputText,
           terminalKey: pendingId,
@@ -504,7 +500,7 @@ public struct MonitoringPanelView: View {
           dangerouslySkipPermissions: pending.dangerouslySkipPermissions,
           permissionModePlan: pending.permissionModePlan,
           worktreeName: pending.worktreeName,
-          onToggleTerminal: { _ in },
+  
           onStopMonitoring: {
             viewModel.cancelPendingSession(pending)
           },
@@ -533,13 +529,9 @@ public struct MonitoringPanelView: View {
           claudeClient: claudeClient,
           cliConfiguration: viewModel.cliConfiguration,
           providerKind: viewModel.providerKind,
-          showTerminal: viewModel.sessionsWithTerminalView.contains(session.id),
           initialPrompt: initialPrompt,
           terminalKey: session.id,
           viewModel: viewModel,
-          onToggleTerminal: { show in
-            viewModel.setTerminalView(for: session.id, show: show)
-          },
           onStopMonitoring: {
             viewModel.stopMonitoring(session: session)
           },
@@ -592,7 +584,7 @@ public struct MonitoringPanelView: View {
         claudeClient: claudeClient,
         cliConfiguration: viewModel.cliConfiguration,
         providerKind: viewModel.providerKind,
-        showTerminal: true,
+
         initialPrompt: pending.initialPrompt,
         initialInputText: pending.initialInputText,
         terminalKey: pendingId,
@@ -600,7 +592,7 @@ public struct MonitoringPanelView: View {
         dangerouslySkipPermissions: pending.dangerouslySkipPermissions,
         permissionModePlan: pending.permissionModePlan,
         worktreeName: pending.worktreeName,
-        onToggleTerminal: { _ in },
+
         onStopMonitoring: {
           viewModel.cancelPendingSession(pending)
         },
@@ -634,13 +626,9 @@ public struct MonitoringPanelView: View {
         claudeClient: claudeClient,
         cliConfiguration: viewModel.cliConfiguration,
         providerKind: viewModel.providerKind,
-        showTerminal: viewModel.sessionsWithTerminalView.contains(session.id),
         initialPrompt: initialPrompt,
         terminalKey: session.id,
         viewModel: viewModel,
-        onToggleTerminal: { show in
-          viewModel.setTerminalView(for: session.id, show: show)
-        },
         onStopMonitoring: {
           viewModel.stopMonitoring(session: session)
         },
@@ -773,14 +761,12 @@ public struct MonitoringPanelView: View {
     case .pending:
       return MonitoringCardView.listHeightMetrics(
         providerKind: viewModel.providerKind,
-        state: nil,
-        showTerminal: true
+        state: nil
       )
-    case .monitored(let session, let state):
+    case .monitored(_, let state):
       return MonitoringCardView.listHeightMetrics(
         providerKind: viewModel.providerKind,
-        state: state,
-        showTerminal: viewModel.sessionsWithTerminalView.contains(session.id)
+        state: state
       )
     }
   }

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderMonitoringPanelView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderMonitoringPanelView.swift
@@ -599,7 +599,7 @@ public struct MultiProviderMonitoringPanelView: View {
           claudeClient: viewModel.claudeClient,
           cliConfiguration: viewModel.cliConfiguration,
           providerKind: item.providerKind,
-          showTerminal: true,
+
           initialPrompt: pending.initialPrompt,
           initialInputText: pending.initialInputText,
           terminalKey: pendingId,
@@ -607,7 +607,7 @@ public struct MultiProviderMonitoringPanelView: View {
           dangerouslySkipPermissions: pending.dangerouslySkipPermissions,
           permissionModePlan: pending.permissionModePlan,
           worktreeName: pending.worktreeName,
-          onToggleTerminal: { _ in },
+
           onStopMonitoring: { viewModel.cancelPendingSession(pending) },
           onConnect: { },
           onCopySessionId: { },
@@ -635,13 +635,9 @@ public struct MultiProviderMonitoringPanelView: View {
             claudeClient: viewModel.claudeClient,
             cliConfiguration: viewModel.cliConfiguration,
             providerKind: item.providerKind,
-            showTerminal: viewModel.sessionsWithTerminalView.contains(session.id),
             initialPrompt: initialPrompt,
             terminalKey: session.id,
             viewModel: viewModel,
-            onToggleTerminal: { show in
-              viewModel.setTerminalView(for: session.id, show: show)
-            },
             onStopMonitoring: {
               viewModel.stopMonitoring(session: session)
             },
@@ -827,7 +823,6 @@ public struct MultiProviderMonitoringPanelView: View {
         claudeClient: viewModel.claudeClient,
         cliConfiguration: viewModel.cliConfiguration,
         providerKind: item.providerKind,
-        showTerminal: true,
         initialPrompt: pending.initialPrompt,
         initialInputText: pending.initialInputText,
         terminalKey: "pending-\(pending.id.uuidString)",
@@ -835,7 +830,6 @@ public struct MultiProviderMonitoringPanelView: View {
         dangerouslySkipPermissions: pending.dangerouslySkipPermissions,
         permissionModePlan: pending.permissionModePlan,
         worktreeName: pending.worktreeName,
-        onToggleTerminal: { _ in },
         onStopMonitoring: { viewModel.cancelPendingSession(pending) },
         onConnect: { },
         onCopySessionId: { },
@@ -864,13 +858,9 @@ public struct MultiProviderMonitoringPanelView: View {
         claudeClient: viewModel.claudeClient,
         cliConfiguration: viewModel.cliConfiguration,
         providerKind: item.providerKind,
-        showTerminal: viewModel.sessionsWithTerminalView.contains(session.id),
         initialPrompt: initialPrompt,
         terminalKey: session.id,
         viewModel: viewModel,
-        onToggleTerminal: { show in
-          viewModel.setTerminalView(for: session.id, show: show)
-        },
         onStopMonitoring: {
           viewModel.stopMonitoring(session: session)
         },
@@ -995,7 +985,7 @@ public struct MultiProviderMonitoringPanelView: View {
           claudeClient: viewModel.claudeClient,
           cliConfiguration: viewModel.cliConfiguration,
           providerKind: item.providerKind,
-          showTerminal: true,
+
           initialPrompt: pending.initialPrompt,
           initialInputText: pending.initialInputText,
           terminalKey: "pending-\(pending.id.uuidString)",
@@ -1003,7 +993,7 @@ public struct MultiProviderMonitoringPanelView: View {
           dangerouslySkipPermissions: pending.dangerouslySkipPermissions,
           permissionModePlan: pending.permissionModePlan,
           worktreeName: pending.worktreeName,
-          onToggleTerminal: { _ in },
+
           onStopMonitoring: {
             viewModel.cancelPendingSession(pending)
             withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) {
@@ -1035,13 +1025,9 @@ public struct MultiProviderMonitoringPanelView: View {
           claudeClient: viewModel.claudeClient,
           cliConfiguration: viewModel.cliConfiguration,
           providerKind: item.providerKind,
-          showTerminal: viewModel.sessionsWithTerminalView.contains(session.id),
           initialPrompt: initialPrompt,
           terminalKey: session.id,
           viewModel: viewModel,
-          onToggleTerminal: { show in
-            viewModel.setTerminalView(for: session.id, show: show)
-          },
           onStopMonitoring: {
             viewModel.stopMonitoring(session: session)
             withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) {
@@ -1211,14 +1197,12 @@ public struct MultiProviderMonitoringPanelView: View {
     case .pending(let providerKind, _, _):
       return MonitoringCardView.listHeightMetrics(
         providerKind: providerKind,
-        state: nil,
-        showTerminal: true
+        state: nil
       )
-    case .monitored(let providerKind, let viewModel, let session, let state):
+    case .monitored(let providerKind, _, _, let state):
       return MonitoringCardView.listHeightMetrics(
         providerKind: providerKind,
-        state: state,
-        showTerminal: viewModel.sessionsWithTerminalView.contains(session.id)
+        state: state
       )
     }
   }

--- a/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/CLISessionsViewModel.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/CLISessionsViewModel.swift
@@ -101,16 +101,8 @@ public final class CLISessionsViewModel {
   private var pendingAutoObserveWorktreePath: String? = nil
   /// Session IDs that existed before we opened the terminal (to detect new ones)
   private var existingSessionIdsBeforeTerminal: Set<String> = []
-  /// Whether the next auto-observed session should show terminal view (from "Start in Hub")
-  public var pendingHubSessionWithTerminal: Bool = false
-
   /// Session IDs awaiting progressive restoration on app launch
   private var pendingRestorationSessionIds: Set<String> = []
-
-  /// Terminal view IDs loaded from persistence, used during progressive restoration
-  private var restoringTerminalViewIds: Set<String> = []
-  /// Session IDs that should show terminal view (tracks current state for each row)
-  public var sessionsWithTerminalView: Set<String> = []
 
   /// Maps session IDs to prompts that should be sent to the terminal when it becomes ready.
   ///
@@ -124,30 +116,7 @@ public final class CLISessionsViewModel {
   ///   with the terminal's input buffer (see `EmbeddedTerminalView.sendPromptIfNeeded`).
   public var pendingTerminalPrompts: [String: String] = [:]
 
-  /// Updates the terminal view state for a session.
-  /// Polling continues in both modes to enable Preview/Plan buttons in terminal mode.
-  public func setTerminalView(for sessionId: String, show: Bool) {
-    let mode = show ? "TERMINAL" : "MONITOR"
-    AppLogger.session.info("[Polling] setTerminalView -> \(mode, privacy: .public) for session: \(sessionId.prefix(8), privacy: .public)")
-
-    if show {
-      // Switching TO terminal mode - keep polling for Preview/Plan buttons
-      sessionsWithTerminalView.insert(sessionId)
-      // Ensure polling is running (may not be if session just started)
-      if let session = monitoredSessionBackup[sessionId] {
-        startPolling(session: session)
-      }
-    } else {
-      // Switching TO monitor/list mode - polling already running
-      sessionsWithTerminalView.remove(sessionId)
-      if let session = monitoredSessionBackup[sessionId] {
-        startPolling(session: session)
-      }
-    }
-    persistSessionsWithTerminalView()
-  }
-
-  /// Start polling for a session (when switching to monitor mode)
+  /// Start polling for a session
   private func startPolling(session: CLISession) {
     AppLogger.session.info("[Polling] startPolling called for session: \(session.id.prefix(8), privacy: .public)")
 
@@ -200,8 +169,6 @@ public final class CLISessionsViewModel {
     }
     // Store the pending prompt
     pendingTerminalPrompts[session.id] = prompt
-    // Show terminal view
-    sessionsWithTerminalView.insert(session.id)
   }
 
   /// Returns the pending prompt for a session (read-only, safe during view body)
@@ -396,10 +363,6 @@ public final class CLISessionsViewModel {
   private var monitoredSessionsKey: String {
     AgentHubDefaults.monitoredSessionIds + "." + providerDefaultsSuffix
   }
-  private var terminalViewKey: String {
-    AgentHubDefaults.sessionsWithTerminalView + "." + providerDefaultsSuffix
-  }
-
   // MARK: - Initialization
 
   public init(
@@ -584,11 +547,6 @@ public final class CLISessionsViewModel {
       let persistedSessionIds = loadPersistedSessionIds()
       if !persistedSessionIds.isEmpty {
         pendingRestorationSessionIds = persistedSessionIds
-        // Load terminal view state for restoration decisions
-        if let tvData = UserDefaults.standard.data(forKey: terminalViewKey),
-           let tvIds = try? JSONDecoder().decode([String].self, from: tvData) {
-          restoringTerminalViewIds = Set(tvIds)
-        }
       }
 
       // Add repositories (triggers refreshSessions → setupSubscriptions)
@@ -600,7 +558,6 @@ public final class CLISessionsViewModel {
       // Safety timeout: stop trying to restore after 10 seconds
       try? await Task.sleep(for: .seconds(10))
       pendingRestorationSessionIds.removeAll()
-      restoringTerminalViewIds.removeAll()
     }
   }
 
@@ -628,11 +585,6 @@ public final class CLISessionsViewModel {
         // Populate monitoring state directly (skip persistence — persisted state is already correct)
         monitoredSessionIds.insert(session.id)
         monitoredSessionBackup[session.id] = session
-
-        // Restore terminal view mode from persisted state
-        if restoringTerminalViewIds.contains(session.id) {
-          sessionsWithTerminalView.insert(session.id)
-        }
 
         // Start polling for file changes
         startPolling(session: session)
@@ -692,14 +644,6 @@ public final class CLISessionsViewModel {
     let sessionIds = Array(monitoredSessionIds)
     if let data = try? JSONEncoder().encode(sessionIds) {
       UserDefaults.standard.set(data, forKey: monitoredSessionsKey)
-    }
-  }
-
-  /// Persists which sessions have terminal view enabled
-  private func persistSessionsWithTerminalView() {
-    let sessionIds = Array(sessionsWithTerminalView)
-    if let data = try? JSONEncoder().encode(sessionIds) {
-      UserDefaults.standard.set(data, forKey: terminalViewKey)
     }
   }
 
@@ -1476,8 +1420,6 @@ public final class CLISessionsViewModel {
             AppLogger.session.info("[HandleNewSession] Resolved: pending=\(pending.id.uuidString.prefix(8), privacy: .public) -> real=\(session.id.prefix(8), privacy: .public)")
             // Transfer terminal from pending key to real session ID
             transferTerminal(fromPendingId: pending.id, toSessionId: session.id)
-            // Keep terminal view visible during transition
-            sessionsWithTerminalView.insert(session.id)
             startMonitoring(session: session)
             found = true
             break
@@ -1495,8 +1437,6 @@ public final class CLISessionsViewModel {
               AppLogger.session.info("[HandleNewSession] Resolved: pending=\(pending.id.uuidString.prefix(8), privacy: .public) -> real=\(session.id.prefix(8), privacy: .public)")
               // Transfer terminal from pending key to real session ID
               transferTerminal(fromPendingId: pending.id, toSessionId: session.id)
-              // Keep terminal view visible during transition
-              sessionsWithTerminalView.insert(session.id)
               startMonitoring(session: session)
               return
             }
@@ -1543,7 +1483,6 @@ public final class CLISessionsViewModel {
           resolvedPendingSessions[pending.id] = sessionId
           AppLogger.session.info("[HandleNewSession] Resolved: pending=\(pending.id.uuidString.prefix(8), privacy: .public) -> real=\(sessionId.prefix(8), privacy: .public)")
           transferTerminal(fromPendingId: pending.id, toSessionId: sessionId)
-          sessionsWithTerminalView.insert(sessionId)
           startMonitoring(session: newSession)
 #if DEBUG
           AppLogger.session.info(
@@ -1586,7 +1525,6 @@ public final class CLISessionsViewModel {
           resolvedPendingSessions[pending.id] = sessionId
           AppLogger.session.info("[HandleNewSession] Resolved: pending=\(pending.id.uuidString.prefix(8), privacy: .public) -> real=\(sessionId.prefix(8), privacy: .public)")
           transferTerminal(fromPendingId: pending.id, toSessionId: sessionId)
-          sessionsWithTerminalView.insert(sessionId)
           startMonitoring(session: newSession)
 #if DEBUG
           AppLogger.session.info(
@@ -1876,12 +1814,10 @@ public final class CLISessionsViewModel {
 
     monitoredSessionIds.insert(session.id)
     monitoredSessionBackup[session.id] = session
-    sessionsWithTerminalView.insert(session.id)  // Default to terminal view
 
     persistMonitoredSessions()
-    persistSessionsWithTerminalView()
 
-    // Start polling for Preview/Plan buttons (works in both terminal and monitor modes)
+    // Start polling for Preview/Plan buttons
     startPolling(session: session)
   }
 
@@ -1894,7 +1830,6 @@ public final class CLISessionsViewModel {
   public func stopMonitoring(sessionId: String) {
     monitoredSessionIds.remove(sessionId)
     monitoredSessionBackup.removeValue(forKey: sessionId)
-    sessionsWithTerminalView.remove(sessionId)
     monitorStates.removeValue(forKey: sessionId)
     monitoringCancellables.removeValue(forKey: sessionId)
 
@@ -1902,7 +1837,6 @@ public final class CLISessionsViewModel {
     removeTerminal(forKey: sessionId)
 
     persistMonitoredSessions()
-    persistSessionsWithTerminalView()
 
     Task {
       await fileWatcher.stopMonitoring(sessionId: sessionId)
@@ -2061,12 +1995,6 @@ public final class CLISessionsViewModel {
               if let wtIndex = selectedRepositories[repoIndex].worktrees.firstIndex(where: { $0.id == worktree.id }) {
                 selectedRepositories[repoIndex].worktrees[wtIndex].isExpanded = true
               }
-            }
-
-            // If started via "Start in Hub", mark session to show terminal view
-            if pendingHubSessionWithTerminal {
-              sessionsWithTerminalView.insert(session.id)
-              pendingHubSessionWithTerminal = false
             }
 
             startMonitoring(session: session)


### PR DESCRIPTION
## Summary

- Session cards now always display the embedded terminal, removing the toggle between "Recent Activity" feed and terminal view
- Removed `showTerminal`/`onToggleTerminal` parameters, monitor segmented control, `FlatActivityRow`, `StatusActivityRow`, and `sessionsWithTerminalView` persistence
- Removed `toolCalls: [String: Int]` tracking from parsers (`SessionJSONLParser`, `CodexSessionJSONLParser`), file watchers, and `SessionMonitorState`
- All JSONL parsing infrastructure preserved for plan detection, sidebar status, approval notifications, resource links, and mermaid detection

## Test plan

- [ ] Session cards always show terminal — no toggle visible
- [ ] Sidebar status indicators still work (thinking/executing/idle colors)
- [ ] Approval notifications still fire
- [ ] Plan/Diff/Files/Preview buttons still work
- [ ] Resources panel still shows detected links
- [ ] Drag-and-drop files onto terminal still works
- [ ] "Add Files" and "Refresh terminal" buttons visible
- [ ] `showTerminalWithPrompt` (inline edit from GitDiffView) still works
- [ ] App launch restoration of monitored sessions still works