### PR TITLE
Integrate PierreDiffsSwift inline annotations

### DIFF
--- a/app/AgentHub.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/app/AgentHub.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -69,8 +69,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/jamesrochabrun/PierreDiffsSwift",
       "state" : {
-        "revision" : "df6cb6b8ae6953ae4985322a89d4a6873438bf0b",
-        "version" : "1.1.6"
+        "revision" : "1308e72cb8ea388b122a722dadd7f80fcc96f236",
+        "version" : "1.1.7"
       }
     },
     {

--- a/app/AgentHub.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/app/AgentHub.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -69,8 +69,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/jamesrochabrun/PierreDiffsSwift",
       "state" : {
-        "revision" : "3bd094d3041e0dc2c601d2cd609a7ef946e77c82",
-        "version" : "1.1.5"
+        "revision" : "df6cb6b8ae6953ae4985322a89d4a6873438bf0b",
+        "version" : "1.1.6"
       }
     },
     {

--- a/app/modules/AgentHubCore/Package.resolved
+++ b/app/modules/AgentHubCore/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "7b48263abbd7d29650a7b2215474baaf9b226ab6eb950c7b25ee89437285c739",
+  "originHash" : "dda0356e7628bb72e381dd290279263dc000ab7418068572c5662c1de638cd7f",
   "pins" : [
     {
       "identity" : "beautiful-mermaid-swift",
@@ -69,8 +69,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/jamesrochabrun/PierreDiffsSwift",
       "state" : {
-        "revision" : "3bd094d3041e0dc2c601d2cd609a7ef946e77c82",
-        "version" : "1.1.5"
+        "revision" : "df6cb6b8ae6953ae4985322a89d4a6873438bf0b",
+        "version" : "1.1.6"
       }
     },
     {

--- a/app/modules/AgentHubCore/Package.resolved
+++ b/app/modules/AgentHubCore/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "dda0356e7628bb72e381dd290279263dc000ab7418068572c5662c1de638cd7f",
+  "originHash" : "33c89abc499c33d9a3ca8be4824e97fd2422e1b662ebcedd353bf7cc467abfa4",
   "pins" : [
     {
       "identity" : "beautiful-mermaid-swift",
@@ -69,8 +69,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/jamesrochabrun/PierreDiffsSwift",
       "state" : {
-        "revision" : "df6cb6b8ae6953ae4985322a89d4a6873438bf0b",
-        "version" : "1.1.6"
+        "revision" : "1308e72cb8ea388b122a722dadd7f80fcc96f236",
+        "version" : "1.1.7"
       }
     },
     {

--- a/app/modules/AgentHubCore/Package.swift
+++ b/app/modules/AgentHubCore/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
   dependencies: [
     .package(path: "../AgentHubGitHub"),
     .package(url: "https://github.com/jamesrochabrun/Canvas", from: "1.2.0"),
-    .package(url: "https://github.com/jamesrochabrun/PierreDiffsSwift", exact: "1.1.5"),
+    .package(path: "../../../../PierreDiffsSwift"),
     .package(url: "https://github.com/migueldeicaza/SwiftTerm", from: "1.13.0"),
     .package(url: "https://github.com/gonzalezreal/swift-markdown-ui", from: "2.0.0"),
     .package(url: "https://github.com/groue/GRDB.swift", from: "6.24.0"),

--- a/app/modules/AgentHubCore/Package.swift
+++ b/app/modules/AgentHubCore/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
   dependencies: [
     .package(path: "../AgentHubGitHub"),
     .package(url: "https://github.com/jamesrochabrun/Canvas", from: "1.2.0"),
-    .package(path: "../../../../PierreDiffsSwift"),
+    .package(url: "https://github.com/jamesrochabrun/PierreDiffsSwift", exact: "1.1.7"),
     .package(url: "https://github.com/migueldeicaza/SwiftTerm", from: "1.13.0"),
     .package(url: "https://github.com/gonzalezreal/swift-markdown-ui", from: "2.0.0"),
     .package(url: "https://github.com/groue/GRDB.swift", from: "6.24.0"),

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/DiffCommentsPanelView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/DiffCommentsPanelView.swift
@@ -7,21 +7,15 @@
 
 import SwiftUI
 
-/// A collapsible panel showing all pending review comments.
-///
-/// Displays at the bottom of the diff viewer with a header showing count
-/// and actions to send all comments to Claude or clear them.
+/// A compact bottom toolbar showing the pending review comment count
+/// with clear and send actions. Individual comments are managed via
+/// inline annotations in the diff view.
 struct DiffCommentsPanelView: View {
 
   // MARK: - Properties
 
-  /// The shared state manager containing all pending review comments.
   @Bindable var commentsState: DiffCommentsState
-
-  /// The provider kind to display in button text
   let providerKind: SessionProviderKind
-
-  /// Called when the user taps "Send to [Provider]" to submit all comments as a batch.
   let onSendToCloud: () -> Void
 
   @State private var showClearConfirmation = false
@@ -29,76 +23,14 @@ struct DiffCommentsPanelView: View {
   // MARK: - Body
 
   var body: some View {
-    VStack(spacing: 0) {
-      // Header bar (always visible when there are comments)
-      headerBar
-
-      // Content (shown when expanded)
-      if commentsState.isPanelExpanded {
-        Divider()
-
-        ScrollView {
-          let sortedFiles = commentsState.commentsByFile.keys.sorted()
-          VStack(alignment: .leading, spacing: 0) {
-            ForEach(Array(sortedFiles.enumerated()), id: \.element) { index, filePath in
-              if let comments = commentsState.commentsByFile[filePath] {
-                if index > 0 {
-                  Divider()
-                    .padding(.vertical, 4)
-                }
-                fileSection(filePath: filePath, comments: comments)
-              }
-            }
-          }
-          .padding(.vertical, 8)
-        }
-        .frame(maxHeight: 200)
-      }
-    }
-    .background(Color.surfaceElevated)
-    .overlay(
-      Rectangle()
-        .frame(height: 1)
-        .foregroundColor(Color(NSColor.separatorColor)),
-      alignment: .top
-    )
-    .confirmationDialog(
-      "Clear All Comments",
-      isPresented: $showClearConfirmation,
-      titleVisibility: .visible
-    ) {
-      Button("Clear All", role: .destructive) {
-        commentsState.clearAll()
-      }
-      Button("Cancel", role: .cancel) {}
-    } message: {
-      Text("This will remove all \(commentsState.commentCount) pending comments. This action cannot be undone.")
-    }
-  }
-
-  // MARK: - Header Bar
-
-  private var headerBar: some View {
     HStack(spacing: 12) {
-      // Expand/collapse button with count
-      Button {
-        withAnimation(.easeInOut(duration: 0.2)) {
-          commentsState.isPanelExpanded.toggle()
-        }
-      } label: {
-        HStack(spacing: 6) {
-          Image(systemName: commentsState.isPanelExpanded ? "chevron.down" : "chevron.up")
-            .font(.caption.bold())
+      Image(systemName: "text.bubble.fill")
+        .font(.caption)
+        .foregroundColor(.secondary)
 
-          Image(systemName: "text.bubble.fill")
-            .font(.caption)
-
-          Text("\(commentsState.commentCount) Comment\(commentsState.commentCount == 1 ? "" : "s")")
-            .font(.caption.bold())
-        }
+      Text("\(commentsState.commentCount) Comment\(commentsState.commentCount == 1 ? "" : "s")")
+        .font(.caption.bold())
         .foregroundColor(.primary)
-      }
-      .buttonStyle(.plain)
 
       Spacer()
 
@@ -138,46 +70,24 @@ struct DiffCommentsPanelView: View {
     }
     .padding(.horizontal, 12)
     .padding(.vertical, 8)
-  }
-
-  // MARK: - File Section
-
-  private func fileSection(filePath: String, comments: [DiffComment]) -> some View {
-    VStack(alignment: .leading, spacing: 0) {
-      // File header
-      HStack(spacing: 6) {
-        Image(systemName: "doc.text.fill")
-          .font(.caption)
-          .foregroundColor(.primary)
-
-        Text(URL(fileURLWithPath: filePath).lastPathComponent)
-          .font(.system(.caption, design: .monospaced, weight: .semibold))
-          .foregroundColor(.primary)
-
-        Text("(\(comments.count))")
-          .font(.caption2)
-          .foregroundColor(.secondary)
-
-        Spacer()
+    .background(Color.surfaceElevated)
+    .overlay(
+      Rectangle()
+        .frame(height: 1)
+        .foregroundColor(Color(NSColor.separatorColor)),
+      alignment: .top
+    )
+    .confirmationDialog(
+      "Clear All Comments",
+      isPresented: $showClearConfirmation,
+      titleVisibility: .visible
+    ) {
+      Button("Clear All", role: .destructive) {
+        commentsState.clearAll()
       }
-      .padding(.vertical, 6)
-      .padding(.horizontal, 10)
-
-      // Comments for this file with dividers
-      ForEach(Array(comments.enumerated()), id: \.element.id) { index, comment in
-        if index > 0 {
-          Divider()
-            .padding(.leading, 10)
-        }
-
-        DiffCommentRow(
-          comment: comment,
-          onSave: { newText in
-            commentsState.updateComment(id: comment.id, newText: newText)
-          },
-          onDelete: { commentsState.removeComment(id: comment.id) }
-        )
-      }
+      Button("Cancel", role: .cancel) {}
+    } message: {
+      Text("This will remove all \(commentsState.commentCount) pending comments. This action cannot be undone.")
     }
   }
 }
@@ -221,7 +131,6 @@ struct DiffCommentsPanelView: View {
           lineContent: "func doSomething()",
           text: "Add documentation"
         )
-        commentsState.isPanelExpanded = true
       }
     }
   }

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/DiffCommentsState.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/DiffCommentsState.swift
@@ -5,6 +5,7 @@
 //  Created by Assistant on 1/29/26.
 //
 
+import PierreDiffsSwift
 import SwiftUI
 
 /// Observable state manager for PR-style review comments on diffs.
@@ -166,6 +167,35 @@ final class DiffCommentsState {
       locationKey = "\(filePath):\(lineNumber):\(side)"
     }
     return comments[locationKey]
+  }
+
+  // MARK: - Annotation Bridge
+
+  /// Converts stored comments for a file into `DiffAnnotation` values for PierreDiffView.
+  func annotations(for filePath: String) -> [DiffAnnotation] {
+    commentsByFile[filePath]?.map { comment in
+      DiffAnnotation(
+        side: comment.side == "left" ? .deletions : .additions,
+        lineNumber: comment.lineNumber,
+        metadata: AnnotationMetadata(
+          id: comment.id.uuidString,
+          author: "You",
+          body: comment.text
+        )
+      )
+    } ?? []
+  }
+
+  /// Finds a comment by its annotation ID (UUID string).
+  func comment(byAnnotationId id: String) -> DiffComment? {
+    comments.values.first { $0.id.uuidString == id }
+  }
+
+  /// Removes a comment by its annotation ID (UUID string).
+  func removeComment(byAnnotationId id: String) {
+    if let key = comments.first(where: { $0.value.id.uuidString == id })?.key {
+      comments.removeValue(forKey: key)
+    }
   }
 
   /// Clears all comments.

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/DiffCommentsState.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/DiffCommentsState.swift
@@ -185,7 +185,8 @@ final class DiffCommentsState {
         metadata: AnnotationMetadata(
           id: comment.id.uuidString,
           author: "You",
-          body: comment.text
+          body: comment.text,
+          subtitle: comment.lineLabel
         )
       )
     }

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/DiffCommentsState.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/DiffCommentsState.swift
@@ -172,9 +172,14 @@ final class DiffCommentsState {
   // MARK: - Annotation Bridge
 
   /// Converts stored comments for a file into `DiffAnnotation` values for PierreDiffView.
+  /// Deduplicates by (side, lineNumber) so only one annotation renders per line.
   func annotations(for filePath: String) -> [DiffAnnotation] {
-    commentsByFile[filePath]?.map { comment in
-      DiffAnnotation(
+    guard let fileComments = commentsByFile[filePath] else { return [] }
+    var seen = Set<String>()
+    return fileComments.compactMap { comment in
+      let key = "\(comment.lineNumber)"
+      guard seen.insert(key).inserted else { return nil }
+      return DiffAnnotation(
         side: comment.side == "left" ? .deletions : .additions,
         lineNumber: comment.lineNumber,
         metadata: AnnotationMetadata(
@@ -183,7 +188,15 @@ final class DiffCommentsState {
           body: comment.text
         )
       )
-    } ?? []
+    }
+  }
+
+  /// Finds any comment at a given line regardless of endLineNumber.
+  /// Used by the inline editor to detect existing comments when the user clicks a line.
+  func getCommentForLine(filePath: String, lineNumber: Int, side: String) -> DiffComment? {
+    comments.values.first {
+      $0.filePath == filePath && $0.lineNumber == lineNumber && $0.side == side
+    }
   }
 
   /// Finds a comment by its annotation ID (UUID string).

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/DiffCommentsState.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/DiffCommentsState.swift
@@ -186,7 +186,7 @@ final class DiffCommentsState {
           id: comment.id.uuidString,
           author: "You",
           body: comment.text,
-          subtitle: comment.lineLabel
+          subtitle: "Code review: \(comment.lineLabel.lowercased())"
         )
       )
     }

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/GitDiffView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/GitDiffView.swift
@@ -1057,10 +1057,6 @@ private struct GitDiffContentView: View {
                   lineContent: context.lineContent,
                   text: message
                 )
-                // Auto-expand panel when first comment is added
-                if commentsState.commentCount == 1 {
-                  commentsState.isPanelExpanded = true
-                }
               },
               commentsState: commentsState
             )

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/GitDiffView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/GitDiffView.swift
@@ -969,10 +969,9 @@ private struct GitDiffContentView: View {
                   )
                 }
               } : nil,
-              onAnnotationClick: isInlineEditorEnabled ? { id, side, lineNumber, localPoint in
+              onAnnotationClick: isInlineEditorEnabled ? { id, _, _, localPoint in
                 if let comment = commentsState.comment(byAnnotationId: id) {
-                  let commentSide = side == "deletions" ? "left" : "right"
-                  let fileContent = commentSide == "left" ? oldContent : newContent
+                  let fileContent = comment.side == "left" ? oldContent : newContent
                   let anchorPoint = CGPoint(x: geometry.size.width / 2, y: localPoint.y)
 
                   withAnimation(.easeOut(duration: 0.2)) {
@@ -980,7 +979,7 @@ private struct GitDiffContentView: View {
                       at: anchorPoint,
                       lineNumber: comment.lineNumber,
                       endLineNumber: comment.endLineNumber,
-                      side: commentSide,
+                      side: comment.side,
                       fileName: comment.filePath,
                       lineContent: comment.lineContent,
                       fullFileContent: fileContent

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/GitDiffView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/GitDiffView.swift
@@ -930,6 +930,7 @@ private struct GitDiffContentView: View {
               fileName: fileName,
               diffStyle: $diffStyle,
               overflowMode: $overflowMode,
+              annotations: commentsState.annotations(for: filePath),
               onLineClickWithPosition: isInlineEditorEnabled ? { position, localPoint in
                 let anchorPoint = CGPoint(x: geometry.size.width / 2, y: localPoint.y)
 
@@ -968,6 +969,28 @@ private struct GitDiffContentView: View {
                   )
                 }
               } : nil,
+              onAnnotationClick: isInlineEditorEnabled ? { id, side, lineNumber, localPoint in
+                if let comment = commentsState.comment(byAnnotationId: id) {
+                  let commentSide = side == "deletions" ? "left" : "right"
+                  let fileContent = commentSide == "left" ? oldContent : newContent
+                  let anchorPoint = CGPoint(x: geometry.size.width / 2, y: localPoint.y)
+
+                  withAnimation(.easeOut(duration: 0.2)) {
+                    inlineEditorState.show(
+                      at: anchorPoint,
+                      lineNumber: comment.lineNumber,
+                      endLineNumber: comment.endLineNumber,
+                      side: commentSide,
+                      fileName: comment.filePath,
+                      lineContent: comment.lineContent,
+                      fullFileContent: fileContent
+                    )
+                  }
+                }
+              } : nil,
+              onAnnotationDelete: { id, _, _ in
+                commentsState.removeComment(byAnnotationId: id)
+              },
               onReady: {
                 withAnimation(.easeInOut(duration: 0.3)) {
                   isWebViewReady = true

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/InlineEditorOverlay.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/InlineEditorOverlay.swift
@@ -65,12 +65,12 @@ struct InlineEditorOverlay: View {
     )
   }
 
-  /// Check if there's an existing comment at the current location
+  /// Check if there's an existing comment at the current line (ignores endLineNumber
+  /// so single-click and range-selection both find the same comment).
   private var existingComment: DiffComment? {
-    commentsState?.getComment(
+    commentsState?.getCommentForLine(
       filePath: state.fileName,
       lineNumber: state.lineNumber,
-      endLineNumber: state.endLineNumber,
       side: state.side
     )
   }


### PR DESCRIPTION
## Summary
- Wire `DiffCommentsState` to `PierreDiffView` annotations so Cmd+Enter comments render inline below diff lines with click-to-edit and X-to-delete
- Redesigned annotation card in PierreDiffsSwift 1.1.7: SVG person avatar, purple left border, box-shadow, "Code review: line N" subtitle
- Fix duplicate annotations and edit mode detection (side mismatch, dedup, fuzzy lookup)
- Replace expandable bottom comments panel with compact toolbar (count + clear + send)

## Test plan
- [ ] Click a diff line, type a comment, press Cmd+Enter — annotation appears inline with purple border, avatar, and line subtitle
- [ ] Click the inline annotation — editor opens in edit mode with existing text pre-filled
- [ ] Click X on annotation — annotation is removed (including the last one)
- [ ] Bottom toolbar shows comment count, Clear (with confirmation), and Send button
- [ ] Send dispatches all comments as batch prompt to provider
- [ ] No duplicate annotations on same line after multiple clicks

🤖 Generated with [Claude Code](https://claude.com/claude-code)