### PR TITLE
[codex] Fix provider-scoped pinned sessions

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/Models/ProviderScopedPinnedSessions.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Models/ProviderScopedPinnedSessions.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+/// Snapshot of pinned session IDs keyed by provider.
+///
+/// Session IDs can overlap across providers, so multi-provider UI must resolve
+/// pin state using both provider and session ID instead of a global union.
+struct ProviderScopedPinnedSessions: Equatable, Sendable {
+  let claudeSessionIds: Set<String>
+  let codexSessionIds: Set<String>
+
+  init(
+    claudeSessionIds: Set<String> = [],
+    codexSessionIds: Set<String> = []
+  ) {
+    self.claudeSessionIds = claudeSessionIds
+    self.codexSessionIds = codexSessionIds
+  }
+
+  func contains(sessionId: String, providerKind: SessionProviderKind) -> Bool {
+    switch providerKind {
+    case .claude:
+      return claudeSessionIds.contains(sessionId)
+    case .codex:
+      return codexSessionIds.contains(sessionId)
+    }
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
@@ -848,23 +848,30 @@ public struct MultiProviderSessionsListView: View {
     return itemPath
   }
 
-  private var allPinnedIds: Set<String> {
-    claudeViewModel.pinnedSessionIds.union(codexViewModel.pinnedSessionIds)
+  private var pinnedSessionSnapshot: ProviderScopedPinnedSessions {
+    ProviderScopedPinnedSessions(
+      claudeSessionIds: claudeViewModel.pinnedSessionIds,
+      codexSessionIds: codexViewModel.pinnedSessionIds
+    )
+  }
+
+  private func isPinned(_ item: SelectedSessionItem) -> Bool {
+    pinnedSessionSnapshot.contains(
+      sessionId: item.session.id,
+      providerKind: item.providerKind
+    )
   }
 
   private var pinnedSessionItems: [SelectedSessionItem] {
-    let pinned = allPinnedIds
-    guard !pinned.isEmpty else { return [] }
     return selectedSessionItems
-      .filter { pinned.contains($0.session.id) }
+      .filter { isPinned($0) }
       .sorted { $0.timestamp > $1.timestamp }
   }
 
   /// Groups built from tracked repos first (even empty), then an orphan bucket
   /// for sessions whose path doesn't belong to any tracked repo.
   private var groupedSelectedSessions: [SessionGroup] {
-    let pinned = allPinnedIds
-    let allItems = selectedSessionItems.filter { !pinned.contains($0.session.id) }
+    let allItems = selectedSessionItems.filter { !isPinned($0) }
     var byRepo: [String: [SelectedSessionItem]] = [:]
     for item in allItems {
       let key = findParentRepoPath(for: item.session.projectPath)
@@ -899,9 +906,8 @@ public struct MultiProviderSessionsListView: View {
 
   /// Sessions grouped by status category (Working / Needs Attention / Idle).
   private var statusGroupedSessions: [StatusGroupCategory: [SelectedSessionItem]] {
-    let pinned = allPinnedIds
     var result: [StatusGroupCategory: [SelectedSessionItem]] = [:]
-    for item in selectedSessionItems where !pinned.contains(item.session.id) {
+    for item in selectedSessionItems where !isPinned(item) {
       let category = StatusGroupCategory.category(for: item.sessionStatus)
       result[category, default: []].append(item)
     }
@@ -1055,7 +1061,7 @@ public struct MultiProviderSessionsListView: View {
           customName: selectedSessionCustomName(for: item),
           sessionStatus: item.sessionStatus,
           colorScheme: colorScheme,
-          isPinned: allPinnedIds.contains(item.session.id),
+          isPinned: isPinned(item),
           onPin: item.isPending ? nil : {
             withAnimation(.easeInOut(duration: 0.3)) {
               switch item.providerKind {
@@ -1091,7 +1097,7 @@ public struct MultiProviderSessionsListView: View {
       }
     }
     .padding(.top, 2)
-    .animation(.easeInOut(duration: 0.25), value: allPinnedIds)
+    .animation(.easeInOut(duration: 0.25), value: pinnedSessionSnapshot)
   }
 
   @ViewBuilder

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/AIConfigSettingsTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/AIConfigSettingsTests.swift
@@ -261,6 +261,22 @@ struct AIConfigServicePersistenceTests {
     #expect(try await store.getRepoMapping(for: "session-1") == nil)
     #expect(try await store.getAIConfig(for: "claude") == nil)
   }
+
+  @Test("Pinned session IDs round-trip through async and sync reads")
+  func pinnedSessionRoundTrip() async throws {
+    let dbPath = temporaryDatabasePath()
+    let store = try SessionMetadataStore(path: dbPath)
+
+    try await store.setPinned(true, for: "session-1")
+
+    #expect(try await store.getPinnedSessionIds() == Set(["session-1"]))
+    #expect(store.getPinnedSessionIdsSync() == Set(["session-1"]))
+
+    try await store.setPinned(false, for: "session-1")
+
+    #expect(try await store.getPinnedSessionIds().isEmpty)
+    #expect(store.getPinnedSessionIdsSync().isEmpty)
+  }
 }
 
 @Suite("AIConfigSettingsViewModel")

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/ProviderScopedPinnedSessionsTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/ProviderScopedPinnedSessionsTests.swift
@@ -1,0 +1,20 @@
+import Testing
+
+@testable import AgentHubCore
+
+@Suite("Provider-scoped pinned sessions")
+struct ProviderScopedPinnedSessionsTests {
+
+  @Test("Pin state is resolved by provider and session ID")
+  func resolvesByProviderAndSessionId() {
+    let snapshot = ProviderScopedPinnedSessions(
+      claudeSessionIds: ["shared-session", "claude-only"],
+      codexSessionIds: ["codex-only"]
+    )
+
+    #expect(snapshot.contains(sessionId: "shared-session", providerKind: .claude))
+    #expect(!snapshot.contains(sessionId: "shared-session", providerKind: .codex))
+    #expect(snapshot.contains(sessionId: "codex-only", providerKind: .codex))
+    #expect(!snapshot.contains(sessionId: "codex-only", providerKind: .claude))
+  }
+}


### PR DESCRIPTION
## Summary

Fixes pinned sessions that could not be unpinned after relaunch in the multi-provider sidebar.

## Root Cause

Pinned session IDs are persisted globally by `sessionId`, and both provider view models load the same persisted pinned ID set on launch. The multi-provider sidebar previously treated `claudeViewModel.pinnedSessionIds.union(codexViewModel.pinnedSessionIds)` as the source of truth. Unpinning through the owning provider removed the ID from that provider cache and SQLite, but the sibling provider cache could still keep the ID in the union, so the row continued to render as pinned and the next click pinned it again.

## Changes

- Add `ProviderScopedPinnedSessions` to resolve pin state by `(provider, sessionId)`.
- Update `MultiProviderSessionsListView` to filter, group, render, and animate pinned rows using provider-scoped pin state.
- Add provider-scoped pin tests for overlapping session IDs.
- Add metadata persistence coverage for pin/unpin round-trips through async and sync reads.

## Validation

- `swift test --filter ProviderScopedPinnedSessionsTests`
- `swift test --filter AIConfigServicePersistenceTests`

Full `swift test` built successfully, but the broader test runner exited with signal 5 after launching the suite, so targeted tests were used for this change.