### PR TITLE
Add Threads sidebar with per-project compact launcher

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/CollapsibleSessionRow.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/CollapsibleSessionRow.swift
@@ -182,10 +182,10 @@ struct CollapsibleSessionRow: View {
           } label: {
             Text("Confirm")
               .font(.secondaryCaption)
-              .foregroundColor(.white)
+              .foregroundColor(colorScheme == .dark ? .black : .white)
               .padding(.horizontal, 6)
               .padding(.vertical, 2)
-              .background(Color.brandPrimary(for: providerKind))
+              .background(colorScheme == .dark ? Color.white : Color.black)
               .clipShape(RoundedRectangle(cornerRadius: 4))
           }
           .buttonStyle(.plain)

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderMonitoringPanelView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderMonitoringPanelView.swift
@@ -78,14 +78,12 @@ public enum HubLayoutMode: Int, CaseIterable {
   case single = 0
   case list = 1
   case twoColumn = 2
-  case threeColumn = 3
 
   public var columnCount: Int {
     switch self {
     case .single: return 1
     case .list: return 1
     case .twoColumn: return 2
-    case .threeColumn: return 3
     }
   }
 
@@ -94,7 +92,6 @@ public enum HubLayoutMode: Int, CaseIterable {
     case .single: return "rectangle"
     case .list: return "list.bullet"
     case .twoColumn: return "square.grid.2x2"
-    case .threeColumn: return "square.grid.3x3"
     }
   }
 }

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
@@ -717,9 +717,9 @@ public struct MultiProviderSessionsListView: View {
                 }
               }
             },
-            onCreateSession: { provider in
-              createNewSession(for: group.id, provider: provider)
-            }
+            repoPath: group.id,
+            launchViewModel: multiLaunchViewModel,
+            intelligenceViewModel: intelligenceViewModel
           )
 
           if isExpanded {
@@ -942,27 +942,6 @@ public struct MultiProviderSessionsListView: View {
   private func addRepository(at path: String) {
     claudeViewModel.addRepository(at: path)
     codexViewModel.addRepository(at: path)
-  }
-
-  /// Creates an empty pending session for the given repo path using the picked provider.
-  /// The new pending session is auto-promoted to primary via the existing
-  /// `lastCreatedPendingId` onChange handler, so the terminal appears in the detail pane.
-  private func createNewSession(for repoPath: String, provider: SessionProviderKind) {
-    let repos = claudeViewModel.selectedRepositories + codexViewModel.selectedRepositories
-    let branchName = repos
-      .first(where: { $0.path == repoPath })?
-      .worktrees
-      .first(where: { !$0.isWorktree })?
-      .name ?? "main"
-
-    let worktree = WorktreeBranch(
-      name: branchName,
-      path: repoPath,
-      isWorktree: false
-    )
-
-    let viewModel = viewModel(for: provider)
-    viewModel.startNewSessionInHub(worktree)
   }
 
   private func removeRepository(_ repository: SelectedRepository, from viewModel: CLISessionsViewModel) {
@@ -1239,9 +1218,12 @@ private struct ProjectGroupHeader: View {
   let isExpanded: Bool
   let canToggle: Bool
   let onToggle: () -> Void
-  let onCreateSession: (SessionProviderKind) -> Void
+  let repoPath: String
+  let launchViewModel: MultiSessionLaunchViewModel?
+  let intelligenceViewModel: IntelligenceViewModel?
 
   @State private var isHovered: Bool = false
+  @State private var showStartSheet: Bool = false
   @Environment(\.colorScheme) private var colorScheme
 
   var body: some View {
@@ -1249,29 +1231,41 @@ private struct ProjectGroupHeader: View {
       Button(action: { if canToggle { onToggle() } }) {
         HStack(spacing: 8) {
           Image(systemName: canToggle && isExpanded ? "folder.fill" : "folder")
-            .font(.system(size: 14))
-            .foregroundColor(.secondary)
+            .font(.system(size: 13))
+            .foregroundColor(.primary)
             .contentTransition(.symbolEffect(.replace))
           Text(name)
-            .font(.secondaryLarge)
-            .foregroundColor(.secondary)
+            .font(Font.geist(size: 13, weight: .semibold))
+            .foregroundColor(.primary)
           Spacer(minLength: 0)
         }
         .contentShape(Rectangle())
       }
       .buttonStyle(.plain)
 
-      HeaderIconMenu(
+      HeaderIconButton(
         systemName: "square.and.pencil",
-        size: 10,
+        size: 14,
         help: "Start a new session"
       ) {
-        Button("Claude") { onCreateSession(.claude) }
-        Button("Codex") { onCreateSession(.codex) }
+        guard let vm = launchViewModel else { return }
+        Task { @MainActor in
+          _ = await vm.preselectRepository(path: repoPath)
+          showStartSheet = true
+        }
       }
-      .opacity(isHovered ? 1 : 0)
+      .opacity(isHovered || showStartSheet ? 1 : 0)
+      .sheet(isPresented: $showStartSheet) {
+        if let vm = launchViewModel {
+          StartSessionSheet(
+            launchViewModel: vm,
+            intelligenceViewModel: intelligenceViewModel,
+            onDismiss: { showStartSheet = false }
+          )
+        }
+      }
     }
-    .padding(.vertical, 9)
+    .padding(.vertical, 6)
     .padding(.horizontal, 4)
     .background(
       RoundedRectangle(cornerRadius: 6, style: .continuous)
@@ -1282,6 +1276,60 @@ private struct ProjectGroupHeader: View {
     .contentShape(Rectangle())
     .onHover { isHovered = $0 }
     .animation(.easeInOut(duration: 0.15), value: isHovered)
+  }
+}
+
+// MARK: - StartSessionSheet
+
+/// Sheet wrapper that renders `MultiSessionLaunchView` in compact style for the
+/// project-row pencil entry point. Auto-dismisses when the launch pipeline
+/// finishes (unless the user cancelled or is in an interactive smart-mode phase).
+private struct StartSessionSheet: View {
+  @Bindable var launchViewModel: MultiSessionLaunchViewModel
+  let intelligenceViewModel: IntelligenceViewModel?
+  let onDismiss: () -> Void
+
+  @Environment(\.colorScheme) private var colorScheme
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 0) {
+      HStack {
+        Text("Start Session")
+          .font(.heading)
+        Spacer()
+        Button {
+          onDismiss()
+        } label: {
+          Image(systemName: "xmark.circle.fill")
+            .font(.system(size: 16))
+            .foregroundColor(.secondary)
+        }
+        .buttonStyle(.plain)
+        .keyboardShortcut(.escape, modifiers: [])
+        .help("Close")
+      }
+      .padding(.horizontal, 16)
+      .padding(.top, 14)
+      .padding(.bottom, 10)
+
+      Divider()
+
+      MultiSessionLaunchView(
+        viewModel: launchViewModel,
+        intelligenceViewModel: intelligenceViewModel,
+        expandRequestID: 0,
+        style: .compact
+      )
+      .padding(16)
+    }
+    .frame(minWidth: 480, idealWidth: 520)
+    .background(colorScheme == .dark ? Color.black : Color(nsColor: .windowBackgroundColor))
+    .onChange(of: launchViewModel.isLaunching) { wasLaunching, isLaunching in
+      guard wasLaunching, !isLaunching else { return }
+      if launchViewModel.isSmartInteractive { return }
+      if launchViewModel.lastLaunchEndedByCancellation { return }
+      onDismiss()
+    }
   }
 }
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
@@ -44,6 +44,12 @@ public struct MultiProviderSessionsListView: View {
   @State private var scrollToSessionId: String?
   @State private var launchExpandRequestID = 0
   @State private var createWorktreeContext: WorktreeCreateContext?
+
+  // TODO: Remove along with MultiSessionLaunchView once the new Threads-based
+  // session-start flow is fully implemented. Flip to `true` to restore the
+  // legacy launcher during iteration.
+  private let showLegacyLauncher = false
+
   @AppStorage(AgentHubDefaults.auxiliaryShellVisible) private var isAuxiliaryShellVisible = false
   @State private var isEmbeddedTrailingPanelVisible = false
   @State private var sidebarVisibilityBeforeAutoHide: NavigationSplitViewVisibility?
@@ -328,8 +334,8 @@ public struct MultiProviderSessionsListView: View {
 
   private var sessionListContent: some View {
     VStack(alignment: .leading, spacing: 0) {
-      // 1. Session Launcher (always visible)
-      if let multiLaunchViewModel {
+      // 1. Session Launcher (legacy — hidden behind flag during Threads redesign)
+      if showLegacyLauncher, let multiLaunchViewModel {
         MultiSessionLaunchView(
           viewModel: multiLaunchViewModel,
           intelligenceViewModel: intelligenceViewModel,
@@ -338,7 +344,7 @@ public struct MultiProviderSessionsListView: View {
         .padding(.bottom, 8)
       }
 
-      // 2. Inline Selected Sessions (monitored + pending)
+      // 2. Threads (Inline Selected Sessions — monitored + pending)
       inlineSelectedSessions
 
       // 3. Collapsible Browse Sessions section
@@ -691,23 +697,30 @@ public struct MultiProviderSessionsListView: View {
   @ViewBuilder
   private var inlineSelectedSessions: some View {
     let groups = groupedSelectedSessions
-    if !groups.isEmpty {
-      VStack(alignment: .leading, spacing: 0) {
+    VStack(alignment: .leading, spacing: 0) {
+      ThreadsSectionHeader(onAddFolder: { showAddRepositoryPicker() })
+
+      if !groups.isEmpty {
         ForEach(groups) { group in
           let isExpanded = !collapsedProjectGroups.contains(group.id)
 
           ProjectGroupHeader(
             name: group.displayName,
-            isExpanded: isExpanded
-          ) {
-            withAnimation(.easeInOut(duration: 0.25)) {
-              if isExpanded {
-                collapsedProjectGroups.insert(group.id)
-              } else {
-                collapsedProjectGroups.remove(group.id)
+            isExpanded: isExpanded,
+            canToggle: !group.items.isEmpty,
+            onToggle: {
+              withAnimation(.easeInOut(duration: 0.25)) {
+                if isExpanded {
+                  collapsedProjectGroups.insert(group.id)
+                } else {
+                  collapsedProjectGroups.remove(group.id)
+                }
               }
+            },
+            onCreateSession: { provider in
+              createNewSession(for: group.id, provider: provider)
             }
-          }
+          )
 
           if isExpanded {
             ForEach(group.items) { item in
@@ -748,8 +761,8 @@ public struct MultiProviderSessionsListView: View {
           }
         }
       }
-      .padding(.bottom, 8)
     }
+    .padding(.bottom, 8)
   }
 
   // MARK: - Per-Provider Content
@@ -926,6 +939,27 @@ public struct MultiProviderSessionsListView: View {
   private func addRepository(at path: String) {
     claudeViewModel.addRepository(at: path)
     codexViewModel.addRepository(at: path)
+  }
+
+  /// Creates an empty pending session for the given repo path using the picked provider.
+  /// The new pending session is auto-promoted to primary via the existing
+  /// `lastCreatedPendingId` onChange handler, so the terminal appears in the detail pane.
+  private func createNewSession(for repoPath: String, provider: SessionProviderKind) {
+    let repos = claudeViewModel.selectedRepositories + codexViewModel.selectedRepositories
+    let branchName = repos
+      .first(where: { $0.path == repoPath })?
+      .worktrees
+      .first(where: { !$0.isWorktree })?
+      .name ?? "main"
+
+    let worktree = WorktreeBranch(
+      name: branchName,
+      path: repoPath,
+      isWorktree: false
+    )
+
+    let viewModel = viewModel(for: provider)
+    viewModel.startNewSessionInHub(worktree)
   }
 
   private func removeRepository(_ repository: SelectedRepository, from viewModel: CLISessionsViewModel) {
@@ -1200,25 +1234,133 @@ public struct MultiProviderSessionsListView: View {
 private struct ProjectGroupHeader: View {
   let name: String
   let isExpanded: Bool
+  let canToggle: Bool
   let onToggle: () -> Void
+  let onCreateSession: (SessionProviderKind) -> Void
+
+  @State private var isHovered: Bool = false
+  @Environment(\.colorScheme) private var colorScheme
 
   var body: some View {
-    Button(action: onToggle) {
-      HStack(spacing: 8) {
-        Image(systemName: isExpanded ? "folder.fill" : "folder")
-          .font(.system(size: 12))
-          .foregroundColor(.secondary)
-          .contentTransition(.symbolEffect(.replace))
-        Text(name)
-          .font(.secondaryDefault)
-          .foregroundColor(.secondary)
-        Spacer()
+    HStack(spacing: 4) {
+      Button(action: { if canToggle { onToggle() } }) {
+        HStack(spacing: 8) {
+          Image(systemName: canToggle && isExpanded ? "folder.fill" : "folder")
+            .font(.system(size: 12))
+            .foregroundColor(.secondary)
+            .contentTransition(.symbolEffect(.replace))
+          Text(name)
+            .font(.secondaryDefault)
+            .foregroundColor(.secondary)
+          Spacer(minLength: 0)
+        }
+        .contentShape(Rectangle())
       }
-      .padding(.vertical, 6)
-      .padding(.horizontal, 4)
+      .buttonStyle(.plain)
+
+      HeaderIconMenu(
+        systemName: "square.and.pencil",
+        size: 10,
+        help: "Start a new session"
+      ) {
+        Button("Claude") { onCreateSession(.claude) }
+        Button("Codex") { onCreateSession(.codex) }
+      }
+      .opacity(isHovered ? 1 : 0)
+    }
+    .padding(.vertical, 6)
+    .padding(.horizontal, 4)
+    .background(
+      RoundedRectangle(cornerRadius: 6, style: .continuous)
+        .fill(isHovered
+              ? Color.brandPrimary.opacity(colorScheme == .dark ? 0.12 : 0.1)
+              : Color.clear)
+    )
+    .contentShape(Rectangle())
+    .onHover { isHovered = $0 }
+    .animation(.easeInOut(duration: 0.15), value: isHovered)
+  }
+}
+
+// MARK: - ThreadsSectionHeader
+
+private struct ThreadsSectionHeader: View {
+  let onAddFolder: () -> Void
+
+  var body: some View {
+    VStack(spacing: 0) {
+      HStack(spacing: 2) {
+        Text("Threads")
+          .font(.heading)
+          .foregroundColor(.secondary)
+
+        Spacer()
+
+        // Stub — non-functional in step 1
+        HeaderIconButton(systemName: "line.3.horizontal.decrease") {}
+
+        HeaderIconButton(
+          systemName: "folder.badge.plus",
+          help: "Add a folder as a new module",
+          action: onAddFolder
+        )
+      }
+      .padding(.vertical, 4)
+      .padding(.leading, 4)
+
+      Divider()
+    }
+  }
+}
+
+// MARK: - Header icon primitives
+
+/// Shared styling for small icon buttons/menus used in sidebar section headers.
+/// Keeps the hit area generous (28×28) while the glyph size is tunable so
+/// in-row controls can be visually smaller without losing tap area.
+private extension View {
+  func headerIconStyle(size: CGFloat = DesignTokens.IconSize.sm) -> some View {
+    self
+      .font(.system(size: size))
+      .foregroundColor(.secondary)
+      .frame(width: 28, height: 28)
       .contentShape(Rectangle())
+  }
+}
+
+/// Small icon button with an enlarged square hit area, used in sidebar section headers.
+private struct HeaderIconButton: View {
+  let systemName: String
+  var size: CGFloat = DesignTokens.IconSize.sm
+  var help: String? = nil
+  let action: () -> Void
+
+  var body: some View {
+    Button(action: action) {
+      Image(systemName: systemName).headerIconStyle(size: size)
     }
     .buttonStyle(.plain)
+    .help(help ?? "")
+  }
+}
+
+/// Icon-only Menu with the same styling as HeaderIconButton.
+private struct HeaderIconMenu<Content: View>: View {
+  let systemName: String
+  var size: CGFloat = DesignTokens.IconSize.sm
+  var help: String? = nil
+  @ViewBuilder let content: () -> Content
+
+  var body: some View {
+    Menu {
+      content()
+    } label: {
+      Image(systemName: systemName).headerIconStyle(size: size)
+    }
+    .menuStyle(.borderlessButton)
+    .menuIndicator(.hidden)
+    .fixedSize()
+    .help(help ?? "")
   }
 }
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
@@ -723,41 +723,44 @@ public struct MultiProviderSessionsListView: View {
           )
 
           if isExpanded {
-            ForEach(group.items) { item in
-              CollapsibleSessionRow(
-                session: item.session,
-                providerKind: item.providerKind,
-                timestamp: item.timestamp,
-                isPending: item.isPending,
-                isPrimary: item.id == primarySessionId,
-                customName: selectedSessionCustomName(for: item),
-                sessionStatus: item.sessionStatus,
-                colorScheme: colorScheme,
-                onArchive: item.isPending ? nil : {
-                  withAnimation(.easeInOut(duration: 0.25)) {
-                    switch item.providerKind {
-                    case .claude: claudeViewModel.stopMonitoring(session: item.session)
-                    case .codex: codexViewModel.stopMonitoring(session: item.session)
+            VStack(spacing: 2) {
+              ForEach(group.items) { item in
+                CollapsibleSessionRow(
+                  session: item.session,
+                  providerKind: item.providerKind,
+                  timestamp: item.timestamp,
+                  isPending: item.isPending,
+                  isPrimary: item.id == primarySessionId,
+                  customName: selectedSessionCustomName(for: item),
+                  sessionStatus: item.sessionStatus,
+                  colorScheme: colorScheme,
+                  onArchive: item.isPending ? nil : {
+                    withAnimation(.easeInOut(duration: 0.25)) {
+                      switch item.providerKind {
+                      case .claude: claudeViewModel.stopMonitoring(session: item.session)
+                      case .codex: codexViewModel.stopMonitoring(session: item.session)
+                      }
                     }
+                  },
+                  onDeleteWorktree: (!item.isPending && item.session.isWorktree) ? {
+                    sessionToDeleteWorktree = item.session
+                    showDeleteWorktreeAlert = true
+                  } : nil,
+                  isDeletingWorktree: item.session.isWorktree && {
+                    switch item.providerKind {
+                    case .claude: return claudeViewModel.deletingWorktreePath == item.session.projectPath
+                    case .codex: return codexViewModel.deletingWorktreePath == item.session.projectPath
+                    }
+                  }(),
+                  onSelect: {
+                    primarySessionId = item.id
                   }
-                },
-                onDeleteWorktree: (!item.isPending && item.session.isWorktree) ? {
-                  sessionToDeleteWorktree = item.session
-                  showDeleteWorktreeAlert = true
-                } : nil,
-                isDeletingWorktree: item.session.isWorktree && {
-                  switch item.providerKind {
-                  case .claude: return claudeViewModel.deletingWorktreePath == item.session.projectPath
-                  case .codex: return codexViewModel.deletingWorktreePath == item.session.projectPath
-                  }
-                }(),
-                onSelect: {
-                  primarySessionId = item.id
-                }
-              )
-              .transition(.opacity)
-              .id(item.id)
+                )
+                .transition(.opacity)
+                .id(item.id)
+              }
             }
+            .padding(.top, 2)
           }
         }
       }
@@ -1246,11 +1249,11 @@ private struct ProjectGroupHeader: View {
       Button(action: { if canToggle { onToggle() } }) {
         HStack(spacing: 8) {
           Image(systemName: canToggle && isExpanded ? "folder.fill" : "folder")
-            .font(.system(size: 12))
+            .font(.system(size: 14))
             .foregroundColor(.secondary)
             .contentTransition(.symbolEffect(.replace))
           Text(name)
-            .font(.secondaryDefault)
+            .font(.secondaryLarge)
             .foregroundColor(.secondary)
           Spacer(minLength: 0)
         }
@@ -1268,7 +1271,7 @@ private struct ProjectGroupHeader: View {
       }
       .opacity(isHovered ? 1 : 0)
     }
-    .padding(.vertical, 6)
+    .padding(.vertical, 9)
     .padding(.horizontal, 4)
     .background(
       RoundedRectangle(cornerRadius: 6, style: .continuous)

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiSessionLaunchView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiSessionLaunchView.swift
@@ -12,12 +12,28 @@ import AppKit
 import SwiftUI
 import UniformTypeIdentifiers
 
+// MARK: - LaunchFormStyle
+
+/// Controls which sections of `MultiSessionLaunchView` are rendered.
+///
+/// - `full`: the default — everything (form header, repo picker, prompt editor,
+///   attached files, provider pills, work mode, worktree row, smart mode, etc.)
+/// - `compact`: for modal/sheet entry points where the project is already known
+///   and the caller doesn't want a prompt editor. Hides the form header, repo
+///   picker, prompt editor, attached files, and plan-mode hint. Always behaves
+///   as if the form were expanded.
+public enum LaunchFormStyle: Sendable {
+  case full
+  case compact
+}
+
 // MARK: - MultiSessionLaunchView
 
 public struct MultiSessionLaunchView: View {
   @Bindable var viewModel: MultiSessionLaunchViewModel
   var intelligenceViewModel: IntelligenceViewModel?
   var expandRequestID: Int = 0
+  var style: LaunchFormStyle = .full
 
   @AppStorage(AgentHubDefaults.smartModeEnabled) private var smartModeEnabled: Bool = false
 
@@ -30,40 +46,56 @@ public struct MultiSessionLaunchView: View {
 
   public var body: some View {
     VStack(alignment: .leading, spacing: 10) {
-      formHeader
+      if style == .full {
+        formHeader
+      }
 
-      if isExpanded {
-        Divider()
+      if style == .compact || isExpanded {
+        if style == .full {
+          Divider()
+        }
 
         if viewModel.isSmartModeAvailable && smartModeEnabled {
           launchModeToggle
         }
 
-        repositorySection
+        if style == .full {
+          repositorySection
 
-        promptEditor
+          promptEditor
 
-        if viewModel.isPlanModeEnabled {
-          planModeHint
-            .transition(.asymmetric(
-              insertion: .move(edge: .top).combined(with: .opacity),
-              removal: .move(edge: .top).combined(with: .opacity)
-            ))
-        }
+          if viewModel.isPlanModeEnabled {
+            planModeHint
+              .transition(.asymmetric(
+                insertion: .move(edge: .top).combined(with: .opacity),
+                removal: .move(edge: .top).combined(with: .opacity)
+              ))
+          }
 
-        if !viewModel.attachedFiles.isEmpty {
-          attachedFilesSection
+          if !viewModel.attachedFiles.isEmpty {
+            attachedFilesSection
+          }
         }
 
         if viewModel.launchMode == .manual {
-          if viewModel.selectedRepository != nil {
-            workModeRow
-          }
+          if style == .compact {
+            // Compact order: providers first, then work mode.
+            providerPills
 
-          providerPills
+            if viewModel.selectedRepository != nil {
+              workModeRow
+            }
+          } else {
+            // Full order: work mode first, then providers.
+            if viewModel.selectedRepository != nil {
+              workModeRow
+            }
 
-          if viewModel.selectedRepository != nil && viewModel.isClaudeSelected && !viewModel.isCodexSelected && viewModel.workMode == .local {
-            worktreeRow
+            providerPills
+
+            if viewModel.selectedRepository != nil && viewModel.isClaudeSelected && !viewModel.isCodexSelected && viewModel.workMode == .local {
+              worktreeRow
+            }
           }
 
           if viewModel.isLaunching && viewModel.workMode == .worktree {
@@ -110,9 +142,9 @@ public struct MultiSessionLaunchView: View {
     )
     .onDrop(
       of: [.fileURL, .png, .tiff, .image, .pdf],
-      isTargeted: isExpanded ? $isDragging : .constant(false)
+      isTargeted: (isExpanded && style == .full) ? $isDragging : .constant(false)
     ) { providers in
-      guard isExpanded else { return false }
+      guard isExpanded, style == .full else { return false }
       handleDroppedFiles(providers)
       return true
     }
@@ -596,11 +628,30 @@ public struct MultiSessionLaunchView: View {
       claudePill
       providerPill(
         label: "Codex",
-        isSelected: $viewModel.isCodexSelected,
+        isSelected: codexSelectionBinding,
         disabled: viewModel.isPlanModeEnabled
       )
       Spacer()
     }
+  }
+
+  /// In compact mode the sheet allows only one provider at a time. A tap that
+  /// turns Codex ON also turns Claude off (mutually exclusive). In full mode
+  /// this is a pass-through. Both mutations happen inside the same transaction
+  /// so the launch-button title never observes an intermediate "both selected"
+  /// state across re-renders.
+  private var codexSelectionBinding: Binding<Bool> {
+    Binding(
+      get: { viewModel.isCodexSelected },
+      set: { newValue in
+        withAnimation(.easeInOut(duration: 0.2)) {
+          if style == .compact && newValue {
+            viewModel.claudeMode = .disabled
+          }
+          viewModel.isCodexSelected = newValue
+        }
+      }
+    )
   }
 
   private var planModeHint: some View {
@@ -621,6 +672,10 @@ public struct MultiSessionLaunchView: View {
   private var claudePill: some View {
     Button(action: {
       withAnimation(.easeInOut(duration: 0.2)) {
+        if style == .compact {
+          // Mutually exclusive in the sheet: activating Claude deactivates Codex.
+          viewModel.isCodexSelected = false
+        }
         viewModel.claudeMode = viewModel.claudeMode.next
       }
     }) {
@@ -1278,10 +1333,12 @@ public struct MultiSessionLaunchView: View {
 
   private var actionButtons: some View {
     HStack {
-      Button("Reset") {
-        viewModel.reset()
+      if style == .full {
+        Button("Reset") {
+          viewModel.reset()
+        }
+        .disabled(viewModel.isLaunching)
       }
-      .disabled(viewModel.isLaunching)
 
       Spacer()
 
@@ -1300,6 +1357,8 @@ public struct MultiSessionLaunchView: View {
                 .scaleEffect(0.7)
             }
             Text(launchButtonTitle)
+              .contentTransition(.identity)
+              .animation(nil, value: launchButtonTitle)
             if !viewModel.isLaunching {
               Text("⌘↵")
                 .font(.secondarySmall)

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/SettingsView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/SettingsView.swift
@@ -150,13 +150,6 @@ public struct SettingsView: View {
         }
       }
 
-      Section("AI Features") {
-        settingsToggle(
-          title: "Smart mode",
-          description: "Use AI to plan and orchestrate multi-session launches",
-          isOn: $smartModeEnabled
-        )
-      }
     }
     .formStyle(.grouped)
   }
@@ -220,6 +213,14 @@ public struct SettingsView: View {
 #if DEBUG
   private var developerSettingsForm: some View {
     Form {
+      Section("AI Features") {
+        settingsToggle(
+          title: "Smart mode",
+          description: "Use AI to plan and orchestrate multi-session launches",
+          isOn: $smartModeEnabled
+        )
+      }
+
       Section {
         settingsToggle(
           title: "Enable web preview design tools",

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/WorktreeBranchNamingProgressCard.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/WorktreeBranchNamingProgressCard.swift
@@ -19,7 +19,7 @@ struct WorktreeBranchNamingProgressCard: View {
       if progress.isVisible, let startedAt {
         VStack(alignment: .leading, spacing: 10) {
           header(startedAt: startedAt)
-          stepsRow
+//          stepsRow
 
           if !progress.resolvedBranchNames.isEmpty {
             branchNamesSection
@@ -44,7 +44,7 @@ struct WorktreeBranchNamingProgressCard: View {
   }
 
   private func header(startedAt: Date) -> some View {
-    HStack(alignment: .top, spacing: 10) {
+    HStack(alignment: .center, spacing: 10) {
       ZStack {
         Circle()
           .fill(accentColor.opacity(0.14))
@@ -239,9 +239,9 @@ struct WorktreeBranchNamingProgressCard: View {
     case .idle:
       return ""
     case .preparingContext, .queryingModel, .sanitizing:
-      return "Setting up branch"
+      return "Setting up worktree"
     case .completed:
-      return "Branch name ready"
+      return "worktree ready"
     case .cancelled:
       return "Branch naming cancelled"
     case .failed:
@@ -326,3 +326,111 @@ struct WorktreeBranchNamingProgressCard: View {
     completionAnimationToken += 1
   }
 }
+
+// MARK: - Previews
+
+#if DEBUG
+#Preview("Preparing Context (step 1)") {
+  WorktreeBranchNamingProgressCard(
+    progress: .preparingContext(message: "Gathering repo context"),
+    startedAt: Date().addingTimeInterval(-1.2),
+    finishedAt: nil
+  )
+  .padding(24)
+  .frame(width: 520)
+  .background(Color.black)
+}
+
+#Preview("Querying Model (step 2)") {
+  WorktreeBranchNamingProgressCard(
+    progress: .queryingModel(model: "claude-sonnet-4-5", message: "Generating branch name"),
+    startedAt: Date().addingTimeInterval(-4.0),
+    finishedAt: nil
+  )
+  .padding(24)
+  .frame(width: 520)
+  .background(Color.black)
+}
+
+#Preview("Sanitizing (step 3)") {
+  WorktreeBranchNamingProgressCard(
+    progress: .sanitizing(message: "Finalizing branch name"),
+    startedAt: Date().addingTimeInterval(-6.3),
+    finishedAt: nil
+  )
+  .padding(24)
+  .frame(width: 520)
+  .background(Color.black)
+}
+
+#Preview("Completed — AI") {
+  WorktreeBranchNamingProgressCard(
+    progress: .completed(
+      message: "Branch ready",
+      source: .ai,
+      branchNames: ["jroch/refactor-session-launcher"]
+    ),
+    startedAt: Date().addingTimeInterval(-7.8),
+    finishedAt: Date()
+  )
+  .padding(24)
+  .frame(width: 520)
+  .background(Color.black)
+}
+
+#Preview("Completed — Multiple names") {
+  WorktreeBranchNamingProgressCard(
+    progress: .completed(
+      message: "Branches ready",
+      source: .ai,
+      branchNames: [
+        "jroch/refactor-session-launcher",
+        "jroch/add-threads-sidebar",
+        "jroch/tighten-project-row"
+      ]
+    ),
+    startedAt: Date().addingTimeInterval(-9.4),
+    finishedAt: Date()
+  )
+  .padding(24)
+  .frame(width: 520)
+  .background(Color.black)
+}
+
+#Preview("Completed — Deterministic fallback") {
+  WorktreeBranchNamingProgressCard(
+    progress: .completed(
+      message: "Using fallback name",
+      source: .deterministicFallback,
+      branchNames: ["jroch/2026-04-11-session"]
+    ),
+    startedAt: Date().addingTimeInterval(-3.2),
+    finishedAt: Date()
+  )
+  .padding(24)
+  .frame(width: 520)
+  .background(Color.black)
+}
+
+#Preview("Failed") {
+  WorktreeBranchNamingProgressCard(
+    progress: .failed(message: "Model request timed out"),
+    startedAt: Date().addingTimeInterval(-5.1),
+    finishedAt: Date()
+  )
+  .padding(24)
+  .frame(width: 520)
+  .background(Color.black)
+}
+
+#Preview("Cancelled") {
+  WorktreeBranchNamingProgressCard(
+    progress: .cancelled(message: "User cancelled"),
+    startedAt: Date().addingTimeInterval(-2.0),
+    finishedAt: Date()
+  )
+  .padding(24)
+  .frame(width: 520)
+  .background(Color.black)
+}
+#endif


### PR DESCRIPTION
## Summary

- Introduce a **Threads** section header above the grouped-sessions list with a folder+ button that adds modules (including empty project groups with zero sessions). Hides the legacy `MultiSessionLaunchView` row behind a local flag.
- Each project row gets a hover-triggered pencil button that opens a **compact sheet** reusing `MultiSessionLaunchView`. A new public `LaunchFormStyle` enum (`.full` / `.compact`) gates the form header, repo picker, prompt editor, attached files, plan-mode hint, and Reset button so the same view powers both entry points. Section order is swapped and Claude/Codex become mutually-exclusive in compact mode.
- Polish: remove `.threeColumn` layout, move Smart mode toggle to the DEBUG-only Developer tab, fix Confirm-button legibility in `CollapsibleSessionRow`, project-row typography/padding/color tweaks, add `#Preview`s for `WorktreeBranchNamingProgressCard`.

## Test plan

- [ ] Build: `xcodebuild -workspace app/AgentHub.xcodeproj/project.xcworkspace -scheme AgentHub build`
- [ ] **Threads header** — folder+ opens `NSOpenPanel`; picking a folder adds an empty project group to the list. Empty groups are not togglable.
- [ ] **Project row hover** — pencil fades in; row gets brand-primary hover highlight matching `CollapsibleSessionRow`.
- [ ] **Pencil → sheet** — sheet opens with provider pills + work mode row (Local/Worktree); no prompt editor, no repo picker, no attachments, no Reset button, no `--worktree` auto-name row. Dark mode has a solid black background.
- [ ] **Mutual exclusion** — selecting Claude clears Codex and vice-versa; launch button title swaps cleanly without cross-fade.
- [ ] **Launch Claude / Codex (local)** — sheet dismisses on launch; new pending session appears in the right project group and the embedded terminal pops in via the existing `lastCreatedPendingId` handler.
- [ ] **Launch Worktree mode** — worktree creation progress UI appears inside the sheet; on completion the sheet dismisses.
- [ ] **Legacy launcher (flag on)** — flip `showLegacyLauncher = true` in `MultiProviderSessionsListView.swift`; confirm the legacy row still renders with full functionality (prompt editor, repo picker, attachments, Reset, `--worktree` pill, smart mode toggle when enabled).
- [ ] **Smart mode toggle** — only visible under Settings → Developer in DEBUG builds.
- [ ] **Layout picker** — only 4 options (terminal + single + list + 2-column); a previously-saved 3-column falls back to single.
- [ ] **Confirm button** — the archive Confirm pill is legible in both light and dark themes.
- [ ] **`WorktreeBranchNamingProgressCard` previews** — open in Xcode canvas and cycle through the 8 named previews.