### PR TITLE
Add approval-priority sorting for sessions awaiting tool approval

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubDefaults.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubDefaults.swift
@@ -133,6 +133,10 @@ public enum AgentHubDefaults {
   /// Type: Bool (default: false)
   public static let fileExplorerAlwaysModal = "\(keyPrefix)features.fileExplorerAlwaysModal"
 
+  /// Whether sessions awaiting approval are sorted to the top of the Hub and selected sessions panels
+  /// Type: Bool (default: true)
+  public static let approvalPrioritySorting = "\(keyPrefix)hub.approvalPrioritySorting"
+
   /// Whether debug-only web preview design tools are enabled
   /// Type: Bool (default: true in debug)
   public static let webPreviewAdvancedEditingEnabled = "\(keyPrefix)developer.webPreviewAdvancedEditingEnabled"

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringPanelView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringPanelView.swift
@@ -69,6 +69,31 @@ private struct ModuleSectionHeader: View {
   }
 }
 
+// MARK: - ApprovalSectionHeader
+
+/// Section header for sessions awaiting tool approval
+private struct ApprovalSectionHeader: View {
+  let sessionCount: Int
+
+  var body: some View {
+    HStack(spacing: 6) {
+      Image(systemName: "exclamationmark.circle.fill")
+        .foregroundColor(.yellow)
+        .font(.caption)
+      Text("Requires Approval")
+        .font(.secondarySmall)
+        .foregroundColor(.yellow)
+      Spacer()
+      Text("\(sessionCount)")
+        .font(.secondarySmall)
+        .foregroundColor(.secondary)
+    }
+    .padding(.horizontal, 4)
+    .padding(.top, 6)
+    .padding(.bottom, 10)
+  }
+}
+
 // MARK: - MonitoringItem
 
 /// Unified type for both pending and monitored sessions in the monitoring panel
@@ -106,6 +131,8 @@ public struct MonitoringPanelView: View {
   private var previousLayoutModeRawValue: Int = -1
   @AppStorage(AgentHubDefaults.flatSessionLayout)
   private var flatSessionLayout: Bool = false
+  @AppStorage(AgentHubDefaults.approvalPrioritySorting)
+  private var approvalPrioritySorting: Bool = true
   @Environment(\.colorScheme) private var colorScheme
   @Environment(\.runtimeTheme) private var runtimeTheme
   @State private var cardHeights: [String: CGFloat] = [:]
@@ -170,9 +197,20 @@ public struct MonitoringPanelView: View {
     return allItems
   }
 
+  /// Items awaiting approval, sorted by approval timestamp ascending (oldest-waiting first)
+  private var approvalItems: [MonitoringItem] {
+    guard approvalPrioritySorting else { return [] }
+    return visibleItems
+      .filter { isAwaitingApproval($0) }
+      .sorted { (approvalTimestamp($0) ?? .distantFuture) < (approvalTimestamp($1) ?? .distantFuture) }
+  }
+
   /// All sessions (pending + monitored) grouped by module (main repository path)
   private var groupedMonitoredSessions: [(modulePath: String, items: [MonitoringItem])] {
-    let grouped = Dictionary(grouping: visibleItems) { findModulePath(for: $0) }
+    let itemsToGroup = approvalPrioritySorting
+      ? visibleItems.filter { !isAwaitingApproval($0) }
+      : visibleItems
+    let grouped = Dictionary(grouping: itemsToGroup) { findModulePath(for: $0) }
     return grouped.sorted { $0.key < $1.key }
       .map { (modulePath: $0.key, items: $0.value.sorted { item1, item2 in
         // Sort by timestamp descending (newest first)
@@ -181,7 +219,7 @@ public struct MonitoringPanelView: View {
   }
 
   private var flatSortedItems: [MonitoringItem] {
-    groupedMonitoredSessions.flatMap { $0.items }
+    approvalItems + groupedMonitoredSessions.flatMap { $0.items }
   }
 
   /// Helper to get timestamp for sorting MonitoringItems
@@ -189,6 +227,20 @@ public struct MonitoringPanelView: View {
     switch item {
     case .pending(let p): return p.startedAt
     case .monitored(let session, _): return session.lastActivityAt
+    }
+  }
+
+  private func isAwaitingApproval(_ item: MonitoringItem) -> Bool {
+    switch item {
+    case .pending: return false
+    case .monitored(_, let state): return state?.isAwaitingApproval ?? false
+    }
+  }
+
+  private func approvalTimestamp(_ item: MonitoringItem) -> Date? {
+    switch item {
+    case .pending: return nil
+    case .monitored(_, let state): return state?.pendingToolUse?.timestamp
     }
   }
 
@@ -655,6 +707,16 @@ public struct MonitoringPanelView: View {
   @ViewBuilder
   private var listModeGroupedContent: some View {
     VStack(alignment: .leading, spacing: 1) {
+      if !approvalItems.isEmpty {
+        VStack(alignment: .leading, spacing: 1) {
+          ApprovalSectionHeader(sessionCount: approvalItems.count)
+
+          ForEach(approvalItems) { item in
+            listModeCard(for: item)
+          }
+        }
+      }
+
       ForEach(groupedMonitoredSessions, id: \.modulePath) { group in
         VStack(alignment: .leading, spacing: 1) {
           ModuleSectionHeader(
@@ -672,6 +734,14 @@ public struct MonitoringPanelView: View {
 
   @ViewBuilder
   private var monitoredSessionsGroupedContent: some View {
+    if !approvalItems.isEmpty {
+      Section(header: ApprovalSectionHeader(sessionCount: approvalItems.count)) {
+        ForEach(approvalItems) { item in
+          itemCardView(for: item)
+        }
+      }
+    }
+
     ForEach(groupedMonitoredSessions, id: \.modulePath) { group in
       Section(header: ModuleSectionHeader(
         name: URL(fileURLWithPath: group.modulePath).lastPathComponent,

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderMonitoringPanelView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderMonitoringPanelView.swift
@@ -125,6 +125,31 @@ private struct ModuleSectionHeader: View {
   }
 }
 
+// MARK: - ApprovalSectionHeader
+
+/// Section header for sessions awaiting tool approval
+private struct ApprovalSectionHeader: View {
+  let sessionCount: Int
+
+  var body: some View {
+    HStack(spacing: 6) {
+      Image(systemName: "exclamationmark.circle.fill")
+        .foregroundColor(.yellow)
+        .font(.caption)
+      Text("Requires Approval")
+        .font(.secondarySmall)
+        .foregroundColor(.yellow)
+      Spacer()
+      Text("\(sessionCount)")
+        .font(.secondarySmall)
+        .foregroundColor(.secondary)
+    }
+    .padding(.horizontal, 4)
+    .padding(.top, 6)
+    .padding(.bottom, 10)
+  }
+}
+
 // MARK: - HubFilterControl
 
 struct HubFilterControl: View {
@@ -259,6 +284,8 @@ public struct MultiProviderMonitoringPanelView: View {
   private var previousLayoutModeRawValue: Int = -1
   @AppStorage(AgentHubDefaults.flatSessionLayout)
   private var flatSessionLayout: Bool = false
+  @AppStorage(AgentHubDefaults.approvalPrioritySorting)
+  private var approvalPrioritySorting: Bool = true
   @AppStorage(AgentHubDefaults.fileExplorerAlwaysModal)
   private var fileExplorerAlwaysModal: Bool = false
   @State private var showQuickFilePicker = false
@@ -1066,6 +1093,16 @@ public struct MultiProviderMonitoringPanelView: View {
   @ViewBuilder
   private var listModeGroupedContent: some View {
     VStack(alignment: .leading, spacing: 18) {
+      if !approvalItems.isEmpty {
+        VStack(alignment: .leading, spacing: 12) {
+          ApprovalSectionHeader(sessionCount: approvalItems.count)
+
+          ForEach(approvalItems) { item in
+            listModeCard(for: item)
+          }
+        }
+      }
+
       ForEach(groupedMonitoredSessions, id: \.modulePath) { group in
         VStack(alignment: .leading, spacing: 12) {
           ModuleSectionHeader(
@@ -1083,6 +1120,14 @@ public struct MultiProviderMonitoringPanelView: View {
 
   @ViewBuilder
   private var monitoredSessionsGroupedContent: some View {
+    if !approvalItems.isEmpty {
+      Section(header: ApprovalSectionHeader(sessionCount: approvalItems.count)) {
+        ForEach(approvalItems) { item in
+          itemCardView(for: item)
+        }
+      }
+    }
+
     ForEach(groupedMonitoredSessions, id: \.modulePath) { group in
       Section(header: ModuleSectionHeader(
         name: URL(fileURLWithPath: group.modulePath).lastPathComponent,
@@ -1259,14 +1304,39 @@ public struct MultiProviderMonitoringPanelView: View {
     return claudeItems + codexItems
   }
 
+  /// Items awaiting approval, sorted by approval timestamp ascending (oldest-waiting first)
+  private var approvalItems: [ProviderMonitoringItem] {
+    guard approvalPrioritySorting else { return [] }
+    return visibleItems
+      .filter { isAwaitingApproval($0) }
+      .sorted { (approvalTimestamp($0) ?? .distantFuture) < (approvalTimestamp($1) ?? .distantFuture) }
+  }
+
   private var groupedMonitoredSessions: [(modulePath: String, items: [ProviderMonitoringItem])] {
-    let grouped = Dictionary(grouping: visibleItems) { findModulePath(for: $0) }
+    let itemsToGroup = approvalPrioritySorting
+      ? visibleItems.filter { !isAwaitingApproval($0) }
+      : visibleItems
+    let grouped = Dictionary(grouping: itemsToGroup) { findModulePath(for: $0) }
     return grouped.sorted { $0.key < $1.key }
       .map { (modulePath: $0.key, items: $0.value.sorted { $0.timestamp > $1.timestamp }) }
   }
 
   private var flatSortedItems: [ProviderMonitoringItem] {
-    groupedMonitoredSessions.flatMap { $0.items }
+    approvalItems + groupedMonitoredSessions.flatMap { $0.items }
+  }
+
+  private func isAwaitingApproval(_ item: ProviderMonitoringItem) -> Bool {
+    switch item {
+    case .pending: return false
+    case .monitored(_, _, _, let state): return state?.isAwaitingApproval ?? false
+    }
+  }
+
+  private func approvalTimestamp(_ item: ProviderMonitoringItem) -> Date? {
+    switch item {
+    case .pending: return nil
+    case .monitored(_, _, _, let state): return state?.pendingToolUse?.timestamp
+    }
   }
 
   private var effectivePrimaryItem: ProviderMonitoringItem? {

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/SelectedSessionsPanelView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/SelectedSessionsPanelView.swift
@@ -7,11 +7,38 @@
 
 import SwiftUI
 
+// MARK: - ApprovalSectionHeader
+
+/// Section header for sessions awaiting tool approval
+private struct ApprovalSectionHeader: View {
+  let sessionCount: Int
+
+  var body: some View {
+    HStack(spacing: 6) {
+      Image(systemName: "exclamationmark.circle.fill")
+        .foregroundColor(.yellow)
+        .font(.caption)
+      Text("Requires Approval")
+        .font(.secondarySmall)
+        .foregroundColor(.yellow)
+      Spacer()
+      Text("\(sessionCount)")
+        .font(.secondarySmall)
+        .foregroundColor(.secondary)
+    }
+    .padding(.horizontal, 4)
+    .padding(.top, 6)
+    .padding(.bottom, 10)
+  }
+}
+
 // MARK: - SelectedSessionsPanelView (Single Provider)
 
 public struct SelectedSessionsPanelView: View {
   @Bindable var viewModel: CLISessionsViewModel
   @Binding var primarySessionId: String?
+  @AppStorage(AgentHubDefaults.approvalPrioritySorting)
+  private var approvalPrioritySorting: Bool = true
 
   public init(
     viewModel: CLISessionsViewModel,
@@ -26,11 +53,28 @@ public struct SelectedSessionsPanelView: View {
       header
         .padding(.bottom, 8)
 
-      if groupedItems.isEmpty {
+      if groupedItems.isEmpty && approvalItems.isEmpty {
         emptyState
       } else {
         ScrollView(showsIndicators: false) {
           LazyVStack(spacing: 12, pinnedViews: [.sectionHeaders]) {
+            if !approvalItems.isEmpty {
+              Section(header: ApprovalSectionHeader(sessionCount: approvalItems.count)) {
+                ForEach(approvalItems) { item in
+                  SelectedSessionRow(
+                    session: item.session,
+                    providerKind: viewModel.providerKind,
+                    timestamp: item.timestamp,
+                    isPending: item.isPending,
+                    isPrimary: item.id == primarySessionId,
+                    customName: viewModel.sessionCustomNames[item.session.id]
+                  ) {
+                    primarySessionId = item.id
+                  }
+                }
+              }
+            }
+
             ForEach(groupedItems, id: \.modulePath) { group in
               Section(header: ModuleSectionHeader(
                 name: URL(fileURLWithPath: group.modulePath).lastPathComponent,
@@ -106,6 +150,8 @@ public struct SelectedSessionsPanelView: View {
     let timestamp: Date
     let modulePath: String
     let isPending: Bool
+    let isAwaitingApproval: Bool
+    let approvalTimestamp: Date?
   }
 
   private var items: [SelectedSessionItem] {
@@ -117,7 +163,9 @@ public struct SelectedSessionsPanelView: View {
         session: pending.placeholderSession,
         timestamp: pending.startedAt,
         modulePath: findModulePath(for: pending.worktree.path),
-        isPending: true
+        isPending: true,
+        isAwaitingApproval: false,
+        approvalTimestamp: nil
       ))
     }
 
@@ -127,15 +175,27 @@ public struct SelectedSessionsPanelView: View {
         session: item.session,
         timestamp: item.session.lastActivityAt,
         modulePath: findModulePath(for: item.session.projectPath),
-        isPending: false
+        isPending: false,
+        isAwaitingApproval: item.state?.isAwaitingApproval ?? false,
+        approvalTimestamp: item.state?.pendingToolUse?.timestamp
       ))
     }
 
     return results.sorted { $0.timestamp > $1.timestamp }
   }
 
+  private var approvalItems: [SelectedSessionItem] {
+    guard approvalPrioritySorting else { return [] }
+    return items
+      .filter { $0.isAwaitingApproval }
+      .sorted { ($0.approvalTimestamp ?? .distantFuture) < ($1.approvalTimestamp ?? .distantFuture) }
+  }
+
   private var groupedItems: [(modulePath: String, items: [SelectedSessionItem])] {
-    let grouped = Dictionary(grouping: items) { $0.modulePath }
+    let itemsToGroup = approvalPrioritySorting
+      ? items.filter { !$0.isAwaitingApproval }
+      : items
+    let grouped = Dictionary(grouping: itemsToGroup) { $0.modulePath }
     return grouped.sorted { $0.key < $1.key }
       .map { (modulePath: $0.key, items: $0.value.sorted { $0.timestamp > $1.timestamp }) }
   }
@@ -169,6 +229,8 @@ public struct MultiProviderSelectedSessionsPanelView: View {
   @Bindable var claudeViewModel: CLISessionsViewModel
   @Bindable var codexViewModel: CLISessionsViewModel
   @Binding var primarySessionId: String?
+  @AppStorage(AgentHubDefaults.approvalPrioritySorting)
+  private var approvalPrioritySorting: Bool = true
 
   public init(
     claudeViewModel: CLISessionsViewModel,
@@ -185,11 +247,28 @@ public struct MultiProviderSelectedSessionsPanelView: View {
       header
         .padding(.bottom, 8)
 
-      if groupedItems.isEmpty {
+      if groupedItems.isEmpty && approvalItems.isEmpty {
         emptyState
       } else {
         ScrollView(showsIndicators: false) {
           LazyVStack(spacing: 12, pinnedViews: [.sectionHeaders]) {
+            if !approvalItems.isEmpty {
+              Section(header: ApprovalSectionHeader(sessionCount: approvalItems.count)) {
+                ForEach(approvalItems) { item in
+                  SelectedSessionRow(
+                    session: item.session,
+                    providerKind: item.providerKind,
+                    timestamp: item.timestamp,
+                    isPending: item.isPending,
+                    isPrimary: item.id == primarySessionId,
+                    customName: customName(for: item)
+                  ) {
+                    primarySessionId = item.id
+                  }
+                }
+              }
+            }
+
             ForEach(groupedItems, id: \.modulePath) { group in
               Section(header: ModuleSectionHeader(
                 name: URL(fileURLWithPath: group.modulePath).lastPathComponent,
@@ -266,6 +345,8 @@ public struct MultiProviderSelectedSessionsPanelView: View {
     let timestamp: Date
     let modulePath: String
     let isPending: Bool
+    let isAwaitingApproval: Bool
+    let approvalTimestamp: Date?
   }
 
   private var items: [SelectedSessionItem] {
@@ -278,7 +359,9 @@ public struct MultiProviderSelectedSessionsPanelView: View {
         providerKind: .claude,
         timestamp: pending.startedAt,
         modulePath: findModulePath(for: pending.worktree.path),
-        isPending: true
+        isPending: true,
+        isAwaitingApproval: false,
+        approvalTimestamp: nil
       ))
     }
 
@@ -289,7 +372,9 @@ public struct MultiProviderSelectedSessionsPanelView: View {
         providerKind: .codex,
         timestamp: pending.startedAt,
         modulePath: findModulePath(for: pending.worktree.path),
-        isPending: true
+        isPending: true,
+        isAwaitingApproval: false,
+        approvalTimestamp: nil
       ))
     }
 
@@ -300,7 +385,9 @@ public struct MultiProviderSelectedSessionsPanelView: View {
         providerKind: .claude,
         timestamp: item.session.lastActivityAt,
         modulePath: findModulePath(for: item.session.projectPath),
-        isPending: false
+        isPending: false,
+        isAwaitingApproval: item.state?.isAwaitingApproval ?? false,
+        approvalTimestamp: item.state?.pendingToolUse?.timestamp
       ))
     }
 
@@ -311,15 +398,27 @@ public struct MultiProviderSelectedSessionsPanelView: View {
         providerKind: .codex,
         timestamp: item.session.lastActivityAt,
         modulePath: findModulePath(for: item.session.projectPath),
-        isPending: false
+        isPending: false,
+        isAwaitingApproval: item.state?.isAwaitingApproval ?? false,
+        approvalTimestamp: item.state?.pendingToolUse?.timestamp
       ))
     }
 
     return results.sorted { $0.timestamp > $1.timestamp }
   }
 
+  private var approvalItems: [SelectedSessionItem] {
+    guard approvalPrioritySorting else { return [] }
+    return items
+      .filter { $0.isAwaitingApproval }
+      .sorted { ($0.approvalTimestamp ?? .distantFuture) < ($1.approvalTimestamp ?? .distantFuture) }
+  }
+
   private var groupedItems: [(modulePath: String, items: [SelectedSessionItem])] {
-    let grouped = Dictionary(grouping: items) { $0.modulePath }
+    let itemsToGroup = approvalPrioritySorting
+      ? items.filter { !$0.isAwaitingApproval }
+      : items
+    let grouped = Dictionary(grouping: itemsToGroup) { $0.modulePath }
     return grouped.sorted { $0.key < $1.key }
       .map { (modulePath: $0.key, items: $0.value.sorted { $0.timestamp > $1.timestamp }) }
   }

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/SettingsView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/SettingsView.swift
@@ -23,6 +23,9 @@ public struct SettingsView: View {
   @AppStorage(AgentHubDefaults.fileExplorerAlwaysModal)
   private var fileExplorerAlwaysModal: Bool = false
 
+  @AppStorage(AgentHubDefaults.approvalPrioritySorting)
+  private var approvalPrioritySorting: Bool = true
+
   @AppStorage(AgentHubDefaults.terminalFontSize)
   private var terminalFontSize: Double = 12
 
@@ -109,6 +112,12 @@ public struct SettingsView: View {
       }
 
       Section("Features") {
+        settingsToggle(
+          title: "Approval-priority sorting",
+          description: "Surface sessions awaiting tool approval to the top of the Hub",
+          isOn: $approvalPrioritySorting
+        )
+
         settingsToggle(
           title: "File explorer always modal",
           description: "Open file explorer as a floating window instead of a side panel",


### PR DESCRIPTION
## Summary
This PR adds a new feature to surface sessions awaiting tool approval at the top of the Hub and selected sessions panels. A new "Approval-priority sorting" toggle in Settings allows users to control whether sessions requiring approval are prioritized in the UI.

## Key Changes

- **New `ApprovalSectionHeader` component**: Added a reusable section header with yellow warning styling to highlight sessions awaiting approval across multiple views
- **Approval filtering and sorting**: Implemented `approvalItems` computed properties in:
  - `SelectedSessionsPanelView` (single provider)
  - `MultiProviderSelectedSessionsPanelView`
  - `MonitoringPanelView`
  - `MultiProviderMonitoringPanelView`
  
  These filter sessions where `isAwaitingApproval` is true and sort by approval timestamp (oldest-waiting first)

- **Updated session item models**: Extended `SelectedSessionItem` and `ProviderMonitoringItem` to track:
  - `isAwaitingApproval` flag
  - `approvalTimestamp` for sorting

- **Conditional grouping logic**: Modified `groupedItems` computed properties to exclude approval items when `approvalPrioritySorting` is enabled, preventing duplicates

- **Settings UI**: Added "Approval-priority sorting" toggle in SettingsView under Features section

- **Configuration**: Added `approvalPrioritySorting` key to `AgentHubDefaults` with default value `true`

## Implementation Details

- The approval section appears at the top of all session lists when enabled and approval items exist
- Sessions are identified as awaiting approval via `state?.isAwaitingApproval` property
- Approval timestamps come from `state?.pendingToolUse?.timestamp`
- The feature gracefully degrades when disabled, showing all sessions in normal module-grouped layout
- Consistent implementation across single-provider and multi-provider views

https://claude.ai/code/session_018Y73D2P3PLbLEsuZomkJny