### PR TITLE
Fix Cmd+F only firing for terminal when it has focus

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -205,6 +205,32 @@ Cmd+K (palette), Cmd+N (new session), Cmd+B (sidebar), Cmd+[/] (navigate session
 | Yams | YAML parsing for themes |
 | Sparkle | Auto-updates with EdDSA verification |
 
+## Terminal Enhancements
+
+The embedded terminal uses a fork of SwiftTerm (`jamesrochabrun/SwiftTerm`, branch `agenthub`) with modular additions in `Sources/SwiftTerm/AgentHub/`. All new code lives in that directory to minimize merge conflicts with upstream.
+
+### Features
+
+| Feature | Shortcut | Description |
+|---------|----------|-------------|
+| **Search** | `Cmd+F` | Built-in find bar with regex, case-sensitive, whole-word toggles |
+| **Cmd+Click URLs** | `Cmd+Click` | Opens plain URLs in browser (no OSC 8 required) |
+| **Cmd+Click file paths** | `Cmd+Click` | Opens file in inline Files panel (configurable: AgentHub / VS Code / Xcode) |
+| **Theme integration** | Automatic | Terminal background and cursor follow active YAML theme (dark mode) |
+| **OSC 133 tracking** | — | Semantic prompt boundary tracking (foundation for future features) |
+
+### Fork Architecture
+
+- **Branch:** `agenthub` — all additions live here; `main` tracks upstream
+- **New files:** `Sources/SwiftTerm/AgentHub/` — PlainURLDetection, FilePathDetection, SemanticPromptTracker, MarkStore, SmartSelectionEngine
+- **Upstream changes:** Minimal — `cellDimension` and `displayBuffer` exposed as public, `requestOpenFile` delegate added
+- **Merge upstream:** `git fetch upstream && git merge upstream/main` into `agenthub`
+
+### Settings
+
+- **Open files with** — Choose AgentHub (inline), VS Code, or Xcode for Cmd+Click file paths
+- **Terminal colors** — YAML themes can define `terminal.background` and `terminal.cursor` hex colors
+
 ## Common Commands
 
 ```bash

--- a/app/AgentHub.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/app/AgentHub.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -142,7 +142,7 @@
       "location" : "https://github.com/jamesrochabrun/SwiftTerm",
       "state" : {
         "branch" : "agenthub",
-        "revision" : "a3c61c4d364b1a818fc7290586adb8c22a85a2b8"
+        "revision" : "d03ad83eecfe5b19f911408c7845ccd11ba2bf4f"
       }
     },
     {

--- a/app/modules/AgentHubCore/Package.resolved
+++ b/app/modules/AgentHubCore/Package.resolved
@@ -133,7 +133,7 @@
       "location" : "https://github.com/jamesrochabrun/SwiftTerm",
       "state" : {
         "branch" : "agenthub",
-        "revision" : "a3c61c4d364b1a818fc7290586adb8c22a85a2b8"
+        "revision" : "d03ad83eecfe5b19f911408c7845ccd11ba2bf4f"
       }
     },
     {

--- a/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubDefaults.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubDefaults.swift
@@ -99,6 +99,11 @@ public enum AgentHubDefaults {
   /// See: NewlineShortcut enum in EmbeddedTerminalView.swift
   public static let terminalNewlineShortcut = "\(keyPrefix)terminal.newlineShortcut"
 
+  /// Preferred editor for Cmd+Click file paths in the terminal
+  /// Type: Int (default: 0 = AgentHub inline)
+  /// See: FileOpenEditor enum in ManagedLocalProcessTerminalView.swift
+  public static let terminalFileOpenEditor = "\(keyPrefix)terminal.fileOpenEditor"
+
   /// Monitoring panel layout mode (list, 2-column, 3-column grid)
   /// Type: Int (default: 0 = list)
   public static let monitoringPanelLayoutMode = "\(keyPrefix)ui.monitoringPanelLayoutMode"

--- a/app/modules/AgentHubCore/Sources/AgentHub/Design/Theme/BundledThemes/betelgeuse.yaml
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Design/Theme/BundledThemes/betelgeuse.yaml
@@ -1,5 +1,5 @@
 name: "Betelgeuse"
-version: "1.0"
+version: "1.1"
 author: "AgentHub"
 description: "Warm orange gradient inspired by the red supergiant"
 
@@ -14,3 +14,25 @@ colors:
       opacity: 0.44
     - color: "#FF8C42"
       opacity: 0.25
+
+  terminal:
+    background: "#1C1410"
+    foreground: "#F0E4D8"
+    cursor: "#FF8C42"
+    ansi:
+      black: "#1C1410"
+      red: "#E84C3D"
+      green: "#6ABF69"
+      yellow: "#FF8C42"
+      blue: "#5B9BD5"
+      magenta: "#C76DD7"
+      cyan: "#50B4C8"
+      white: "#F0E4D8"
+      brightBlack: "#5A4A3E"
+      brightRed: "#FF6B5A"
+      brightGreen: "#8CD98C"
+      brightYellow: "#FFA04D"
+      brightBlue: "#7CB6E8"
+      brightMagenta: "#DE92EB"
+      brightCyan: "#72CCE0"
+      brightWhite: "#FFFFFF"

--- a/app/modules/AgentHubCore/Sources/AgentHub/Design/Theme/BundledThemes/sentry.yaml
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Design/Theme/BundledThemes/sentry.yaml
@@ -1,5 +1,5 @@
 name: "Sentry"
-version: "1.0"
+version: "1.1"
 author: "Sentry"
 description: "Official Sentry-inspired color theme"
 
@@ -12,3 +12,25 @@ colors:
   backgrounds:
     dark: "#1A1625"
     light: "#FAF9FB"
+
+  terminal:
+    background: "#1A1625"
+    foreground: "#E8E6F0"
+    cursor: "#E1567C"
+    ansi:
+      black: "#1A1625"
+      red: "#E1567C"
+      green: "#33BF8C"
+      yellow: "#F5B944"
+      blue: "#6C63FF"
+      magenta: "#C463E1"
+      cyan: "#45C4E8"
+      white: "#E8E6F0"
+      brightBlack: "#584774"
+      brightRed: "#FF7A9A"
+      brightGreen: "#57D9A5"
+      brightYellow: "#FFD06B"
+      brightBlue: "#9490FF"
+      brightMagenta: "#DA8FEF"
+      brightCyan: "#6FD6F0"
+      brightWhite: "#FFFFFF"

--- a/app/modules/AgentHubCore/Sources/AgentHub/Design/Theme/Models/RuntimeTheme.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Design/Theme/Models/RuntimeTheme.swift
@@ -5,6 +5,7 @@
 //  Runtime theme with resolved colors
 //
 
+import AppKit
 import SwiftUI
 
 /// Runtime theme with resolved colors
@@ -27,6 +28,12 @@ public struct RuntimeTheme: Identifiable {
 
   // Background gradient (optional)
   public let backgroundGradient: LinearGradient?
+
+  // Terminal colors (optional — falls back to default dark/light if nil)
+  public let terminalBackground: NSColor?
+  public let terminalForeground: NSColor?
+  public let terminalCursor: NSColor?
+  public let terminalAnsiColors: [NSColor]?  // Exactly 16 if defined
 
   // Source file name for YAML themes (e.g., "sentry.yaml")
   public let sourceFileName: String?
@@ -65,6 +72,42 @@ public struct RuntimeTheme: Identifiable {
       self.expandedContentBackgroundLight = nil
     }
 
+    // Resolve terminal colors
+    if let tc = yaml.colors.terminal {
+      self.terminalBackground = tc.background.flatMap { NSColor(hex: $0) }
+      self.terminalForeground = tc.foreground.flatMap { NSColor(hex: $0) }
+      self.terminalCursor = tc.cursor.flatMap { NSColor(hex: $0) }
+      if let ansi = tc.ansi {
+        let colors: [NSColor?] = [
+          ansi.black.flatMap { NSColor(hex: $0) },
+          ansi.red.flatMap { NSColor(hex: $0) },
+          ansi.green.flatMap { NSColor(hex: $0) },
+          ansi.yellow.flatMap { NSColor(hex: $0) },
+          ansi.blue.flatMap { NSColor(hex: $0) },
+          ansi.magenta.flatMap { NSColor(hex: $0) },
+          ansi.cyan.flatMap { NSColor(hex: $0) },
+          ansi.white.flatMap { NSColor(hex: $0) },
+          ansi.brightBlack.flatMap { NSColor(hex: $0) },
+          ansi.brightRed.flatMap { NSColor(hex: $0) },
+          ansi.brightGreen.flatMap { NSColor(hex: $0) },
+          ansi.brightYellow.flatMap { NSColor(hex: $0) },
+          ansi.brightBlue.flatMap { NSColor(hex: $0) },
+          ansi.brightMagenta.flatMap { NSColor(hex: $0) },
+          ansi.brightCyan.flatMap { NSColor(hex: $0) },
+          ansi.brightWhite.flatMap { NSColor(hex: $0) },
+        ]
+        let resolved = colors.compactMap { $0 }
+        self.terminalAnsiColors = resolved.count == 16 ? resolved : nil
+      } else {
+        self.terminalAnsiColors = nil
+      }
+    } else {
+      self.terminalBackground = nil
+      self.terminalForeground = nil
+      self.terminalCursor = nil
+      self.terminalAnsiColors = nil
+    }
+
     // Resolve gradient
     if let gradient = yaml.colors.backgroundGradient, !gradient.isEmpty {
       let colors = gradient.map { Color(hex: $0.color).opacity($0.opacity) }
@@ -91,7 +134,11 @@ public struct RuntimeTheme: Identifiable {
     self.brandSecondary = colors.brandSecondary
     self.brandTertiary = colors.brandTertiary
 
-    // Built-in themes use code-defined backgrounds
+    // Built-in themes use code-defined backgrounds and default terminal colors
+    self.terminalBackground = nil
+    self.terminalForeground = nil
+    self.terminalCursor = nil
+    self.terminalAnsiColors = nil
     self.backgroundDark = nil
     self.backgroundLight = nil
     self.expandedContentBackgroundDark = nil

--- a/app/modules/AgentHubCore/Sources/AgentHub/Design/Theme/Models/YAMLTheme.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Design/Theme/Models/YAMLTheme.swift
@@ -19,6 +19,33 @@ public struct YAMLTheme: Codable, Sendable {
     public let brand: BrandColors
     public let backgrounds: BackgroundColors?
     public let backgroundGradient: [GradientStop]?
+    public let terminal: TerminalColors?
+  }
+
+  public struct TerminalColors: Codable, Sendable {
+    public let background: String?
+    public let foreground: String?
+    public let cursor: String?
+    public let ansi: AnsiColors?
+  }
+
+  public struct AnsiColors: Codable, Sendable {
+    public let black: String?
+    public let red: String?
+    public let green: String?
+    public let yellow: String?
+    public let blue: String?
+    public let magenta: String?
+    public let cyan: String?
+    public let white: String?
+    public let brightBlack: String?
+    public let brightRed: String?
+    public let brightGreen: String?
+    public let brightYellow: String?
+    public let brightBlue: String?
+    public let brightMagenta: String?
+    public let brightCyan: String?
+    public let brightWhite: String?
   }
 
   public struct BrandColors: Codable, Sendable {

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/EmbeddedTerminalView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/EmbeddedTerminalView.swift
@@ -467,9 +467,8 @@ public class TerminalContainerView: NSView, ManagedLocalProcessTerminalViewDeleg
         let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
         let isTerminalVisible = terminal.superview != nil && !terminal.isHidden && terminal.alphaValue > 0
 
-        // Terminal-wide shortcuts (work when terminal is visible, even without focus)
-        if isTerminalVisible {
-          // Cmd+F: activate SwiftTerm's built-in search/find bar
+        // Cmd+F: only when terminal has focus (let file editor handle it otherwise)
+        if isTerminalVisible, self.isTerminalResponderActive(window: window, terminal: terminal) {
           if flags == .command, event.charactersIgnoringModifiers == "f" {
             window.makeFirstResponder(terminal)
             // performFindPanelAction requires an NSMenuItem with the correct tag

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/EmbeddedTerminalView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/EmbeddedTerminalView.swift
@@ -430,8 +430,8 @@ public class TerminalContainerView: NSView, ManagedLocalProcessTerminalViewDeleg
     let needsUpdate = lastAppliedIsDark != isDark || lastAppliedThemeId != themeId
     guard needsUpdate else { return }
 
-    // Background: theme → default dark/light
-    if let bg = theme?.terminalBackground {
+    // Theme terminal colors only apply in dark mode
+    if isDark, let bg = theme?.terminalBackground {
       terminal.nativeBackgroundColor = bg
     } else if isDark {
       terminal.nativeBackgroundColor = NSColor(red: 0.1, green: 0.1, blue: 0.12, alpha: 1.0)
@@ -439,15 +439,13 @@ public class TerminalContainerView: NSView, ManagedLocalProcessTerminalViewDeleg
       terminal.nativeBackgroundColor = NSColor(red: 0.98, green: 0.98, blue: 0.98, alpha: 1.0)
     }
 
-    // Foreground: always default (CLI controls its own text colors)
     if isDark {
       terminal.nativeForegroundColor = NSColor(red: 0.9, green: 0.9, blue: 0.88, alpha: 1.0)
     } else {
       terminal.nativeForegroundColor = NSColor(red: 0.1, green: 0.1, blue: 0.1, alpha: 1.0)
     }
 
-    // Cursor: theme → default brand color
-    if let cursor = theme?.terminalCursor {
+    if isDark, let cursor = theme?.terminalCursor {
       terminal.caretColor = cursor
     } else {
       terminal.caretColor = NSColor(red: 204/255, green: 120/255, blue: 92/255, alpha: 1.0)

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/EmbeddedTerminalView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/EmbeddedTerminalView.swift
@@ -85,6 +85,7 @@ class SafeLocalProcessTerminalView: ManagedLocalProcessTerminalView {
 public struct EmbeddedTerminalView: NSViewRepresentable {
   @Environment(\.agentHub) private var agentHub
   @Environment(\.colorScheme) private var colorScheme
+  @Environment(\.runtimeTheme) private var runtimeTheme
   @AppStorage(AgentHubDefaults.terminalFontSize) private var terminalFontSize: Double = 12
 
   let terminalKey: String  // Key for terminal storage (session ID or "pending-{pendingId}")
@@ -174,7 +175,7 @@ public struct EmbeddedTerminalView: NSViewRepresentable {
   public func updateNSView(_ nsView: TerminalContainerView, context: Context) {
     nsView.onUserInteraction = onUserInteraction
     nsView.consumeQueuedWebPreviewContextOnSubmit = consumeQueuedWebPreviewContextOnSubmit
-    nsView.syncAppearance(isDark: colorScheme == .dark, fontSize: CGFloat(terminalFontSize))
+    nsView.syncAppearance(isDark: colorScheme == .dark, fontSize: CGFloat(terminalFontSize), theme: runtimeTheme)
 
     // If there's a pending prompt in the viewModel, send it (and clear it)
     // Use terminalKey (not sessionId) since it works for both pending and real sessions
@@ -399,8 +400,8 @@ public class TerminalContainerView: NSView, ManagedLocalProcessTerminalViewDeleg
     typeText(text)
   }
 
-  public func syncAppearance(isDark: Bool, fontSize: CGFloat) {
-    updateColors(isDark: isDark)
+  public func syncAppearance(isDark: Bool, fontSize: CGFloat, theme: RuntimeTheme? = nil) {
+    updateColors(isDark: isDark, theme: theme)
     updateFont(size: fontSize)
   }
 
@@ -417,21 +418,43 @@ public class TerminalContainerView: NSView, ManagedLocalProcessTerminalViewDeleg
     lastAppliedFontSize = resolvedSize
   }
 
-  /// Updates terminal colors based on color scheme.
-  /// Called when the app's color scheme changes.
-  public func updateColors(isDark: Bool) {
-    guard let terminal = terminalView else { return }
-    guard lastAppliedIsDark != isDark else { return }
+  private var lastAppliedThemeId: String?
 
-    if isDark {
+  /// Updates terminal colors from theme or falls back to default dark/light.
+  /// Only background and cursor are themed — foreground and ANSI colors are left
+  /// untouched to preserve Claude Code / Codex syntax highlighting.
+  public func updateColors(isDark: Bool, theme: RuntimeTheme? = nil) {
+    guard let terminal = terminalView else { return }
+
+    let themeId = theme?.id
+    let needsUpdate = lastAppliedIsDark != isDark || lastAppliedThemeId != themeId
+    guard needsUpdate else { return }
+
+    // Background: theme → default dark/light
+    if let bg = theme?.terminalBackground {
+      terminal.nativeBackgroundColor = bg
+    } else if isDark {
       terminal.nativeBackgroundColor = NSColor(red: 0.1, green: 0.1, blue: 0.12, alpha: 1.0)
-      terminal.nativeForegroundColor = NSColor(red: 0.9, green: 0.9, blue: 0.88, alpha: 1.0)
     } else {
       terminal.nativeBackgroundColor = NSColor(red: 0.98, green: 0.98, blue: 0.98, alpha: 1.0)
+    }
+
+    // Foreground: always default (CLI controls its own text colors)
+    if isDark {
+      terminal.nativeForegroundColor = NSColor(red: 0.9, green: 0.9, blue: 0.88, alpha: 1.0)
+    } else {
       terminal.nativeForegroundColor = NSColor(red: 0.1, green: 0.1, blue: 0.1, alpha: 1.0)
     }
 
+    // Cursor: theme → default brand color
+    if let cursor = theme?.terminalCursor {
+      terminal.caretColor = cursor
+    } else {
+      terminal.caretColor = NSColor(red: 204/255, green: 120/255, blue: 92/255, alpha: 1.0)
+    }
+
     lastAppliedIsDark = isDark
+    lastAppliedThemeId = themeId
     terminal.needsDisplay = true
   }
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/ManagedLocalProcessTerminalView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/ManagedLocalProcessTerminalView.swift
@@ -9,6 +9,26 @@ import AppKit
 import Darwin
 import SwiftTerm
 
+// MARK: - FileOpenEditor
+
+/// Preferred editor for opening files from Cmd+Click in the terminal.
+public enum FileOpenEditor: Int, CaseIterable {
+  /// Open in AgentHub's inline file viewer (default)
+  case agentHub = 0
+  /// Open in VS Code
+  case vscode = 1
+  /// Open in Xcode
+  case xcode = 2
+
+  public var label: String {
+    switch self {
+    case .agentHub: return "AgentHub"
+    case .vscode: return "VS Code"
+    case .xcode: return "Xcode"
+    }
+  }
+}
+
 /// Delegate for ManagedLocalProcessTerminalView process events.
 public protocol ManagedLocalProcessTerminalViewDelegate: AnyObject {
   func sizeChanged(source: ManagedLocalProcessTerminalView, newCols: Int, newRows: Int)
@@ -114,7 +134,42 @@ open class ManagedLocalProcessTerminalView: TerminalView, TerminalViewDelegate, 
     }
 
     guard FileManager.default.fileExists(atPath: resolvedPath) else { return }
-    onOpenFile?(resolvedPath, lineNumber)
+
+    let editor = FileOpenEditor(
+      rawValue: UserDefaults.standard.integer(forKey: AgentHubDefaults.terminalFileOpenEditor)
+    ) ?? .agentHub
+
+    switch editor {
+    case .agentHub:
+      onOpenFile?(resolvedPath, lineNumber)
+    case .vscode:
+      Self.openInVSCode(path: resolvedPath, line: lineNumber)
+    case .xcode:
+      Self.openInXcode(path: resolvedPath, line: lineNumber)
+    }
+  }
+
+  private static func openInVSCode(path: String, line: Int?) {
+    let codePaths = [
+      "/usr/local/bin/code",
+      "/opt/homebrew/bin/code",
+      "/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code"
+    ]
+    guard let codePath = codePaths.first(where: { FileManager.default.isExecutableFile(atPath: $0) }) else {
+      NSWorkspace.shared.open(URL(fileURLWithPath: path))
+      return
+    }
+    let task = Process()
+    task.executableURL = URL(fileURLWithPath: codePath)
+    task.arguments = ["--goto", line != nil ? "\(path):\(line!)" : path]
+    try? task.run()
+  }
+
+  private static func openInXcode(path: String, line: Int?) {
+    let task = Process()
+    task.executableURL = URL(fileURLWithPath: "/usr/bin/xed")
+    task.arguments = line != nil ? ["--line", "\(line!)", path] : [path]
+    try? task.run()
   }
 
   // MARK: - Process Control

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/SettingsView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/SettingsView.swift
@@ -29,6 +29,9 @@ public struct SettingsView: View {
   @AppStorage(AgentHubDefaults.terminalNewlineShortcut)
   private var newlineShortcutRawValue: Int = NewlineShortcut.system.rawValue
 
+  @AppStorage(AgentHubDefaults.terminalFileOpenEditor)
+  private var fileOpenEditorRawValue: Int = FileOpenEditor.agentHub.rawValue
+
   @AppStorage(AgentHubDefaults.notificationSoundsEnabled)
   private var notificationSoundsEnabled: Bool = true
 
@@ -178,6 +181,12 @@ public struct SettingsView: View {
         Picker("Newline shortcut", selection: $newlineShortcutRawValue) {
           ForEach(NewlineShortcut.allCases, id: \.rawValue) { shortcut in
             Text(shortcut.label).tag(shortcut.rawValue)
+          }
+        }
+
+        Picker("Open files with", selection: $fileOpenEditorRawValue) {
+          ForEach(FileOpenEditor.allCases, id: \.rawValue) { editor in
+            Text(editor.label).tag(editor.rawValue)
           }
         }
       }


### PR DESCRIPTION
## Summary
- Cmd+F now respects which view has focus
- When the Files editor is focused, Cmd+F opens the file editor search bar
- When the terminal is focused, Cmd+F opens the terminal find bar
- Uses the existing `isTerminalResponderActive` check that was missing from the Cmd+F handler

## Test plan
- [ ] Open a session with Files side panel open
- [ ] Click in the file editor, press Cmd+F — file search bar appears
- [ ] Click in the terminal, press Cmd+F — terminal find bar appears
- [ ] Close Files panel, press Cmd+F — terminal find bar still works