### PR TITLE
Redesign sidebar: flat rows, project grouping, collapsible headers

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/CollapsibleSessionRow.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/CollapsibleSessionRow.swift
@@ -16,27 +16,25 @@ struct CollapsibleSessionRow: View {
   var isDeletingWorktree: Bool = false
   let onSelect: () -> Void
 
-  @State private var gradientProgress: CGFloat = 0
+  @State private var isHovered = false
   @State private var showArchiveConfirm = false
   @State private var pulseScale: CGFloat = 1.0
   @State private var isPulseAnimating = false
 
-  private var tildeProjectPath: String {
-    let home = FileManager.default.homeDirectoryForCurrentUser.path
-    if session.projectPath.hasPrefix(home) {
-      return "~" + session.projectPath.dropFirst(home.count)
-    }
-    return session.projectPath
+  // MARK: - Computed
+
+  private var displayName: String {
+    customName ?? session.slug ?? session.shortId
   }
 
   private var statusColor: Color {
-    guard let sessionStatus else { return .brandPrimary(for: providerKind) }
+    guard let sessionStatus else { return .secondary }
     switch sessionStatus {
     case .thinking: return .blue
     case .executingTool: return .orange
     case .waitingForUser: return .green
     case .awaitingApproval: return .yellow
-    case .idle: return .gray
+    case .idle: return .secondary
     }
   }
 
@@ -48,231 +46,184 @@ struct CollapsibleSessionRow: View {
     }
   }
 
-  private var statusIcon: String? {
-    guard let sessionStatus else { return nil }
-    switch sessionStatus {
-    case .thinking: return nil  // Use pulsing dot
-    case .executingTool: return nil  // Use pulsing dot
-    case .waitingForUser: return "checkmark.circle.fill"
-    case .awaitingApproval: return "exclamationmark.circle.fill"
-    case .idle: return nil
-    }
-  }
-
-  private var shouldPulse: Bool {
-    isActiveStatus
-  }
+  private var shouldPulse: Bool { isActiveStatus }
 
   private func statusDisplayText(_ status: SessionStatus) -> String {
     switch status {
-    case .thinking: return "Working"
-    case .executingTool(let name): return name
-    case .waitingForUser: return "Ready"
-    case .awaitingApproval(let tool): return "Approval: \(tool)"
-    case .idle: return "Idle"
+    case .thinking: return "working"
+    case .executingTool(let name): return name.lowercased()
+    case .waitingForUser: return "ready"
+    case .awaitingApproval(let tool): return tool.lowercased()
+    case .idle: return "idle"
     }
   }
 
+  private var showActions: Bool {
+    isHovered && !isPending && (onArchive != nil || onDeleteWorktree != nil)
+  }
+
+  // MARK: - Body
+
   var body: some View {
-    VStack(alignment: .leading, spacing: 2) {
-      // Top row: icon + session ID + status badge
-      HStack(alignment: .top, spacing: 6) {
-        // Terminal prompt icon
-        Text(">_")
-          .font(.jetBrainsMono(size: 13, weight: .bold))
-          .foregroundColor(statusColor.opacity(isActiveStatus ? 1.0 : 0.5))
+    HStack(spacing: 8) {
+      // Status dot
+      Circle()
+        .fill(statusColor)
+        .frame(width: 6, height: 6)
+        .scaleEffect(shouldPulse ? pulseScale : 1.0)
+        .animation(.easeInOut(duration: 0.35), value: statusColor)
 
-        // Session ID
-        HStack(spacing: 4) {
-          Text("session:")
-            .font(.primaryCaption)
-            .foregroundColor(.secondary)
-          Text(customName ?? session.slug ?? session.shortId)
-            .font(.jetBrainsMono(size: 13, weight: .bold))
+      // Content
+      VStack(alignment: .leading, spacing: 2) {
+        // Row 1: name + provider + status + time
+        HStack(spacing: 6) {
+          Text(displayName)
+            .font(.secondaryDefault)
+            .foregroundColor(.primary)
             .lineLimit(1)
-        }
-
-        Spacer(minLength: 4)
-
-        // Status badge
-        VStack(alignment: .trailing, spacing: 4) {
-        // Status badge
-        if let sessionStatus {
-          HStack(spacing: 4) {
-            Circle()
-              .fill(statusColor)
-              .frame(width: 6, height: 6)
-              .scaleEffect(shouldPulse ? pulseScale : 1.0)
-            Text(statusDisplayText(sessionStatus).lowercased())
-              .font(.primaryCaption)
-              .foregroundColor(statusColor)
-          }
-          .padding(.horizontal, 8)
-          .padding(.vertical, 3)
-          .background(statusColor.opacity(0.12))
-          .clipShape(RoundedRectangle(cornerRadius: 4))
-        } else if isPending {
-          Text("starting")
-            .font(.primaryCaption)
-            .foregroundColor(.secondary)
-            .padding(.horizontal, 8)
-            .padding(.vertical, 3)
-            .background(Color.secondary.opacity(0.12))
-            .clipShape(RoundedRectangle(cornerRadius: 4))
-        }
-
-          // Timestamp
-          Text(timestamp.timeAgoDisplay())
-            .font(.secondaryCaption)
-            .foregroundColor(.secondary)
-        }
-      }
-
-      // Branch line (aligned to leading edge)
-      if let branch = session.branchName {
-        HStack(spacing: 4) {
-          Image(systemName: "arrow.triangle.branch")
-            .font(.system(size: 9))
-            .foregroundColor(.secondary.opacity(0.6))
-          Text(branch)
-            .font(.primaryCaption)
-            .foregroundColor(.secondary.opacity(0.9))
-            .lineLimit(1)
-
-          Text("\u{2022}")
-            .font(.secondaryCaption)
-            .foregroundColor(.secondary.opacity(0.6))
+            .layoutPriority(1)
 
           Text(providerKind.rawValue)
             .font(.secondaryCaption)
-            .foregroundColor(.brandPrimary(for: providerKind))
+            .foregroundColor(.brandPrimary(for: providerKind).opacity(0.8))
+
+          Spacer(minLength: 4)
+
+          statusLabel
+            .animation(.easeInOut(duration: 0.3), value: isPending)
+            .animation(.easeInOut(duration: 0.3), value: sessionStatus)
+
+          Text(timestamp.timeAgoDisplay())
+            .font(.secondaryCaption)
+            .foregroundColor(.secondary.opacity(0.7))
+        }
+
+        // Row 2: message + actions
+        HStack(spacing: 0) {
+          if let message = session.firstMessage, !message.isEmpty {
+            Text(message)
+              .font(.secondarySmall)
+              .foregroundColor(.secondary.opacity(0.7))
+              .lineLimit(1)
+          }
+
+          Spacer(minLength: 4)
+
+          actionsView
+            .opacity(showActions ? 1 : 0)
+            .animation(.easeInOut(duration: 0.25), value: showActions)
         }
       }
-      else {
-        Text(providerKind.rawValue)
-          .font(.secondaryCaption)
-          .foregroundColor(.brandPrimary(for: providerKind))
-      }
-
-      // Message preview with $ prompt (aligned to leading edge)
-      if let message = session.firstMessage, !message.isEmpty {
-        Text("$ " + (message.count > 60 ? String(message.prefix(60)) + "..." : message))
-          .font(.primarySmall)
-          .foregroundColor(.primary.opacity(0.5))
-          .lineLimit(1)
-          .padding(.top, 2)
-          .padding(.trailing, 56)
-      }
     }
-    .padding(.horizontal, 8)
+    .padding(.horizontal, 10)
     .padding(.vertical, 8)
-    .foregroundColor(.primary)
     .contentShape(Rectangle())
     .onTapGesture { onSelect() }
     .background(
-      ZStack {
-        RoundedRectangle(cornerRadius: 6)
-          .fill(colorScheme == .dark ? Color(white: 0.08) : Color(white: 0.94))
-        RoundedRectangle(cornerRadius: 6)
-          .fill(LinearGradient(
-            colors: [
-              Color.brandPrimary(for: providerKind).opacity(colorScheme == .dark ? 0.2 : 0.55),
-              Color.clear
-            ],
-            startPoint: .leading,
-            endPoint: .trailing
-          ))
-          .opacity(gradientProgress)
-      }
-    )
-    .overlay(
       RoundedRectangle(cornerRadius: 6)
-        .stroke(
-          isPrimary
-            ? statusColor.opacity(colorScheme == .dark ? 0.3 : 0.55)
-            : Color.clear,
-          lineWidth: 1
-        )
+        .fill(rowBackground)
+        .animation(.easeInOut(duration: 0.3), value: isPending)
     )
-    .overlay(alignment: .bottomTrailing) {
-      if !isPending, (onArchive != nil || onDeleteWorktree != nil) {
-        HStack(spacing: 4) {
-          if let onArchive {
-            Group {
-              if showArchiveConfirm {
-                Button {
-                  showArchiveConfirm = false
-                  onArchive()
-                } label: {
-                  Text("Confirm")
-                    .font(.secondaryCaption)
-                    .foregroundColor(.white)
-                    .padding(.horizontal, 6)
-                    .padding(.vertical, 2)
-                    .background(Color.brandPrimary(for: providerKind))
-                    .clipShape(RoundedRectangle(cornerRadius: 4))
-                }
-                .buttonStyle(.plain)
-              } else {
-                Button {
-                  withAnimation(.easeInOut(duration: 0.15)) {
-                    showArchiveConfirm = true
-                  }
-                } label: {
-                  Image(systemName: "archivebox")
-                    .font(.system(size: 11))
-                    .foregroundColor(.secondary)
-                    .frame(width: 20, height: 20)
-                }
-                .buttonStyle(.plain)
-                .help("Archive session")
-              }
-            }
-            .transition(.opacity.combined(with: .scale(scale: 0.8)))
-          }
-
-          if let onDeleteWorktree {
-            if isDeletingWorktree {
-              ProgressView()
-                .controlSize(.small)
-                .frame(width: 20, height: 20)
-            } else {
-              Button {
-                onDeleteWorktree()
-              } label: {
-                Image(systemName: "trash")
-                  .font(.system(size: 11))
-                  .foregroundColor(.secondary)
-                  .frame(width: 20, height: 20)
-              }
-              .buttonStyle(.plain)
-              .help("Delete worktree")
-            }
-          }
-        }
-        .padding(.trailing, 8)
-        .padding(.bottom, 8)
-      }
-    }
-    .padding(.vertical, 2)
     .onHover { hovering in
+      withAnimation(.easeInOut(duration: 0.12)) {
+        isHovered = hovering
+      }
       if !hovering && showArchiveConfirm {
         withAnimation(.easeInOut(duration: 0.15)) {
           showArchiveConfirm = false
         }
       }
     }
-    .onAppear {
-      gradientProgress = isPrimary ? 1 : 0
-      startPulseAnimation()
+    .onAppear { startPulseAnimation() }
+    .onChange(of: sessionStatus) { _, _ in startPulseAnimation() }
+    .onChange(of: isPending) { _, _ in startPulseAnimation() }
+  }
+
+  @ViewBuilder
+  private var statusLabel: some View {
+    if let sessionStatus {
+      Text(statusDisplayText(sessionStatus))
+        .font(.secondaryCaption)
+        .foregroundColor(statusColor)
+        .transition(.opacity.combined(with: .scale(scale: 0.9)))
+        .id("status-\(statusDisplayText(sessionStatus))")
+    } else if isPending {
+      Text("starting")
+        .font(.secondaryCaption)
+        .foregroundColor(.secondary)
+        .transition(.opacity.combined(with: .scale(scale: 0.9)))
+        .id("status-pending")
     }
-    .onChange(of: isPrimary) { _, newValue in
-      withAnimation(.interpolatingSpring(mass: 0.8, stiffness: 350, damping: 22, initialVelocity: 0)) {
-        gradientProgress = newValue ? 1 : 0
+  }
+
+  // MARK: - Subviews
+
+  private var rowBackground: Color {
+    if isPrimary && isHovered {
+      return Color.brandPrimary(for: providerKind).opacity(colorScheme == .dark ? 0.28 : 0.22)
+    }
+    if isPrimary {
+      return Color.brandPrimary(for: providerKind).opacity(colorScheme == .dark ? 0.2 : 0.16)
+    }
+    if isHovered {
+      return Color.brandPrimary(for: providerKind).opacity(colorScheme == .dark ? 0.12 : 0.1)
+    }
+    return .clear
+  }
+
+  @ViewBuilder
+  private var actionsView: some View {
+    HStack(spacing: 2) {
+      if let onArchive {
+        if showArchiveConfirm {
+          Button {
+            showArchiveConfirm = false
+            onArchive()
+          } label: {
+            Text("Confirm")
+              .font(.secondaryCaption)
+              .foregroundColor(.white)
+              .padding(.horizontal, 6)
+              .padding(.vertical, 2)
+              .background(Color.brandPrimary(for: providerKind))
+              .clipShape(RoundedRectangle(cornerRadius: 4))
+          }
+          .buttonStyle(.plain)
+          .transition(.opacity.combined(with: .scale(scale: 0.8)))
+        } else {
+          Button {
+            withAnimation(.easeInOut(duration: 0.15)) {
+              showArchiveConfirm = true
+            }
+          } label: {
+            Image(systemName: "archivebox")
+              .font(.system(size: 10))
+              .foregroundColor(.secondary)
+              .frame(width: 18, height: 18)
+          }
+          .buttonStyle(.plain)
+          .help("Archive session")
+        }
       }
-    }
-    .onChange(of: sessionStatus) { _, _ in
-      startPulseAnimation()
+
+      if let onDeleteWorktree {
+        if isDeletingWorktree {
+          ProgressView()
+            .controlSize(.mini)
+            .frame(width: 18, height: 18)
+        } else {
+          Button {
+            onDeleteWorktree()
+          } label: {
+            Image(systemName: "trash")
+              .font(.system(size: 10))
+              .foregroundColor(.secondary)
+              .frame(width: 18, height: 18)
+          }
+          .buttonStyle(.plain)
+          .help("Delete worktree")
+        }
+      }
     }
   }
 
@@ -303,221 +254,171 @@ struct CollapsibleSessionRow: View {
 
 // MARK: - Preview
 
-#Preview("CollapsibleSessionRow States") {
-  let claudeSession = CLISession(
-    id: "abc12345-6789-0def-ghij-klmnopqrstuv",
-    projectPath: "/Users/dev/projects/AgentHub",
-    branchName: "feature/multi-session",
-    lastActivityAt: Date(),
-    messageCount: 12,
-    isActive: true,
-    firstMessage: "Help me refactor the authentication module to use async/await patterns",
-    slug: "cryptic-orbiting-flame"
-  )
+#Preview("CollapsibleSessionRow — Flat Design") {
+  let sessions = [
+    CLISession(
+      id: "abc12345-6789-0def-ghij-klmnopqrstuv",
+      projectPath: "/Users/dev/projects/AgentHub",
+      branchName: "feature/multi-session",
+      lastActivityAt: Date(),
+      messageCount: 12,
+      isActive: true,
+      firstMessage: "Help me refactor the authentication module to use async/await patterns",
+      slug: "cryptic-orbiting-flame"
+    ),
+    CLISession(
+      id: "def98765-4321-0abc-wxyz-abcdefghijkl",
+      projectPath: "/Users/dev/projects/AgentHub",
+      branchName: "main",
+      lastActivityAt: Date().addingTimeInterval(-3600),
+      messageCount: 5,
+      isActive: true,
+      firstMessage: "Write unit tests for the session manager",
+      slug: "bright-wandering-star"
+    ),
+    CLISession(
+      id: "fff11111-2222-3333-4444-555566667777",
+      projectPath: "/Users/dev/projects/AgentHub",
+      branchName: "fix/login-bug",
+      lastActivityAt: Date().addingTimeInterval(-86400),
+      messageCount: 0,
+      isActive: false,
+      slug: "silent-morning-dew"
+    ),
+    CLISession(
+      id: "aaa22222-3333-4444-5555-666677778888",
+      projectPath: "/Users/dev/projects/AgentHub",
+      branchName: "refactor/db-layer",
+      lastActivityAt: Date().addingTimeInterval(-7200),
+      messageCount: 8,
+      isActive: true,
+      firstMessage: "Migrate the persistence layer from CoreData to GRDB",
+      slug: nil
+    ),
+  ]
 
-  let codexSession = CLISession(
-    id: "def98765-4321-0abc-wxyz-abcdefghijkl",
-    projectPath: "/Users/dev/projects/AgentHub",
-    branchName: "main",
-    lastActivityAt: Date().addingTimeInterval(-3600),
-    messageCount: 5,
-    isActive: true,
-    firstMessage: "Write unit tests for the session manager",
-    slug: "bright-wandering-star"
-  )
-
-  let pendingSession = CLISession(
-    id: "fff11111-2222-3333-4444-555566667777",
-    projectPath: "/Users/dev/projects/AgentHub",
-    branchName: "fix/login-bug",
-    lastActivityAt: Date(),
-    messageCount: 0,
-    isActive: false,
-    slug: "silent-morning-dew"
-  )
+  let statuses: [(SessionStatus?, Bool, Bool)] = [
+    (.thinking, false, true),
+    (.executingTool(name: "Bash"), false, false),
+    (.idle, false, false),
+    (.waitingForUser, false, true),
+    (.awaitingApproval(tool: "Edit"), false, false),
+    (nil, true, false),
+  ]
 
   ScrollView {
-    VStack(spacing: 16) {
-      // Section: Claude provider
-      Text("Claude — Selected (isPrimary)")
-        .font(.caption).foregroundColor(.secondary)
-        .frame(maxWidth: .infinity, alignment: .leading)
+    VStack(alignment: .leading, spacing: 24) {
 
-      CollapsibleSessionRow(
-        session: claudeSession,
-        providerKind: .claude,
-        timestamp: Date(),
-        isPending: false,
-        isPrimary: true,
-        customName: nil,
-        sessionStatus: .thinking,
-        colorScheme: .dark,
-        onArchive: {},
-        onDeleteWorktree: nil,
-        onSelect: {}
-      )
-
-      Text("Claude — Default")
-        .font(.caption).foregroundColor(.secondary)
-        .frame(maxWidth: .infinity, alignment: .leading)
-
-      CollapsibleSessionRow(
-        session: claudeSession,
-        providerKind: .claude,
-        timestamp: Date(),
-        isPending: false,
-        isPrimary: false,
-        customName: nil,
-        sessionStatus: .idle,
-        colorScheme: .dark,
-        onArchive: {},
-        onDeleteWorktree: nil,
-        onSelect: {}
-      )
+      // --- All states ---
+      sectionHeader("All States")
+      VStack(spacing: 1) {
+        ForEach(Array(statuses.enumerated()), id: \.offset) { idx, state in
+          let s = sessions[idx % sessions.count]
+          CollapsibleSessionRow(
+            session: s,
+            providerKind: idx % 2 == 0 ? .claude : .codex,
+            timestamp: s.lastActivityAt,
+            isPending: state.1,
+            isPrimary: state.2,
+            customName: idx == 3 ? "Auth Refactor" : nil,
+            sessionStatus: state.0,
+            colorScheme: .dark,
+            onArchive: state.1 ? nil : {},
+            onDeleteWorktree: nil,
+            onSelect: {}
+          )
+        }
+      }
 
       Divider().padding(.vertical, 4)
 
-      // Section: Codex provider
-      Text("Codex — Selected (isPrimary)")
-        .font(.caption).foregroundColor(.secondary)
-        .frame(maxWidth: .infinity, alignment: .leading)
-
-      CollapsibleSessionRow(
-        session: codexSession,
-        providerKind: .codex,
-        timestamp: Date().addingTimeInterval(-3600),
-        isPending: false,
-        isPrimary: true,
-        customName: nil,
-        sessionStatus: .executingTool(name: "Bash"),
-        colorScheme: .dark,
-        onArchive: {},
-        onDeleteWorktree: nil,
-        onSelect: {}
-      )
-
-      Text("Codex — Default")
-        .font(.caption).foregroundColor(.secondary)
-        .frame(maxWidth: .infinity, alignment: .leading)
-
-      CollapsibleSessionRow(
-        session: codexSession,
-        providerKind: .codex,
-        timestamp: Date().addingTimeInterval(-3600),
-        isPending: false,
-        isPrimary: false,
-        customName: nil,
-        sessionStatus: .waitingForUser,
-        colorScheme: .dark,
-        onArchive: {},
-        onDeleteWorktree: nil,
-        onSelect: {}
-      )
+      // --- List feel ---
+      sectionHeader("List — multiple sessions")
+      VStack(spacing: 1) {
+        ForEach(Array(sessions.enumerated()), id: \.1.id) { idx, s in
+          CollapsibleSessionRow(
+            session: s,
+            providerKind: idx < 2 ? .claude : .codex,
+            timestamp: s.lastActivityAt,
+            isPending: false,
+            isPrimary: idx == 0,
+            customName: nil,
+            sessionStatus: idx == 0 ? .thinking : (idx == 1 ? .executingTool(name: "Read") : .idle),
+            colorScheme: .dark,
+            onArchive: {},
+            onDeleteWorktree: nil,
+            onSelect: {}
+          )
+        }
+      }
 
       Divider().padding(.vertical, 4)
 
-      // Section: Pending state
-      Text("Claude — Pending + Selected")
-        .font(.caption).foregroundColor(.secondary)
-        .frame(maxWidth: .infinity, alignment: .leading)
+      // --- Light mode ---
+      sectionHeader("Light Mode")
+      VStack(spacing: 1) {
+        CollapsibleSessionRow(
+          session: sessions[0],
+          providerKind: .claude,
+          timestamp: Date(),
+          isPending: false,
+          isPrimary: true,
+          customName: nil,
+          sessionStatus: .thinking,
+          colorScheme: .light,
+          onArchive: {},
+          onDeleteWorktree: nil,
+          onSelect: {}
+        )
+        .environment(\.colorScheme, .light)
 
-      CollapsibleSessionRow(
-        session: pendingSession,
-        providerKind: .claude,
-        timestamp: Date(),
-        isPending: true,
-        isPrimary: true,
-        customName: nil,
-        sessionStatus: nil,
-        colorScheme: .dark,
-        onArchive: nil,
-        onDeleteWorktree: nil,
-        onSelect: {}
-      )
+        CollapsibleSessionRow(
+          session: sessions[1],
+          providerKind: .claude,
+          timestamp: Date().addingTimeInterval(-3600),
+          isPending: false,
+          isPrimary: false,
+          customName: nil,
+          sessionStatus: .idle,
+          colorScheme: .light,
+          onArchive: {},
+          onDeleteWorktree: nil,
+          onSelect: {}
+        )
+        .environment(\.colorScheme, .light)
 
-      Text("Codex — Pending + Default")
-        .font(.caption).foregroundColor(.secondary)
-        .frame(maxWidth: .infinity, alignment: .leading)
-
-      CollapsibleSessionRow(
-        session: pendingSession,
-        providerKind: .codex,
-        timestamp: Date(),
-        isPending: true,
-        isPrimary: false,
-        customName: nil,
-        sessionStatus: nil,
-        colorScheme: .dark,
-        onArchive: nil,
-        onDeleteWorktree: nil,
-        onSelect: {}
-      )
-
-      Divider().padding(.vertical, 4)
-
-      // Section: Custom name
-      Text("Claude — Custom Name + Selected")
-        .font(.caption).foregroundColor(.secondary)
-        .frame(maxWidth: .infinity, alignment: .leading)
-
-      CollapsibleSessionRow(
-        session: claudeSession,
-        providerKind: .claude,
-        timestamp: Date(),
-        isPending: false,
-        isPrimary: true,
-        customName: "Auth Refactor",
-        sessionStatus: .awaitingApproval(tool: "Edit"),
-        colorScheme: .dark,
-        onArchive: {},
-        onDeleteWorktree: nil,
-        onSelect: {}
-      )
-
-      Divider().padding(.vertical, 4)
-
-      // Section: Light mode
-      Text("Claude — Selected (Light Mode)")
-        .font(.caption).foregroundColor(.secondary)
-        .frame(maxWidth: .infinity, alignment: .leading)
-
-      CollapsibleSessionRow(
-        session: claudeSession,
-        providerKind: .claude,
-        timestamp: Date(),
-        isPending: false,
-        isPrimary: true,
-        customName: nil,
-        sessionStatus: .thinking,
-        colorScheme: .light,
-        onArchive: {},
-        onDeleteWorktree: nil,
-        onSelect: {}
-      )
-      .environment(\.colorScheme, .light)
-
-      Text("Claude — Default (Light Mode)")
-        .font(.caption).foregroundColor(.secondary)
-        .frame(maxWidth: .infinity, alignment: .leading)
-
-      CollapsibleSessionRow(
-        session: claudeSession,
-        providerKind: .claude,
-        timestamp: Date(),
-        isPending: false,
-        isPrimary: false,
-        customName: nil,
-        sessionStatus: .idle,
-        colorScheme: .light,
-        onArchive: {},
-        onDeleteWorktree: nil,
-        onSelect: {}
-      )
-      .environment(\.colorScheme, .light)
+        CollapsibleSessionRow(
+          session: sessions[2],
+          providerKind: .codex,
+          timestamp: Date().addingTimeInterval(-86400),
+          isPending: false,
+          isPrimary: false,
+          customName: nil,
+          sessionStatus: .waitingForUser,
+          colorScheme: .light,
+          onArchive: {},
+          onDeleteWorktree: nil,
+          onSelect: {}
+        )
+        .environment(\.colorScheme, .light)
+      }
+      .background(Color(white: 0.96))
+      .clipShape(RoundedRectangle(cornerRadius: 8))
     }
     .padding()
   }
-  .frame(width: 320, height: 900)
+  .frame(width: 340, height: 800)
   .background(Color(nsColor: .windowBackgroundColor))
   .preferredColorScheme(.dark)
+}
+
+// MARK: - Preview Helpers
+
+@ViewBuilder
+private func sectionHeader(_ title: String) -> some View {
+  Text(title)
+    .font(.secondaryCaption)
+    .foregroundColor(.secondary)
+    .textCase(.uppercase)
+    .frame(maxWidth: .infinity, alignment: .leading)
 }

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderMonitoringPanelView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderMonitoringPanelView.swift
@@ -101,22 +101,6 @@ public enum HubLayoutMode: Int, CaseIterable {
 
 private typealias LayoutMode = HubLayoutMode
 
-// MARK: - HubFilterMode
-
-public enum HubFilterMode: Int, CaseIterable {
-  case all = 0
-  case claude = 1
-  case codex = 2
-
-  var displayName: String {
-    switch self {
-    case .all: return "All"
-    case .claude: return "Claude"
-    case .codex: return "Codex"
-    }
-  }
-}
-
 // MARK: - ModuleSectionHeader
 
 private struct ModuleSectionHeader: View {
@@ -136,51 +120,6 @@ private struct ModuleSectionHeader: View {
     .padding(.horizontal, 4)
     .padding(.top, 6)
     .padding(.bottom, 10)
-  }
-}
-
-// MARK: - HubFilterControl
-
-struct HubFilterControl: View {
-  @Binding var filterMode: HubFilterMode
-  let claudeCount: Int
-  let codexCount: Int
-  let totalCount: Int
-
-  var body: some View {
-    HStack(spacing: 12) {
-      filterTab(for: .all, count: totalCount)
-      filterTab(for: .claude, count: claudeCount)
-      filterTab(for: .codex, count: codexCount)
-    }
-  }
-
-  private func filterTab(for mode: HubFilterMode, count: Int) -> some View {
-    let isSelected = filterMode == mode
-
-    return Button(action: { filterMode = mode }) {
-      VStack(spacing: 2) {
-        HStack(spacing: 3) {
-          Text(mode.displayName)
-            .fontWeight(isSelected ? .semibold : .regular)
-          Text("\(count)")
-            .foregroundColor(.secondary)
-        }
-        .font(.secondarySmall)
-        .foregroundColor(isSelected ? .primary : .secondary)
-
-        // Underline indicator
-        Rectangle()
-          .fill(Color.primary)
-          .frame(height: 1.5)
-          .opacity(isSelected ? 1 : 0)
-      }
-      .padding(.horizontal, 4)
-      .fixedSize()
-      .contentShape(Rectangle())
-    }
-    .buttonStyle(.plain)
-    .animation(.easeInOut(duration: 0.2), value: filterMode)
   }
 }
 
@@ -264,7 +203,6 @@ public struct MultiProviderMonitoringPanelView: View {
   @State private var persistedFEProjectPath: String = ""
   @State private var persistedFENavId: UUID = UUID()
   @State private var persistedFEInitPath: String? = nil
-  @Binding var filterMode: HubFilterMode
   @State private var availableDetailWidth: CGFloat = 0
   @Binding var primarySessionId: String?
   @AppStorage(AgentHubDefaults.hubLayoutMode)
@@ -333,14 +271,12 @@ public struct MultiProviderMonitoringPanelView: View {
   public init(
     claudeViewModel: CLISessionsViewModel,
     codexViewModel: CLISessionsViewModel,
-    filterMode: Binding<HubFilterMode>,
     primarySessionId: Binding<String?>,
     onEmbeddedSidePanelVisibilityChange: @escaping (Bool) -> Void = { _ in },
     onRequestStartSession: @escaping (String?) -> Void
   ) {
     self.claudeViewModel = claudeViewModel
     self.codexViewModel = codexViewModel
-    self._filterMode = filterMode
     self._primarySessionId = primarySessionId
     self.onEmbeddedSidePanelVisibilityChange = onEmbeddedSidePanelVisibilityChange
     self.onRequestStartSession = onRequestStartSession
@@ -506,7 +442,7 @@ public struct MultiProviderMonitoringPanelView: View {
     }
     .onChange(of: primarySessionId) { _, newId in
       guard let newId else { return }
-      if let item = filteredItems.first(where: { $0.id == newId }) {
+      if let item = allItems.first(where: { $0.id == newId }) {
         item.viewModel.focusTerminal(forKey: item.sessionId)
       }
     }
@@ -561,8 +497,6 @@ public struct MultiProviderMonitoringPanelView: View {
       loadingState
     } else if allItems.isEmpty {
       emptyState
-    } else if visibleItems.isEmpty {
-      filteredEmptyState
     } else {
       monitoredSessionsList
     }
@@ -592,26 +526,6 @@ public struct MultiProviderMonitoringPanelView: View {
       viewModel: emptyStateViewModel,
       onStartSession: onRequestStartSession
     )
-  }
-
-  // MARK: - Filtered Empty State
-
-  private var filteredEmptyState: some View {
-    VStack(spacing: 12) {
-      Image(systemName: "line.3.horizontal.decrease.circle")
-        .font(.largeTitle)
-        .foregroundColor(.secondary.opacity(0.5))
-
-      Text("No \(filterMode.displayName) Sessions")
-        .font(.heading)
-        .foregroundColor(.secondary)
-
-      Button("Show All") {
-        filterMode = .all
-      }
-      .buttonStyle(.bordered)
-    }
-    .frame(maxWidth: .infinity, maxHeight: .infinity)
   }
 
   // MARK: - Monitored Sessions List
@@ -1102,41 +1016,19 @@ public struct MultiProviderMonitoringPanelView: View {
     }
   }
 
-  // MARK: - Filter Helpers
-
-  private func shouldShowItem(_ item: ProviderMonitoringItem) -> Bool {
-    switch filterMode {
-    case .all: return true
-    case .claude: return item.providerKind == .claude
-    case .codex: return item.providerKind == .codex
-    }
-  }
-
-  private var filteredItems: [ProviderMonitoringItem] {
-    allItems.filter { shouldShowItem($0) }
-  }
-
   private var effectivePrimarySessionId: String? {
-    if let current = primarySessionId, filteredItems.contains(where: { $0.id == current }) {
+    if let current = primarySessionId, allItems.contains(where: { $0.id == current }) {
       return current
     }
-    return filteredItems.sorted { $0.timestamp > $1.timestamp }.first?.id
+    return allItems.sorted { $0.timestamp > $1.timestamp }.first?.id
   }
 
   private var visibleItems: [ProviderMonitoringItem] {
     if layoutMode == .single {
       guard let selectedId = effectivePrimarySessionId else { return [] }
-      return filteredItems.filter { $0.id == selectedId }
+      return allItems.filter { $0.id == selectedId }
     }
-    return filteredItems
-  }
-
-  private var claudeItemCount: Int {
-    allItems.filter { $0.providerKind == .claude }.count
-  }
-
-  private var codexItemCount: Int {
-    allItems.filter { $0.providerKind == .codex }.count
+    return allItems
   }
 
   // MARK: - Helpers
@@ -1278,7 +1170,7 @@ public struct MultiProviderMonitoringPanelView: View {
 
   private var effectivePrimaryItem: ProviderMonitoringItem? {
     guard let selectedId = effectivePrimarySessionId else { return nil }
-    return filteredItems.first(where: { $0.id == selectedId })
+    return allItems.first(where: { $0.id == selectedId })
   }
 
   private var auxiliaryShellTarget: HubAuxiliaryShellTarget? {
@@ -1312,16 +1204,9 @@ public struct MultiProviderMonitoringPanelView: View {
   }
 
   private var emptyStateViewModel: CLISessionsViewModel {
-    switch filterMode {
-    case .claude:
-      return claudeViewModel
-    case .codex:
-      return codexViewModel
-    case .all:
-      if !claudeViewModel.selectedRepositories.isEmpty { return claudeViewModel }
-      if !codexViewModel.selectedRepositories.isEmpty { return codexViewModel }
-      return claudeViewModel
-    }
+    if !claudeViewModel.selectedRepositories.isEmpty { return claudeViewModel }
+    if !codexViewModel.selectedRepositories.isEmpty { return codexViewModel }
+    return claudeViewModel
   }
 
   private func findModulePath(for item: ProviderMonitoringItem) -> String {

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
@@ -40,7 +40,6 @@ public struct MultiProviderSessionsListView: View {
   @State private var showDeleteWorktreeAlert = false
   @State private var sessionToDeleteWorktree: CLISession? = nil
   @State private var showCommandPalette = false
-  @State private var hubFilterMode: HubFilterMode = .all
   @State private var scrollToSessionId: String?
   @State private var launchExpandRequestID = 0
   @State private var createWorktreeContext: WorktreeCreateContext?
@@ -97,7 +96,6 @@ public struct MultiProviderSessionsListView: View {
         MultiProviderMonitoringPanelView(
           claudeViewModel: claudeViewModel,
           codexViewModel: codexViewModel,
-          filterMode: $hubFilterMode,
           primarySessionId: $primarySessionId,
           onEmbeddedSidePanelVisibilityChange: handleEmbeddedSidePanelVisibilityChange,
           onRequestStartSession: { preferredRepositoryPath in
@@ -153,13 +151,7 @@ public struct MultiProviderSessionsListView: View {
     }
     .onChange(of: selectedSessionItems.map(\.id)) { _, _ in
       ensurePrimarySelection()
-      if filteredSelectedSessionItems.isEmpty {
-        setAuxiliaryShellVisible(false)
-      }
-    }
-    .onChange(of: hubFilterMode) { _, _ in
-      applyHubFilterToSidebar()
-      if filteredSelectedSessionItems.isEmpty {
+      if selectedSessionItems.isEmpty {
         setAuxiliaryShellVisible(false)
       }
     }
@@ -345,23 +337,10 @@ public struct MultiProviderSessionsListView: View {
         .padding(.bottom, 8)
       }
 
-      // 2. Provider Filter (mirrors Hub filter)
-      if !selectedSessionItems.isEmpty {
-        HubFilterControl(
-          filterMode: $hubFilterMode,
-          claudeCount: claudeFocusedSessionCount,
-          codexCount: codexFocusedSessionCount,
-          totalCount: selectedSessionItems.count
-        )
-        .padding(.top, 8)
-        .padding(.bottom, 12)
-        .transition(.move(edge: .top).combined(with: .opacity))
-      }
-
-      // 3. Inline Selected Sessions (monitored + pending)
+      // 2. Inline Selected Sessions (monitored + pending)
       inlineSelectedSessions
 
-      // 4. Collapsible Browse Sessions section
+      // 3. Collapsible Browse Sessions section
       browseSectionView
     }
     .animation(.easeInOut(duration: 0.2), value: isSearchExpanded)
@@ -629,25 +608,6 @@ public struct MultiProviderSessionsListView: View {
     return results.sorted { $0.timestamp > $1.timestamp }
   }
 
-  private var filteredSelectedSessionItems: [SelectedSessionItem] {
-    switch hubFilterMode {
-    case .all:
-      return selectedSessionItems
-    case .claude:
-      return selectedSessionItems.filter { $0.providerKind == .claude }
-    case .codex:
-      return selectedSessionItems.filter { $0.providerKind == .codex }
-    }
-  }
-
-  private var claudeFocusedSessionCount: Int {
-    selectedSessionItems.filter { $0.providerKind == .claude }.count
-  }
-
-  private var codexFocusedSessionCount: Int {
-    selectedSessionItems.filter { $0.providerKind == .codex }.count
-  }
-
   private func selectedSessionCustomName(for item: SelectedSessionItem) -> String? {
     switch item.providerKind {
     case .claude: return claudeViewModel.sessionCustomNames[item.session.id]
@@ -657,19 +617,9 @@ public struct MultiProviderSessionsListView: View {
 
   @ViewBuilder
   private var inlineSelectedSessions: some View {
-    let items = filteredSelectedSessionItems
+    let items = selectedSessionItems
     if !items.isEmpty {
       VStack(alignment: .leading, spacing: 0) {
-        HStack {
-          Text("Focused Sessions")
-            .font(.heading)
-          Text("(\(items.count))")
-            .font(.secondaryCaption)
-            .foregroundColor(.secondary)
-          Spacer()
-        }
-        .padding(.vertical, 6)
-
         ForEach(items) { item in
           CollapsibleSessionRow(
             session: item.session,
@@ -763,16 +713,14 @@ public struct MultiProviderSessionsListView: View {
 
       if isBrowseExpanded {
         VStack(spacing: 6) {
-          if hubFilterMode == .all {
-            ProviderSegmentedControl(
-              selectedProvider: Binding(
-                get: { selectedProvider },
-                set: { selectedProviderRaw = $0.rawValue }
-              ),
-              claudeSessionCount: claudeViewModel.totalSessionCount,
-              codexSessionCount: codexViewModel.totalSessionCount
-            )
-          }
+          ProviderSegmentedControl(
+            selectedProvider: Binding(
+              get: { selectedProvider },
+              set: { selectedProviderRaw = $0.rawValue }
+            ),
+            claudeSessionCount: claudeViewModel.totalSessionCount,
+            codexSessionCount: codexViewModel.totalSessionCount
+          )
 
           if hasCurrentProviderRepositories {
             statusHeader
@@ -942,26 +890,6 @@ public struct MultiProviderSessionsListView: View {
     currentViewModel.showLastMessage.toggle()
   }
 
-  private func applyHubFilterToSidebar() {
-    switch hubFilterMode {
-    case .all:
-      break
-    case .claude:
-      selectedProviderRaw = SessionProviderKind.claude.rawValue
-    case .codex:
-      selectedProviderRaw = SessionProviderKind.codex.rawValue
-    }
-
-    guard let current = primarySessionId else {
-      primarySessionId = filteredSelectedSessionItems.first?.id
-      return
-    }
-
-    if !filteredSelectedSessionItems.contains(where: { $0.id == current }) {
-      primarySessionId = filteredSelectedSessionItems.first?.id
-    }
-  }
-
   private func handleResolvedSessions(
     _ resolutions: [UUID: String],
     provider: SessionProviderKind,
@@ -980,7 +908,7 @@ public struct MultiProviderSessionsListView: View {
   }
 
   private func ensurePrimarySelection() {
-    let items = filteredSelectedSessionItems
+    let items = selectedSessionItems
     guard !items.isEmpty else {
       primarySessionId = nil
       return
@@ -1135,7 +1063,7 @@ public struct MultiProviderSessionsListView: View {
 
   private func toggleAuxiliaryShellDock() {
     ensurePrimarySelection()
-    guard !filteredSelectedSessionItems.isEmpty else { return }
+    guard !selectedSessionItems.isEmpty else { return }
     withAnimation(auxiliaryShellToggleAnimation) {
       isAuxiliaryShellVisible.toggle()
     }
@@ -1157,7 +1085,7 @@ public struct MultiProviderSessionsListView: View {
   }
 
   private func navigateSessionHistory(direction: NavigationDirection) {
-    let items = filteredSelectedSessionItems
+    let items = selectedSessionItems
     guard !items.isEmpty else { return }
 
     if let currentId = primarySessionId,

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
@@ -615,48 +615,123 @@ public struct MultiProviderSessionsListView: View {
     }
   }
 
+  // MARK: - Project Grouping
+
+  private struct SessionGroup: Identifiable {
+    let id: String            // repoPath
+    let displayName: String
+    let items: [SelectedSessionItem]
+  }
+
+  /// Deduplicated tracked repos from both providers, preserving insertion order,
+  /// newest-first. Claude's repos are walked first, then Codex-only repos.
+  private var orderedTrackedRepos: [SelectedRepository] {
+    var seen: Set<String> = []
+    var combined: [SelectedRepository] = []
+    for repo in claudeViewModel.selectedRepositories {
+      if seen.insert(repo.path).inserted { combined.append(repo) }
+    }
+    for repo in codexViewModel.selectedRepositories {
+      if seen.insert(repo.path).inserted { combined.append(repo) }
+    }
+    // Newest-added first (reverse of insertion order).
+    return combined.reversed()
+  }
+
+  /// Returns the parent repo path for an arbitrary session path — handles both
+  /// "path is the repo root" and "path is a worktree under the repo". Falls back
+  /// to the original path when no tracked repo matches (used for the orphan group).
+  private func findParentRepoPath(for itemPath: String) -> String {
+    for repo in orderedTrackedRepos {
+      if repo.path == itemPath { return repo.path }
+      if repo.worktrees.contains(where: { $0.path == itemPath }) {
+        return repo.path
+      }
+    }
+    return itemPath
+  }
+
+  /// Groups built from tracked repos first (even empty), then an orphan bucket
+  /// for sessions whose path doesn't belong to any tracked repo.
+  private var groupedSelectedSessions: [SessionGroup] {
+    let allItems = selectedSessionItems
+    var byRepo: [String: [SelectedSessionItem]] = [:]
+    for item in allItems {
+      let key = findParentRepoPath(for: item.session.projectPath)
+      byRepo[key, default: []].append(item)
+    }
+
+    var groups: [SessionGroup] = []
+    var handledKeys: Set<String> = []
+
+    // Tracked repos — always emit a header, even if empty.
+    for repo in orderedTrackedRepos {
+      let items = (byRepo[repo.path] ?? []).sorted { $0.timestamp > $1.timestamp }
+      groups.append(SessionGroup(
+        id: repo.path,
+        displayName: URL(fileURLWithPath: repo.path).lastPathComponent,
+        items: items
+      ))
+      handledKeys.insert(repo.path)
+    }
+
+    // Orphan sessions (repo not tracked yet — e.g. a brand-new pending one).
+    for (key, items) in byRepo where !handledKeys.contains(key) {
+      groups.append(SessionGroup(
+        id: key,
+        displayName: URL(fileURLWithPath: key).lastPathComponent,
+        items: items.sorted { $0.timestamp > $1.timestamp }
+      ))
+    }
+
+    return groups
+  }
+
   @ViewBuilder
   private var inlineSelectedSessions: some View {
-    let items = selectedSessionItems
-    if !items.isEmpty {
+    let groups = groupedSelectedSessions
+    if !groups.isEmpty {
       VStack(alignment: .leading, spacing: 0) {
-        ForEach(items) { item in
-          CollapsibleSessionRow(
-            session: item.session,
-            providerKind: item.providerKind,
-            timestamp: item.timestamp,
-            isPending: item.isPending,
-            isPrimary: item.id == primarySessionId,
-            customName: selectedSessionCustomName(for: item),
-            sessionStatus: item.sessionStatus,
-            colorScheme: colorScheme,
-            onArchive: item.isPending ? nil : {
-              withAnimation(.easeInOut(duration: 0.25)) {
-                switch item.providerKind {
-                case .claude: claudeViewModel.stopMonitoring(session: item.session)
-                case .codex: codexViewModel.stopMonitoring(session: item.session)
+        ForEach(groups) { group in
+          ProjectGroupHeader(name: group.displayName)
+          ForEach(group.items) { item in
+            CollapsibleSessionRow(
+              session: item.session,
+              providerKind: item.providerKind,
+              timestamp: item.timestamp,
+              isPending: item.isPending,
+              isPrimary: item.id == primarySessionId,
+              customName: selectedSessionCustomName(for: item),
+              sessionStatus: item.sessionStatus,
+              colorScheme: colorScheme,
+              onArchive: item.isPending ? nil : {
+                withAnimation(.easeInOut(duration: 0.25)) {
+                  switch item.providerKind {
+                  case .claude: claudeViewModel.stopMonitoring(session: item.session)
+                  case .codex: codexViewModel.stopMonitoring(session: item.session)
+                  }
                 }
+              },
+              onDeleteWorktree: (!item.isPending && item.session.isWorktree) ? {
+                sessionToDeleteWorktree = item.session
+                showDeleteWorktreeAlert = true
+              } : nil,
+              isDeletingWorktree: item.session.isWorktree && {
+                switch item.providerKind {
+                case .claude: return claudeViewModel.deletingWorktreePath == item.session.projectPath
+                case .codex: return codexViewModel.deletingWorktreePath == item.session.projectPath
+                }
+              }(),
+              onSelect: {
+                primarySessionId = item.id
               }
-            },
-            onDeleteWorktree: (!item.isPending && item.session.isWorktree) ? {
-              sessionToDeleteWorktree = item.session
-              showDeleteWorktreeAlert = true
-            } : nil,
-            isDeletingWorktree: item.session.isWorktree && {
-              switch item.providerKind {
-              case .claude: return claudeViewModel.deletingWorktreePath == item.session.projectPath
-              case .codex: return codexViewModel.deletingWorktreePath == item.session.projectPath
-              }
-            }(),
-            onSelect: {
-              primarySessionId = item.id
-            }
-          )
-          .transition(.asymmetric(
-            insertion: .opacity,
-            removal: .move(edge: .trailing).combined(with: .opacity)
-          ))
-          .id(item.id)
+            )
+            .transition(.asymmetric(
+              insertion: .opacity,
+              removal: .move(edge: .trailing).combined(with: .opacity)
+            ))
+            .id(item.id)
+          }
         }
       }
       .padding(.bottom, 8)
@@ -1103,6 +1178,26 @@ public struct MultiProviderSessionsListView: View {
       primarySessionId = items.first?.id
       scrollToSessionId = items.first?.id
     }
+  }
+}
+
+// MARK: - ProjectGroupHeader
+
+private struct ProjectGroupHeader: View {
+  let name: String
+
+  var body: some View {
+    HStack(spacing: 8) {
+      Image(systemName: "folder")
+        .font(.system(size: 12))
+        .foregroundColor(.secondary)
+      Text(name)
+        .font(.secondaryDefault)
+        .foregroundColor(.secondary)
+      Spacer()
+    }
+    .padding(.vertical, 6)
+    .padding(.horizontal, 4)
   }
 }
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
@@ -40,6 +40,7 @@ public struct MultiProviderSessionsListView: View {
   @State private var showDeleteWorktreeAlert = false
   @State private var sessionToDeleteWorktree: CLISession? = nil
   @State private var showCommandPalette = false
+  @State private var collapsedProjectGroups: Set<String> = []
   @State private var scrollToSessionId: String?
   @State private var launchExpandRequestID = 0
   @State private var createWorktreeContext: WorktreeCreateContext?
@@ -693,44 +694,60 @@ public struct MultiProviderSessionsListView: View {
     if !groups.isEmpty {
       VStack(alignment: .leading, spacing: 0) {
         ForEach(groups) { group in
-          ProjectGroupHeader(name: group.displayName)
-          ForEach(group.items) { item in
-            CollapsibleSessionRow(
-              session: item.session,
-              providerKind: item.providerKind,
-              timestamp: item.timestamp,
-              isPending: item.isPending,
-              isPrimary: item.id == primarySessionId,
-              customName: selectedSessionCustomName(for: item),
-              sessionStatus: item.sessionStatus,
-              colorScheme: colorScheme,
-              onArchive: item.isPending ? nil : {
-                withAnimation(.easeInOut(duration: 0.25)) {
-                  switch item.providerKind {
-                  case .claude: claudeViewModel.stopMonitoring(session: item.session)
-                  case .codex: codexViewModel.stopMonitoring(session: item.session)
-                  }
-                }
-              },
-              onDeleteWorktree: (!item.isPending && item.session.isWorktree) ? {
-                sessionToDeleteWorktree = item.session
-                showDeleteWorktreeAlert = true
-              } : nil,
-              isDeletingWorktree: item.session.isWorktree && {
-                switch item.providerKind {
-                case .claude: return claudeViewModel.deletingWorktreePath == item.session.projectPath
-                case .codex: return codexViewModel.deletingWorktreePath == item.session.projectPath
-                }
-              }(),
-              onSelect: {
-                primarySessionId = item.id
+          let isExpanded = !collapsedProjectGroups.contains(group.id)
+
+          ProjectGroupHeader(
+            name: group.displayName,
+            isExpanded: isExpanded
+          ) {
+            withAnimation(.easeInOut(duration: 0.25)) {
+              if isExpanded {
+                collapsedProjectGroups.insert(group.id)
+              } else {
+                collapsedProjectGroups.remove(group.id)
               }
-            )
-            .transition(.asymmetric(
-              insertion: .opacity,
-              removal: .move(edge: .trailing).combined(with: .opacity)
-            ))
-            .id(item.id)
+            }
+          }
+
+          if isExpanded {
+            ForEach(group.items) { item in
+              CollapsibleSessionRow(
+                session: item.session,
+                providerKind: item.providerKind,
+                timestamp: item.timestamp,
+                isPending: item.isPending,
+                isPrimary: item.id == primarySessionId,
+                customName: selectedSessionCustomName(for: item),
+                sessionStatus: item.sessionStatus,
+                colorScheme: colorScheme,
+                onArchive: item.isPending ? nil : {
+                  withAnimation(.easeInOut(duration: 0.25)) {
+                    switch item.providerKind {
+                    case .claude: claudeViewModel.stopMonitoring(session: item.session)
+                    case .codex: codexViewModel.stopMonitoring(session: item.session)
+                    }
+                  }
+                },
+                onDeleteWorktree: (!item.isPending && item.session.isWorktree) ? {
+                  sessionToDeleteWorktree = item.session
+                  showDeleteWorktreeAlert = true
+                } : nil,
+                isDeletingWorktree: item.session.isWorktree && {
+                  switch item.providerKind {
+                  case .claude: return claudeViewModel.deletingWorktreePath == item.session.projectPath
+                  case .codex: return codexViewModel.deletingWorktreePath == item.session.projectPath
+                  }
+                }(),
+                onSelect: {
+                  primarySessionId = item.id
+                }
+              )
+              .transition(.asymmetric(
+                insertion: .opacity,
+                removal: .move(edge: .trailing).combined(with: .opacity)
+              ))
+              .id(item.id)
+            }
           }
         }
       }
@@ -1185,19 +1202,26 @@ public struct MultiProviderSessionsListView: View {
 
 private struct ProjectGroupHeader: View {
   let name: String
+  let isExpanded: Bool
+  let onToggle: () -> Void
 
   var body: some View {
-    HStack(spacing: 8) {
-      Image(systemName: "folder")
-        .font(.system(size: 12))
-        .foregroundColor(.secondary)
-      Text(name)
-        .font(.secondaryDefault)
-        .foregroundColor(.secondary)
-      Spacer()
+    Button(action: onToggle) {
+      HStack(spacing: 8) {
+        Image(systemName: isExpanded ? "folder.fill" : "folder")
+          .font(.system(size: 12))
+          .foregroundColor(.secondary)
+          .contentTransition(.symbolEffect(.replace))
+        Text(name)
+          .font(.secondaryDefault)
+          .foregroundColor(.secondary)
+        Spacer()
+      }
+      .padding(.vertical, 6)
+      .padding(.horizontal, 4)
+      .contentShape(Rectangle())
     }
-    .padding(.vertical, 6)
-    .padding(.horizontal, 4)
+    .buttonStyle(.plain)
   }
 }
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
@@ -742,10 +742,7 @@ public struct MultiProviderSessionsListView: View {
                   primarySessionId = item.id
                 }
               )
-              .transition(.asymmetric(
-                insertion: .opacity,
-                removal: .move(edge: .trailing).combined(with: .opacity)
-              ))
+              .transition(.opacity)
               .id(item.id)
             }
           }


### PR DESCRIPTION
## Summary

- **Flatten `CollapsibleSessionRow`**: strip the bordered card with gradient + branch/provider stack down to a two-line row (status dot + name + provider + status + time, then message + hover actions). Reserves space for archive/delete so the row doesn't jump on hover. Animates transitions for status label, status dot color, and hover reveal.
- **Remove provider filter tabs** (`HubFilterControl`, `HubFilterMode`) and the `"Focused Sessions"` header — the sidebar always shows everything, no filter UI.
- **Group focused sessions by parent project**: `inlineSelectedSessions` now buckets sessions under a `ProjectGroupHeader` for each tracked repo (sessions in worktrees roll up to their parent repo). Groups are ordered newest-added first, and every tracked repo gets a header even when it has zero focused sessions.
- **Collapsible group headers** with an `folder` ↔ `folder.fill` SF Symbol toggle, animated via `.contentTransition(.symbolEffect(.replace))`. Collapse state is in-memory only.

## Test plan

- [ ] Launch app with 2+ tracked repos, each with focused sessions — each repo shows as its own group header
- [ ] Add a new repo → empty header appears at the **top** of the list
- [ ] Remove a repo → its group disappears; remaining order preserved
- [ ] Start a session in a worktree of repo A → row appears under repo A's header (not a new group)
- [ ] Tap a group header → sessions hide and folder icon switches to outline; tap again → sessions return and icon fills
- [ ] Archive / delete-worktree buttons still fire from each row
- [ ] Hover a row → archive/delete buttons appear without the row re-laying out
- [ ] Pending → real session transition keeps the row under the same project header

🤖 Generated with [Claude Code](https://claude.com/claude-code)