### PR TITLE
Redesign Browse all Sessions as slide-up panel

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/Design/AgentHubStyle.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Design/AgentHubStyle.swift
@@ -130,23 +130,29 @@ private struct AgentHubFlatRowModifier: ViewModifier {
   let isHighlighted: Bool
   let providerKind: SessionProviderKind?
 
+  @State private var isHovered = false
+
   func body(content: Content) -> some View {
-    // Always show subtle background, selection indicated only by left border
-    let backgroundColor = colorScheme == .dark ? Color(white: 0.07) : Color(white: 0.92)
     let accentColor: Color = if let provider = providerKind {
       Color.brandPrimary(for: provider)
     } else {
       Color.brandPrimary
     }
 
+    let hoverBackground = accentColor.opacity(colorScheme == .dark ? 0.12 : 0.35)
+
     return content
-      .background(backgroundColor)
+      .background(isHovered ? hoverBackground : .clear)
       .overlay(alignment: .leading) {
-        // Left accent bar for highlighted state only
         if isHighlighted {
           Rectangle()
             .fill(accentColor)
             .frame(width: 2)
+        }
+      }
+      .onHover { hovering in
+        withAnimation(.easeInOut(duration: 0.12)) {
+          isHovered = hovering
         }
       }
   }

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
@@ -504,21 +504,18 @@ public struct MultiProviderSessionsListView: View {
     }
   }
 
+  private var browseAnimation: Animation {
+    accessibilityReduceMotion
+      ? .easeInOut(duration: 0.15)
+      : .spring(response: 0.35, dampingFraction: 0.88)
+  }
+
   private var sidePanelView: some View {
     VStack(spacing: 0) {
       ScrollViewReader { proxy in
         ScrollView(showsIndicators: false) {
-          VStack(spacing: 0) {
-            sessionListContent
-              .padding(12)
-
-            // Browse content (scrollable, shown when expanded)
-            if isBrowseExpanded {
-              browseExpandedContent
-                .padding(.horizontal, 12)
-                .padding(.bottom, 12)
-            }
-          }
+          sessionListContent
+            .padding(12)
         }
         .onChange(of: scrollToSessionId) { _, newId in
           guard let newId else { return }
@@ -529,16 +526,45 @@ public struct MultiProviderSessionsListView: View {
         }
       }
 
-      // Pinned browse header at bottom
+      // Browse panel slides up from bottom with fixed max height
+      if isBrowseExpanded {
+        browsePanel
+          .transition(
+            accessibilityReduceMotion
+              ? .opacity
+              : .move(edge: .bottom).combined(with: .opacity)
+          )
+      } else {
+        browseHeaderView
+          .padding(.horizontal, 12)
+          .padding(.vertical, 6)
+          .overlay(alignment: .top) {
+            Divider()
+          }
+          .transition(.move(edge: .bottom).combined(with: .opacity))
+      }
+    }
+    .animation(browseAnimation, value: isBrowseExpanded)
+  }
+
+  private var browsePanel: some View {
+    VStack(spacing: 0) {
       browseHeaderView
         .padding(.horizontal, 12)
         .padding(.vertical, 6)
-        .background(.clear)
         .overlay(alignment: .top) {
-          Divider()
+          Rectangle()
+            .fill(Color.primary.opacity(0.15))
+            .frame(height: 3)
         }
+
+      ScrollView(showsIndicators: false) {
+        browseExpandedContent
+          .padding(.horizontal, 12)
+          .padding(.vertical, 12)
+      }
     }
-    .animation(.easeInOut(duration: 0.25), value: isBrowseExpanded)
+    .frame(maxHeight: 420)
   }
 
   // MARK: - Collapsible Search Button
@@ -1047,18 +1073,19 @@ public struct MultiProviderSessionsListView: View {
 
   @State private var showBrowseInfo = false
 
-  /// Pinned header bar at the bottom of the sidebar.
+  /// Browse header — pinned at bottom when collapsed, at top of browse panel when expanded.
   private var browseHeaderView: some View {
     HStack(spacing: 8) {
       Button {
-        withAnimation(.easeInOut(duration: 0.25)) {
+        withAnimation(browseAnimation) {
           isBrowseExpanded.toggle()
         }
       } label: {
-        HStack(spacing: 8) {
-          Image(systemName: "chevron.right")
-            .rotationEffect(.degrees(isBrowseExpanded ? 90 : 0))
-            .font(.system(size: 10))
+        HStack(spacing: 6) {
+          Image(systemName: isBrowseExpanded ? "chevron.down" : "chevron.up")
+            .font(.system(size: DesignTokens.IconSize.sm, weight: .semibold))
+            .frame(width: 12, height: 12)
+            .contentTransition(.symbolEffect(.replace))
           Text("Browse all Sessions")
             .font(.heading)
         }
@@ -1071,12 +1098,13 @@ public struct MultiProviderSessionsListView: View {
         showBrowseInfo.toggle()
       } label: {
         Image(systemName: "info.circle")
-          .font(.system(size: 12))
+          .font(.system(size: DesignTokens.IconSize.sm))
           .foregroundColor(.secondary)
+          .frame(width: 12, height: 12)
       }
       .buttonStyle(.plain)
       .help("About Browse all Sessions")
-      .popover(isPresented: $showBrowseInfo, arrowEdge: .top) {
+      .popover(isPresented: $showBrowseInfo, arrowEdge: isBrowseExpanded ? .bottom : .top) {
         Text("Find all local Claude and Codex sessions started from the terminal and bring them into AgentHub.")
           .font(.callout)
           .foregroundColor(.secondary)
@@ -1391,7 +1419,7 @@ public struct MultiProviderSessionsListView: View {
   }
 
   private func triggerNewSessionFlow(preferredRepositoryPath: String? = nil) {
-    withAnimation(.easeInOut(duration: 0.2)) {
+    withAnimation(browseAnimation) {
       isBrowseExpanded = true
     }
     launchExpandRequestID += 1


### PR DESCRIPTION
## Summary
- Replaces the inline expand behavior with a slide-up panel animation (spring-based, respects reduce-motion) that pushes the sessions list up with a fixed max height
- Fixes vertical misalignment in the browse header by using consistent `DesignTokens.IconSize.sm` sizing and explicit frames
- Swaps rotation-based chevron for semantic `chevron.up`/`chevron.down` icons with smooth symbol replace transition
- Removes static background from flat row modifier, adds hover-to-highlight matching the main session rows
- Uses a thicker 3pt divider when the browse panel is expanded

## Test plan
- [ ] Tap "Browse all Sessions" — panel slides up from bottom with spring animation
- [ ] Tap header again — panel slides back down
- [ ] Verify chevron icon: up arrow when collapsed, down arrow when expanded
- [ ] Hover over session rows in browse panel — should highlight with brand color
- [ ] Verify the thicker divider appears above the header when expanded
- [ ] Check vertical alignment of chevron, text, and info icon in the header
- [ ] Test with Accessibility > Reduce Motion enabled — should use opacity fade instead