### PR TITLE
Add pinned sessions to sidebar

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/Models/SessionMetadata.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Models/SessionMetadata.swift
@@ -24,6 +24,9 @@ public struct SessionMetadata: Codable, Sendable, FetchableRecord, PersistableRe
   /// When the metadata was last updated
   public var updatedAt: Date
 
+  /// Whether the session is pinned to the top of the sidebar
+  public var isPinned: Bool = false
+
   // MARK: - GRDB Configuration
 
   public static var databaseTableName: String { "session_metadata" }
@@ -33,11 +36,13 @@ public struct SessionMetadata: Codable, Sendable, FetchableRecord, PersistableRe
   public init(
     sessionId: String,
     customName: String? = nil,
+    isPinned: Bool = false,
     createdAt: Date = Date(),
     updatedAt: Date = Date()
   ) {
     self.sessionId = sessionId
     self.customName = customName
+    self.isPinned = isPinned
     self.createdAt = createdAt
     self.updatedAt = updatedAt
   }

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/SessionMetadataStore.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/SessionMetadataStore.swift
@@ -139,13 +139,21 @@ public actor SessionMetadataStore {
   /// Gets all pinned session IDs
   public func getPinnedSessionIds() throws -> Set<String> {
     try dbQueue.read { db in
-      let ids = try SessionMetadata
+      let records = try SessionMetadata
         .filter(Column("isPinned") == true)
-        .select(Column("sessionId"))
         .fetchAll(db)
-        .map(\.sessionId)
-      return Set(ids)
+      return Set(records.map(\.sessionId))
     }
+  }
+
+  /// Synchronous read for pinned session IDs — safe to call from non-async contexts.
+  public nonisolated func getPinnedSessionIdsSync() -> Set<String> {
+    (try? dbQueue.read { db in
+      let records = try SessionMetadata
+        .filter(Column("isPinned") == true)
+        .fetchAll(db)
+      return Set(records.map(\.sessionId))
+    }) ?? []
   }
 
   /// Gets all metadata for multiple sessions at once (batch fetch)

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/SessionMetadataStore.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/SessionMetadataStore.swift
@@ -79,6 +79,12 @@ public actor SessionMetadataStore {
       }
     }
 
+    migrator.registerMigration("v4_add_pinned") { db in
+      try db.alter(table: "session_metadata") { t in
+        t.add(column: "isPinned", .boolean).notNull().defaults(to: false)
+      }
+    }
+
     return migrator
   }
 
@@ -109,6 +115,36 @@ public actor SessionMetadataStore {
         )
         try metadata.insert(db)
       }
+    }
+  }
+
+  /// Sets the pinned state for a session
+  /// Creates new record if none exists, updates if it does
+  public func setPinned(_ isPinned: Bool, for sessionId: String) throws {
+    try dbQueue.write { db in
+      if var existing = try SessionMetadata.fetchOne(db, key: sessionId) {
+        existing.isPinned = isPinned
+        existing.updatedAt = Date()
+        try existing.update(db)
+      } else if isPinned {
+        let metadata = SessionMetadata(
+          sessionId: sessionId,
+          isPinned: true
+        )
+        try metadata.insert(db)
+      }
+    }
+  }
+
+  /// Gets all pinned session IDs
+  public func getPinnedSessionIds() throws -> Set<String> {
+    try dbQueue.read { db in
+      let ids = try SessionMetadata
+        .filter(Column("isPinned") == true)
+        .select(Column("sessionId"))
+        .fetchAll(db)
+        .map(\.sessionId)
+      return Set(ids)
     }
   }
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/CollapsibleSelectedSessionsPanel.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/CollapsibleSelectedSessionsPanel.swift
@@ -150,6 +150,20 @@ public struct CollapsibleSelectedSessionsPanel: View {
             customName: customName(for: item),
             sessionStatus: item.sessionStatus,
             colorScheme: colorScheme,
+            isPinned: {
+              switch item.providerKind {
+              case .claude: return claudeViewModel.pinnedSessionIds.contains(item.session.id)
+              case .codex: return codexViewModel.pinnedSessionIds.contains(item.session.id)
+              }
+            }(),
+            onPin: {
+              withAnimation(.easeInOut(duration: 0.3)) {
+                switch item.providerKind {
+                case .claude: claudeViewModel.togglePin(for: item.session)
+                case .codex: codexViewModel.togglePin(for: item.session)
+                }
+              }
+            },
             onArchive: item.isPending ? nil : {
               switch item.providerKind {
               case .claude: claudeViewModel.stopMonitoring(session: item.session)
@@ -390,6 +404,12 @@ public struct SingleProviderCollapsibleSelectedSessionsPanel: View {
             customName: viewModel.sessionCustomNames[item.session.id],
             sessionStatus: item.sessionStatus,
             colorScheme: colorScheme,
+            isPinned: viewModel.pinnedSessionIds.contains(item.session.id),
+            onPin: {
+              withAnimation(.easeInOut(duration: 0.3)) {
+                viewModel.togglePin(for: item.session)
+              }
+            },
             onArchive: item.isPending ? nil : {
               viewModel.stopMonitoring(session: item.session)
             },

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/CollapsibleSessionRow.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/CollapsibleSessionRow.swift
@@ -11,6 +11,8 @@ struct CollapsibleSessionRow: View {
   let customName: String?
   let sessionStatus: SessionStatus?
   let colorScheme: ColorScheme
+  let isPinned: Bool
+  let onPin: (() -> Void)?
   let onArchive: (() -> Void)?
   let onDeleteWorktree: (() -> Void)?
   var isDeletingWorktree: Bool = false
@@ -59,7 +61,7 @@ struct CollapsibleSessionRow: View {
   }
 
   private var showActions: Bool {
-    isHovered && !isPending && (onArchive != nil || onDeleteWorktree != nil)
+    isHovered && !isPending && (onPin != nil || onArchive != nil || onDeleteWorktree != nil)
   }
 
   // MARK: - Body
@@ -174,6 +176,17 @@ struct CollapsibleSessionRow: View {
   @ViewBuilder
   private var actionsView: some View {
     HStack(spacing: 2) {
+      if let onPin {
+        Button(action: onPin) {
+          Image(systemName: isPinned ? "pin.fill" : "pin")
+            .font(.system(size: 10))
+            .foregroundColor(.secondary)
+            .frame(width: 18, height: 18)
+        }
+        .buttonStyle(.plain)
+        .help(isPinned ? "Unpin session" : "Pin session")
+      }
+
       if let onArchive {
         if showArchiveConfirm {
           Button {
@@ -323,6 +336,8 @@ struct CollapsibleSessionRow: View {
             customName: idx == 3 ? "Auth Refactor" : nil,
             sessionStatus: state.0,
             colorScheme: .dark,
+            isPinned: idx == 0,
+            onPin: {},
             onArchive: state.1 ? nil : {},
             onDeleteWorktree: nil,
             onSelect: {}
@@ -345,6 +360,8 @@ struct CollapsibleSessionRow: View {
             customName: nil,
             sessionStatus: idx == 0 ? .thinking : (idx == 1 ? .executingTool(name: "Read") : .idle),
             colorScheme: .dark,
+            isPinned: false,
+            onPin: {},
             onArchive: {},
             onDeleteWorktree: nil,
             onSelect: {}
@@ -366,6 +383,8 @@ struct CollapsibleSessionRow: View {
           customName: nil,
           sessionStatus: .thinking,
           colorScheme: .light,
+          isPinned: false,
+          onPin: {},
           onArchive: {},
           onDeleteWorktree: nil,
           onSelect: {}
@@ -381,6 +400,8 @@ struct CollapsibleSessionRow: View {
           customName: nil,
           sessionStatus: .idle,
           colorScheme: .light,
+          isPinned: false,
+          onPin: {},
           onArchive: {},
           onDeleteWorktree: nil,
           onSelect: {}
@@ -396,6 +417,8 @@ struct CollapsibleSessionRow: View {
           customName: nil,
           sessionStatus: .waitingForUser,
           colorScheme: .light,
+          isPinned: false,
+          onPin: {},
           onArchive: {},
           onDeleteWorktree: nil,
           onSelect: {}

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
@@ -49,7 +49,7 @@ private struct ArchiveConfirmationAlert: ViewModifier {
 
   func body(content: Content) -> some View {
     content.alert(
-      confirmation.map { "Archive \($0.count) threads?" } ?? "",
+      confirmation.map { "Archive \($0.count) sessions?" } ?? "",
       isPresented: Binding(
         get: { confirmation != nil },
         set: { if !$0 { confirmation = nil } }
@@ -158,6 +158,7 @@ public struct MultiProviderSessionsListView: View {
   @State private var collapsedProjectGroups: Set<String> = []
   @State private var sidebarGroupMode: SidebarGroupMode = .repo
   @State private var collapsedStatusGroups: Set<StatusGroupCategory> = []
+  @State private var isPinnedSectionCollapsed: Bool = false
   @State private var scrollToSessionId: String?
   @State private var launchExpandRequestID = 0
   @State private var createWorktreeContext: WorktreeCreateContext?
@@ -847,10 +848,23 @@ public struct MultiProviderSessionsListView: View {
     return itemPath
   }
 
+  private var allPinnedIds: Set<String> {
+    claudeViewModel.pinnedSessionIds.union(codexViewModel.pinnedSessionIds)
+  }
+
+  private var pinnedSessionItems: [SelectedSessionItem] {
+    let pinned = allPinnedIds
+    guard !pinned.isEmpty else { return [] }
+    return selectedSessionItems
+      .filter { pinned.contains($0.session.id) }
+      .sorted { $0.timestamp > $1.timestamp }
+  }
+
   /// Groups built from tracked repos first (even empty), then an orphan bucket
   /// for sessions whose path doesn't belong to any tracked repo.
   private var groupedSelectedSessions: [SessionGroup] {
-    let allItems = selectedSessionItems
+    let pinned = allPinnedIds
+    let allItems = selectedSessionItems.filter { !pinned.contains($0.session.id) }
     var byRepo: [String: [SelectedSessionItem]] = [:]
     for item in allItems {
       let key = findParentRepoPath(for: item.session.projectPath)
@@ -885,8 +899,9 @@ public struct MultiProviderSessionsListView: View {
 
   /// Sessions grouped by status category (Working / Needs Attention / Idle).
   private var statusGroupedSessions: [StatusGroupCategory: [SelectedSessionItem]] {
+    let pinned = allPinnedIds
     var result: [StatusGroupCategory: [SelectedSessionItem]] = [:]
-    for item in selectedSessionItems {
+    for item in selectedSessionItems where !pinned.contains(item.session.id) {
       let category = StatusGroupCategory.category(for: item.sessionStatus)
       result[category, default: []].append(item)
     }
@@ -907,6 +922,25 @@ public struct MultiProviderSessionsListView: View {
         intelligenceViewModel: intelligenceViewModel,
         onAddFolder: { showAddRepositoryPicker() }
       )
+
+      // Pinned sessions section
+      let pinned = pinnedSessionItems
+      if !pinned.isEmpty {
+        PinnedSectionHeader(
+          count: pinned.count,
+          isExpanded: !isPinnedSectionCollapsed,
+          onToggle: {
+            withAnimation(.easeInOut(duration: 0.25)) {
+              isPinnedSectionCollapsed.toggle()
+            }
+          }
+        )
+        .transition(.opacity)
+
+        if !isPinnedSectionCollapsed {
+          sessionRows(for: pinned)
+        }
+      }
 
       switch sidebarGroupMode {
       case .repo:
@@ -1021,6 +1055,15 @@ public struct MultiProviderSessionsListView: View {
           customName: selectedSessionCustomName(for: item),
           sessionStatus: item.sessionStatus,
           colorScheme: colorScheme,
+          isPinned: allPinnedIds.contains(item.session.id),
+          onPin: item.isPending ? nil : {
+            withAnimation(.easeInOut(duration: 0.3)) {
+              switch item.providerKind {
+              case .claude: claudeViewModel.togglePin(for: item.session)
+              case .codex: codexViewModel.togglePin(for: item.session)
+              }
+            }
+          },
           onArchive: item.isPending ? nil : {
             withAnimation(.easeInOut(duration: 0.25)) {
               switch item.providerKind {
@@ -1048,6 +1091,7 @@ public struct MultiProviderSessionsListView: View {
       }
     }
     .padding(.top, 2)
+    .animation(.easeInOut(duration: 0.25), value: allPinnedIds)
   }
 
   @ViewBuilder
@@ -1602,6 +1646,54 @@ private struct ProjectGroupHeader: View {
   }
 }
 
+// MARK: - PinnedSectionHeader
+
+private struct PinnedSectionHeader: View {
+  let count: Int
+  let isExpanded: Bool
+  let onToggle: () -> Void
+
+  @State private var isHovered: Bool = false
+  @Environment(\.colorScheme) private var colorScheme
+
+  var body: some View {
+    Button(action: onToggle) {
+      HStack(spacing: 6) {
+        Image(systemName: "pin.fill")
+          .font(.system(size: 10))
+          .foregroundColor(.secondary)
+        Text("Pinned")
+          .font(Font.geist(size: 13, weight: .semibold))
+          .foregroundColor(.primary)
+        Text("\(count)")
+          .font(Font.geist(size: 11, weight: .regular))
+          .foregroundColor(.secondary)
+        Spacer(minLength: 0)
+        Image(systemName: "chevron.right")
+          .font(.system(size: 10, weight: .medium))
+          .foregroundColor(.secondary)
+          .rotationEffect(.degrees(isExpanded ? 90 : 0))
+          .animation(.easeInOut(duration: 0.15), value: isExpanded)
+          .padding(.trailing, 4)
+      }
+      .contentShape(Rectangle())
+    }
+    .buttonStyle(.plain)
+    .padding(.vertical, 6)
+    .padding(.horizontal, 4)
+    .background(
+      RoundedRectangle(cornerRadius: 6, style: .continuous)
+        .fill(isHovered
+              ? Color.brandPrimary.opacity(colorScheme == .dark ? 0.12 : 0.1)
+              : Color.clear)
+    )
+    .padding(.top, 2)
+    .contentShape(Rectangle())
+    .onHover { isHovered = $0 }
+    .animation(.easeInOut(duration: 0.15), value: isHovered)
+  }
+}
+
 // MARK: - StatusGroupSectionHeader
 
 private struct StatusGroupSectionHeader: View {
@@ -1629,6 +1721,7 @@ private struct StatusGroupSectionHeader: View {
         Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
           .font(.system(size: 10, weight: .medium))
           .foregroundColor(.secondary)
+          .padding(.trailing, 4)
       }
       .contentShape(Rectangle())
     }

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
@@ -900,7 +900,7 @@ public struct MultiProviderSessionsListView: View {
   @ViewBuilder
   private var inlineSelectedSessions: some View {
     VStack(alignment: .leading, spacing: 0) {
-      ThreadsSectionHeader(
+      SessionsSectionHeader(
         groupMode: $sidebarGroupMode,
         repos: orderedTrackedRepos,
         launchViewModel: multiLaunchViewModel,
@@ -937,7 +937,7 @@ public struct MultiProviderSessionsListView: View {
               onOpenGitHub: {
                 gitHubSheetItem = GitHubSheetItem(projectPath: group.id)
               },
-              onArchiveThreads: group.items.isEmpty ? nil : {
+              onArchiveSessions: group.items.isEmpty ? nil : {
                 let items = group.items
                 archiveConfirmation = ArchiveConfirmation(
                   repoName: group.displayName,
@@ -1514,7 +1514,7 @@ private struct ProjectGroupHeader: View {
   let intelligenceViewModel: IntelligenceViewModel?
   let onOpenInFinder: () -> Void
   let onOpenGitHub: () -> Void
-  let onArchiveThreads: (() -> Void)?
+  let onArchiveSessions: (() -> Void)?
   let onRemove: () -> Void
 
   @State private var isHovered: Bool = false
@@ -1532,6 +1532,14 @@ private struct ProjectGroupHeader: View {
           Text(name)
             .font(Font.geist(size: 13, weight: .semibold))
             .foregroundColor(.primary)
+          if canToggle {
+            Image(systemName: "chevron.right")
+              .font(.system(size: 10, weight: .semibold))
+              .foregroundColor(.secondary)
+              .rotationEffect(.degrees(isExpanded ? 90 : 0))
+              .animation(.easeInOut(duration: 0.15), value: isExpanded)
+              .opacity(isHovered ? 1 : 0)
+          }
           Spacer(minLength: 0)
         }
         .contentShape(Rectangle())
@@ -1546,9 +1554,9 @@ private struct ProjectGroupHeader: View {
           Label("GitHub", systemImage: "arrow.triangle.pull")
         }
         Divider()
-        if let onArchiveThreads {
-          Button(action: onArchiveThreads) {
-            Label("Archive Threads", systemImage: "archivebox")
+        if let onArchiveSessions {
+          Button(action: onArchiveSessions) {
+            Label("Archive Sessions", systemImage: "archivebox")
           }
         }
         Button(action: onRemove) {
@@ -1587,6 +1595,7 @@ private struct ProjectGroupHeader: View {
               ? Color.brandPrimary.opacity(colorScheme == .dark ? 0.12 : 0.1)
               : Color.clear)
     )
+    .padding(.top, 2)
     .contentShape(Rectangle())
     .onHover { isHovered = $0 }
     .animation(.easeInOut(duration: 0.15), value: isHovered)
@@ -1692,9 +1701,9 @@ private struct StartSessionSheet: View {
   }
 }
 
-// MARK: - ThreadsSectionHeader
+// MARK: - SessionsSectionHeader
 
-private struct ThreadsSectionHeader: View {
+private struct SessionsSectionHeader: View {
   @Binding var groupMode: SidebarGroupMode
   let repos: [SelectedRepository]
   let launchViewModel: MultiSessionLaunchViewModel?
@@ -1707,7 +1716,7 @@ private struct ThreadsSectionHeader: View {
   var body: some View {
     VStack(spacing: 0) {
       HStack(spacing: 2) {
-        Text("Threads")
+        Text("Sessions")
           .font(.heading)
           .foregroundColor(.secondary)
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/CLISessionsViewModel.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/CLISessionsViewModel.swift
@@ -45,6 +45,11 @@ public final class CLISessionsViewModel {
   /// Cache of custom names keyed by session ID
   public private(set) var sessionCustomNames: [String: String] = [:]
 
+  // MARK: - Pinned Sessions State
+
+  /// Cache of pinned session IDs
+  public private(set) var pinnedSessionIds: Set<String> = []
+
   // MARK: - Worktree Deletion State
 
   public private(set) var deletingWorktreePath: String? = nil
@@ -635,6 +640,45 @@ public final class CLISessionsViewModel {
     }
   }
 
+  // MARK: - Pinned Sessions
+
+  /// Toggles the pinned state for a session
+  public func togglePin(for session: CLISession) {
+    guard let store = metadataStore else { return }
+    let newPinned = !pinnedSessionIds.contains(session.id)
+
+    Task {
+      do {
+        try await store.setPinned(newPinned, for: session.id)
+        await MainActor.run {
+          if newPinned {
+            pinnedSessionIds.insert(session.id)
+          } else {
+            pinnedSessionIds.remove(session.id)
+          }
+        }
+      } catch {
+        AppLogger.session.error("Failed to set pinned state: \(error.localizedDescription)")
+      }
+    }
+  }
+
+  /// Loads pinned session IDs from database
+  public func loadPinnedSessions() {
+    guard let store = metadataStore else { return }
+
+    Task {
+      do {
+        let pinned = try await store.getPinnedSessionIds()
+        await MainActor.run {
+          pinnedSessionIds = pinned
+        }
+      } catch {
+        AppLogger.session.error("Failed to load pinned sessions: \(error.localizedDescription)")
+      }
+    }
+  }
+
   // MARK: - Subscriptions
 
   private func setupSubscriptions() {
@@ -766,6 +810,7 @@ public final class CLISessionsViewModel {
       pendingRestorationSessionIds.subtract(restoredIds)
       expandItemsContainingMonitoredSessions()
       loadCustomNames()
+      loadPinnedSessions()
     }
   }
 
@@ -851,6 +896,7 @@ public final class CLISessionsViewModel {
 
     // Load custom session names from database
     loadCustomNames()
+    loadPinnedSessions()
   }
 
   /// Expands repositories and worktrees that contain monitored sessions.

--- a/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/CLISessionsViewModel.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/CLISessionsViewModel.swift
@@ -569,6 +569,11 @@ public final class CLISessionsViewModel {
       loadingState = .restoringRepositories
     }
 
+    // Pre-populate pinned sessions synchronously to avoid flicker on launch
+    if let store = metadataStore {
+      pinnedSessionIds = store.getPinnedSessionIdsSync()
+    }
+
     setupSubscriptions()
     restorePersistedRepositories()
     requestNotificationPermissions()
@@ -647,17 +652,23 @@ public final class CLISessionsViewModel {
     guard let store = metadataStore else { return }
     let newPinned = !pinnedSessionIds.contains(session.id)
 
+    if newPinned {
+      pinnedSessionIds.insert(session.id)
+    } else {
+      pinnedSessionIds.remove(session.id)
+    }
+
     Task {
       do {
         try await store.setPinned(newPinned, for: session.id)
+      } catch {
         await MainActor.run {
           if newPinned {
-            pinnedSessionIds.insert(session.id)
-          } else {
             pinnedSessionIds.remove(session.id)
+          } else {
+            pinnedSessionIds.insert(session.id)
           }
         }
-      } catch {
         AppLogger.session.error("Failed to set pinned state: \(error.localizedDescription)")
       }
     }


### PR DESCRIPTION
## Summary
- Rename "Threads" to "Sessions" throughout the sidebar UI
- Add hover chevron to project rows that rotates based on expand/collapse state
- Add session pinning: pin button on session rows, persistent via SQLite (GRDB v4 migration), dedicated collapsible "Pinned" section at the top of the sidebar that persists across group mode changes
- Fix pinned sessions persistence: synchronous load on init to avoid flicker, optimistic cache updates for smooth animations, fixed GRDB partial-column decode bug

## Test plan
- [ ] Pin a session → appears in "Pinned" section at top of sidebar
- [ ] Unpin a session → returns to its normal group
- [ ] Switch group mode (repo ↔ status) → pinned section stays at top
- [ ] Collapse/expand pinned section via chevron
- [ ] Quit and relaunch app → pinned sessions persist
- [ ] Verify "Sessions" label in sidebar header and "Archive Sessions" in menus

🤖 Generated with [Claude Code](https://claude.com/claude-code)