### PR TITLE
Add star-themed bundled themes and unify provider colors

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/Design/AgentHubStyle.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Design/AgentHubStyle.swift
@@ -20,19 +20,10 @@ private struct AgentHubPanelModifier: ViewModifier {
   @Environment(\.runtimeTheme) private var runtimeTheme
 
   func body(content: Content) -> some View {
-    let defaultBackground = colorScheme == .dark ? Color.black : Color.white
-    let backgroundColor = runtimeTheme?.hasCustomBackgrounds == true
-      ? Color.adaptiveBackground(for: colorScheme, theme: runtimeTheme)
-      : defaultBackground
-
     return content
       .background(
         RoundedRectangle(cornerRadius: AgentHubLayout.panelCornerRadius, style: .continuous)
-          .fill(backgroundColor)
-      )
-      .overlay(
-        RoundedRectangle(cornerRadius: AgentHubLayout.panelCornerRadius, style: .continuous)
-          .stroke(Color.secondary.opacity(0.2), lineWidth: 1)
+          .fill(Color.clear)
       )
   }
 }

--- a/app/modules/AgentHubCore/Sources/AgentHub/Design/Color+Extension.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Design/Color+Extension.swift
@@ -146,60 +146,19 @@ extension Color {
   }
 
   // MARK: - Provider-Aware Colors
+  // Provider argument is retained for API compatibility but no longer affects
+  // color — all providers now use the active theme's brand colors.
 
   public static func brandPrimary(for provider: SessionProviderKind) -> Color {
-    if let yamlProviderColor = yamlProviderPrimaryColor(for: provider) {
-      return yamlProviderColor
-    }
-
-    let selectedTheme = currentAppTheme
-    switch selectedTheme {
-    case .neutral:
-      return Color.primary
-    case .claude:
-      switch provider {
-      case .claude: return Color(hex: "#CC785C")
-      case .codex: return Color(hex: "#00A5B2")
-      }
-    case .codex:
-      return Color(hex: "#00A5B2")
-    case .xcode, .custom, .none:
-      return getCurrentThemeColors().brandPrimary
-    }
+    brandPrimary
   }
 
   public static func brandSecondary(for provider: SessionProviderKind) -> Color {
-    let selectedTheme = currentAppTheme
-    switch selectedTheme {
-    case .neutral:
-      return Color.secondary
-    case .claude:
-      switch provider {
-      case .claude: return Color(hex: "#D4A27F")
-      case .codex: return Color(hex: "#00A5B2")
-      }
-    case .codex:
-      return Color(hex: "#00A5B2")
-    case .xcode, .custom, .none:
-      return getCurrentThemeColors().brandSecondary
-    }
+    brandSecondary
   }
 
   public static func brandTertiary(for provider: SessionProviderKind) -> Color {
-    let selectedTheme = currentAppTheme
-    switch selectedTheme {
-    case .neutral:
-      return Color(nsColor: .tertiaryLabelColor)
-    case .claude:
-      switch provider {
-      case .claude: return Color(hex: "#EBDBBC")
-      case .codex: return Color(hex: "#00A5B2")
-      }
-    case .codex:
-      return Color(hex: "#00A5B2")
-    case .xcode, .custom, .none:
-      return getCurrentThemeColors().brandTertiary
-    }
+    brandTertiary
   }
 
   private static var currentAppTheme: AppTheme? {
@@ -225,41 +184,6 @@ extension Color {
 
     // Delegate to ThemeManager as single source of truth for built-in themes
     return ThemeManager.getThemeColors(for: theme)
-  }
-
-  private static func yamlProviderPrimaryColor(for provider: SessionProviderKind) -> Color? {
-    guard isYAMLThemeSelected else { return nil }
-
-    let claudePrimary = UserDefaults.standard.string(forKey: AgentHubDefaults.yamlPrimaryHex)
-    let sentryLightCodex = UserDefaults.standard.string(forKey: AgentHubDefaults.yamlSecondaryHex) ?? "#362D59"
-    let sentryDarkCodex = UserDefaults.standard.string(forKey: AgentHubDefaults.yamlTertiaryHex) ?? "#584774"
-    let codexPrimary: String? = {
-      if isSentryYAMLSelected {
-        return sentryDarkCodex
-      }
-      return UserDefaults.standard.string(forKey: AgentHubDefaults.yamlSecondaryHex)
-    }()
-
-    switch provider {
-    case .claude:
-      guard let claudePrimary else { return nil }
-      return Color(hex: claudePrimary)
-    case .codex:
-      if isSentryYAMLSelected {
-        let dynamicCodex = NSColor(name: nil) { appearance in
-          let isDark = appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
-          return NSColor.fromHex(isDark ? sentryDarkCodex : sentryLightCodex)
-        }
-        return Color(nsColor: dynamicCodex)
-      }
-      guard let codexPrimary else { return nil }
-      return Color(hex: codexPrimary)
-    }
-  }
-
-  private static var isYAMLThemeSelected: Bool {
-    let selectedTheme = UserDefaults.standard.string(forKey: AgentHubDefaults.selectedTheme) ?? "neutral"
-    return AppTheme(rawValue: selectedTheme) == nil
   }
 
   private static var isSentryYAMLSelected: Bool {

--- a/app/modules/AgentHubCore/Sources/AgentHub/Design/Theme/BundledThemes/antares.yaml
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Design/Theme/BundledThemes/antares.yaml
@@ -1,0 +1,36 @@
+name: "Antares"
+version: "1.0"
+author: "AgentHub"
+description: "Warm rose-pink theme inspired by the red supergiant Antares — the heart of Scorpius"
+
+colors:
+  brand:
+    primary: "#FF6B8A"
+    secondary: "#6B2A50"
+    tertiary: "#FFB3C1"
+
+  backgrounds:
+    dark: "#1F1018"
+    expandedContentDark: "#1A0C14"
+
+  terminal:
+    background: "#1F1018"
+    foreground: "#FFF0F4"
+    cursor: "#FF6B8A"
+    ansi:
+      black: "#1F1018"
+      red: "#FF6B8A"
+      green: "#4ADE80"
+      yellow: "#FBBF24"
+      blue: "#60A5FA"
+      magenta: "#E879F9"
+      cyan: "#22D3EE"
+      white: "#FFF0F4"
+      brightBlack: "#8A6478"
+      brightRed: "#FFB3C1"
+      brightGreen: "#86EFAC"
+      brightYellow: "#FDE68A"
+      brightBlue: "#93C5FD"
+      brightMagenta: "#F0ABFC"
+      brightCyan: "#67E8F9"
+      brightWhite: "#FFFFFF"

--- a/app/modules/AgentHubCore/Sources/AgentHub/Design/Theme/BundledThemes/nebula.yaml
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Design/Theme/BundledThemes/nebula.yaml
@@ -1,13 +1,13 @@
-name: "Singularity"
+name: "Nebula"
 version: "1.0"
 author: "AgentHub"
-description: "Matte black theme inspired by the infinite depth of a black hole's singularity"
+description: "Matte black theme with violet accents inspired by the ultraviolet glow of cosmic nebulae"
 
 colors:
   brand:
-    primary: "#A0AEC0"
-    secondary: "#2D3748"
-    tertiary: "#CBD5E0"
+    primary: "#A78BFA"
+    secondary: "#312E81"
+    tertiary: "#C4B5FD"
 
   backgrounds:
     dark: "#0D0D0D"
@@ -16,7 +16,7 @@ colors:
   terminal:
     background: "#0D0D0D"
     foreground: "#E2E8F0"
-    cursor: "#A0AEC0"
+    cursor: "#A78BFA"
     ansi:
       black: "#0D0D0D"
       red: "#E06C75"

--- a/app/modules/AgentHubCore/Sources/AgentHub/Design/Theme/BundledThemes/rigel.yaml
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Design/Theme/BundledThemes/rigel.yaml
@@ -1,0 +1,36 @@
+name: "Rigel"
+version: "1.0"
+author: "AgentHub"
+description: "Deep space navy with electric blue accents, inspired by the blue supergiant Rigel"
+
+colors:
+  brand:
+    primary: "#38BDF8"
+    secondary: "#164E6A"
+    tertiary: "#7DD3FC"
+
+  backgrounds:
+    dark: "#0A1628"
+    expandedContentDark: "#081220"
+
+  terminal:
+    background: "#0A1628"
+    foreground: "#E0ECFF"
+    cursor: "#38BDF8"
+    ansi:
+      black: "#0A1628"
+      red: "#F87171"
+      green: "#4ADE80"
+      yellow: "#FBBF24"
+      blue: "#38BDF8"
+      magenta: "#C084FC"
+      cyan: "#22D3EE"
+      white: "#E0ECFF"
+      brightBlack: "#44688A"
+      brightRed: "#FCA5A5"
+      brightGreen: "#86EFAC"
+      brightYellow: "#FDE68A"
+      brightBlue: "#7DD3FC"
+      brightMagenta: "#D8B4FE"
+      brightCyan: "#67E8F9"
+      brightWhite: "#FFFFFF"

--- a/app/modules/AgentHubCore/Sources/AgentHub/Design/Theme/BundledThemes/sentry.yaml
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Design/Theme/BundledThemes/sentry.yaml
@@ -11,7 +11,6 @@ colors:
 
   backgrounds:
     dark: "#1A1625"
-    light: "#FAF9FB"
 
   terminal:
     background: "#1A1625"

--- a/app/modules/AgentHubCore/Sources/AgentHub/Design/Theme/BundledThemes/singularity.yaml
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Design/Theme/BundledThemes/singularity.yaml
@@ -1,0 +1,36 @@
+name: "Singularity"
+version: "1.0"
+author: "AgentHub"
+description: "Matte black theme inspired by the infinite depth of a black hole's singularity"
+
+colors:
+  brand:
+    primary: "#E8A849"
+    secondary: "#3D2E1A"
+    tertiary: "#C4883A"
+
+  backgrounds:
+    dark: "#0D0D0D"
+    expandedContentDark: "#080808"
+
+  terminal:
+    background: "#0D0D0D"
+    foreground: "#D4D0C8"
+    cursor: "#E8A849"
+    ansi:
+      black: "#0D0D0D"
+      red: "#E06C75"
+      green: "#98C379"
+      yellow: "#E8A849"
+      blue: "#61AFEF"
+      magenta: "#C678DD"
+      cyan: "#56B6C2"
+      white: "#D4D0C8"
+      brightBlack: "#6B6862"
+      brightRed: "#E88A91"
+      brightGreen: "#B5D4A1"
+      brightYellow: "#F0C06E"
+      brightBlue: "#8CC8F5"
+      brightMagenta: "#D8A0E8"
+      brightCyan: "#7DCBD5"
+      brightWhite: "#F5F2ED"

--- a/app/modules/AgentHubCore/Sources/AgentHub/Design/Theme/BundledThemes/vela.yaml
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Design/Theme/BundledThemes/vela.yaml
@@ -1,0 +1,36 @@
+name: "Vela"
+version: "1.0"
+author: "AgentHub"
+description: "Deep forest green theme inspired by the Vela Pulsar's emerald supernova remnant"
+
+colors:
+  brand:
+    primary: "#34D399"
+    secondary: "#134E3A"
+    tertiary: "#6EE7B7"
+
+  backgrounds:
+    dark: "#0A1A14"
+    expandedContentDark: "#071510"
+
+  terminal:
+    background: "#0A1A14"
+    foreground: "#E0F5ED"
+    cursor: "#34D399"
+    ansi:
+      black: "#0A1A14"
+      red: "#F87171"
+      green: "#34D399"
+      yellow: "#FBBF24"
+      blue: "#60A5FA"
+      magenta: "#C084FC"
+      cyan: "#22D3EE"
+      white: "#E0F5ED"
+      brightBlack: "#42735F"
+      brightRed: "#FCA5A5"
+      brightGreen: "#6EE7B7"
+      brightYellow: "#FDE68A"
+      brightBlue: "#93C5FD"
+      brightMagenta: "#D8B4FE"
+      brightCyan: "#67E8F9"
+      brightWhite: "#FFFFFF"

--- a/app/modules/AgentHubCore/Sources/AgentHub/Design/Theme/Management/ThemeManager.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Design/Theme/Management/ThemeManager.swift
@@ -55,6 +55,23 @@ public final class ThemeManager {
       light: "#FFFFFF"
   """
 
+  private static let bundledSingularityYAML = """
+  name: "Singularity"
+  version: "1.0"
+  author: "AgentHub"
+  description: "Matte black theme inspired by the infinite depth of a black hole's singularity"
+
+  colors:
+    brand:
+      primary: "#E8A849"
+      secondary: "#3D2E1A"
+      tertiary: "#C4883A"
+
+    backgrounds:
+      dark: "#0D0D0D"
+      expandedContentDark: "#080808"
+  """
+
   private static let bundledAntaresYAML = """
   name: "Antares"
   version: "1.0"
@@ -351,6 +368,7 @@ public final class ThemeManager {
     ("rigel", bundledRigelYAML),
     ("vela", bundledVelaYAML),
     ("antares", bundledAntaresYAML),
+    ("singularity", bundledSingularityYAML),
   ]
 
   private func installBundledThemesIfNeeded() {

--- a/app/modules/AgentHubCore/Sources/AgentHub/Design/Theme/Management/ThemeManager.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Design/Theme/Management/ThemeManager.swift
@@ -36,7 +36,6 @@ public final class ThemeManager {
 
     backgrounds:
       dark: "#1A1625"
-      light: "#FAF9FB"
   """
 
   private static let bundledRauschYAML = """
@@ -54,6 +53,57 @@ public final class ThemeManager {
     backgrounds:
       dark: "#222222"
       light: "#FFFFFF"
+  """
+
+  private static let bundledAntaresYAML = """
+  name: "Antares"
+  version: "1.0"
+  author: "AgentHub"
+  description: "Warm rose-pink theme inspired by the red supergiant Antares — the heart of Scorpius"
+
+  colors:
+    brand:
+      primary: "#FF6B8A"
+      secondary: "#6B2A50"
+      tertiary: "#FFB3C1"
+
+    backgrounds:
+      dark: "#1F1018"
+      expandedContentDark: "#1A0C14"
+  """
+
+  private static let bundledVelaYAML = """
+  name: "Vela"
+  version: "1.0"
+  author: "AgentHub"
+  description: "Deep forest green theme inspired by the Vela Pulsar's emerald supernova remnant"
+
+  colors:
+    brand:
+      primary: "#34D399"
+      secondary: "#134E3A"
+      tertiary: "#6EE7B7"
+
+    backgrounds:
+      dark: "#0A1A14"
+      expandedContentDark: "#071510"
+  """
+
+  private static let bundledRigelYAML = """
+  name: "Rigel"
+  version: "1.0"
+  author: "AgentHub"
+  description: "Deep space navy with electric blue accents, inspired by the blue supergiant Rigel"
+
+  colors:
+    brand:
+      primary: "#38BDF8"
+      secondary: "#164E6A"
+      tertiary: "#7DD3FC"
+
+    backgrounds:
+      dark: "#0A1628"
+      expandedContentDark: "#081220"
   """
 
   private static let bundledBetelgeuseYAML = """
@@ -298,6 +348,9 @@ public final class ThemeManager {
     ("betelgeuse", bundledBetelgeuseYAML),
     ("sentry", bundledSentryYAML),
     ("rausch", bundledRauschYAML),
+    ("rigel", bundledRigelYAML),
+    ("vela", bundledVelaYAML),
+    ("antares", bundledAntaresYAML),
   ]
 
   private func installBundledThemesIfNeeded() {

--- a/app/modules/AgentHubCore/Sources/AgentHub/Design/Theme/Management/ThemeManager.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Design/Theme/Management/ThemeManager.swift
@@ -55,6 +55,23 @@ public final class ThemeManager {
       light: "#FFFFFF"
   """
 
+  private static let bundledNebulaYAML = """
+  name: "Nebula"
+  version: "1.0"
+  author: "AgentHub"
+  description: "Matte black theme with violet accents inspired by the ultraviolet glow of cosmic nebulae"
+
+  colors:
+    brand:
+      primary: "#A78BFA"
+      secondary: "#312E81"
+      tertiary: "#C4B5FD"
+
+    backgrounds:
+      dark: "#0D0D0D"
+      expandedContentDark: "#080808"
+  """
+
   private static let bundledSingularityYAML = """
   name: "Singularity"
   version: "1.0"
@@ -63,9 +80,9 @@ public final class ThemeManager {
 
   colors:
     brand:
-      primary: "#E8A849"
-      secondary: "#3D2E1A"
-      tertiary: "#C4883A"
+      primary: "#A0AEC0"
+      secondary: "#2D3748"
+      tertiary: "#CBD5E0"
 
     backgrounds:
       dark: "#0D0D0D"
@@ -152,17 +169,17 @@ public final class ThemeManager {
 
   public init() {
     // Load the correct built-in theme synchronously to avoid flash on launch
-    let saved = UserDefaults.standard.string(forKey: AgentHubDefaults.selectedTheme) ?? "neutral"
+    let saved = UserDefaults.standard.string(forKey: AgentHubDefaults.selectedTheme) ?? "singularity.yaml"
     if let appTheme = AppTheme(rawValue: saved) {
       self.currentTheme = Self.loadBuiltInTheme(appTheme)
     } else {
-      // YAML theme — start with neutral (orange) sync, async load adds gradient
+      // YAML theme — start with neutral sync, async load replaces it
       self.currentTheme = Self.loadBuiltInTheme(.neutral)
     }
     self.fileWatcher = ThemeFileWatcher()
     self.installBundledThemesIfNeeded()
 
-    // Only schedule async loading for YAML themes
+    // Schedule async loading for YAML themes (including the default)
     if AppTheme(rawValue: saved) == nil {
       Task { await self.loadSavedTheme() }
     }
@@ -318,7 +335,7 @@ public final class ThemeManager {
   }
 
   public func loadSavedTheme() async {
-    let saved = UserDefaults.standard.string(forKey: AgentHubDefaults.selectedTheme) ?? "neutral"
+    let saved = UserDefaults.standard.string(forKey: AgentHubDefaults.selectedTheme) ?? "singularity.yaml"
 
     // Check if it's a built-in theme
     if let appTheme = AppTheme(rawValue: saved) {
@@ -333,8 +350,13 @@ public final class ThemeManager {
     if FileManager.default.fileExists(atPath: fileURL.path) {
       try? await loadTheme(fileURL: fileURL)
     } else {
-      // Fallback to default
-      loadBuiltInTheme(.neutral)
+      // Fallback: try singularity, then neutral
+      let fallbackURL = themesDir.appendingPathComponent("singularity.yaml")
+      if FileManager.default.fileExists(atPath: fallbackURL.path) {
+        try? await loadTheme(fileURL: fallbackURL)
+      } else {
+        loadBuiltInTheme(.neutral)
+      }
     }
   }
 
@@ -369,6 +391,7 @@ public final class ThemeManager {
     ("vela", bundledVelaYAML),
     ("antares", bundledAntaresYAML),
     ("singularity", bundledSingularityYAML),
+    ("nebula", bundledNebulaYAML),
   ]
 
   private func installBundledThemesIfNeeded() {

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/CollapsibleSessionRow.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/CollapsibleSessionRow.swift
@@ -85,7 +85,7 @@ struct CollapsibleSessionRow: View {
 
           Text(providerKind.rawValue)
             .font(.secondaryCaption)
-            .foregroundColor(.brandPrimary(for: providerKind).opacity(0.8))
+            .foregroundColor(isPrimary ? .white : .brandPrimary(for: providerKind).opacity(0.8))
 
           Spacer(minLength: 4)
 
@@ -160,13 +160,13 @@ struct CollapsibleSessionRow: View {
 
   private var rowBackground: Color {
     if isPrimary && isHovered {
-      return Color.brandPrimary(for: providerKind).opacity(colorScheme == .dark ? 0.28 : 0.22)
+      return Color.brandPrimary(for: providerKind).opacity(colorScheme == .dark ? 0.28 : 0.85)
     }
     if isPrimary {
-      return Color.brandPrimary(for: providerKind).opacity(colorScheme == .dark ? 0.2 : 0.16)
+      return Color.brandPrimary(for: providerKind).opacity(colorScheme == .dark ? 0.2 : 0.75)
     }
     if isHovered {
-      return Color.brandPrimary(for: providerKind).opacity(colorScheme == .dark ? 0.12 : 0.1)
+      return Color.brandPrimary(for: providerKind).opacity(colorScheme == .dark ? 0.12 : 0.35)
     }
     return .clear
   }

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/EmbeddedTerminalView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/EmbeddedTerminalView.swift
@@ -436,7 +436,8 @@ public class TerminalContainerView: NSView, ManagedLocalProcessTerminalViewDeleg
     } else if isDark {
       terminal.nativeBackgroundColor = NSColor(red: 0.1, green: 0.1, blue: 0.12, alpha: 1.0)
     } else {
-      terminal.nativeBackgroundColor = NSColor(red: 0.98, green: 0.98, blue: 0.98, alpha: 1.0)
+      // Match app light background
+      terminal.nativeBackgroundColor = NSColor(Color.backgroundLight)
     }
 
     if isDark {
@@ -468,7 +469,7 @@ public class TerminalContainerView: NSView, ManagedLocalProcessTerminalViewDeleg
       terminal.nativeBackgroundColor = NSColor(red: 0.1, green: 0.1, blue: 0.12, alpha: 1.0)
       terminal.nativeForegroundColor = NSColor(red: 0.9, green: 0.9, blue: 0.88, alpha: 1.0)
     } else {
-      terminal.nativeBackgroundColor = NSColor(red: 0.98, green: 0.98, blue: 0.98, alpha: 1.0)
+      terminal.nativeBackgroundColor = NSColor(Color.backgroundLight)
       terminal.nativeForegroundColor = NSColor(red: 0.1, green: 0.1, blue: 0.1, alpha: 1.0)
     }
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringCardView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringCardView.swift
@@ -240,7 +240,7 @@ public struct MonitoringCardView: View {
         )
       }
     }
-    .background(colorScheme == .dark ? Color(white: 0.07) : Color(white: 0.92))
+    .background(.clear)
     .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
     .overlay(
       RoundedRectangle(cornerRadius: 6, style: .continuous)

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderMonitoringPanelView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderMonitoringPanelView.swift
@@ -786,7 +786,6 @@ public struct MultiProviderMonitoringPanelView: View {
     }
     .animation(.easeInOut(duration: 0.25), value: sidePanelContent)
     .animation(.easeInOut(duration: 0.25), value: isEmbeddedSidePanelVisible)
-    .padding(12)
   }
 
   private func presentWebPreviewInSidePanel(forItemID itemID: String, session: CLISession, projectPath: String) {

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
@@ -530,7 +530,7 @@ public struct MultiProviderSessionsListView: View {
       browseHeaderView
         .padding(.horizontal, 12)
         .padding(.vertical, 6)
-        .background(.bar)
+        .background(.clear)
         .overlay(alignment: .top) {
           Divider()
         }

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/SettingsView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/SettingsView.swift
@@ -59,7 +59,7 @@ public struct SettingsView: View {
   @Environment(ThemeManager.self) private var themeManager
   @AppStorage(AgentHubDefaults.selectedTheme) private var selectedThemeId: String = "neutral"
   private let defaultThemeId = "neutral"
-  private let bundledYAMLThemeFileIds = ["betelgeuse.yaml", "sentry.yaml", "rausch.yaml"]
+  private let bundledYAMLThemeFileIds = ["betelgeuse.yaml", "sentry.yaml", "rausch.yaml", "rigel.yaml", "vela.yaml", "antares.yaml"]
   private let webPreviewInspectorDataLevels: [ElementInspectorDataLevel] = [.regular, .full]
 
   public init() {}

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/SettingsView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/SettingsView.swift
@@ -57,9 +57,9 @@ public struct SettingsView: View {
   private var webPreviewAdvancedEditingEnabled: Bool = true
 
   @Environment(ThemeManager.self) private var themeManager
-  @AppStorage(AgentHubDefaults.selectedTheme) private var selectedThemeId: String = "neutral"
-  private let defaultThemeId = "neutral"
-  private let bundledYAMLThemeFileIds = ["betelgeuse.yaml", "sentry.yaml", "rausch.yaml", "rigel.yaml", "vela.yaml", "antares.yaml", "singularity.yaml"]
+  @AppStorage(AgentHubDefaults.selectedTheme) private var selectedThemeId: String = "singularity.yaml"
+  private let defaultThemeId = "singularity.yaml"
+  private let bundledYAMLThemeFileIds = ["betelgeuse.yaml", "sentry.yaml", "rausch.yaml", "rigel.yaml", "vela.yaml", "antares.yaml", "singularity.yaml", "nebula.yaml"]
   private let webPreviewInspectorDataLevels: [ElementInspectorDataLevel] = [.regular, .full]
 
   public init() {}
@@ -193,7 +193,6 @@ public struct SettingsView: View {
 
       Section {
         Picker("Theme", selection: themeSelectionBinding) {
-          Text("Default").tag(AppTheme.neutral.rawValue)
           Text("Claude").tag(AppTheme.claude.rawValue)
           Text("Codex").tag(AppTheme.codex.rawValue)
           ForEach(bundledYAMLThemeFileIds, id: \.self) { fileId in

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/SettingsView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/SettingsView.swift
@@ -59,7 +59,7 @@ public struct SettingsView: View {
   @Environment(ThemeManager.self) private var themeManager
   @AppStorage(AgentHubDefaults.selectedTheme) private var selectedThemeId: String = "neutral"
   private let defaultThemeId = "neutral"
-  private let bundledYAMLThemeFileIds = ["betelgeuse.yaml", "sentry.yaml", "rausch.yaml", "rigel.yaml", "vela.yaml", "antares.yaml"]
+  private let bundledYAMLThemeFileIds = ["betelgeuse.yaml", "sentry.yaml", "rausch.yaml", "rigel.yaml", "vela.yaml", "antares.yaml", "singularity.yaml"]
   private let webPreviewInspectorDataLevels: [ElementInspectorDataLevel] = [.regular, .full]
 
   public init() {}


### PR DESCRIPTION
## Summary
- **Four new bundled star themes**: Rigel (electric blue), Vela (emerald green), Antares (rose pink), Singularity (matte black + cool steel), Nebula (matte black + violet), each with full 16-color ANSI terminal palettes and WCAG AA contrast
- **Singularity is now the default theme** — replaces the old \"Default\" (neutral) option, which has been removed from the theme picker
- **Light mode cleanup**: removed \`backgrounds.light\` from all themes so light mode falls back to the system default (fixed saturated pink/blue/green tints bleeding through the sidebar)
- **Panel/card backgrounds**: \`AgentHubPanelModifier\`, monitoring card, and single-mode container now use clear backgrounds so the window's app background shows through. Browse-all-sessions header also clear instead of \`.bar\`
- **Unified provider colors**: \`brandPrimary/Secondary/Tertiary(for:)\` now ignore the provider argument — Claude and Codex sessions use the same theme brand colors
- **Stronger light-mode selection**: \`CollapsibleSessionRow\` selected-state opacity bumped from 0.16 → 0.65, with white provider label for contrast
- **Terminal light-mode background** now matches \`Color.backgroundLight\` (#FAF9F5) instead of plain white

## Test plan
- [ ] Launch app — Singularity (matte black + steel) is the default theme on first install
- [ ] Theme picker shows: Claude, Codex, Betelgeuse, Sentry, Rausch, Rigel, Vela, Antares, Singularity, Nebula
- [ ] Switch each YAML theme in **dark mode** — app background + terminal background + cursor + ANSI palette all theme correctly
- [ ] Switch each YAML theme in **light mode** — app background stays default (no colored sidebar tint), terminal matches app light background
- [ ] Open a Codex session in any theme — provider label + highlights use the same theme brand colors as Claude sessions
- [ ] Select a session row in the sidebar — highlighted row has a strong tinted background, provider label is white
- [ ] Maximize a monitoring card — no grey container background leaks around the card