### PR TITLE
Simplify inline editor to queue-only with collapsible comments panel

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/DiffCommentsPanelView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/DiffCommentsPanelView.swift
@@ -7,9 +7,8 @@
 
 import SwiftUI
 
-/// A compact bottom toolbar showing the pending review comment count
-/// with clear and send actions. Individual comments are managed via
-/// inline annotations in the diff view.
+/// A collapsible bottom toolbar showing the pending review comment count.
+/// Starts collapsed as a header; tapping expands to reveal clear and send actions.
 struct DiffCommentsPanelView: View {
 
   // MARK: - Properties
@@ -18,20 +17,98 @@ struct DiffCommentsPanelView: View {
   let providerKind: SessionProviderKind
   let onSendToCloud: () -> Void
 
+  @State private var isExpanded = false
   @State private var showClearConfirmation = false
 
   // MARK: - Body
 
   var body: some View {
+    VStack(spacing: 0) {
+      // Collapsed header — always visible
+      headerView
+
+      // Expanded content — shown on tap
+      if isExpanded {
+        Divider()
+
+        // Comment list
+        ScrollView {
+          LazyVStack(spacing: 0) {
+            ForEach(commentsState.orderedComments) { comment in
+              DiffCommentRow(
+                comment: comment,
+                onSave: { newText in
+                  commentsState.updateComment(id: comment.id, newText: newText)
+                },
+                onDelete: {
+                  commentsState.removeComment(id: comment.id)
+                }
+              )
+              Divider()
+            }
+          }
+        }
+        .frame(maxHeight: 200)
+
+        toolbarView
+          .transition(.move(edge: .bottom).combined(with: .opacity))
+      }
+    }
+    .background(Color.surfaceElevated)
+    .overlay(
+      Rectangle()
+        .frame(height: 1)
+        .foregroundColor(Color(NSColor.separatorColor)),
+      alignment: .top
+    )
+    .animation(.easeInOut(duration: 0.2), value: isExpanded)
+    .confirmationDialog(
+      "Clear All Comments",
+      isPresented: $showClearConfirmation,
+      titleVisibility: .visible
+    ) {
+      Button("Clear All", role: .destructive) {
+        commentsState.clearAll()
+      }
+      Button("Cancel", role: .cancel) {}
+    } message: {
+      Text("This will remove all \(commentsState.commentCount) pending comments. This action cannot be undone.")
+    }
+  }
+
+  // MARK: - Header
+
+  private var headerView: some View {
+    Button {
+      isExpanded.toggle()
+    } label: {
+      HStack(spacing: 8) {
+        Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
+          .font(.caption2.weight(.semibold))
+          .foregroundColor(.secondary)
+          .frame(width: 10)
+
+        Image(systemName: "text.bubble.fill")
+          .font(.caption)
+          .foregroundColor(.secondary)
+
+        Text("\(commentsState.commentCount) Comment\(commentsState.commentCount == 1 ? "" : "s")")
+          .font(.caption.bold())
+          .foregroundColor(.primary)
+
+        Spacer()
+      }
+      .padding(.horizontal, 12)
+      .padding(.vertical, 8)
+      .contentShape(Rectangle())
+    }
+    .buttonStyle(.plain)
+  }
+
+  // MARK: - Toolbar
+
+  private var toolbarView: some View {
     HStack(spacing: 12) {
-      Image(systemName: "text.bubble.fill")
-        .font(.caption)
-        .foregroundColor(.secondary)
-
-      Text("\(commentsState.commentCount) Comment\(commentsState.commentCount == 1 ? "" : "s")")
-        .font(.caption.bold())
-        .foregroundColor(.primary)
-
       Spacer()
 
       // Clear all button
@@ -69,26 +146,7 @@ struct DiffCommentsPanelView: View {
       .help("Send all comments to \(providerKind.rawValue) (⌘⇧↵)")
     }
     .padding(.horizontal, 12)
-    .padding(.vertical, 8)
-    .background(Color.surfaceElevated)
-    .overlay(
-      Rectangle()
-        .frame(height: 1)
-        .foregroundColor(Color(NSColor.separatorColor)),
-      alignment: .top
-    )
-    .confirmationDialog(
-      "Clear All Comments",
-      isPresented: $showClearConfirmation,
-      titleVisibility: .visible
-    ) {
-      Button("Clear All", role: .destructive) {
-        commentsState.clearAll()
-      }
-      Button("Cancel", role: .cancel) {}
-    } message: {
-      Text("This will remove all \(commentsState.commentCount) pending comments. This action cannot be undone.")
-    }
+    .padding(.bottom, 8)
   }
 }
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/GitDiffView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/GitDiffView.swift
@@ -506,9 +506,7 @@ public struct GitDiffView: View {
             commentsState: commentsState,
             cliConfiguration: cliConfiguration,
             providerKind: providerKind,
-            session: session,
-            onDismissView: onDismiss,
-            onInlineRequestSubmit: onInlineRequestSubmit
+            session: session
           )
           .frame(minHeight: 400)
           .id(selectedId)
@@ -885,8 +883,6 @@ private struct GitDiffContentView: View {
   let cliConfiguration: CLICommandConfiguration?
   let providerKind: SessionProviderKind
   let session: CLISession
-  let onDismissView: () -> Void
-  let onInlineRequestSubmit: ((String, CLISession) -> Void)?
 
   @State private var webViewOpacity: Double = 1.0
   @State private var isWebViewReady = false
@@ -1017,36 +1013,6 @@ private struct GitDiffContentView: View {
               state: inlineEditorState,
               containerSize: geometry.size,
               providerKind: providerKind,
-              onSubmit: { message, context in
-                // Build contextual prompt with line context
-                let prompt = buildInlinePrompt(
-                  question: message,
-                  lineNumber: context.lineNumber,
-                  endLineNumber: context.endLineNumber,
-                  side: context.side,
-                  lineContent: context.lineContent,
-                  fileName: context.fileName
-                )
-
-                // Use callback if provided (redirects to built-in terminal)
-                if let callback = onInlineRequestSubmit {
-                  callback(prompt, session)
-                  inlineEditorState.dismiss()
-                  onDismissView()
-                } else if let config = cliConfiguration {
-                  // Fallback to external Terminal with cliConfiguration
-                  if let error = TerminalLauncher.launchTerminalWithSession(
-                    session.id,
-                    cliConfiguration: config,
-                    projectPath: session.projectPath,
-                    initialPrompt: prompt
-                  ) {
-                    inlineEditorState.errorMessage = error.localizedDescription
-                  } else {
-                    onDismissView()
-                  }
-                }
-              },
               onAddComment: { message, context in
                 // Add comment to the collection
                 commentsState.addComment(
@@ -1203,36 +1169,6 @@ private struct GitDiffContentView: View {
     return lines[startIndex...endIndex].joined(separator: "\n")
   }
 
-  /// Builds a contextual prompt for the inline question
-  private func buildInlinePrompt(
-    question: String,
-    lineNumber: Int,
-    endLineNumber: Int? = nil,
-    side: String,
-    lineContent: String,
-    fileName: String
-  ) -> String {
-    let sideLabel = side == "left" ? "old" : "new"
-    let lineLabel: String
-    if let end = endLineNumber {
-      lineLabel = "Lines \(lineNumber)-\(end)"
-    } else {
-      lineLabel = "Line \(lineNumber)"
-    }
-    return """
-      I have the following review comment on the code changes:
-
-      ## \(fileName)
-
-      **\(lineLabel)** (\(sideLabel)):
-      ```
-      \(lineContent)
-      ```
-      Comment: \(question)
-
-      Please address this review comment.
-      """
-  }
 }
 
 // MARK: - Preview

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/InlineEditorOverlay.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/InlineEditorOverlay.swift
@@ -10,7 +10,7 @@ import SwiftUI
 /// An overlay that positions the inline editor below clicked diff lines.
 /// Handles tap-outside dismissal and edge positioning.
 ///
-/// Supports both immediate submission and adding comments to a review collection.
+/// Comments are added to the review collection; sending happens from the bottom panel.
 struct InlineEditorOverlay: View {
 
   // MARK: - Properties
@@ -19,11 +19,8 @@ struct InlineEditorOverlay: View {
   let containerSize: CGSize
   let providerKind: SessionProviderKind
 
-  /// Called when user presses Enter - sends immediately to the provider
-  let onSubmit: (String, DiffLineContext) -> Void
-
-  /// Called when user presses Cmd+Enter - adds to comment collection (optional)
-  let onAddComment: ((String, DiffLineContext) -> Void)?
+  /// Called when user presses Return - adds to comment collection
+  let onAddComment: (String, DiffLineContext) -> Void
 
   /// Comments state for checking existing comments (optional)
   let commentsState: DiffCommentsState?
@@ -40,14 +37,12 @@ struct InlineEditorOverlay: View {
     state: InlineEditorState,
     containerSize: CGSize,
     providerKind: SessionProviderKind = .claude,
-    onSubmit: @escaping (String, DiffLineContext) -> Void,
-    onAddComment: ((String, DiffLineContext) -> Void)? = nil,
+    onAddComment: @escaping (String, DiffLineContext) -> Void,
     commentsState: DiffCommentsState? = nil
   ) {
     self.state = state
     self.containerSize = containerSize
     self.providerKind = providerKind
-    self.onSubmit = onSubmit
     self.onAddComment = onAddComment
     self.commentsState = commentsState
   }
@@ -106,15 +101,12 @@ struct InlineEditorOverlay: View {
           fileName: state.fileName,
           errorMessage: state.errorMessage,
           providerKind: providerKind,
-          onSubmit: { message in
-            onSubmit(message, currentContext)
-          },
-          onAddComment: onAddComment != nil ? { message in
-            onAddComment?(message, currentContext)
+          onAddComment: { message in
+            onAddComment(message, currentContext)
             withAnimation(.easeOut(duration: 0.15)) {
               state.dismiss()
             }
-          } : nil,
+          },
           onDeleteComment: isEditMode ? {
             // Delete existing comment
             if let comment = existingComment {
@@ -200,7 +192,7 @@ struct InlineEditorOverlay: View {
         InlineEditorOverlay(
           state: state,
           containerSize: CGSize(width: 600, height: 600),
-          onSubmit: { _, _ in }
+          onAddComment: { _, _ in }
         )
       }
       .frame(width: 600, height: 600)

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/InlineEditorView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/InlineEditorView.swift
@@ -11,9 +11,8 @@ import AppKit
 /// A compact floating text editor for asking questions about specific diff lines.
 /// Appears below clicked lines in the diff view.
 ///
-/// Supports two modes:
-/// - **Send immediately**: Press Enter to send the comment to Claude right away
-/// - **Add to review**: Press Cmd+Enter to add the comment to the review collection
+/// Comments are always added to the review collection. The only way to send
+/// feedback to Claude is via the bottom panel's "Send to Claude" button.
 struct InlineEditorView: View {
 
   // MARK: - Properties
@@ -25,11 +24,8 @@ struct InlineEditorView: View {
   let errorMessage: String?
   let providerKind: SessionProviderKind
 
-  /// Called when user presses Enter - sends immediately to the provider
-  let onSubmit: (String) -> Void
-
-  /// Called when user presses Cmd+Enter - adds to comment collection (optional)
-  let onAddComment: ((String) -> Void)?
+  /// Called when user presses Return - adds to comment collection
+  let onAddComment: (String) -> Void
 
   /// Called when user wants to delete an existing comment (optional, edit mode only)
   let onDeleteComment: (() -> Void)?
@@ -65,8 +61,7 @@ struct InlineEditorView: View {
     fileName: String,
     errorMessage: String?,
     providerKind: SessionProviderKind = .claude,
-    onSubmit: @escaping (String) -> Void,
-    onAddComment: ((String) -> Void)? = nil,
+    onAddComment: @escaping (String) -> Void,
     onDeleteComment: (() -> Void)? = nil,
     onDismiss: @escaping () -> Void,
     initialText: String = "",
@@ -78,7 +73,6 @@ struct InlineEditorView: View {
     self.fileName = fileName
     self.errorMessage = errorMessage
     self.providerKind = providerKind
-    self.onSubmit = onSubmit
     self.onAddComment = onAddComment
     self.onDeleteComment = onDeleteComment
     self.onDismiss = onDismiss
@@ -139,13 +133,8 @@ struct InlineEditorView: View {
       // Text input
       textEditorView
 
-      // Add comment button (if callback provided)
-      if onAddComment != nil {
-        addCommentButton
-      }
-
-      // Send button (rounded square with arrow)
-      sendButton
+      // Add comment button with return key hint
+      addCommentButton
     }
     .padding(8)
   }
@@ -208,54 +197,35 @@ struct InlineEditorView: View {
     .help("Dismiss (Esc)")
   }
 
-  // MARK: - Send Button
-
-  private var sendButton: some View {
-    Button(action: submitMessage) {
-      Image(systemName: "arrow.up")
-        .font(.system(size: 14, weight: .semibold))
-        .foregroundColor(.white)
-        .frame(width: 32, height: 32)
-        .contentShape(Rectangle())
-    }
-    .buttonStyle(.plain)
-    .frame(width: 32, height: 32)
-    .background(
-      RoundedRectangle(cornerRadius: 8)
-        .fill(isTextEmpty ? Color.secondary.opacity(0.3) : Color.brandPrimary(for: providerKind))
-    )
-    .overlay(
-      RoundedRectangle(cornerRadius: 8)
-        .stroke(Color(NSColor.separatorColor), lineWidth: 1)
-    )
-    .contentShape(Rectangle())
-    .disabled(isTextEmpty)
-    .help("Send to \(providerKind.rawValue) (Enter)")
-  }
-
   // MARK: - Add Comment Button
 
   private var addCommentButton: some View {
-    Button(action: addComment) {
-      Image(systemName: isEditMode ? "checkmark" : "plus")
-        .font(.system(size: 14, weight: .semibold))
-        .foregroundColor(isTextEmpty ? .secondary : .primary)
-        .frame(width: 32, height: 32)
-        .contentShape(Rectangle())
+    HStack(spacing: 4) {
+      Button(action: addComment) {
+        Image(systemName: isEditMode ? "checkmark" : "plus")
+          .font(.system(size: 14, weight: .semibold))
+          .foregroundColor(isTextEmpty ? .secondary : .primary)
+          .frame(width: 32, height: 32)
+          .contentShape(Rectangle())
+      }
+      .buttonStyle(.plain)
+      .frame(width: 32, height: 32)
+      .background(
+        RoundedRectangle(cornerRadius: 8)
+          .fill(Color(NSColor.controlBackgroundColor))
+      )
+      .overlay(
+        RoundedRectangle(cornerRadius: 8)
+          .stroke(isTextEmpty ? Color(NSColor.separatorColor) : Color.brandPrimary(for: providerKind).opacity(0.5), lineWidth: 1)
+      )
+      .contentShape(Rectangle())
+      .disabled(isTextEmpty)
+      .help(isEditMode ? "Update comment (↵)" : "Add to review (↵)")
+
+      Text("⏎")
+        .font(.system(size: 11, weight: .medium, design: .rounded))
+        .foregroundColor(.secondary)
     }
-    .buttonStyle(.plain)
-    .frame(width: 32, height: 32)
-    .background(
-      RoundedRectangle(cornerRadius: 8)
-        .fill(Color(NSColor.controlBackgroundColor))
-    )
-    .overlay(
-      RoundedRectangle(cornerRadius: 8)
-        .stroke(isTextEmpty ? Color(NSColor.separatorColor) : Color.brandPrimary(for: providerKind).opacity(0.5), lineWidth: 1)
-    )
-    .contentShape(Rectangle())
-    .disabled(isTextEmpty)
-    .help(isEditMode ? "Update comment (⌘↵)" : "Add to review (⌘↵)")
   }
 
   // MARK: - Delete Button
@@ -290,31 +260,23 @@ struct InlineEditorView: View {
     text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
   }
 
-  /// Submits the trimmed message text via the `onSubmit` callback.
+  /// Adds the comment to the review collection.
   ///
   /// Clears the text field immediately after capturing the message. This ensures
   /// the input is reset before the callback triggers view updates (e.g., dismissing
   /// the inline editor), preventing stale text from appearing if the editor is reused.
-  private func submitMessage() {
+  private func addComment() {
     guard !isTextEmpty else { return }
     let messageText = text.trimmingCharacters(in: .whitespacesAndNewlines)
     text = ""
-    onSubmit(messageText)
-  }
-
-  /// Adds the comment to the review collection without sending to Claude.
-  private func addComment() {
-    guard !isTextEmpty, let callback = onAddComment else { return }
-    let messageText = text.trimmingCharacters(in: .whitespacesAndNewlines)
-    text = ""
-    callback(messageText)
+    onAddComment(messageText)
   }
 
   /// Handles keyboard shortcuts for the inline editor.
   ///
-  /// - **Enter**: Submits the message immediately to Claude
-  /// - **Cmd+Enter**: Adds comment to review collection (if callback provided)
-  /// - **Shift+Enter**: Inserts a new line (returns `.ignored` to allow default behavior)
+  /// - **Return**: Adds comment to review collection
+  /// - **Cmd+Return**: Also adds comment (alias)
+  /// - **Shift+Return**: Inserts a new line (returns `.ignored` to allow default behavior)
   /// - **Escape**: Dismisses the editor without submitting
   private func handleKeyPress(_ key: KeyPress) -> KeyPress.Result {
     switch key.key {
@@ -322,13 +284,9 @@ struct InlineEditorView: View {
       if key.modifiers.contains(.shift) {
         // Shift+Enter: insert newline
         return .ignored
-      } else if key.modifiers.contains(.command) {
-        // Cmd+Enter: add to comment collection
-        addComment()
-        return .handled
       }
-      // Enter: submit immediately
-      submitMessage()
+      // Return (or Cmd+Return): add to comment collection
+      addComment()
       return .handled
 
     case .escape:
@@ -349,20 +307,6 @@ struct InlineEditorView: View {
     side: "right",
     fileName: "Example.swift",
     errorMessage: nil,
-    onSubmit: { _ in },
-    onDismiss: { }
-  )
-  .padding(40)
-  .background(Color.gray.opacity(0.2))
-}
-
-#Preview("With Add Comment") {
-  InlineEditorView(
-    lineNumber: 42,
-    side: "right",
-    fileName: "Example.swift",
-    errorMessage: nil,
-    onSubmit: { _ in },
     onAddComment: { _ in },
     onDismiss: { }
   )
@@ -376,7 +320,6 @@ struct InlineEditorView: View {
     side: "right",
     fileName: "Example.swift",
     errorMessage: nil,
-    onSubmit: { _ in },
     onAddComment: { _ in },
     onDeleteComment: { },
     onDismiss: { },
@@ -393,7 +336,7 @@ struct InlineEditorView: View {
     side: "right",
     fileName: "Example.swift",
     errorMessage: "Failed to connect to Claude",
-    onSubmit: { _ in },
+    onAddComment: { _ in },
     onDismiss: {}
   )
   .padding(40)

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/PlanView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/PlanView.swift
@@ -304,11 +304,6 @@ public struct PlanView: View {
           fileName: planFilePath,
           errorMessage: nil,
           providerKind: providerKind,
-          onSubmit: { message in
-            let feedback = "Feedback on line \(lineNumber): \(message)"
-            onSendFeedback?("\u{1B}[B\u{1B}[B\u{1B}[B\r\(feedback)", session)
-            withAnimation { activeLineIndex = nil }
-          },
           onAddComment: { message in
             commentsState.addComment(
               filePath: planFilePath,


### PR DESCRIPTION
## Summary
- Remove direct send button and shortcut from the inline text editor — Return key now adds comments to the review queue instead of sending immediately
- Add `⏎` return key hint next to the plus button for discoverability
- Make the bottom comments panel collapsible: starts as a compact header showing comment count, expands on tap to reveal the comment list with edit/delete actions and the send toolbar
- The only way to send feedback to Claude is now via the bottom panel's "Send to Claude" button

## Test plan
- [ ] Click a diff line, type a comment, press Return — comment is added to queue and editor dismisses
- [ ] Shift+Return inserts a newline in the editor
- [ ] No send button visible in the inline editor
- [ ] Bottom panel shows collapsed header with comment count
- [ ] Tapping the header expands to show comment list and send toolbar
- [ ] Edit and delete actions work on individual comments in the expanded panel
- [ ] "Send N to Claude" button sends all queued comments
- [ ] Clicking an existing annotation opens editor in edit mode with checkmark button