### PR TITLE
Add ellipsis menu to repo rows with GitHub integration

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/EmbeddedTerminalView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/EmbeddedTerminalView.swift
@@ -37,6 +37,12 @@ public enum NewlineShortcut: Int, CaseIterable {
 class SafeLocalProcessTerminalView: ManagedLocalProcessTerminalView {
   private var _isStopped = false
   private let stopLock = NSLock()
+  private var readyDebounceTask: Task<Void, Never>?
+
+  /// Called once after the process has finished its initial output burst
+  /// (i.e., the CLI prompt is rendered and ready for input).
+  /// Uses a debounce: fires after data stops arriving for 300ms.
+  var onProcessReady: (() -> Void)?
 
   var isStopped: Bool {
     stopLock.lock()
@@ -49,11 +55,26 @@ class SafeLocalProcessTerminalView: ManagedLocalProcessTerminalView {
     stopLock.lock()
     _isStopped = true
     stopLock.unlock()
+    readyDebounceTask?.cancel()
+    readyDebounceTask = nil
+    onProcessReady = nil
   }
 
   override func dataReceived(slice: ArraySlice<UInt8>) {
     guard !isStopped else { return }
     super.dataReceived(slice: slice)
+    if onProcessReady != nil {
+      // Reset debounce timer on each data chunk.
+      // When data stops flowing for 300ms, the CLI has finished rendering.
+      readyDebounceTask?.cancel()
+      readyDebounceTask = Task { @MainActor [weak self] in
+        try? await Task.sleep(for: .milliseconds(300))
+        guard !Task.isCancelled else { return }
+        self?.onProcessReady?()
+        self?.onProcessReady = nil
+        self?.readyDebounceTask = nil
+      }
+    }
   }
 }
 
@@ -258,8 +279,7 @@ public class TerminalContainerView: NSView, ManagedLocalProcessTerminalViewDeleg
     registerProcessIfNeeded(for: terminal)
 
     if let initialInputText, !initialInputText.isEmpty {
-      Task { @MainActor [weak self] in
-        try? await Task.sleep(for: .milliseconds(300))
+      terminal.onProcessReady = { [weak self] in
         self?.typeInitialTextIfNeeded(initialInputText)
       }
     }

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/GitHubIssueDetailView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/GitHubIssueDetailView.swift
@@ -15,6 +15,7 @@ struct GitHubIssueDetailView: View {
   let issue: GitHubIssue
   let session: CLISession?
   let onSendToSession: ((String, CLISession) -> Void)?
+  let onStartNewSession: ((String, SessionProviderKind) -> Void)?
 
   @Environment(\.colorScheme) private var colorScheme
 
@@ -69,6 +70,28 @@ struct GitHubIssueDetailView: View {
             Text("Send to Session")
           }
         }
+        .buttonStyle(.agentHubOutlined(tint: Color.brandPrimary))
+      } else if let onStartNewSession {
+        Menu {
+          Button {
+            onStartNewSession("fix \(issue.url)", .claude)
+          } label: {
+            Label("Claude", systemImage: "c.circle")
+          }
+          Button {
+            onStartNewSession("fix \(issue.url)", .codex)
+          } label: {
+            Label("Codex", systemImage: "c.square")
+          }
+        } label: {
+          HStack(spacing: 3) {
+            Image(systemName: "wrench")
+              .font(.system(size: 10))
+            Text("Fix")
+          }
+        }
+        .menuStyle(.borderlessButton)
+        .menuIndicator(.hidden)
         .buttonStyle(.agentHubOutlined(tint: Color.brandPrimary))
       }
     }

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/GitHubPRDetailView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/GitHubPRDetailView.swift
@@ -37,6 +37,7 @@ struct GitHubPRDetailView: View {
   let pr: GitHubPullRequest
   let session: CLISession?
   let onSendToSession: ((String, CLISession) -> Void)?
+  let onStartNewSession: ((String, SessionProviderKind) -> Void)?
 
   @State private var selectedTab: PRDetailTab = .overview
   @State private var selectedFile: GitHubPRFile?
@@ -122,6 +123,28 @@ struct GitHubPRDetailView: View {
               Text("Send to Session")
             }
           }
+          .buttonStyle(.agentHubOutlined(tint: Color.brandPrimary))
+        } else if let onStartNewSession {
+          Menu {
+            Button {
+              onStartNewSession("/review \(pr.url)", .claude)
+            } label: {
+              Label("Claude", systemImage: "c.circle")
+            }
+            Button {
+              onStartNewSession("/review \(pr.url)", .codex)
+            } label: {
+              Label("Codex", systemImage: "c.square")
+            }
+          } label: {
+            HStack(spacing: 3) {
+              Image(systemName: "eye")
+                .font(.system(size: 10))
+              Text("Code Review")
+            }
+          }
+          .menuStyle(.borderlessButton)
+          .menuIndicator(.hidden)
           .buttonStyle(.agentHubOutlined(tint: Color.brandPrimary))
         }
       }

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/GitHubPanelView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/GitHubPanelView.swift
@@ -17,6 +17,7 @@ public struct GitHubPanelView: View {
   let onDismiss: () -> Void
   var isEmbedded: Bool = false
   var onSendToSession: ((String, CLISession) -> Void)?
+  var onStartNewSession: ((String, SessionProviderKind) -> Void)?
   var session: CLISession?
   var onPopOut: (() -> Void)?
 
@@ -29,6 +30,7 @@ public struct GitHubPanelView: View {
     isEmbedded: Bool = false,
     session: CLISession? = nil,
     onSendToSession: ((String, CLISession) -> Void)? = nil,
+    onStartNewSession: ((String, SessionProviderKind) -> Void)? = nil,
     onPopOut: (() -> Void)? = nil
   ) {
     self.projectPath = projectPath
@@ -36,6 +38,7 @@ public struct GitHubPanelView: View {
     self.isEmbedded = isEmbedded
     self.session = session
     self.onSendToSession = onSendToSession
+    self.onStartNewSession = onStartNewSession
     self.onPopOut = onPopOut
   }
 
@@ -190,7 +193,8 @@ public struct GitHubPanelView: View {
         viewModel: viewModel,
         pr: pr,
         session: session,
-        onSendToSession: onSendToSession
+        onSendToSession: onSendToSession,
+        onStartNewSession: onStartNewSession
       )
     } else {
       prListContent
@@ -396,7 +400,8 @@ public struct GitHubPanelView: View {
         viewModel: viewModel,
         issue: issue,
         session: session,
-        onSendToSession: onSendToSession
+        onSendToSession: onSendToSession,
+        onStartNewSession: onStartNewSession
       )
     } else {
       issueListContent

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
@@ -19,6 +19,85 @@ private struct SessionFileSheetItem: Identifiable {
   let content: String
 }
 
+// MARK: - GitHubSheetItem
+
+private struct GitHubSheetItem: Identifiable {
+  let id = UUID()
+  let projectPath: String
+}
+
+// MARK: - ArchiveConfirmation
+
+private struct ArchiveConfirmation {
+  let repoName: String
+  let count: Int
+  let action: () -> Void
+}
+
+// MARK: - RemoveConfirmation
+
+private struct RemoveConfirmation {
+  let repoName: String
+  let sessionCount: Int
+  let action: () -> Void
+}
+
+// MARK: - ArchiveConfirmationAlert
+
+private struct ArchiveConfirmationAlert: ViewModifier {
+  @Binding var confirmation: ArchiveConfirmation?
+
+  func body(content: Content) -> some View {
+    content.alert(
+      confirmation.map { "Archive \($0.count) threads?" } ?? "",
+      isPresented: Binding(
+        get: { confirmation != nil },
+        set: { if !$0 { confirmation = nil } }
+      )
+    ) {
+      Button("Cancel", role: .cancel) { confirmation = nil }
+      Button("Archive all", role: .destructive) {
+        confirmation?.action()
+        confirmation = nil
+      }
+    } message: {
+      if let confirmation {
+        Text("This will archive the threads in \(confirmation.repoName). You can find them later in your archived threads.")
+      }
+    }
+  }
+}
+
+// MARK: - RemoveConfirmationAlert
+
+private struct RemoveConfirmationAlert: ViewModifier {
+  @Binding var confirmation: RemoveConfirmation?
+
+  func body(content: Content) -> some View {
+    content.alert(
+      confirmation.map { "Remove \($0.repoName)?" } ?? "",
+      isPresented: Binding(
+        get: { confirmation != nil },
+        set: { if !$0 { confirmation = nil } }
+      )
+    ) {
+      Button("Cancel", role: .cancel) { confirmation = nil }
+      Button("Remove", role: .destructive) {
+        confirmation?.action()
+        confirmation = nil
+      }
+    } message: {
+      if let confirmation {
+        if confirmation.sessionCount > 0 {
+          Text("This will archive \(confirmation.sessionCount) active threads and remove \(confirmation.repoName) from your list.")
+        } else {
+          Text("This will remove \(confirmation.repoName) from your list.")
+        }
+      }
+    }
+  }
+}
+
 // MARK: - SidebarGroupMode
 
 private enum SidebarGroupMode: String, CaseIterable {
@@ -82,6 +161,9 @@ public struct MultiProviderSessionsListView: View {
   @State private var scrollToSessionId: String?
   @State private var launchExpandRequestID = 0
   @State private var createWorktreeContext: WorktreeCreateContext?
+  @State private var gitHubSheetItem: GitHubSheetItem?
+  @State private var archiveConfirmation: ArchiveConfirmation?
+  @State private var removeConfirmation: RemoveConfirmation?
 
   // TODO: Remove along with MultiSessionLaunchView once the new Threads-based
   // session-start flow is fully implemented. Flip to `true` to restore the
@@ -297,6 +379,29 @@ public struct MultiProviderSessionsListView: View {
         }
       )
     }
+    .sheet(item: $gitHubSheetItem) { item in
+      GitHubPanelView(
+        projectPath: item.projectPath,
+        onDismiss: { gitHubSheetItem = nil },
+        isEmbedded: false,
+        onSendToSession: { prompt, session in
+          claudeViewModel.showTerminalWithPrompt(for: session, prompt: prompt)
+        },
+        onStartNewSession: { inputText, provider in
+          let projectPath = item.projectPath
+          let vm = provider == .claude ? claudeViewModel : codexViewModel
+          let repo = vm.selectedRepositories.first(where: { $0.path == projectPath })
+            ?? claudeViewModel.selectedRepositories.first(where: { $0.path == projectPath })
+            ?? codexViewModel.selectedRepositories.first(where: { $0.path == projectPath })
+          if let worktree = repo?.worktrees.first {
+            gitHubSheetItem = nil
+            vm.startNewSessionInHub(worktree, initialInputText: inputText)
+          }
+        }
+      )
+    }
+    .modifier(ArchiveConfirmationAlert(confirmation: $archiveConfirmation))
+    .modifier(RemoveConfirmationAlert(confirmation: $removeConfirmation))
   }
 
   // MARK: - UI Helpers
@@ -796,7 +901,42 @@ public struct MultiProviderSessionsListView: View {
               },
               repoPath: group.id,
               launchViewModel: multiLaunchViewModel,
-              intelligenceViewModel: intelligenceViewModel
+              intelligenceViewModel: intelligenceViewModel,
+              onOpenInFinder: {
+                NSWorkspace.shared.selectFile(nil, inFileViewerRootedAtPath: group.id)
+              },
+              onOpenGitHub: {
+                gitHubSheetItem = GitHubSheetItem(projectPath: group.id)
+              },
+              onArchiveThreads: group.items.isEmpty ? nil : {
+                let items = group.items
+                archiveConfirmation = ArchiveConfirmation(
+                  repoName: group.displayName,
+                  count: items.count
+                ) {
+                  withAnimation(.easeInOut(duration: 0.25)) {
+                    for item in items where !item.isPending {
+                      switch item.providerKind {
+                      case .claude: claudeViewModel.stopMonitoring(session: item.session)
+                      case .codex: codexViewModel.stopMonitoring(session: item.session)
+                      }
+                    }
+                  }
+                }
+              },
+              onRemove: {
+                removeConfirmation = RemoveConfirmation(
+                  repoName: group.displayName,
+                  sessionCount: group.items.count
+                ) {
+                  if let repo = claudeViewModel.selectedRepositories.first(where: { $0.path == group.id }) {
+                    claudeViewModel.removeRepository(repo)
+                  }
+                  if let repo = codexViewModel.selectedRepositories.first(where: { $0.path == group.id }) {
+                    codexViewModel.removeRepository(repo)
+                  }
+                }
+              }
             )
 
             if isExpanded {
@@ -1341,6 +1481,10 @@ private struct ProjectGroupHeader: View {
   let repoPath: String
   let launchViewModel: MultiSessionLaunchViewModel?
   let intelligenceViewModel: IntelligenceViewModel?
+  let onOpenInFinder: () -> Void
+  let onOpenGitHub: () -> Void
+  let onArchiveThreads: (() -> Void)?
+  let onRemove: () -> Void
 
   @State private var isHovered: Bool = false
   @State private var showStartSheet: Bool = false
@@ -1362,6 +1506,25 @@ private struct ProjectGroupHeader: View {
         .contentShape(Rectangle())
       }
       .buttonStyle(.plain)
+
+      HeaderIconMenu(systemName: "ellipsis", size: 14, help: "More actions") {
+        Button(action: onOpenInFinder) {
+          Label("Open in Finder", systemImage: "folder")
+        }
+        Button(action: onOpenGitHub) {
+          Label("GitHub", systemImage: "arrow.triangle.pull")
+        }
+        Divider()
+        if let onArchiveThreads {
+          Button(action: onArchiveThreads) {
+            Label("Archive Threads", systemImage: "archivebox")
+          }
+        }
+        Button(action: onRemove) {
+          Label("Remove", systemImage: "xmark")
+        }
+      }
+      .opacity(isHovered || showStartSheet ? 1 : 0)
 
       HeaderIconButton(
         systemName: "square.and.pencil",


### PR DESCRIPTION
## Summary
- Add ellipsis menu (hover-reveal) to `ProjectGroupHeader` in sidebar repo rows with 4 actions: Open in Finder, GitHub, Archive Threads, Remove
- GitHub opens a sheet with `GitHubPanelView`; when no session exists, PR detail shows "Code Review" and issue detail shows "Fix" button with Claude/Codex provider picker that starts a new session with prefilled text (`/review <url>` or `fix <url>`)
- Replace fragile 300ms sleep for `initialInputText` delivery with debounced `onProcessReady` callback on `SafeLocalProcessTerminalView` that fires after CLI output settles
- Archive Threads and Remove show confirmation alerts before executing

## Test plan
- [ ] Hover a repo row in sidebar (group by repo mode) — ellipsis icon appears left of pencil
- [ ] Open in Finder opens the repo folder
- [ ] GitHub opens the panel sheet; select a PR → "Code Review" button with Claude/Codex picker
- [ ] Pick Claude → new session starts with `/review https://...` prefilled (not submitted)
- [ ] Same for issues: "Fix" button → prefills `fix https://...`
- [ ] Archive Threads shows "Archive N threads?" confirmation, then archives
- [ ] Remove shows "Remove RepoName?" confirmation, then removes from list