### PR TITLE
Add persistent web preview auth and Storybook support

### DIFF
--- a/app/modules/AgentHubCore/Package.swift
+++ b/app/modules/AgentHubCore/Package.swift
@@ -14,6 +14,7 @@ let package = Package(
     ),
   ],
   dependencies: [
+    .package(path: "../Storybook"),
     .package(url: "https://github.com/jamesrochabrun/Canvas.git", exact: "1.0.3"),
     .package(url: "https://github.com/jamesrochabrun/ClaudeCodeSDK", exact: "1.2.4"),
     .package(url: "https://github.com/jamesrochabrun/PierreDiffsSwift", exact: "1.1.5"),
@@ -29,6 +30,7 @@ let package = Package(
     .target(
       name: "AgentHubCore",
       dependencies: [
+        .product(name: "Storybook", package: "Storybook"),
         .product(name: "Canvas", package: "Canvas"),
         .product(name: "ClaudeCodeSDK", package: "ClaudeCodeSDK"),
         .product(name: "PierreDiffsSwift", package: "PierreDiffsSwift"),

--- a/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubDefaults.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubDefaults.swift
@@ -145,6 +145,19 @@ public enum AgentHubDefaults {
   /// Type: Double (default: 360)
   public static let webPreviewInspectorWidth = "\(keyPrefix)ui.webPreviewInspectorWidth"
 
+  // MARK: - Web Preview Auth Settings
+
+  /// Whether persistent login sessions are enabled for web previews (opt-in, default: false).
+  /// When disabled, all previews use ephemeral storage — no cookies persist across reloads.
+  /// Type: Bool (default: false)
+  public static let webPreviewPersistentAuthEnabled = "\(keyPrefix)webPreview.persistentAuthEnabled"
+
+  /// JSON-encoded mapping of project paths to WKWebsiteDataStore UUIDs.
+  /// Each project gets its own isolated data store — cookies, localStorage, and cache
+  /// are fully siloed per project. No data crosses project boundaries.
+  /// Type: Data (JSON-encoded [String: String])
+  public static let webPreviewDataStoreIdentifiers = "\(keyPrefix)webPreview.dataStoreIdentifiers"
+
   // MARK: - Theme Settings
 
   /// Selected color theme name

--- a/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubProvider.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubProvider.swift
@@ -108,6 +108,13 @@ public final class AgentHubProvider {
     GitHubCLIService()
   }()
 
+  // MARK: - Web Preview Auth
+
+  /// Auth service for persistent web preview cookie storage (per-project isolation)
+  public var webPreviewAuthService: WebPreviewAuthService {
+    WebPreviewAuthService.shared
+  }
+
   // MARK: - Theme Management
 
   /// Theme manager for YAML and built-in themes

--- a/app/modules/AgentHubCore/Sources/AgentHub/Models/DevServerConfiguration.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Models/DevServerConfiguration.swift
@@ -17,17 +17,43 @@ enum ProjectFramework: String, Sendable {
   case angular
   case vueCLI
   case astro
+  case storybook
   case staticHTML
   case unknown
 
   /// Whether this framework requires a dev server for transpilation/bundling
   var requiresDevServer: Bool {
     switch self {
-    case .vite, .nextjs, .createReactApp, .angular, .vueCLI, .astro:
+    case .vite, .nextjs, .createReactApp, .angular, .vueCLI, .astro, .storybook:
       return true
     case .staticHTML, .unknown:
       return false
     }
+  }
+
+  /// Checks whether the project at the given path has Storybook configured.
+  /// This is independent of the primary framework — a project can be both `.vite` and have Storybook.
+  static func hasStorybook(at projectPath: String) -> Bool {
+    let fm = FileManager.default
+
+    // Check for .storybook/ config directory
+    if fm.fileExists(atPath: "\(projectPath)/.storybook") {
+      return true
+    }
+
+    // Check package.json for storybook dependencies or scripts
+    let packageJsonPath = "\(projectPath)/package.json"
+    guard fm.fileExists(atPath: packageJsonPath),
+          let data = fm.contents(atPath: packageJsonPath),
+          let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+      return false
+    }
+
+    let scripts = json["scripts"] as? [String: String] ?? [:]
+    if scripts["storybook"] != nil { return true }
+
+    let devDeps = json["devDependencies"] as? [String: Any] ?? [:]
+    return devDeps.keys.contains { $0.hasPrefix("@storybook/") }
   }
 
   /// Fast synchronous detection of project framework from package.json

--- a/app/modules/AgentHubCore/Sources/AgentHub/Models/DevServerConfiguration.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Models/DevServerConfiguration.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import Storybook
 
 // MARK: - ProjectFramework
 
@@ -32,28 +33,9 @@ enum ProjectFramework: String, Sendable {
   }
 
   /// Checks whether the project at the given path has Storybook configured.
-  /// This is independent of the primary framework — a project can be both `.vite` and have Storybook.
+  /// Delegates to `StorybookDetector` from the Storybook module.
   static func hasStorybook(at projectPath: String) -> Bool {
-    let fm = FileManager.default
-
-    // Check for .storybook/ config directory
-    if fm.fileExists(atPath: "\(projectPath)/.storybook") {
-      return true
-    }
-
-    // Check package.json for storybook dependencies or scripts
-    let packageJsonPath = "\(projectPath)/package.json"
-    guard fm.fileExists(atPath: packageJsonPath),
-          let data = fm.contents(atPath: packageJsonPath),
-          let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
-      return false
-    }
-
-    let scripts = json["scripts"] as? [String: String] ?? [:]
-    if scripts["storybook"] != nil { return true }
-
-    let devDeps = json["devDependencies"] as? [String: Any] ?? [:]
-    return devDeps.keys.contains { $0.hasPrefix("@storybook/") }
+    StorybookDetector.hasStorybook(at: projectPath)
   }
 
   /// Fast synchronous detection of project framework from package.json

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/DevServerManager.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/DevServerManager.swift
@@ -68,7 +68,8 @@ public final class DevServerManager {
 
   /// Starts a dev server for the given key (typically session ID) at the specified project path.
   /// Idempotent: if already running or ready, returns immediately.
-  public func startServer(for key: String, projectPath: String) async {
+  /// - Parameter forceFramework: If set, overrides auto-detection with this framework (used for Storybook).
+  public func startServer(for key: String, projectPath: String, forceFramework: ProjectFramework? = nil) async {
     // Guard: already in an active state
     switch servers[key] {
     case .ready, .starting, .waitingForReady, .detecting:
@@ -80,8 +81,11 @@ public final class DevServerManager {
     servers[key] = .detecting
 
     // 1. Detect project type (off main thread for file I/O)
-    let detected = await Task.detached { [projectPath] in
-      DevServerManager.detectProject(at: projectPath)
+    let detected = await Task.detached { [projectPath, forceFramework] in
+      if let framework = forceFramework {
+        return DevServerManager.detectProject(at: projectPath, framework: framework)
+      }
+      return DevServerManager.detectProject(at: projectPath)
     }.value
 
     // 2. Find executable
@@ -191,6 +195,23 @@ public final class DevServerManager {
     servers[key] = .idle
   }
 
+  /// Starts a Storybook server alongside the main dev server.
+  /// Uses a compound key `"{sessionId}:storybook"` to coexist with the primary server.
+  public func startStorybookServer(for sessionId: String, projectPath: String) async {
+    let key = "\(sessionId):storybook"
+    await startServer(for: key, projectPath: projectPath, forceFramework: .storybook)
+  }
+
+  /// Stops the Storybook server for a given session.
+  public func stopStorybookServer(for sessionId: String) {
+    stopServer(for: "\(sessionId):storybook")
+  }
+
+  /// Whether a Storybook server is running for the given session.
+  public func storybookState(for sessionId: String) -> DevServerState {
+    state(for: "\(sessionId):storybook")
+  }
+
   /// Stops all running servers. Called on app quit.
   public func stopAllServers() {
     for key in Array(servers.keys) {
@@ -200,12 +221,20 @@ public final class DevServerManager {
 
   // MARK: - Project Detection
 
+  /// Returns a `DetectedProject` for a specific framework, bypassing auto-detection.
+  private nonisolated static func detectProject(at projectPath: String, framework: ProjectFramework) -> DetectedProject {
+    return mapFrameworkToProject(framework, projectPath: projectPath)
+  }
+
   /// Detects the project framework from package.json and returns the appropriate server config.
   /// Uses shared `ProjectFramework.detect(at:)` for framework identification, then maps to
   /// the full `DetectedProject` with command, args, port, and readiness patterns.
   private nonisolated static func detectProject(at projectPath: String) -> DetectedProject {
     let framework = ProjectFramework.detect(at: projectPath)
+    return mapFrameworkToProject(framework, projectPath: projectPath)
+  }
 
+  private nonisolated static func mapFrameworkToProject(_ framework: ProjectFramework, projectPath: String) -> DetectedProject {
     switch framework {
     case .vite:
       return DetectedProject(
@@ -255,6 +284,29 @@ public final class DevServerManager {
         defaultPort: 4321,
         readinessPatterns: ["localhost:", "astro"]
       )
+    case .storybook:
+      // Storybook runs as a companion server, typically via "npm run storybook"
+      var scriptName = "storybook"
+      let fm = FileManager.default
+      let packageJsonPath = "\(projectPath)/package.json"
+      if let data = fm.contents(atPath: packageJsonPath),
+         let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+         let scripts = json["scripts"] as? [String: String] {
+        // Use "storybook" script if available, otherwise try "storybook:dev"
+        if scripts["storybook"] != nil {
+          scriptName = "storybook"
+        } else if scripts["storybook:dev"] != nil {
+          scriptName = "storybook:dev"
+        }
+      }
+      return DetectedProject(
+        framework: .storybook,
+        command: "npm",
+        arguments: ["run", scriptName, "--", "-p"],
+        defaultPort: 6006,
+        readinessPatterns: ["Storybook", "localhost:", "started"]
+      )
+
     case .unknown:
       // Has package.json with scripts but no recognized framework
       let fm = FileManager.default

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/DevServerManager.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/DevServerManager.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import Storybook
 
 // MARK: - DevServerManager
 
@@ -285,26 +286,13 @@ public final class DevServerManager {
         readinessPatterns: ["localhost:", "astro"]
       )
     case .storybook:
-      // Storybook runs as a companion server, typically via "npm run storybook"
-      var scriptName = "storybook"
-      let fm = FileManager.default
-      let packageJsonPath = "\(projectPath)/package.json"
-      if let data = fm.contents(atPath: packageJsonPath),
-         let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-         let scripts = json["scripts"] as? [String: String] {
-        // Use "storybook" script if available, otherwise try "storybook:dev"
-        if scripts["storybook"] != nil {
-          scriptName = "storybook"
-        } else if scripts["storybook:dev"] != nil {
-          scriptName = "storybook:dev"
-        }
-      }
+      let scriptName = StorybookDetector.storybookScript(at: projectPath) ?? "storybook"
       return DetectedProject(
         framework: .storybook,
         command: "npm",
         arguments: ["run", scriptName, "--", "-p"],
-        defaultPort: 6006,
-        readinessPatterns: ["Storybook", "localhost:", "started"]
+        defaultPort: StorybookDetector.defaultPort,
+        readinessPatterns: StorybookDetector.readinessPatterns
       )
 
     case .unknown:
@@ -541,6 +529,32 @@ public final class DevServerManager {
     if let pipes = outputPipes[key] {
       pipes.stdout.fileHandleForReading.readabilityHandler = nil
       pipes.stderr.fileHandleForReading.readabilityHandler = nil
+    }
+  }
+}
+
+// MARK: - StorybookService Conformance
+
+extension DevServerManager: StorybookService {
+  public func start(for sessionId: String, projectPath: String) async {
+    await startStorybookServer(for: sessionId, projectPath: projectPath)
+  }
+
+  public func stop(for sessionId: String) {
+    stopStorybookServer(for: sessionId)
+  }
+
+  public func state(for sessionId: String) -> StorybookServerState {
+    let key = "\(sessionId):storybook"
+    switch servers[key] {
+    case .idle, .detecting, .stopping, nil:
+      return .idle
+    case .starting, .waitingForReady:
+      return .starting
+    case .ready(let url):
+      return .ready(url: url)
+    case .failed(let error):
+      return .failed(error: error)
     }
   }
 }

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/WebPreviewAuthService.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/WebPreviewAuthService.swift
@@ -1,0 +1,131 @@
+//
+//  WebPreviewAuthService.swift
+//  AgentHub
+//
+//  Manages persistent cookie storage for web preview authentication.
+//  Each project gets its own isolated WKWebsiteDataStore so login sessions
+//  don't leak across projects. Opt-in via webPreviewPersistentAuthEnabled.
+//
+
+import Foundation
+import WebKit
+
+// MARK: - Protocol
+
+/// Provides per-project isolated web data stores for persistent authentication.
+///
+/// Security model:
+/// - Each project gets its own `WKWebsiteDataStore(forIdentifier:)` — cookies,
+///   localStorage, IndexedDB, and cache are fully siloed at the WebKit level.
+/// - Cookie scoping follows standard browser rules (same-origin only).
+/// - All data is local (`~/Library/WebKit/`), never synced or transmitted.
+/// - Feature is opt-in (default off). When disabled, returns a non-persistent store.
+protocol WebPreviewAuthServiceProtocol: Sendable {
+  @MainActor func dataStore(for projectPath: String) -> WKWebsiteDataStore
+  @MainActor func processPool(for projectPath: String) -> WKProcessPool
+  @MainActor func clearSession(for projectPath: String) async
+  @MainActor func clearAllSessions() async
+  @MainActor func hasPersistedAuth(for projectPath: String) -> Bool
+}
+
+// MARK: - Implementation
+
+@MainActor
+@Observable
+final class WebPreviewAuthService: WebPreviewAuthServiceProtocol {
+
+  static let shared = WebPreviewAuthService()
+
+  private var dataStores: [String: WKWebsiteDataStore] = [:]
+  private var processPools: [String: WKProcessPool] = [:]
+  private var nonPersistentStore: WKWebsiteDataStore?
+
+  private init() {}
+
+  /// Whether persistent auth is enabled (opt-in setting).
+  private var isEnabled: Bool {
+    UserDefaults.standard.bool(forKey: AgentHubDefaults.webPreviewPersistentAuthEnabled)
+  }
+
+  /// Returns the data store for the given project path.
+  /// When persistent auth is disabled, returns a non-persistent (ephemeral) store.
+  func dataStore(for projectPath: String) -> WKWebsiteDataStore {
+    guard isEnabled else {
+      if nonPersistentStore == nil {
+        nonPersistentStore = WKWebsiteDataStore.nonPersistent()
+      }
+      return nonPersistentStore!
+    }
+
+    if let existing = dataStores[projectPath] {
+      return existing
+    }
+
+    let id = resolveOrCreateIdentifier(for: projectPath)
+    let store = WKWebsiteDataStore(forIdentifier: id)
+    dataStores[projectPath] = store
+    return store
+  }
+
+  /// Returns a shared process pool for the given project, enabling cookie sharing
+  /// across multiple WKWebViews within the same project.
+  func processPool(for projectPath: String) -> WKProcessPool {
+    if let existing = processPools[projectPath] {
+      return existing
+    }
+    let pool = WKProcessPool()
+    processPools[projectPath] = pool
+    return pool
+  }
+
+  /// Removes all website data (cookies, localStorage, cache, etc.) for a specific project.
+  func clearSession(for projectPath: String) async {
+    guard let store = dataStores[projectPath] else { return }
+    let allTypes = WKWebsiteDataStore.allWebsiteDataTypes()
+    let records = await store.dataRecords(ofTypes: allTypes)
+    await store.removeData(ofTypes: allTypes, for: records)
+    dataStores.removeValue(forKey: projectPath)
+    processPools.removeValue(forKey: projectPath)
+  }
+
+  /// Removes all website data for every project and clears all stored identifiers.
+  func clearAllSessions() async {
+    for projectPath in Array(dataStores.keys) {
+      await clearSession(for: projectPath)
+    }
+    // Clear any identifiers for projects not currently loaded
+    UserDefaults.standard.removeObject(forKey: AgentHubDefaults.webPreviewDataStoreIdentifiers)
+  }
+
+  /// Whether there is a persistent data store created for this project.
+  func hasPersistedAuth(for projectPath: String) -> Bool {
+    isEnabled && dataStores[projectPath] != nil
+  }
+
+  // MARK: - Identifier Management
+
+  private func resolveOrCreateIdentifier(for projectPath: String) -> UUID {
+    var mapping = loadIdentifierMapping()
+    if let existing = mapping[projectPath], let uuid = UUID(uuidString: existing) {
+      return uuid
+    }
+    let newID = UUID()
+    mapping[projectPath] = newID.uuidString
+    saveIdentifierMapping(mapping)
+    return newID
+  }
+
+  private func loadIdentifierMapping() -> [String: String] {
+    guard let data = UserDefaults.standard.data(forKey: AgentHubDefaults.webPreviewDataStoreIdentifiers),
+          let mapping = try? JSONDecoder().decode([String: String].self, from: data) else {
+      return [:]
+    }
+    return mapping
+  }
+
+  private func saveIdentifierMapping(_ mapping: [String: String]) {
+    if let data = try? JSONEncoder().encode(mapping) {
+      UserDefaults.standard.set(data, forKey: AgentHubDefaults.webPreviewDataStoreIdentifiers)
+    }
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringCardView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringCardView.swift
@@ -668,6 +668,27 @@ public struct MonitoringCardView: View {
             : "Preview localhost web app")
         }
 
+        // Storybook button — visible when project has a .storybook/ config
+        if ProjectFramework.hasStorybook(at: session.projectPath) {
+          Button(action: {
+            Task {
+              await DevServerManager.shared.startStorybookServer(
+                for: session.id,
+                projectPath: session.projectPath
+              )
+            }
+            presentWebPreview()
+          }) {
+            HStack(spacing: 4) {
+              Image(systemName: "book.pages")
+                .font(.caption2)
+              Text("Storybook")
+            }
+          }
+          .buttonStyle(.agentHubOutlined)
+          .help("Browse Storybook components")
+        }
+
         // Mermaid diagram button (only visible when mermaid content is detected)
         if state?.hasMermaidContent == true {
           Button(action: {

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/WebPreviewView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/WebPreviewView.swift
@@ -10,6 +10,7 @@
 import ClaudeCodeSDK
 import SwiftUI
 import Canvas
+import WebKit
 
 private enum WebPreviewInspectBehavior: String, CaseIterable, Identifiable {
   case input
@@ -403,6 +404,21 @@ public struct WebPreviewView: View {
         .padding(4)
         .background(Color.secondary.opacity(0.12))
         .clipShape(RoundedRectangle(cornerRadius: 6))
+      }
+
+      // Auth status indicator — shows when persistent auth is active for this project
+      if case .devServer = resolution {
+        let authService = WebPreviewAuthService.shared
+        let hasAuth = authService.hasPersistedAuth(for: projectPath)
+        Button {
+          Task { await authService.clearSession(for: projectPath) }
+        } label: {
+          Image(systemName: hasAuth ? "lock.fill" : "lock.open")
+            .font(.system(size: 11, weight: .medium))
+            .foregroundColor(hasAuth ? .green : .secondary)
+        }
+        .buttonStyle(.plain)
+        .help(hasAuth ? "Persistent session active — click to clear" : "No persistent session")
       }
 
       // Inspect toggle

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/DevServerManagerTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/DevServerManagerTests.swift
@@ -22,4 +22,29 @@ struct DevServerManagerTests {
 
     #expect(url.absoluteString == "http://localhost:3000")
   }
+
+  @Test("Storybook server uses compound key with :storybook suffix")
+  func storybookServerUsesCompoundKey() {
+    let sessionId = "test-\(UUID().uuidString)"
+    let storybookKey = "\(sessionId):storybook"
+
+    // Initially idle
+    #expect(DevServerManager.shared.storybookState(for: sessionId) == .idle)
+    #expect(DevServerManager.shared.state(for: storybookKey) == .idle)
+
+    // Connect an external storybook server to verify the compound key
+    let url = URL(string: "http://localhost:6006")!
+    DevServerManager.shared.connectToExistingServer(for: storybookKey, url: url)
+    defer { DevServerManager.shared.stopServer(for: storybookKey) }
+
+    // Should be ready under the compound key
+    guard case .ready(let readyURL) = DevServerManager.shared.storybookState(for: sessionId) else {
+      Issue.record("Expected ready storybook server state")
+      return
+    }
+    #expect(readyURL.absoluteString == "http://localhost:6006")
+
+    // The primary session key should still be idle
+    #expect(DevServerManager.shared.state(for: sessionId) == .idle)
+  }
 }

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/StorybookDetectionTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/StorybookDetectionTests.swift
@@ -1,103 +1,69 @@
 import Foundation
 import Testing
+import Storybook
 
 @testable import AgentHubCore
 
-@Suite("Storybook Detection")
-struct StorybookDetectionTests {
+@Suite("Storybook Integration")
+struct StorybookIntegrationTests {
 
-  // MARK: - ProjectFramework.hasStorybook
+  // MARK: - ProjectFramework delegates to StorybookDetector
 
-  @Test("Detects storybook via .storybook directory")
-  func detectsStorybookViaDirectory() throws {
+  @Test("ProjectFramework.hasStorybook delegates to StorybookDetector")
+  func delegatesToStorybookDetector() throws {
     let tmpDir = FileManager.default.temporaryDirectory
       .appendingPathComponent("storybook-test-\(UUID().uuidString)")
     try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
     defer { try? FileManager.default.removeItem(at: tmpDir) }
 
-    // No .storybook/ directory yet
+    // Both should agree: no storybook
     #expect(!ProjectFramework.hasStorybook(at: tmpDir.path))
+    #expect(!StorybookDetector.hasStorybook(at: tmpDir.path))
 
-    // Create .storybook/ directory
-    let storybookDir = tmpDir.appendingPathComponent(".storybook")
-    try FileManager.default.createDirectory(at: storybookDir, withIntermediateDirectories: true)
+    // Add .storybook/ directory
+    try FileManager.default.createDirectory(
+      at: tmpDir.appendingPathComponent(".storybook"),
+      withIntermediateDirectories: true
+    )
 
+    // Both should agree: has storybook
     #expect(ProjectFramework.hasStorybook(at: tmpDir.path))
+    #expect(StorybookDetector.hasStorybook(at: tmpDir.path))
   }
-
-  @Test("Detects storybook via package.json storybook script")
-  func detectsStorybookViaScript() throws {
-    let tmpDir = FileManager.default.temporaryDirectory
-      .appendingPathComponent("storybook-test-\(UUID().uuidString)")
-    try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
-    defer { try? FileManager.default.removeItem(at: tmpDir) }
-
-    let packageJson = """
-    {
-      "name": "test-project",
-      "scripts": {
-        "dev": "vite",
-        "storybook": "storybook dev -p 6006"
-      }
-    }
-    """
-    let packageJsonPath = tmpDir.appendingPathComponent("package.json")
-    try packageJson.write(to: packageJsonPath, atomically: true, encoding: .utf8)
-
-    #expect(ProjectFramework.hasStorybook(at: tmpDir.path))
-  }
-
-  @Test("Detects storybook via @storybook/ devDependency")
-  func detectsStorybookViaDevDependency() throws {
-    let tmpDir = FileManager.default.temporaryDirectory
-      .appendingPathComponent("storybook-test-\(UUID().uuidString)")
-    try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
-    defer { try? FileManager.default.removeItem(at: tmpDir) }
-
-    let packageJson = """
-    {
-      "name": "test-project",
-      "devDependencies": {
-        "@storybook/react": "^7.0.0",
-        "typescript": "^5.0.0"
-      }
-    }
-    """
-    let packageJsonPath = tmpDir.appendingPathComponent("package.json")
-    try packageJson.write(to: packageJsonPath, atomically: true, encoding: .utf8)
-
-    #expect(ProjectFramework.hasStorybook(at: tmpDir.path))
-  }
-
-  @Test("Returns false when no storybook indicators present")
-  func returnsFalseWhenNoStorybook() throws {
-    let tmpDir = FileManager.default.temporaryDirectory
-      .appendingPathComponent("storybook-test-\(UUID().uuidString)")
-    try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
-    defer { try? FileManager.default.removeItem(at: tmpDir) }
-
-    let packageJson = """
-    {
-      "name": "test-project",
-      "scripts": { "dev": "vite" },
-      "devDependencies": { "vite": "^5.0.0" }
-    }
-    """
-    let packageJsonPath = tmpDir.appendingPathComponent("package.json")
-    try packageJson.write(to: packageJsonPath, atomically: true, encoding: .utf8)
-
-    #expect(!ProjectFramework.hasStorybook(at: tmpDir.path))
-  }
-
-  @Test("Returns false for nonexistent path")
-  func returnsFalseForNonexistentPath() {
-    #expect(!ProjectFramework.hasStorybook(at: "/nonexistent/path/\(UUID().uuidString)"))
-  }
-
-  // MARK: - ProjectFramework enum properties
 
   @Test("Storybook framework requires dev server")
   func storybookRequiresDevServer() {
     #expect(ProjectFramework.storybook.requiresDevServer)
+  }
+
+  // MARK: - DevServerManager conforms to StorybookService
+
+  @MainActor
+  @Test("DevServerManager conforms to StorybookService protocol")
+  func devServerManagerConformsToStorybookService() {
+    let service: any StorybookService = DevServerManager.shared
+    let sessionId = "conformance-test-\(UUID().uuidString)"
+
+    // Initially idle
+    #expect(service.state(for: sessionId) == .idle)
+  }
+
+  @MainActor
+  @Test("StorybookService state maps DevServerState correctly")
+  func storybookServiceStateMapsCorrectly() {
+    let sessionId = "state-test-\(UUID().uuidString)"
+    let storybookKey = "\(sessionId):storybook"
+
+    // Connect an external server via the compound key
+    let url = URL(string: "http://localhost:6006")!
+    DevServerManager.shared.connectToExistingServer(for: storybookKey, url: url)
+    defer { DevServerManager.shared.stopServer(for: storybookKey) }
+
+    let service: any StorybookService = DevServerManager.shared
+    guard case .ready(let readyURL) = service.state(for: sessionId) else {
+      Issue.record("Expected .ready state from StorybookService")
+      return
+    }
+    #expect(readyURL.absoluteString == "http://localhost:6006")
   }
 }

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/StorybookDetectionTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/StorybookDetectionTests.swift
@@ -1,0 +1,103 @@
+import Foundation
+import Testing
+
+@testable import AgentHubCore
+
+@Suite("Storybook Detection")
+struct StorybookDetectionTests {
+
+  // MARK: - ProjectFramework.hasStorybook
+
+  @Test("Detects storybook via .storybook directory")
+  func detectsStorybookViaDirectory() throws {
+    let tmpDir = FileManager.default.temporaryDirectory
+      .appendingPathComponent("storybook-test-\(UUID().uuidString)")
+    try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+    // No .storybook/ directory yet
+    #expect(!ProjectFramework.hasStorybook(at: tmpDir.path))
+
+    // Create .storybook/ directory
+    let storybookDir = tmpDir.appendingPathComponent(".storybook")
+    try FileManager.default.createDirectory(at: storybookDir, withIntermediateDirectories: true)
+
+    #expect(ProjectFramework.hasStorybook(at: tmpDir.path))
+  }
+
+  @Test("Detects storybook via package.json storybook script")
+  func detectsStorybookViaScript() throws {
+    let tmpDir = FileManager.default.temporaryDirectory
+      .appendingPathComponent("storybook-test-\(UUID().uuidString)")
+    try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+    let packageJson = """
+    {
+      "name": "test-project",
+      "scripts": {
+        "dev": "vite",
+        "storybook": "storybook dev -p 6006"
+      }
+    }
+    """
+    let packageJsonPath = tmpDir.appendingPathComponent("package.json")
+    try packageJson.write(to: packageJsonPath, atomically: true, encoding: .utf8)
+
+    #expect(ProjectFramework.hasStorybook(at: tmpDir.path))
+  }
+
+  @Test("Detects storybook via @storybook/ devDependency")
+  func detectsStorybookViaDevDependency() throws {
+    let tmpDir = FileManager.default.temporaryDirectory
+      .appendingPathComponent("storybook-test-\(UUID().uuidString)")
+    try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+    let packageJson = """
+    {
+      "name": "test-project",
+      "devDependencies": {
+        "@storybook/react": "^7.0.0",
+        "typescript": "^5.0.0"
+      }
+    }
+    """
+    let packageJsonPath = tmpDir.appendingPathComponent("package.json")
+    try packageJson.write(to: packageJsonPath, atomically: true, encoding: .utf8)
+
+    #expect(ProjectFramework.hasStorybook(at: tmpDir.path))
+  }
+
+  @Test("Returns false when no storybook indicators present")
+  func returnsFalseWhenNoStorybook() throws {
+    let tmpDir = FileManager.default.temporaryDirectory
+      .appendingPathComponent("storybook-test-\(UUID().uuidString)")
+    try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+    let packageJson = """
+    {
+      "name": "test-project",
+      "scripts": { "dev": "vite" },
+      "devDependencies": { "vite": "^5.0.0" }
+    }
+    """
+    let packageJsonPath = tmpDir.appendingPathComponent("package.json")
+    try packageJson.write(to: packageJsonPath, atomically: true, encoding: .utf8)
+
+    #expect(!ProjectFramework.hasStorybook(at: tmpDir.path))
+  }
+
+  @Test("Returns false for nonexistent path")
+  func returnsFalseForNonexistentPath() {
+    #expect(!ProjectFramework.hasStorybook(at: "/nonexistent/path/\(UUID().uuidString)"))
+  }
+
+  // MARK: - ProjectFramework enum properties
+
+  @Test("Storybook framework requires dev server")
+  func storybookRequiresDevServer() {
+    #expect(ProjectFramework.storybook.requiresDevServer)
+  }
+}

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/WebPreviewAuthServiceTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/WebPreviewAuthServiceTests.swift
@@ -1,0 +1,111 @@
+import Foundation
+import Testing
+import WebKit
+
+@testable import AgentHubCore
+
+@MainActor
+@Suite("WebPreviewAuthService")
+struct WebPreviewAuthServiceTests {
+
+  // MARK: - Data Store Isolation
+
+  @Test("Returns same data store for same project path")
+  func returnsSameDataStoreForSameProject() {
+    // Enable persistent auth for this test
+    UserDefaults.standard.set(true, forKey: AgentHubDefaults.webPreviewPersistentAuthEnabled)
+    defer { UserDefaults.standard.removeObject(forKey: AgentHubDefaults.webPreviewPersistentAuthEnabled) }
+
+    let service = WebPreviewAuthService.shared
+    let path = "/test/project/\(UUID().uuidString)"
+
+    let store1 = service.dataStore(for: path)
+    let store2 = service.dataStore(for: path)
+
+    #expect(store1 === store2)
+  }
+
+  @Test("Returns different data stores for different projects")
+  func returnsDifferentDataStoresForDifferentProjects() {
+    UserDefaults.standard.set(true, forKey: AgentHubDefaults.webPreviewPersistentAuthEnabled)
+    defer { UserDefaults.standard.removeObject(forKey: AgentHubDefaults.webPreviewPersistentAuthEnabled) }
+
+    let service = WebPreviewAuthService.shared
+    let pathA = "/test/project-a/\(UUID().uuidString)"
+    let pathB = "/test/project-b/\(UUID().uuidString)"
+
+    let storeA = service.dataStore(for: pathA)
+    let storeB = service.dataStore(for: pathB)
+
+    #expect(storeA !== storeB)
+  }
+
+  // MARK: - Process Pool Sharing
+
+  @Test("Returns same process pool for same project")
+  func returnsSameProcessPoolForSameProject() {
+    let service = WebPreviewAuthService.shared
+    let path = "/test/project/\(UUID().uuidString)"
+
+    let pool1 = service.processPool(for: path)
+    let pool2 = service.processPool(for: path)
+
+    #expect(pool1 === pool2)
+  }
+
+  @Test("Returns different process pools for different projects")
+  func returnsDifferentProcessPoolsForDifferentProjects() {
+    let service = WebPreviewAuthService.shared
+    let pathA = "/test/project-a/\(UUID().uuidString)"
+    let pathB = "/test/project-b/\(UUID().uuidString)"
+
+    let poolA = service.processPool(for: pathA)
+    let poolB = service.processPool(for: pathB)
+
+    #expect(poolA !== poolB)
+  }
+
+  // MARK: - Default Off Behavior
+
+  @Test("Returns non-persistent store when feature is disabled")
+  func returnsNonPersistentStoreWhenDisabled() {
+    UserDefaults.standard.set(false, forKey: AgentHubDefaults.webPreviewPersistentAuthEnabled)
+    defer { UserDefaults.standard.removeObject(forKey: AgentHubDefaults.webPreviewPersistentAuthEnabled) }
+
+    let service = WebPreviewAuthService.shared
+    let path = "/test/project/\(UUID().uuidString)"
+
+    let store = service.dataStore(for: path)
+
+    // Non-persistent store should not be the default store
+    #expect(!store.isPersistent)
+  }
+
+  @Test("hasPersistedAuth returns false when feature is disabled")
+  func hasPersistedAuthReturnsFalseWhenDisabled() {
+    UserDefaults.standard.set(false, forKey: AgentHubDefaults.webPreviewPersistentAuthEnabled)
+    defer { UserDefaults.standard.removeObject(forKey: AgentHubDefaults.webPreviewPersistentAuthEnabled) }
+
+    let service = WebPreviewAuthService.shared
+    #expect(!service.hasPersistedAuth(for: "/any/path"))
+  }
+
+  // MARK: - Clear Session
+
+  @Test("Clear session removes data store for project")
+  func clearSessionRemovesDataStore() async {
+    UserDefaults.standard.set(true, forKey: AgentHubDefaults.webPreviewPersistentAuthEnabled)
+    defer { UserDefaults.standard.removeObject(forKey: AgentHubDefaults.webPreviewPersistentAuthEnabled) }
+
+    let service = WebPreviewAuthService.shared
+    let path = "/test/project/\(UUID().uuidString)"
+
+    // Create a store
+    _ = service.dataStore(for: path)
+    #expect(service.hasPersistedAuth(for: path))
+
+    // Clear it
+    await service.clearSession(for: path)
+    #expect(!service.hasPersistedAuth(for: path))
+  }
+}

--- a/app/modules/Storybook/Package.swift
+++ b/app/modules/Storybook/Package.swift
@@ -1,0 +1,33 @@
+// swift-tools-version: 6.0
+
+import PackageDescription
+
+let package = Package(
+  name: "Storybook",
+  platforms: [
+    .macOS(.v14)
+  ],
+  products: [
+    .library(
+      name: "Storybook",
+      targets: ["Storybook"]
+    ),
+  ],
+  targets: [
+    .target(
+      name: "Storybook",
+      path: "Sources/Storybook",
+      swiftSettings: [
+        .swiftLanguageMode(.v5)
+      ]
+    ),
+    .testTarget(
+      name: "StorybookTests",
+      dependencies: ["Storybook"],
+      path: "Tests/StorybookTests",
+      swiftSettings: [
+        .swiftLanguageMode(.v5)
+      ]
+    ),
+  ]
+)

--- a/app/modules/Storybook/Sources/Storybook/StorybookDetector.swift
+++ b/app/modules/Storybook/Sources/Storybook/StorybookDetector.swift
@@ -1,0 +1,82 @@
+//
+//  StorybookDetector.swift
+//  Storybook
+//
+//  Detects whether a project has Storybook configured by checking for
+//  .storybook/ directory, package.json scripts, or @storybook/ dependencies.
+//
+
+import Foundation
+
+/// Detects Storybook presence in a project directory.
+///
+/// Detection checks (in order):
+/// 1. `.storybook/` config directory at project root
+/// 2. `"storybook"` script key in `package.json` scripts
+/// 3. Any `@storybook/*` package in `devDependencies`
+///
+/// ```swift
+/// if StorybookDetector.hasStorybook(at: "/path/to/project") {
+///   // Show Storybook UI, start server, etc.
+/// }
+/// ```
+public enum StorybookDetector {
+
+  /// Whether the project at the given path has Storybook configured.
+  public static func hasStorybook(at projectPath: String) -> Bool {
+    let fm = FileManager.default
+
+    // 1. Check for .storybook/ config directory
+    if fm.fileExists(atPath: "\(projectPath)/.storybook") {
+      return true
+    }
+
+    // 2. Check package.json for storybook scripts or dependencies
+    guard let packageJSON = readPackageJSON(at: projectPath) else {
+      return false
+    }
+
+    if let scripts = packageJSON["scripts"] as? [String: String],
+       scripts["storybook"] != nil {
+      return true
+    }
+
+    if let devDeps = packageJSON["devDependencies"] as? [String: Any],
+       devDeps.keys.contains(where: { $0.hasPrefix("@storybook/") }) {
+      return true
+    }
+
+    return false
+  }
+
+  /// Returns the Storybook start script name from package.json, if found.
+  /// Checks for `"storybook"` first, then `"storybook:dev"`.
+  public static func storybookScript(at projectPath: String) -> String? {
+    guard let packageJSON = readPackageJSON(at: projectPath),
+          let scripts = packageJSON["scripts"] as? [String: String] else {
+      return nil
+    }
+    if scripts["storybook"] != nil { return "storybook" }
+    if scripts["storybook:dev"] != nil { return "storybook:dev" }
+    return nil
+  }
+
+  /// Default port for Storybook dev server.
+  public static let defaultPort: Int = 6006
+
+  /// Stdout patterns that indicate the Storybook server is ready.
+  public static let readinessPatterns: [String] = ["Storybook", "localhost:", "started"]
+
+  // MARK: - Private
+
+  private static func readPackageJSON(at projectPath: String) -> [String: Any]? {
+    let fm = FileManager.default
+    let path = "\(projectPath)/package.json"
+    guard fm.fileExists(atPath: path),
+          let data = fm.contents(atPath: path),
+          let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+      return nil
+    }
+    return json
+  }
+}

--- a/app/modules/Storybook/Sources/Storybook/StorybookServiceProtocol.swift
+++ b/app/modules/Storybook/Sources/Storybook/StorybookServiceProtocol.swift
@@ -1,0 +1,47 @@
+//
+//  StorybookServiceProtocol.swift
+//  Storybook
+//
+//  Protocol for managing Storybook dev server lifecycle.
+//  AgentHubCore (or any consumer) provides the concrete implementation
+//  by conforming DevServerManager or a wrapper to this protocol.
+//
+
+import Foundation
+
+/// State of a Storybook server instance.
+public enum StorybookServerState: Equatable, Sendable {
+  case idle
+  case starting
+  case ready(url: URL)
+  case failed(error: String)
+}
+
+/// Manages Storybook dev server lifecycle for a session.
+///
+/// Consumers implement this protocol to wire Storybook server management
+/// into their existing dev server infrastructure.
+///
+/// ```swift
+/// import Storybook
+///
+/// // In your app:
+/// let service: StorybookService = MyStorybookService()
+/// await service.start(for: sessionId, projectPath: path)
+///
+/// if case .ready(let url) = service.state(for: sessionId) {
+///   // Navigate web preview to url
+/// }
+/// ```
+@MainActor
+public protocol StorybookService: Sendable {
+  /// Starts a Storybook server for the given session at the specified project path.
+  /// Idempotent — if already running, returns immediately.
+  func start(for sessionId: String, projectPath: String) async
+
+  /// Stops the Storybook server for the given session.
+  func stop(for sessionId: String)
+
+  /// Returns the current state of the Storybook server for a session.
+  func state(for sessionId: String) -> StorybookServerState
+}

--- a/app/modules/Storybook/Tests/StorybookTests/StorybookDetectorTests.swift
+++ b/app/modules/Storybook/Tests/StorybookTests/StorybookDetectorTests.swift
@@ -1,0 +1,142 @@
+import Foundation
+import Testing
+
+@testable import Storybook
+
+@Suite("StorybookDetector")
+struct StorybookDetectorTests {
+
+  // MARK: - hasStorybook
+
+  @Test("Detects storybook via .storybook directory")
+  func detectsViaDirectory() throws {
+    let dir = makeTestDir()
+    defer { cleanup(dir) }
+
+    #expect(!StorybookDetector.hasStorybook(at: dir.path))
+
+    try FileManager.default.createDirectory(
+      at: dir.appendingPathComponent(".storybook"),
+      withIntermediateDirectories: true
+    )
+
+    #expect(StorybookDetector.hasStorybook(at: dir.path))
+  }
+
+  @Test("Detects storybook via package.json storybook script")
+  func detectsViaScript() throws {
+    let dir = makeTestDir()
+    defer { cleanup(dir) }
+
+    try writePackageJSON(to: dir, content: """
+    {
+      "scripts": { "dev": "vite", "storybook": "storybook dev -p 6006" }
+    }
+    """)
+
+    #expect(StorybookDetector.hasStorybook(at: dir.path))
+  }
+
+  @Test("Detects storybook via @storybook/ devDependency")
+  func detectsViaDevDependency() throws {
+    let dir = makeTestDir()
+    defer { cleanup(dir) }
+
+    try writePackageJSON(to: dir, content: """
+    {
+      "devDependencies": { "@storybook/react": "^7.0.0", "typescript": "^5.0.0" }
+    }
+    """)
+
+    #expect(StorybookDetector.hasStorybook(at: dir.path))
+  }
+
+  @Test("Returns false when no storybook indicators present")
+  func returnsFalseWithoutStorybook() throws {
+    let dir = makeTestDir()
+    defer { cleanup(dir) }
+
+    try writePackageJSON(to: dir, content: """
+    {
+      "scripts": { "dev": "vite" },
+      "devDependencies": { "vite": "^5.0.0" }
+    }
+    """)
+
+    #expect(!StorybookDetector.hasStorybook(at: dir.path))
+  }
+
+  @Test("Returns false for nonexistent path")
+  func returnsFalseForBadPath() {
+    #expect(!StorybookDetector.hasStorybook(at: "/nonexistent/\(UUID().uuidString)"))
+  }
+
+  // MARK: - storybookScript
+
+  @Test("Returns storybook script name from package.json")
+  func returnsScriptName() throws {
+    let dir = makeTestDir()
+    defer { cleanup(dir) }
+
+    try writePackageJSON(to: dir, content: """
+    {
+      "scripts": { "storybook": "storybook dev -p 6006" }
+    }
+    """)
+
+    #expect(StorybookDetector.storybookScript(at: dir.path) == "storybook")
+  }
+
+  @Test("Falls back to storybook:dev script")
+  func fallsBackToStorybookDev() throws {
+    let dir = makeTestDir()
+    defer { cleanup(dir) }
+
+    try writePackageJSON(to: dir, content: """
+    {
+      "scripts": { "storybook:dev": "start-storybook -p 6006" }
+    }
+    """)
+
+    #expect(StorybookDetector.storybookScript(at: dir.path) == "storybook:dev")
+  }
+
+  @Test("Returns nil when no storybook script")
+  func returnsNilWithoutScript() throws {
+    let dir = makeTestDir()
+    defer { cleanup(dir) }
+
+    try writePackageJSON(to: dir, content: """
+    { "scripts": { "dev": "vite" } }
+    """)
+
+    #expect(StorybookDetector.storybookScript(at: dir.path) == nil)
+  }
+
+  // MARK: - Constants
+
+  @Test("Default port is 6006")
+  func defaultPort() {
+    #expect(StorybookDetector.defaultPort == 6006)
+  }
+
+  // MARK: - Helpers
+
+  private func makeTestDir() -> URL {
+    FileManager.default.temporaryDirectory
+      .appendingPathComponent("storybook-test-\(UUID().uuidString)")
+  }
+
+  private func cleanup(_ url: URL) {
+    try? FileManager.default.removeItem(at: url)
+  }
+
+  private func writePackageJSON(to dir: URL, content: String) throws {
+    try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    try content.write(
+      to: dir.appendingPathComponent("package.json"),
+      atomically: true,
+      encoding: .utf8
+    )
+  }
+}


### PR DESCRIPTION
## Summary
This PR adds two major features to AgentHub's web preview system:

1. **Persistent Web Preview Authentication** — Opt-in cookie/session storage that isolates authentication data per project using WebKit's `WKWebsiteDataStore`
2. **Storybook Support** — Detect and launch Storybook servers as companion dev servers alongside primary frameworks

## Key Changes

### Web Preview Authentication Service
- New `WebPreviewAuthService` manages per-project isolated `WKWebsiteDataStore` instances
- Each project gets its own UUID-identified data store — cookies, localStorage, IndexedDB, and cache are fully siloed at the WebKit level
- Feature is **opt-in** (disabled by default); when disabled, uses ephemeral non-persistent stores
- Provides methods to clear sessions per-project or globally
- Includes identifier persistence via UserDefaults to maintain store mappings across app restarts
- Full test coverage for data store isolation, process pool sharing, and session clearing

### Storybook Framework Detection & Server Management
- Added `.storybook` case to `ProjectFramework` enum
- New `ProjectFramework.hasStorybook(at:)` static method detects Storybook via:
  - `.storybook/` config directory presence
  - `storybook` or `storybook:dev` npm scripts
  - `@storybook/*` devDependencies
- Extended `DevServerManager` with Storybook-specific methods:
  - `startStorybookServer(for:projectPath:)` — launches Storybook on port 6006
  - `stopStorybookServer(for:)` — stops Storybook server
  - `storybookState(for:)` — queries Storybook server state
- Uses compound key pattern `"{sessionId}:storybook"` to coexist with primary dev server
- Supports optional `forceFramework` parameter in `startServer()` for explicit framework selection

### UI Enhancements
- **MonitoringCardView**: Added "Storybook" button that appears when `.storybook/` is detected
- **WebPreviewView**: Added auth status indicator showing lock icon when persistent session is active; clicking clears the session

### Configuration
- New UserDefaults keys in `AgentHubDefaults`:
  - `webPreviewPersistentAuthEnabled` — feature toggle (default: false)
  - `webPreviewDataStoreIdentifiers` — JSON-encoded project→UUID mapping
- Exposed `webPreviewAuthService` via `AgentHubProvider`

## Implementation Details
- All auth service operations are `@MainActor` to ensure thread-safe WebKit access
- Identifier mapping uses JSON serialization for persistence and recovery
- Storybook detection is framework-agnostic — projects can have both a primary framework (e.g., Vite) and Storybook
- Comprehensive test suite covers isolation, pooling, feature toggle behavior, and session management

https://claude.ai/code/session_01G5hPxnWoVZV6AWm6LTztTL