### PR TITLE
Add terminal power features: search, clickable URLs and file paths

### DIFF
--- a/app/AgentHub.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/app/AgentHub.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "0902c7a92d5daddf48b1355b43dd3d941d9c296fc8885595c4e2aa07c311d27d",
+  "originHash" : "eab8200f5c9d1f95fc7f9892307fd756c56c22d956e5328233b0e91a21389520",
   "pins" : [
     {
       "identity" : "beautiful-mermaid-swift",
@@ -96,8 +96,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-argument-parser",
       "state" : {
-        "revision" : "c5d11a805e765f52ba34ec7284bd4fcd6ba68615",
-        "version" : "1.7.0"
+        "revision" : "626b5b7b2f45e1b0b1c6f4a309296d1d21d7311b",
+        "version" : "1.7.1"
       }
     },
     {
@@ -139,10 +139,10 @@
     {
       "identity" : "swiftterm",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/migueldeicaza/SwiftTerm",
+      "location" : "https://github.com/jamesrochabrun/SwiftTerm",
       "state" : {
-        "revision" : "8e7a1e154f470e19c709a00a8768df348ba5fc43",
-        "version" : "1.13.0"
+        "branch" : "agenthub",
+        "revision" : "d3cc36b52365ce6f50a979d3c7ba076722bba6e0"
       }
     },
     {

--- a/app/AgentHub.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/app/AgentHub.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -142,7 +142,7 @@
       "location" : "https://github.com/jamesrochabrun/SwiftTerm",
       "state" : {
         "branch" : "agenthub",
-        "revision" : "d3cc36b52365ce6f50a979d3c7ba076722bba6e0"
+        "revision" : "8ae2c19c019e9d294d7c22c2d83d9cd445ab01e5"
       }
     },
     {

--- a/app/AgentHub.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/app/AgentHub.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -142,7 +142,7 @@
       "location" : "https://github.com/jamesrochabrun/SwiftTerm",
       "state" : {
         "branch" : "agenthub",
-        "revision" : "8ae2c19c019e9d294d7c22c2d83d9cd445ab01e5"
+        "revision" : "a3c61c4d364b1a818fc7290586adb8c22a85a2b8"
       }
     },
     {

--- a/app/modules/AgentHubCore/Package.resolved
+++ b/app/modules/AgentHubCore/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "33c89abc499c33d9a3ca8be4824e97fd2422e1b662ebcedd353bf7cc467abfa4",
+  "originHash" : "2929b57e1e88ace276de95b5aba8cc10118deb51a28af42ac44c558c70f34bf2",
   "pins" : [
     {
       "identity" : "beautiful-mermaid-swift",
@@ -130,10 +130,10 @@
     {
       "identity" : "swiftterm",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/migueldeicaza/SwiftTerm",
+      "location" : "https://github.com/jamesrochabrun/SwiftTerm",
       "state" : {
-        "revision" : "8e7a1e154f470e19c709a00a8768df348ba5fc43",
-        "version" : "1.13.0"
+        "branch" : "agenthub",
+        "revision" : "d3cc36b52365ce6f50a979d3c7ba076722bba6e0"
       }
     },
     {

--- a/app/modules/AgentHubCore/Package.resolved
+++ b/app/modules/AgentHubCore/Package.resolved
@@ -133,7 +133,7 @@
       "location" : "https://github.com/jamesrochabrun/SwiftTerm",
       "state" : {
         "branch" : "agenthub",
-        "revision" : "8ae2c19c019e9d294d7c22c2d83d9cd445ab01e5"
+        "revision" : "a3c61c4d364b1a818fc7290586adb8c22a85a2b8"
       }
     },
     {

--- a/app/modules/AgentHubCore/Package.resolved
+++ b/app/modules/AgentHubCore/Package.resolved
@@ -133,7 +133,7 @@
       "location" : "https://github.com/jamesrochabrun/SwiftTerm",
       "state" : {
         "branch" : "agenthub",
-        "revision" : "d3cc36b52365ce6f50a979d3c7ba076722bba6e0"
+        "revision" : "8ae2c19c019e9d294d7c22c2d83d9cd445ab01e5"
       }
     },
     {

--- a/app/modules/AgentHubCore/Package.swift
+++ b/app/modules/AgentHubCore/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
     .package(path: "../AgentHubGitHub"),
     .package(url: "https://github.com/jamesrochabrun/Canvas", from: "1.2.0"),
     .package(url: "https://github.com/jamesrochabrun/PierreDiffsSwift", exact: "1.1.7"),
-    .package(url: "https://github.com/migueldeicaza/SwiftTerm", from: "1.13.0"),
+    .package(url: "https://github.com/jamesrochabrun/SwiftTerm", branch: "agenthub"),
     .package(url: "https://github.com/gonzalezreal/swift-markdown-ui", from: "2.0.0"),
     .package(url: "https://github.com/groue/GRDB.swift", from: "6.24.0"),
     .package(url: "https://github.com/appstefan/HighlightSwift", from: "1.1.0"),

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/EmbeddedTerminalView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/EmbeddedTerminalView.swift
@@ -432,14 +432,32 @@ public class TerminalContainerView: NSView, ManagedLocalProcessTerminalViewDeleg
       switch event.type {
       case .keyDown:
         guard let window = terminal.window,
-              event.window === window,
-              isTerminalResponderActive(window: window, terminal: terminal) else { break }
+              event.window === window else { break }
+
+        let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+        let isTerminalVisible = terminal.superview != nil && !terminal.isHidden && terminal.alphaValue > 0
+
+        // Terminal-wide shortcuts (work when terminal is visible, even without focus)
+        if isTerminalVisible {
+          // Cmd+F: activate SwiftTerm's built-in search/find bar
+          if flags == .command, event.charactersIgnoringModifiers == "f" {
+            window.makeFirstResponder(terminal)
+            // performFindPanelAction requires an NSMenuItem with the correct tag
+            let menuItem = NSMenuItem()
+            menuItem.tag = Int(NSFindPanelAction.showFindPanel.rawValue)
+            terminal.performFindPanelAction(menuItem)
+            return nil
+          }
+
+          }
+
+        // Typing shortcuts (require terminal to be first responder)
+        guard isTerminalResponderActive(window: window, terminal: terminal) else { break }
 
         let shortcut = NewlineShortcut(
           rawValue: UserDefaults.standard.integer(forKey: AgentHubDefaults.terminalNewlineShortcut)
         ) ?? .system
 
-        let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
         let isReturn = event.keyCode == 36
 
         let action = TerminalSubmitInterception.keyAction(
@@ -645,6 +663,7 @@ public class TerminalContainerView: NSView, ManagedLocalProcessTerminalViewDeleg
     environment["TERM"] = "xterm-256color"
     environment["COLORTERM"] = "truecolor"
     environment["LANG"] = "en_US.UTF-8"
+    environment["TERM_PROGRAM"] = "SwiftTerm"
 
     let paths = CLIPathResolver.executableSearchPaths(additionalPaths: additionalPaths)
     let pathString = paths.joined(separator: ":")

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/EmbeddedTerminalView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/EmbeddedTerminalView.swift
@@ -126,6 +126,8 @@ public struct EmbeddedTerminalView: NSViewRepresentable {
       )
       terminalContainer.onUserInteraction = onUserInteraction
       terminalContainer.consumeQueuedWebPreviewContextOnSubmit = consumeQueuedWebPreviewContextOnSubmit
+      terminalContainer.terminalSessionKey = terminalKey
+      terminalContainer.sessionViewModel = viewModel
       return terminalContainer
     }
 
@@ -177,6 +179,8 @@ public class TerminalContainerView: NSView, ManagedLocalProcessTerminalViewDeleg
   private var localEventMonitor: Any?
   public var onUserInteraction: (() -> Void)?
   public var consumeQueuedWebPreviewContextOnSubmit: (() -> String?)?
+  var terminalSessionKey: String?
+  weak var sessionViewModel: CLISessionsViewModel?
   var metadataStore: SessionMetadataStore?
   var terminateProcessCallCount = 0
 
@@ -242,6 +246,12 @@ public class TerminalContainerView: NSView, ManagedLocalProcessTerminalViewDeleg
     isConfigured = true
 
     let terminal = prepareTerminalView(isDark: isDark)
+    terminal.projectPath = projectPath
+    terminal.onOpenFile = { [weak self] path, line in
+      if let self, let vm = self.sessionViewModel, let key = self.terminalSessionKey {
+        vm.pendingFileOpen = (sessionId: key, filePath: path, lineNumber: line)
+      }
+    }
     installInteractionMonitorIfNeeded()
 
     // Start the CLI process

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/ManagedLocalProcessTerminalView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/ManagedLocalProcessTerminalView.swift
@@ -95,6 +95,27 @@ open class ManagedLocalProcessTerminalView: TerminalView, TerminalViewDelegate, 
 
   open func rangeChanged(source: TerminalView, startY: Int, endY: Int) {}
 
+  // MARK: - File Path Opening
+
+  /// The project path for resolving relative file paths. Set by TerminalContainerView.
+  public var projectPath: String?
+
+  /// Called when user Cmd+clicks a file path. Set by parent view to route to the Files panel.
+  public var onOpenFile: ((String, Int?) -> Void)?
+
+  public func requestOpenFile(source: TerminalView, path: String, lineNumber: Int?) {
+    let resolvedPath: String
+    if path.hasPrefix("/") || path.hasPrefix("~") {
+      resolvedPath = (path as NSString).expandingTildeInPath
+    } else if let projectPath, !projectPath.isEmpty {
+      resolvedPath = (projectPath as NSString).appendingPathComponent(path)
+    } else {
+      resolvedPath = (NSHomeDirectory() as NSString).appendingPathComponent(path)
+    }
+
+    guard FileManager.default.fileExists(atPath: resolvedPath) else { return }
+    onOpenFile?(resolvedPath, lineNumber)
+  }
 
   // MARK: - Process Control
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/ManagedLocalProcessTerminalView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/ManagedLocalProcessTerminalView.swift
@@ -34,9 +34,23 @@ open class ManagedLocalProcessTerminalView: TerminalView, TerminalViewDelegate, 
     setup()
   }
 
+  /// Tracks OSC 133 semantic prompt boundaries for this terminal.
+  public let semanticPromptTracker = SemanticPromptTracker()
+
+  /// Stores position marks for this terminal.
+  public let markStore = MarkStore()
+
+  /// Smart selection engine for context-aware text selection.
+  public let smartSelectionEngine = SmartSelectionEngine()
+
   private func setup() {
     terminalDelegate = self
     process = LocalProcess(delegate: self)
+
+    // Register OSC 133 handler for semantic prompt tracking
+    terminal.registerOscHandler(code: 133) { [weak self] data in
+      self?.semanticPromptTracker.handleOsc133(data)
+    }
   }
 
   /// PID of the running child process, if any.
@@ -80,6 +94,7 @@ open class ManagedLocalProcessTerminalView: TerminalView, TerminalViewDelegate, 
   open func scrolled(source: TerminalView, position: Double) {}
 
   open func rangeChanged(source: TerminalView, startY: Int, endY: Int) {}
+
 
   // MARK: - Process Control
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderMonitoringPanelView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderMonitoringPanelView.swift
@@ -321,6 +321,19 @@ public struct MultiProviderMonitoringPanelView: View {
     .onChange(of: isAuxiliaryShellVisible) { _, _ in
       syncAuxiliaryShellDockState()
     }
+    .onChange(of: claudeViewModel.pendingFileOpen?.filePath) { _, filePath in
+      guard let pending = claudeViewModel.pendingFileOpen, let filePath else { return }
+      if let session = claudeViewModel.allSessions.first(where: { $0.id == pending.sessionId }) {
+        sidePanelContent = .fileExplorer(
+          sessionId: session.id,
+          session: session,
+          projectPath: session.projectPath,
+          initialFilePath: filePath,
+          navigationId: UUID()
+        )
+      }
+      claudeViewModel.pendingFileOpen = nil
+    }
     .overlay {
       // Hidden Shift+P trigger for QuickFilePicker
       Button("") { showQuickFilePicker = true }

--- a/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/CLISessionsViewModel.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/CLISessionsViewModel.swift
@@ -117,6 +117,10 @@ public final class CLISessionsViewModel {
   /// - Note: Prompts are sent with a 100ms delay before pressing Enter to avoid race conditions
   ///   with the terminal's input buffer (see `EmbeddedTerminalView.sendPromptIfNeeded`).
   public var pendingTerminalPrompts: [String: String] = [:]
+
+  /// Pending file open request from Cmd+Click in terminal.
+  /// Set by TerminalContainerView, consumed by MultiProviderMonitoringPanelView.
+  public var pendingFileOpen: (sessionId: String, filePath: String, lineNumber: Int?)? = nil
   private(set) var queuedWebPreviewContextStore = QueuedWebPreviewContextStore()
 
   public func webPreviewCandidateStatus(for projectPath: String) -> WebPreviewCandidateStatus? {


### PR DESCRIPTION
## Summary
- **Cmd+F** — Terminal search with regex, case-sensitive, whole-word toggles (SwiftTerm built-in find bar)
- **Cmd+Click URLs** — Plain URLs in terminal output open in browser (no OSC 8 required)
- **Cmd+Click file paths** — File paths open in the inline Files panel with the file pre-selected
- Switch SwiftTerm to fork (`jamesrochabrun/SwiftTerm`, branch `agenthub`) with modular additions in `Sources/SwiftTerm/AgentHub/`
- OSC 133 semantic prompt tracking wired up (foundation for future features)
- `TERM_PROGRAM=SwiftTerm` set in process environment

## Test plan
- [ ] Open a Claude Code session, press Cmd+F — find bar should appear with search/regex/case toggles
- [ ] Get Claude to output URLs, Cmd+Click one — should open in browser
- [ ] Get Claude to reference file paths, Cmd+Click one — Files side panel should open with that file
- [ ] Verify normal terminal interaction (typing, Enter, Option+Return) still works