### PR TITLE
Redesign GitHub panel, unify headers, and add resize blur

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/Design/AgentHubStyle.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Design/AgentHubStyle.swift
@@ -13,6 +13,14 @@ public enum AgentHubLayout {
   public static let rowCornerRadius: CGFloat = 10
   public static let chipCornerRadius: CGFloat = 8
   public static let buttonCornerRadius: CGFloat = 4
+
+  /// Shared height for top bars across panels (MonitoringCardView header,
+  /// GitHubPanelView header, etc.) so sibling panels line up exactly.
+  public static let topBarHeight: CGFloat = 34
+
+  /// Shared height for the secondary bar immediately below a top bar
+  /// (MonitoringCardView path row, GitHubPanelView tab bar, etc.).
+  public static let subBarHeight: CGFloat = 30
 }
 
 private struct AgentHubPanelModifier: ViewModifier {
@@ -31,6 +39,7 @@ private struct AgentHubPanelModifier: ViewModifier {
 private struct AgentHubCardModifier: ViewModifier {
   @Environment(\.colorScheme) private var colorScheme
   let isHighlighted: Bool
+  let transparent: Bool
 
   func body(content: Content) -> some View {
     // Simple black/white background
@@ -44,7 +53,7 @@ private struct AgentHubCardModifier: ViewModifier {
     return content
       .background(
         RoundedRectangle(cornerRadius: AgentHubLayout.cardCornerRadius, style: .continuous)
-          .fill(backgroundColor)
+          .fill(transparent ? Color.clear : backgroundColor)
       )
       .overlay(
         RoundedRectangle(cornerRadius: AgentHubLayout.cardCornerRadius, style: .continuous)
@@ -163,8 +172,8 @@ public extension View {
     modifier(AgentHubPanelModifier())
   }
 
-  func agentHubCard(isHighlighted: Bool = false) -> some View {
-    modifier(AgentHubCardModifier(isHighlighted: isHighlighted))
+  func agentHubCard(isHighlighted: Bool = false, transparent: Bool = false) -> some View {
+    modifier(AgentHubCardModifier(isHighlighted: isHighlighted, transparent: transparent))
   }
 
   func agentHubRow(isHighlighted: Bool = false) -> some View {

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/FileExplorerView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/FileExplorerView.swift
@@ -45,6 +45,13 @@ public struct FileExplorerView: View {
   @State private var editorDisplayMode: EditorDisplayMode = .highlighted
   @State private var editorDocumentID = UUID()
 
+  @Environment(\.colorScheme) private var colorScheme
+  @Environment(\.runtimeTheme) private var runtimeTheme
+
+  private var headerBackground: Color {
+    Color.adaptiveExpandedContentBackground(for: colorScheme, theme: runtimeTheme)
+  }
+
 
   // MARK: - Init
 
@@ -230,25 +237,18 @@ public struct FileExplorerView: View {
       }
 
       // Close button
-      Button {
+      Button("Close") {
         if hasUnsavedChanges {
           showDiscardAlert = true
         } else {
           onDismiss()
         }
-      } label: {
-        Image(systemName: "xmark")
-          .font(.system(size: 12, weight: .medium))
-          .foregroundColor(.secondary)
-          .frame(width: 24, height: 24)
-          .contentShape(Rectangle())
       }
-      .buttonStyle(.plain)
-      .help("Close")
+      .controlSize(.small)
     }
-    .padding(.horizontal, 12)
-    .padding(.vertical, 8)
-    .background(Color.surfaceElevated)
+    .padding(.horizontal, DesignTokens.Spacing.sm)
+    .frame(height: AgentHubLayout.topBarHeight)
+    .background(headerBackground)
   }
 
   // MARK: - File Tree Sidebar
@@ -260,8 +260,9 @@ public struct FileExplorerView: View {
           .font(.system(size: 13, weight: .bold, design: .monospaced))
         Spacer()
       }
-      .padding(.horizontal, 12)
-      .padding(.vertical, 10)
+      .padding(.horizontal, DesignTokens.Spacing.sm)
+      .frame(height: AgentHubLayout.topBarHeight)
+      .background(headerBackground)
 
       Divider()
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/FileExplorerView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/FileExplorerView.swift
@@ -107,6 +107,7 @@ public struct FileExplorerView: View {
             Divider()
             fileContentArea
           }
+          .blursWhileResizing()
         }
         .animation(.easeInOut(duration: 0.25), value: showSidebar)
       }

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/GitDiffView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/GitDiffView.swift
@@ -53,6 +53,13 @@ public struct GitDiffView: View {
   @State private var showSidebar: Bool = true
   @State private var treeCommonPrefix: String = ""
 
+  @Environment(\.colorScheme) private var colorScheme
+  @Environment(\.runtimeTheme) private var runtimeTheme
+
+  private var headerBackground: Color {
+    Color.adaptiveExpandedContentBackground(for: colorScheme, theme: runtimeTheme)
+  }
+
   private let gitDiffService = GitDiffService()
 
   public init(
@@ -197,6 +204,7 @@ public struct GitDiffView: View {
         }
       }
       .pickerStyle(.segmented)
+      .controlSize(.small)
       .frame(width: 250)
       .tint(Color.primary)
       .onChange(of: diffMode) { _, newMode in
@@ -210,9 +218,11 @@ public struct GitDiffView: View {
           onDismiss()
         }
       }
+      .controlSize(.small)
     }
-    .padding()
-    .background(Color.surfaceElevated)
+    .padding(.horizontal, DesignTokens.Spacing.sm)
+    .frame(height: AgentHubLayout.topBarHeight)
+    .background(headerBackground)
   }
 
   // MARK: - Loading State
@@ -419,7 +429,9 @@ public struct GitDiffView: View {
             .font(.system(size: 13, weight: .bold, design: .monospaced))
         Spacer()
       }
-      .padding()
+      .padding(.horizontal, DesignTokens.Spacing.sm)
+      .frame(height: AgentHubLayout.topBarHeight)
+      .background(headerBackground)
 
       Divider()
 
@@ -891,6 +903,13 @@ private struct GitDiffContentView: View {
   @State private var previewLoading: Bool = false
   @State private var previewCurrentURL: URL?
 
+  @Environment(\.colorScheme) private var colorScheme
+  @Environment(\.runtimeTheme) private var runtimeTheme
+
+  private var headerBackground: Color {
+    Color.adaptiveExpandedContentBackground(for: colorScheme, theme: runtimeTheme)
+  }
+
   /// Inline editor is enabled when cliConfiguration is available
   private var isInlineEditorEnabled: Bool {
     cliConfiguration != nil
@@ -1114,8 +1133,9 @@ private struct GitDiffContentView: View {
         }
       }
     }
-    .padding(.horizontal)
-    .padding(.vertical, 12)
+    .padding(.horizontal, DesignTokens.Spacing.sm)
+    .frame(height: AgentHubLayout.topBarHeight)
+    .background(headerBackground)
   }
 
   // MARK: - Toggle Functions

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/GitHubComponents.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/GitHubComponents.swift
@@ -26,6 +26,8 @@ struct AuthorAvatarView: View {
   let login: String
   let size: CGFloat
 
+  @Environment(\.runtimeTheme) private var runtimeTheme
+
   init(login: String, size: CGFloat = 22) {
     self.login = login
     self.size = size
@@ -35,16 +37,8 @@ struct AuthorAvatarView: View {
     String(login.prefix(1)).uppercased()
   }
 
-  private var avatarColor: Color {
-    let colors: [Color] = [
-      .primaryPurple, .indigoPurple, .skyBlue,
-      .softGreen, .goldenAmber, .warmCoral, .bluePurple
-    ]
-    let index = abs(login.utf8.reduce(0) { $0 &+ Int($1) }) % colors.count
-    return colors[index]
-  }
-
   var body: some View {
+    let avatarColor = Color.brandPrimary(from: runtimeTheme)
     ZStack {
       Circle()
         .fill(avatarColor.opacity(0.2))
@@ -66,45 +60,36 @@ struct StatCardView: View {
   let tintColor: Color
 
   @Environment(\.colorScheme) private var colorScheme
+  @Environment(\.runtimeTheme) private var runtimeTheme
 
   var body: some View {
-    VStack(alignment: .leading, spacing: 2) {
+    VStack(alignment: .leading, spacing: 4) {
       Text(value)
-        .font(.jetBrainsMono(size: 20, weight: .bold))
-        .foregroundStyle(tintColor)
-      Text(label)
+        .font(.jetBrainsMono(size: 24, weight: .bold))
+        .foregroundStyle(.primary)
+      Text(label.uppercased())
         .font(GitHubTypography.caption)
+        .tracking(0.8)
         .foregroundStyle(.secondary)
     }
     .padding(.horizontal, DesignTokens.Spacing.md)
-    .padding(.vertical, DesignTokens.Spacing.sm)
+    .padding(.vertical, DesignTokens.Spacing.md)
     .frame(maxWidth: .infinity, alignment: .leading)
     .background(
       RoundedRectangle(cornerRadius: AgentHubLayout.cardCornerRadius, style: .continuous)
-        .fill(colorScheme == .dark ? Color(white: 0.08) : Color(white: 0.98))
+        .fill(cardBackground)
     )
     .overlay(
       RoundedRectangle(cornerRadius: AgentHubLayout.cardCornerRadius, style: .continuous)
         .stroke(tintColor.opacity(0.25), lineWidth: 1)
     )
   }
-}
 
-// MARK: - Filter Chip
-
-struct GitHubFilterChip: View {
-  let title: String
-  let isActive: Bool
-  let action: () -> Void
-
-  var body: some View {
-    Button(action: action) {
-      Text(title)
-        .font(GitHubTypography.button)
-        .foregroundStyle(isActive ? Color.brandPrimary : .secondary)
+  private var cardBackground: Color {
+    if runtimeTheme?.hasCustomBackgrounds == true {
+      return Color.adaptiveExpandedContentBackground(for: colorScheme, theme: runtimeTheme)
     }
-    .buttonStyle(.plain)
-    .agentHubChip(isActive: isActive)
+    return colorScheme == .dark ? Color(white: 0.08) : Color(white: 0.98)
   }
 }
 
@@ -269,48 +254,13 @@ struct GitHubUnderlineTabBar<Tab: Identifiable & Hashable>: View {
   var trailing: (() -> AnyView)? = nil
 
   @Namespace private var tabNamespace
+  @Environment(\.runtimeTheme) private var runtimeTheme
 
   var body: some View {
-    HStack(spacing: 0) {
+    let accent = Color.brandPrimary(from: runtimeTheme)
+    HStack(spacing: DesignTokens.Spacing.lg) {
       ForEach(tabs) { tab in
-        Button {
-          withAnimation(.easeInOut(duration: 0.2)) {
-            selected = tab
-          }
-          onSelect?(tab)
-        } label: {
-          VStack(spacing: DesignTokens.Spacing.xs) {
-            HStack(spacing: DesignTokens.Spacing.xs) {
-              Image(systemName: icon(tab))
-                .font(.system(size: 11))
-              Text(title(tab))
-                .font(GitHubTypography.button)
-              if let count = badge?(tab), count > 0 {
-                Text("\(count)")
-                  .font(GitHubTypography.monoCaption)
-                  .padding(.horizontal, 5)
-                  .padding(.vertical, 1)
-                  .background(Color.brandPrimary.opacity(0.15))
-                  .clipShape(Capsule())
-              }
-            }
-            .foregroundStyle(selected == tab ? Color.brandPrimary : .secondary)
-            .padding(.horizontal, DesignTokens.Spacing.md)
-
-            ZStack {
-              Rectangle()
-                .fill(Color.clear)
-                .frame(height: 2)
-              if selected == tab {
-                Rectangle()
-                  .fill(Color.brandPrimary)
-                  .frame(height: 2)
-                  .matchedGeometryEffect(id: "underline", in: tabNamespace)
-              }
-            }
-          }
-        }
-        .buttonStyle(.plain)
+        tabSegment(tab, accent: accent)
       }
 
       Spacer()
@@ -320,18 +270,65 @@ struct GitHubUnderlineTabBar<Tab: Identifiable & Hashable>: View {
       }
     }
     .padding(.horizontal, DesignTokens.Spacing.md)
-    .padding(.top, DesignTokens.Spacing.sm)
+    .frame(height: AgentHubLayout.subBarHeight, alignment: .bottom)
+  }
+
+  @ViewBuilder
+  private func tabSegment(_ tab: Tab, accent: Color) -> some View {
+    let isSelected = selected == tab
+    Button {
+      withAnimation(.easeInOut(duration: 0.2)) {
+        selected = tab
+      }
+      onSelect?(tab)
+    } label: {
+      VStack(spacing: DesignTokens.Spacing.xs) {
+        HStack(spacing: DesignTokens.Spacing.xs) {
+          Image(systemName: icon(tab))
+            .font(.system(size: 11))
+          Text(title(tab))
+            .font(GitHubTypography.button)
+          if let count = badge?(tab), count > 0 {
+            Text("\(count)")
+              .font(GitHubTypography.monoCaption)
+              .padding(.horizontal, 5)
+              .padding(.vertical, 1)
+              .background(Color.secondary.opacity(0.18))
+              .clipShape(Capsule())
+          }
+        }
+        .foregroundStyle(isSelected ? accent : .secondary)
+
+        ZStack {
+          Rectangle()
+            .fill(Color.clear)
+            .frame(height: 2)
+          if isSelected {
+            Rectangle()
+              .fill(accent)
+              .frame(height: 2)
+              .matchedGeometryEffect(id: "underline", in: tabNamespace)
+          }
+        }
+      }
+      .fixedSize(horizontal: true, vertical: false)
+      .contentShape(Rectangle())
+    }
+    .buttonStyle(.plain)
   }
 }
 
 // MARK: - Gradient Divider
 
 struct GradientDivider: View {
+  @Environment(\.runtimeTheme) private var runtimeTheme
+
   var body: some View {
+    let accent = Color.brandPrimary(from: runtimeTheme)
     Rectangle()
       .fill(
         LinearGradient(
-          colors: [Color.brandPrimary.opacity(0.3), Color.brandPrimary.opacity(0.05), Color.clear],
+          colors: [accent.opacity(0.3), accent.opacity(0.05), Color.clear],
           startPoint: .leading,
           endPoint: .trailing
         )
@@ -375,7 +372,7 @@ struct GitHubCommentCard: View {
     }
     .frame(maxWidth: .infinity, alignment: .leading)
     .padding(DesignTokens.Spacing.md)
-    .agentHubCard()
+    .agentHubCard(transparent: true)
   }
 }
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/GitHubIssueDetailView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/GitHubIssueDetailView.swift
@@ -195,7 +195,7 @@ struct GitHubIssueDetailView: View {
                 .foregroundStyle(.secondary)
             }
 
-            MarkdownCardView(content: body)
+            MarkdownCardView(content: body, transparent: true)
           }
           .frame(maxWidth: .infinity, alignment: .leading)
         }

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/GitHubPRDetailView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/GitHubPRDetailView.swift
@@ -317,7 +317,7 @@ struct GitHubPRDetailView: View {
     ScrollView {
       VStack(alignment: .leading, spacing: DesignTokens.Spacing.md) {
         if let body = pr.body, !body.isEmpty {
-          MarkdownCardView(content: body)
+          MarkdownCardView(content: body, transparent: true)
         } else {
           Text("No description provided.")
             .font(GitHubTypography.body)
@@ -352,7 +352,7 @@ struct GitHubPRDetailView: View {
           }
         }
         .padding(DesignTokens.Spacing.md)
-        .agentHubCard()
+        .agentHubCard(transparent: true)
       }
       .padding(DesignTokens.Spacing.md)
     }
@@ -814,7 +814,7 @@ struct GitHubPRDetailView: View {
     }
     .frame(maxWidth: .infinity, alignment: .leading)
     .padding(DesignTokens.Spacing.md)
-    .agentHubCard()
+    .agentHubCard(transparent: true)
   }
 }
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/GitHubPanelView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/GitHubPanelView.swift
@@ -23,6 +23,7 @@ public struct GitHubPanelView: View {
 
   @State private var viewModel = GitHubViewModel()
   @Environment(\.colorScheme) private var colorScheme
+  @Environment(\.runtimeTheme) private var runtimeTheme
 
   public init(
     projectPath: String,
@@ -52,7 +53,7 @@ public struct GitHubPanelView: View {
       minWidth: isEmbedded ? 300 : 700, idealWidth: isEmbedded ? .infinity : 950, maxWidth: .infinity,
       minHeight: isEmbedded ? 300 : 550, idealHeight: isEmbedded ? .infinity : 750, maxHeight: .infinity
     )
-    .background(colorScheme == .dark ? Color(white: 0.05) : Color(white: 0.97))
+    .background(panelBackground)
     .task {
       await viewModel.setup(repoPath: projectPath)
       if viewModel.isGHInstalled && viewModel.isAuthenticated {
@@ -78,7 +79,7 @@ public struct GitHubPanelView: View {
     HStack(spacing: DesignTokens.Spacing.sm) {
       Image(systemName: "arrow.triangle.pull")
         .font(.system(size: 14, weight: .semibold))
-        .foregroundStyle(Color.brandPrimary)
+        .foregroundStyle(accent)
 
       Text("GitHub")
         .font(GitHubTypography.panelTitle)
@@ -101,16 +102,24 @@ public struct GitHubPanelView: View {
         .help("Open in separate window")
       }
 
-      Button { onDismiss() } label: {
-        Image(systemName: "xmark.circle.fill")
-          .font(.system(size: 16))
-          .foregroundStyle(.secondary)
-      }
-      .buttonStyle(.plain)
+      Button("Close") { onDismiss() }
+        .controlSize(.small)
     }
-    .padding(.horizontal, DesignTokens.Spacing.lg)
-    .padding(.vertical, DesignTokens.Spacing.md)
-    .background(colorScheme == .dark ? Color(white: 0.08) : Color.white)
+    .padding(.horizontal, DesignTokens.Spacing.sm)
+    .frame(height: AgentHubLayout.topBarHeight)
+    .background(headerBackground)
+  }
+
+  private var accent: Color {
+    Color.brandPrimary(from: runtimeTheme)
+  }
+
+  private var panelBackground: Color {
+    Color.adaptiveBackground(for: colorScheme, theme: runtimeTheme)
+  }
+
+  private var headerBackground: Color {
+    Color.adaptiveExpandedContentBackground(for: colorScheme, theme: runtimeTheme)
   }
 
   // MARK: - Content
@@ -133,6 +142,12 @@ public struct GitHubPanelView: View {
         selected: $viewModel.selectedTab,
         icon: { $0.icon },
         title: { $0.rawValue },
+        badge: { tab in
+          switch tab {
+          case .pullRequests: return viewModel.pullRequests.isEmpty ? nil : viewModel.pullRequests.count
+          case .issues: return viewModel.issues.isEmpty ? nil : viewModel.issues.count
+          }
+        },
         onSelect: { tab in
           if tab == .issues && viewModel.issues.isEmpty {
             Task { await viewModel.loadIssues() }
@@ -160,12 +175,6 @@ public struct GitHubPanelView: View {
 
       GradientDivider()
 
-      // Current branch PR banner
-      if let branchPR = viewModel.currentBranchPR, viewModel.selectedPR == nil {
-        currentBranchPRBanner(branchPR)
-        GradientDivider()
-      }
-
       // Tab content
       switch viewModel.selectedTab {
       case .pullRequests:
@@ -173,14 +182,6 @@ public struct GitHubPanelView: View {
       case .issues:
         issueContent
       }
-    }
-  }
-
-  // MARK: - Current Branch PR Banner
-
-  private func currentBranchPRBanner(_ pr: GitHubPullRequest) -> some View {
-    CurrentBranchPRBannerView(pr: pr) {
-      viewModel.selectPR(pr)
     }
   }
 
@@ -208,133 +209,7 @@ public struct GitHubPanelView: View {
         statsHeader
       }
 
-      // Filter bar
-      VStack(spacing: 4) {
-        HStack(spacing: 4) {
-          ForEach(GitHubPRFilter.allCases) { filter in
-            Button {
-              viewModel.prFilter = filter
-              Task { await viewModel.loadPullRequests() }
-            } label: {
-              Text(filter.rawValue)
-                .font(GitHubTypography.button)
-                .padding(.horizontal, 8)
-                .padding(.vertical, 3)
-                .background(
-                  viewModel.prFilter == filter
-                    ? Color.secondary.opacity(0.2)
-                    : Color.clear
-                )
-                .clipShape(RoundedRectangle(cornerRadius: 4))
-            }
-            .buttonStyle(.plain)
-          }
-
-          Spacer()
-
-          // Labels menu
-          Menu {
-            ForEach(viewModel.availableLabels) { label in
-              Button {
-                if viewModel.selectedLabels.contains(label.name) {
-                  viewModel.selectedLabels.remove(label.name)
-                } else {
-                  viewModel.selectedLabels.insert(label.name)
-                }
-                Task { await viewModel.loadPullRequests() }
-              } label: {
-                HStack {
-                  Text(label.name)
-                  if viewModel.selectedLabels.contains(label.name) {
-                    Image(systemName: "checkmark")
-                  }
-                }
-              }
-            }
-
-            if !viewModel.selectedLabels.isEmpty {
-              Divider()
-              Button("Clear all labels") {
-                viewModel.selectedLabels.removeAll()
-                Task { await viewModel.loadPullRequests() }
-              }
-            }
-          } label: {
-            HStack(spacing: 3) {
-              Image(systemName: "tag")
-                .font(.system(size: 10))
-              Text("Labels")
-                .font(GitHubTypography.button)
-              if !viewModel.selectedLabels.isEmpty {
-                Text("\(viewModel.selectedLabels.count)")
-                  .font(GitHubTypography.badge)
-                  .padding(.horizontal, 4)
-                  .padding(.vertical, 1)
-                  .background(Color.accentColor.opacity(0.2))
-                  .clipShape(Capsule())
-              }
-            }
-            .padding(.horizontal, 8)
-            .padding(.vertical, 3)
-            .background(
-              viewModel.selectedLabels.isEmpty
-                ? Color.clear
-                : Color.accentColor.opacity(0.1)
-            )
-            .clipShape(RoundedRectangle(cornerRadius: 4))
-          }
-          .menuStyle(.borderlessButton)
-          .fixedSize()
-          .task { await viewModel.loadLabelsIfNeeded() }
-
-          // Mine toggle
-          Button {
-            viewModel.showOnlyMyPRs.toggle()
-            Task { await viewModel.loadPullRequests() }
-          } label: {
-            Image(systemName: viewModel.showOnlyMyPRs ? "person.fill" : "person")
-              .font(.system(size: 11))
-              .padding(.horizontal, 6)
-              .padding(.vertical, 3)
-              .background(
-                viewModel.showOnlyMyPRs
-                  ? Color.accentColor.opacity(0.2)
-                  : Color.clear
-              )
-              .clipShape(RoundedRectangle(cornerRadius: 4))
-          }
-          .buttonStyle(.plain)
-          .help("Show only my pull requests (no limit)")
-        }
-
-        // Active label chips
-        if !viewModel.selectedLabels.isEmpty {
-          ScrollView(.horizontal, showsIndicators: false) {
-            HStack(spacing: 4) {
-              ForEach(viewModel.selectedLabels.sorted(), id: \.self) { label in
-                HStack(spacing: 3) {
-                  Text(label)
-                    .font(GitHubTypography.badge)
-                  Button {
-                    viewModel.selectedLabels.remove(label)
-                    Task { await viewModel.loadPullRequests() }
-                  } label: {
-                    Image(systemName: "xmark")
-                      .font(.system(size: 8, weight: .bold))
-                  }
-                  .buttonStyle(.plain)
-                }
-                .padding(.horizontal, 6)
-                .padding(.vertical, 2)
-                .background(Color.accentColor.opacity(0.1))
-                .clipShape(Capsule())
-              }
-            }
-          }
-        }
-      }
-      .padding(.horizontal, DesignTokens.Spacing.md)
-      .padding(.vertical, DesignTokens.Spacing.sm)
+      prFilterBar
 
       GradientDivider()
 
@@ -349,18 +224,185 @@ public struct GitHubPanelView: View {
       case .loaded where viewModel.pullRequests.isEmpty:
         emptyView("No pull requests", "No \(viewModel.prFilter.rawValue.lowercased()) pull requests found.")
       default:
-        ScrollView {
-          LazyVStack(spacing: DesignTokens.Spacing.sm) {
-            ForEach(viewModel.pullRequests) { pr in
-              GitHubPRRow(pr: pr) {
-                viewModel.selectPR(pr)
+        sectionedPRList
+      }
+    }
+  }
+
+  // MARK: - PR Filter Bar
+
+  private var prFilterBar: some View {
+    VStack(spacing: DesignTokens.Spacing.xs) {
+      HStack(spacing: DesignTokens.Spacing.xs) {
+        ForEach(GitHubPRFilter.allCases) { filter in
+          FilterChipWithCount(
+            title: filter.rawValue,
+            count: viewModel.filterCount(filter),
+            isActive: viewModel.prFilter == filter,
+            accent: accent
+          ) {
+            viewModel.prFilter = filter
+            Task { await viewModel.loadPullRequests() }
+          }
+        }
+
+        Spacer()
+
+        filterMenu
+      }
+
+      // Active label chips
+      if !viewModel.selectedLabels.isEmpty {
+        ScrollView(.horizontal, showsIndicators: false) {
+          HStack(spacing: 4) {
+            ForEach(viewModel.selectedLabels.sorted(), id: \.self) { label in
+              HStack(spacing: 3) {
+                Text(label)
+                  .font(GitHubTypography.badge)
+                Button {
+                  viewModel.selectedLabels.remove(label)
+                  Task { await viewModel.loadPullRequests() }
+                } label: {
+                  Image(systemName: "xmark")
+                    .font(.system(size: 8, weight: .bold))
+                }
+                .buttonStyle(.plain)
+              }
+              .padding(.horizontal, 6)
+              .padding(.vertical, 2)
+              .background(accent.opacity(0.12))
+              .clipShape(Capsule())
+            }
+          }
+        }
+      }
+    }
+    .padding(.horizontal, DesignTokens.Spacing.md)
+    .padding(.vertical, DesignTokens.Spacing.sm)
+  }
+
+  private var filterMenu: some View {
+    Menu {
+      Section("Scope") {
+        Button {
+          viewModel.showOnlyMyPRs.toggle()
+          Task { await viewModel.loadPullRequests() }
+        } label: {
+          HStack {
+            Text("Only my pull requests")
+            if viewModel.showOnlyMyPRs { Image(systemName: "checkmark") }
+          }
+        }
+      }
+
+      if !viewModel.availableLabels.isEmpty {
+        Section("Labels") {
+          ForEach(viewModel.availableLabels) { label in
+            Button {
+              if viewModel.selectedLabels.contains(label.name) {
+                viewModel.selectedLabels.remove(label.name)
+              } else {
+                viewModel.selectedLabels.insert(label.name)
+              }
+              Task { await viewModel.loadPullRequests() }
+            } label: {
+              HStack {
+                Text(label.name)
+                if viewModel.selectedLabels.contains(label.name) {
+                  Image(systemName: "checkmark")
+                }
               }
             }
           }
-          .padding(.horizontal, DesignTokens.Spacing.md)
-          .padding(.vertical, DesignTokens.Spacing.sm)
+          if !viewModel.selectedLabels.isEmpty {
+            Divider()
+            Button("Clear all labels") {
+              viewModel.selectedLabels.removeAll()
+              Task { await viewModel.loadPullRequests() }
+            }
+          }
         }
       }
+    } label: {
+      HStack(spacing: 5) {
+        Text("Filter")
+          .font(GitHubTypography.button)
+          .foregroundStyle(.secondary)
+        Text("/")
+          .font(GitHubTypography.monoCaption)
+          .foregroundStyle(.secondary)
+          .padding(.horizontal, 5)
+          .padding(.vertical, 1)
+          .background(Color.secondary.opacity(0.15))
+          .clipShape(RoundedRectangle(cornerRadius: 3, style: .continuous))
+      }
+    }
+    .menuStyle(.borderlessButton)
+    .fixedSize()
+    .task { await viewModel.loadLabelsIfNeeded() }
+  }
+
+  // MARK: - Sectioned PR List
+
+  private var sectionedPRList: some View {
+    let currentBranchPR = viewModel.currentBranchPR
+    let openPRs = viewModel.pullRequests
+      .filter { $0.stateKind == .open && !$0.isDraft && $0.number != currentBranchPR?.number }
+    let draftPRs = viewModel.pullRequests
+      .filter { $0.isDraft && $0.number != currentBranchPR?.number }
+    let mergedPRs = viewModel.pullRequests
+      .filter { $0.stateKind == .merged && $0.number != currentBranchPR?.number }
+      .prefix(5)
+    let closedPRs = viewModel.pullRequests
+      .filter { $0.stateKind == .closed && $0.number != currentBranchPR?.number }
+
+    return ScrollView {
+      LazyVStack(spacing: 0, pinnedViews: []) {
+        if let branchPR = currentBranchPR,
+           viewModel.pullRequests.contains(where: { $0.number == branchPR.number }) {
+          GitHubSectionHeader(title: "Current Branch")
+          GitHubPRRow(pr: branchPR, isCurrentBranch: true) {
+            viewModel.selectPR(branchPR)
+          }
+        }
+
+        if !openPRs.isEmpty {
+          GitHubSectionHeader(title: "Open")
+          ForEach(openPRs) { pr in
+            GitHubPRRow(pr: pr, isCurrentBranch: false) {
+              viewModel.selectPR(pr)
+            }
+          }
+        }
+
+        if !draftPRs.isEmpty {
+          GitHubSectionHeader(title: "Draft")
+          ForEach(draftPRs) { pr in
+            GitHubPRRow(pr: pr, isCurrentBranch: false) {
+              viewModel.selectPR(pr)
+            }
+          }
+        }
+
+        if !mergedPRs.isEmpty {
+          GitHubSectionHeader(title: "Recently Merged")
+          ForEach(Array(mergedPRs)) { pr in
+            GitHubPRRow(pr: pr, isCurrentBranch: false) {
+              viewModel.selectPR(pr)
+            }
+          }
+        }
+
+        if !closedPRs.isEmpty {
+          GitHubSectionHeader(title: "Closed")
+          ForEach(closedPRs) { pr in
+            GitHubPRRow(pr: pr, isCurrentBranch: false) {
+              viewModel.selectPR(pr)
+            }
+          }
+        }
+      }
+      .padding(.bottom, DesignTokens.Spacing.md)
     }
   }
 
@@ -373,12 +415,12 @@ public struct GitHubPanelView: View {
       StatCardView(
         value: "\(openCount)",
         label: "Open PRs",
-        tintColor: GitHubPalette.merged
+        tintColor: accent
       )
       StatCardView(
         value: "\(mergedCount)",
         label: "Merged",
-        tintColor: .secondary
+        tintColor: GitHubPalette.merged
       )
       StatCardView(
         value: abbreviateNumber(totalLines),
@@ -413,9 +455,11 @@ public struct GitHubPanelView: View {
       // Filter bar
       HStack(spacing: DesignTokens.Spacing.xs) {
         ForEach(GitHubIssueFilter.allCases) { filter in
-          GitHubFilterChip(
+          FilterChipWithCount(
             title: filter.rawValue,
-            isActive: viewModel.issueFilter == filter
+            count: filter == viewModel.issueFilter ? viewModel.issues.count : 0,
+            isActive: viewModel.issueFilter == filter,
+            accent: accent
           ) {
             viewModel.issueFilter = filter
             Task { await viewModel.loadIssues() }
@@ -440,15 +484,14 @@ public struct GitHubPanelView: View {
         emptyView("No issues", "No \(viewModel.issueFilter.rawValue.lowercased()) issues found.")
       default:
         ScrollView {
-          LazyVStack(spacing: DesignTokens.Spacing.sm) {
+          LazyVStack(spacing: 0) {
             ForEach(viewModel.issues) { issue in
               GitHubIssueRow(issue: issue) {
                 viewModel.selectIssue(issue)
               }
             }
           }
-          .padding(.horizontal, DesignTokens.Spacing.md)
-          .padding(.vertical, DesignTokens.Spacing.sm)
+          .padding(.bottom, DesignTokens.Spacing.md)
         }
       }
     }
@@ -461,7 +504,7 @@ public struct GitHubPanelView: View {
       Spacer()
       ProgressView()
         .scaleEffect(0.8)
-        .tint(Color.brandPrimary)
+        .tint(accent)
       Text(message)
         .font(GitHubTypography.body)
         .foregroundStyle(.secondary)
@@ -511,7 +554,7 @@ public struct GitHubPanelView: View {
       Spacer()
       Image(systemName: "terminal")
         .font(.system(size: 36))
-        .foregroundStyle(Color.brandPrimary.opacity(0.5))
+        .foregroundStyle(accent.opacity(0.5))
 
       Text("GitHub CLI Not Installed")
         .font(GitHubTypography.sectionTitle)
@@ -541,7 +584,7 @@ public struct GitHubPanelView: View {
       Spacer()
       Image(systemName: "person.badge.key")
         .font(.system(size: 36))
-        .foregroundStyle(Color.brandPrimary.opacity(0.5))
+        .foregroundStyle(accent.opacity(0.5))
 
       Text("Not Authenticated")
         .font(GitHubTypography.sectionTitle)
@@ -565,65 +608,69 @@ public struct GitHubPanelView: View {
   }
 }
 
-// MARK: - Current Branch PR Banner
+// MARK: - Section Header
 
-private struct CurrentBranchPRBannerView: View {
-  let pr: GitHubPullRequest
-  let onSelect: () -> Void
-
-  @State private var isHovered = false
+struct GitHubSectionHeader: View {
+  let title: String
 
   var body: some View {
-    Button(action: onSelect) {
-      HStack(spacing: 0) {
-        // Left accent bar
-        Rectangle()
-          .fill(Color.brandPrimary)
-          .frame(width: 3)
+    HStack {
+      Text(title.uppercased())
+        .font(GitHubTypography.caption)
+        .tracking(0.8)
+        .foregroundStyle(.secondary)
+      Spacer()
+    }
+    .padding(.horizontal, DesignTokens.Spacing.md)
+    .padding(.top, DesignTokens.Spacing.md)
+    .padding(.bottom, DesignTokens.Spacing.xs)
+  }
+}
 
-        HStack(spacing: DesignTokens.Spacing.sm) {
-          Image(systemName: "arrow.triangle.branch")
-            .font(.system(size: 11, weight: .semibold))
-            .foregroundStyle(Color.brandPrimary)
+// MARK: - Filter Chip With Count
 
-          Text("Current branch:")
-            .font(GitHubTypography.caption)
-            .foregroundStyle(.secondary)
+struct FilterChipWithCount: View {
+  let title: String
+  let count: Int
+  let isActive: Bool
+  let accent: Color
+  let action: () -> Void
 
-          Text("#\(pr.number)")
-            .font(GitHubTypography.monoStrong)
-            .foregroundStyle(Color.brandPrimary)
+  @Environment(\.colorScheme) private var colorScheme
 
-          Text(pr.title)
-            .font(GitHubTypography.button)
-            .lineLimit(1)
-
-          Spacer()
-
-          CIStatusBadge(status: pr.ciStatus)
-
-          Image(systemName: "chevron.right")
-            .font(.system(size: 9, weight: .semibold))
-            .foregroundStyle(.tertiary)
+  var body: some View {
+    Button(action: action) {
+      HStack(spacing: 5) {
+        Text(title)
+          .font(GitHubTypography.button)
+          .foregroundStyle(isActive ? accent : .secondary)
+        if count > 0 {
+          Text("\(count)")
+            .font(GitHubTypography.monoCaption)
+            .foregroundStyle(isActive ? accent : .secondary)
+            .padding(.horizontal, 5)
+            .padding(.vertical, 1)
+            .background(
+              (isActive ? accent : Color.secondary).opacity(colorScheme == .dark ? 0.18 : 0.14)
+            )
+            .clipShape(Capsule())
         }
-        .padding(.horizontal, DesignTokens.Spacing.md)
-        .padding(.vertical, DesignTokens.Spacing.sm)
       }
-      .fixedSize(horizontal: false, vertical: true)
+      .padding(.horizontal, 10)
+      .padding(.vertical, 4)
       .background(
-        LinearGradient(
-          colors: [
-            Color.brandPrimary.opacity(isHovered ? 0.1 : 0.06),
-            Color.brandPrimary.opacity(isHovered ? 0.04 : 0.02)
-          ],
-          startPoint: .leading,
-          endPoint: .trailing
-        )
+        RoundedRectangle(cornerRadius: AgentHubLayout.chipCornerRadius, style: .continuous)
+          .fill(isActive ? accent.opacity(colorScheme == .dark ? 0.15 : 0.12) : .clear)
+      )
+      .overlay(
+        RoundedRectangle(cornerRadius: AgentHubLayout.chipCornerRadius, style: .continuous)
+          .stroke(
+            isActive ? accent.opacity(0.35) : Color.secondary.opacity(0.18),
+            lineWidth: 1
+          )
       )
     }
     .buttonStyle(.plain)
-    .onHover { isHovered = $0 }
-    .animation(.easeInOut(duration: 0.15), value: isHovered)
   }
 }
 
@@ -631,78 +678,47 @@ private struct CurrentBranchPRBannerView: View {
 
 struct GitHubPRRow: View {
   let pr: GitHubPullRequest
+  var isCurrentBranch: Bool = false
   let onSelect: () -> Void
 
-  @State private var isHovered = false
-  @Environment(\.colorScheme) private var colorScheme
+  @Environment(\.runtimeTheme) private var runtimeTheme
 
   var body: some View {
     Button(action: onSelect) {
-      HStack(spacing: 0) {
-        // Left state accent bar
-        RoundedRectangle(cornerRadius: 2)
-          .fill(prStateColor)
-          .frame(width: 3)
-          .padding(.vertical, DesignTokens.Spacing.xs)
+      HStack(spacing: DesignTokens.Spacing.sm) {
+        PRStatusDot(state: pr.stateKind, isDraft: pr.isDraft)
 
-        HStack(spacing: DesignTokens.Spacing.sm) {
-          // Author avatar
-          if let author = pr.author {
-            AuthorAvatarView(login: author.login, size: 28)
-          }
+        if let author = pr.author {
+          AuthorAvatarView(login: author.login, size: 26)
+        }
 
-          VStack(alignment: .leading, spacing: 3) {
-            // Title row
-            HStack(spacing: DesignTokens.Spacing.xs) {
-              Text("#\(pr.number)")
-                .font(GitHubTypography.monoStrong)
-                .foregroundStyle(Color.brandPrimary)
+        VStack(alignment: .leading, spacing: 2) {
+          HStack(spacing: DesignTokens.Spacing.xs) {
+            Text(pr.title)
+              .font(.geist(size: 13, weight: .semibold))
+              .foregroundStyle(.primary)
+              .lineLimit(1)
 
-              Text(pr.title)
-                .font(.geist(size: 12, weight: .semibold))
-                .lineLimit(1)
-
-              if pr.isDraft {
-                Text("Draft")
-                  .font(GitHubTypography.badge)
-                  .padding(.horizontal, 5)
-                  .padding(.vertical, 1)
-                  .background(Color.secondary.opacity(0.15))
-                  .foregroundStyle(.secondary)
-                  .clipShape(Capsule())
-              }
-            }
-
-            // Metadata row
-            HStack(spacing: DesignTokens.Spacing.sm) {
-              if let author = pr.author {
-                Text(author.login)
-                  .font(GitHubTypography.caption)
-                  .foregroundStyle(.tertiary)
-              }
-
-              BranchBadge(name: pr.headRefName)
-
-              if let labels = pr.labels, !labels.isEmpty {
-                ForEach(labels.prefix(2)) { label in
-                  GitHubLabelPill(label: label)
-                }
-              }
+            if pr.isDraft {
+              Text("Draft")
+                .font(GitHubTypography.badge)
+                .padding(.horizontal, 5)
+                .padding(.vertical, 1)
+                .background(Color.secondary.opacity(0.15))
+                .foregroundStyle(.secondary)
+                .clipShape(Capsule())
             }
           }
 
-          Spacer()
-
-          // Right side: stats + badges
           HStack(spacing: DesignTokens.Spacing.sm) {
-            if pr.changedFiles > 0 {
-              HStack(spacing: 2) {
-                Image(systemName: "doc")
-                  .font(.system(size: 9))
-                Text("\(pr.changedFiles)")
-                  .font(GitHubTypography.monoCaption)
-              }
-              .foregroundStyle(.secondary)
+            Text("#\(pr.number)")
+              .font(GitHubTypography.monoCaption)
+              .foregroundStyle(.tertiary)
+
+            if let author = pr.author {
+              Text("@\(author.login)")
+                .font(GitHubTypography.caption)
+                .foregroundStyle(.tertiary)
             }
 
             AdditionsDeletionsBadge(
@@ -710,36 +726,37 @@ struct GitHubPRRow: View {
               deletions: pr.deletions
             )
 
-            if let decision = pr.reviewDecision {
-              ReviewDecisionBadge(decision: decision)
+            if let labels = pr.labels, !labels.isEmpty {
+              ForEach(labels.prefix(1)) { label in
+                GitHubLabelPill(label: label)
+              }
             }
-
-            ciIcon(pr.ciStatus)
-
-            Image(systemName: "chevron.right")
-              .font(.system(size: 9, weight: .semibold))
-              .foregroundStyle(.tertiary)
           }
         }
-        .padding(.horizontal, DesignTokens.Spacing.md)
-        .padding(.vertical, DesignTokens.Spacing.sm)
+
+        Spacer()
+
+        HStack(spacing: DesignTokens.Spacing.sm) {
+          if let decision = pr.reviewDecision {
+            ReviewDecisionBadge(decision: decision)
+          }
+
+          ciIcon(pr.ciStatus)
+
+          if let updated = pr.updatedAt {
+            Text(relativeTime(updated))
+              .font(GitHubTypography.caption)
+              .foregroundStyle(.tertiary)
+              .monospacedDigit()
+          }
+        }
       }
-      .background(
-        RoundedRectangle(cornerRadius: AgentHubLayout.rowCornerRadius, style: .continuous)
-          .fill(rowBackground)
-      )
-      .overlay(
-        RoundedRectangle(cornerRadius: AgentHubLayout.rowCornerRadius, style: .continuous)
-          .stroke(
-            isHovered ? Color.brandPrimary.opacity(0.3) : Color.secondary.opacity(0.15),
-            lineWidth: 1
-          )
-      )
-      .clipShape(RoundedRectangle(cornerRadius: AgentHubLayout.rowCornerRadius, style: .continuous))
+      .padding(.horizontal, DesignTokens.Spacing.md)
+      .padding(.vertical, DesignTokens.Spacing.sm)
+      .contentShape(Rectangle())
     }
     .buttonStyle(.plain)
-    .onHover { isHovered = $0 }
-    .animation(.easeInOut(duration: 0.15), value: isHovered)
+    .agentHubFlatRow(isHighlighted: isCurrentBranch)
     .contextMenu {
       Button {
         if let url = URL(string: pr.url) {
@@ -751,26 +768,13 @@ struct GitHubPRRow: View {
     }
   }
 
-  private var prStateColor: Color {
-    switch pr.stateKind {
-    case .open: return pr.isDraft ? .secondary : GitHubPalette.open
-    case .closed: return GitHubPalette.closed
-    case .merged: return GitHubPalette.merged
-    case .unknown: return .secondary
-    }
-  }
-
-  private var rowBackground: Color {
-    if isHovered {
-      return colorScheme == .dark ? Color(white: 0.10) : Color(white: 0.96)
-    }
-    return colorScheme == .dark ? Color(white: 0.07) : Color(white: 0.98)
-  }
-
+  @ViewBuilder
   private func ciIcon(_ status: CIStatus) -> some View {
-    Image(systemName: status.icon)
-      .font(.system(size: 10))
-      .foregroundStyle(ciColor(status))
+    if status != .none {
+      Image(systemName: status.icon)
+        .font(.system(size: 11, weight: .semibold))
+        .foregroundStyle(ciColor(status))
+    }
   }
 
   private func ciColor(_ status: CIStatus) -> Color {
@@ -783,116 +787,124 @@ struct GitHubPRRow: View {
   }
 }
 
+// MARK: - PR Status Dot
+
+private struct PRStatusDot: View {
+  let state: GitHubPullRequestState
+  let isDraft: Bool
+
+  var body: some View {
+    Circle()
+      .fill(isFilled ? color : .clear)
+      .overlay(Circle().stroke(color, lineWidth: isFilled ? 0 : 1.5))
+      .frame(width: 8, height: 8)
+  }
+
+  private var isFilled: Bool {
+    switch state {
+    case .open: return !isDraft
+    default: return false
+    }
+  }
+
+  private var color: Color {
+    switch state {
+    case .open:   return isDraft ? .secondary : GitHubPalette.open
+    case .closed: return GitHubPalette.closed
+    case .merged: return GitHubPalette.merged
+    case .unknown: return .secondary
+    }
+  }
+}
+
 // MARK: - Issue Row
 
 struct GitHubIssueRow: View {
   let issue: GitHubIssue
   let onSelect: () -> Void
 
-  @State private var isHovered = false
-  @Environment(\.colorScheme) private var colorScheme
-
   var body: some View {
     Button(action: onSelect) {
-      HStack(spacing: 0) {
-        // Left state accent bar
-        RoundedRectangle(cornerRadius: 2)
-          .fill(issueStateColor)
-          .frame(width: 3)
-          .padding(.vertical, DesignTokens.Spacing.xs)
+      HStack(spacing: DesignTokens.Spacing.sm) {
+        IssueStatusDot(state: issue.stateKind)
 
-        HStack(spacing: DesignTokens.Spacing.sm) {
-          // Author avatar
-          if let author = issue.author {
-            AuthorAvatarView(login: author.login, size: 28)
-          }
+        if let author = issue.author {
+          AuthorAvatarView(login: author.login, size: 26)
+        }
 
-          VStack(alignment: .leading, spacing: 3) {
-            // Title row
-            HStack(spacing: DesignTokens.Spacing.xs) {
-              Text("#\(issue.number)")
-                .font(GitHubTypography.monoStrong)
-                .foregroundStyle(Color.brandPrimary)
-
-              Text(issue.title)
-                .font(.geist(size: 12, weight: .semibold))
-                .lineLimit(1)
-            }
-
-            // Metadata row
-            HStack(spacing: DesignTokens.Spacing.sm) {
-              if let author = issue.author {
-                Text(author.login)
-                  .font(GitHubTypography.caption)
-                  .foregroundStyle(.tertiary)
-              }
-
-              if let labels = issue.labels, !labels.isEmpty {
-                ForEach(labels.prefix(3)) { label in
-                  GitHubLabelPill(label: label)
-                }
-              }
-
-              if let timeAgo = issue.createdAt.map(relativeTime) {
-                Text(timeAgo)
-                  .font(GitHubTypography.caption)
-                  .foregroundStyle(.tertiary)
-              }
-            }
-          }
-
-          Spacer()
+        VStack(alignment: .leading, spacing: 2) {
+          Text(issue.title)
+            .font(.geist(size: 13, weight: .semibold))
+            .foregroundStyle(.primary)
+            .lineLimit(1)
 
           HStack(spacing: DesignTokens.Spacing.sm) {
-            if let comments = issue.comments, !comments.isEmpty {
-              HStack(spacing: 2) {
-                Image(systemName: "bubble.right")
-                  .font(.system(size: 9))
-                Text("\(comments.count)")
-                  .font(GitHubTypography.monoCaption)
-              }
-              .foregroundStyle(.secondary)
+            Text("#\(issue.number)")
+              .font(GitHubTypography.monoCaption)
+              .foregroundStyle(.tertiary)
+
+            if let author = issue.author {
+              Text("@\(author.login)")
+                .font(GitHubTypography.caption)
+                .foregroundStyle(.tertiary)
             }
 
-            Image(systemName: "chevron.right")
-              .font(.system(size: 9, weight: .semibold))
-              .foregroundStyle(.tertiary)
+            if let labels = issue.labels, !labels.isEmpty {
+              ForEach(labels.prefix(2)) { label in
+                GitHubLabelPill(label: label)
+              }
+            }
           }
         }
-        .padding(.horizontal, DesignTokens.Spacing.md)
-        .padding(.vertical, DesignTokens.Spacing.sm)
+
+        Spacer()
+
+        HStack(spacing: DesignTokens.Spacing.sm) {
+          if let comments = issue.comments, !comments.isEmpty {
+            HStack(spacing: 2) {
+              Image(systemName: "bubble.right")
+                .font(.system(size: 10))
+              Text("\(comments.count)")
+                .font(GitHubTypography.monoCaption)
+            }
+            .foregroundStyle(.secondary)
+          }
+
+          if let updated = issue.createdAt {
+            Text(relativeTime(updated))
+              .font(GitHubTypography.caption)
+              .foregroundStyle(.tertiary)
+              .monospacedDigit()
+          }
+        }
       }
-      .background(
-        RoundedRectangle(cornerRadius: AgentHubLayout.rowCornerRadius, style: .continuous)
-          .fill(rowBackground)
-      )
-      .overlay(
-        RoundedRectangle(cornerRadius: AgentHubLayout.rowCornerRadius, style: .continuous)
-          .stroke(
-            isHovered ? Color.brandPrimary.opacity(0.3) : Color.secondary.opacity(0.15),
-            lineWidth: 1
-          )
-      )
-      .clipShape(RoundedRectangle(cornerRadius: AgentHubLayout.rowCornerRadius, style: .continuous))
+      .padding(.horizontal, DesignTokens.Spacing.md)
+      .padding(.vertical, DesignTokens.Spacing.sm)
+      .contentShape(Rectangle())
     }
     .buttonStyle(.plain)
-    .onHover { isHovered = $0 }
-    .animation(.easeInOut(duration: 0.15), value: isHovered)
+    .agentHubFlatRow()
+  }
+}
+
+private struct IssueStatusDot: View {
+  let state: GitHubIssueState
+
+  var body: some View {
+    Circle()
+      .fill(isFilled ? color : .clear)
+      .overlay(Circle().stroke(color, lineWidth: isFilled ? 0 : 1.5))
+      .frame(width: 8, height: 8)
   }
 
-  private var issueStateColor: Color {
-    switch issue.stateKind {
+  private var isFilled: Bool { state == .open }
+
+  private var color: Color {
+    switch state {
     case .open: return GitHubPalette.open
     case .closed: return GitHubPalette.merged
     case .unknown: return .secondary
     }
-  }
-
-  private var rowBackground: Color {
-    if isHovered {
-      return colorScheme == .dark ? Color(white: 0.10) : Color(white: 0.96)
-    }
-    return colorScheme == .dark ? Color(white: 0.07) : Color(white: 0.98)
   }
 }
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MarkdownCardView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MarkdownCardView.swift
@@ -9,13 +9,14 @@ import SwiftUI
 
 struct MarkdownCardView: View {
   let content: String
+  var transparent: Bool = false
 
   @Environment(\.colorScheme) private var colorScheme
 
   var body: some View {
     MarkdownView(content: content, includeScrollView: false)
       .padding(DesignTokens.Spacing.lg)
-      .background(cardBackground)
+      .background(transparent ? Color.clear : cardBackground)
       .clipShape(RoundedRectangle(cornerRadius: DesignTokens.Radius.md, style: .continuous))
       .overlay(
         RoundedRectangle(cornerRadius: DesignTokens.Radius.md, style: .continuous)

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/ModalPanelModifier.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/ModalPanelModifier.swift
@@ -10,6 +10,25 @@
 import AppKit
 import SwiftUI
 
+// MARK: - Environment Forwarding
+
+/// Environments captured from the parent view tree and injected into an `NSHostingView`
+/// so detached AppKit-hosted content still respects the active theme and provider.
+/// Reading these in the modifier's `body(content:)` ensures the modifier republishes
+/// when either value changes, which re-hosts the popped-out window.
+private struct HostedPanelEnvironment {
+  var runtimeTheme: RuntimeTheme?
+  var agentHub: AgentHubProvider?
+}
+
+private extension View {
+  func forwardingHostedEnvironment(_ env: HostedPanelEnvironment) -> some View {
+    self
+      .environment(\.runtimeTheme, env.runtimeTheme)
+      .environment(\.agentHub, env.agentHub)
+  }
+}
+
 // MARK: - Panel Window Delegate
 
 private final class PanelWindowDelegate: NSObject, NSWindowDelegate {
@@ -45,6 +64,9 @@ private struct ModalPanelModifier<Item: Identifiable, PanelContent: View>: ViewM
   @State private var panel: NSPanel?
   @State private var windowDelegate: PanelWindowDelegate?
 
+  @Environment(\.runtimeTheme) private var runtimeTheme
+  @Environment(\.agentHub) private var agentHub
+
   func body(content: Content) -> some View {
     content
       .onChange(of: item.map { AnyHashable($0.id) }) { _, newValue in
@@ -62,7 +84,11 @@ private struct ModalPanelModifier<Item: Identifiable, PanelContent: View>: ViewM
   private func presentPanel(for currentItem: Item) {
     dismissPanel()
 
-    let view = panelContent(currentItem)
+    let forwarded = HostedPanelEnvironment(
+      runtimeTheme: runtimeTheme,
+      agentHub: agentHub
+    )
+    let view = panelContent(currentItem).forwardingHostedEnvironment(forwarded)
     let hostingView = NSHostingView(rootView: view)
 
     let newPanel = NSPanel(

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringCardView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringCardView.swift
@@ -217,15 +217,15 @@ public struct MonitoringCardView: View {
     VStack(alignment: .leading, spacing: 0) {
       // Header with session info and actions
       header
-        .padding(.horizontal, 8)
-        .padding(.vertical, 6)
+        .padding(.horizontal, DesignTokens.Spacing.sm)
+        .frame(height: AgentHubLayout.topBarHeight)
 
       Divider()
 
       // Path row with repo path, branch, and GitHub button
       pathRow
-        .padding(.horizontal, 8)
-        .padding(.vertical, 3)
+        .padding(.horizontal, DesignTokens.Spacing.sm)
+        .frame(height: AgentHubLayout.subBarHeight)
 
       // Terminal content
       Divider()
@@ -243,7 +243,7 @@ public struct MonitoringCardView: View {
           Image(systemName: "ellipsis")
             .font(.system(size: 18, weight: .semibold))
             .foregroundColor(Color.brandPrimary)
-            .padding(.horizontal, 8)
+            .padding(.horizontal, DesignTokens.Spacing.sm)
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
@@ -853,7 +853,7 @@ public struct MonitoringCardView: View {
       }
 
       Divider()
-        .padding(.vertical, 4)
+        .padding(.vertical, DesignTokens.Spacing.xs)
 
       PopoverButton(icon: "plus.rectangle.on.folder", title: "Add Files") {
         showingActionsPopover = false
@@ -862,7 +862,7 @@ public struct MonitoringCardView: View {
         }
       }
     }
-    .padding(8)
+    .padding(DesignTokens.Spacing.sm)
   }
 
   // MARK: - Path Row
@@ -917,7 +917,7 @@ public struct MonitoringCardView: View {
         viewModel?.consumeQueuedWebPreviewContextPrompt(for: session.id)
       }
     )
-    .padding(8)
+    .padding(DesignTokens.Spacing.sm)
     .frame(minHeight: 300)
   }
 
@@ -950,7 +950,7 @@ private struct PopoverButton: View {
         Text(title)
         Spacer()
       }
-      .padding(.horizontal, 8)
+      .padding(.horizontal, DesignTokens.Spacing.sm)
       .padding(.vertical, 6)
       .contentShape(Rectangle())
     }

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderMonitoringPanelView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderMonitoringPanelView.swift
@@ -751,6 +751,7 @@ public struct MultiProviderMonitoringPanelView: View {
     HStack(spacing: 0) {
       content()
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
+        .blursWhileResizing()
 
       if let panelContent = sidePanelContent, !panelContent.isFileExplorer {
         ResizablePanelContainer(

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderMonitoringPanelView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderMonitoringPanelView.swift
@@ -63,6 +63,7 @@ private struct GitHubPopOutItem: Identifiable {
   let projectPath: String
 }
 
+
 // MARK: - SessionFileSheetItem
 
 private struct SessionFileSheetItem: Identifiable {

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/PlanView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/PlanView.swift
@@ -33,6 +33,10 @@ public struct PlanView: View {
   @State private var activeLineIndex: Int?
   @State private var isReviewMode: Bool = false
 
+  @Environment(\.colorScheme) private var colorScheme
+  @Environment(\.runtimeTheme) private var runtimeTheme
+
+
   public init(
     session: CLISession,
     planState: PlanState,
@@ -78,6 +82,11 @@ public struct PlanView: View {
       minWidth: isEmbedded ? 300 : 700, idealWidth: isEmbedded ? .infinity : 900, maxWidth: .infinity,
       minHeight: isEmbedded ? 300 : 550, idealHeight: isEmbedded ? .infinity : 750, maxHeight: .infinity
     )
+    .background(
+      isEmbedded
+        ? Color.clear
+        : Color.adaptiveBackground(for: colorScheme, theme: runtimeTheme)
+    )
     .onKeyPress(.escape) {
       onDismiss()
       return .handled
@@ -101,11 +110,12 @@ public struct PlanView: View {
         }
       }
       .buttonStyle(.bordered)
+      .controlSize(.small)
       .disabled(content == nil)
       .help("Copy plan to clipboard")
     }
-    .padding()
-    .background(Color.surfaceElevated)
+    .padding(.horizontal, DesignTokens.Spacing.sm)
+    .frame(height: AgentHubLayout.topBarHeight)
   }
 
   // MARK: - Header
@@ -168,15 +178,17 @@ public struct PlanView: View {
           }
         }
         .buttonStyle(.bordered)
+        .controlSize(.small)
         .help(isReviewMode ? "Switch to rendered preview" : "Switch to review mode to annotate lines")
       }
 
       Button("Close") {
         onDismiss()
       }
+      .controlSize(.small)
     }
-    .padding()
-    .background(Color.surfaceElevated)
+    .padding(.horizontal, DesignTokens.Spacing.sm)
+    .frame(height: AgentHubLayout.topBarHeight)
   }
 
   // MARK: - Loading State
@@ -217,10 +229,9 @@ public struct PlanView: View {
 
   private func markdownContent(_ text: String) -> some View {
     ScrollView {
-      MarkdownCardView(content: text)
+      MarkdownCardView(content: text, transparent: true)
         .padding(DesignTokens.Spacing.xl)
     }
-    .background(Color.surfaceCanvas)
   }
 
   // MARK: - Review Content
@@ -236,7 +247,6 @@ public struct PlanView: View {
         }
         .padding(DesignTokens.Spacing.md)
       }
-      .background(Color.surfaceCanvas)
 
       if commentsState.hasComments {
         DiffCommentsPanelView(

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/ResizableSplitHandle.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/ResizableSplitHandle.swift
@@ -14,6 +14,60 @@ enum ResizablePanelSide: Equatable {
   case trailing
 }
 
+// MARK: - Drag State Propagation
+
+/// Process-wide observable that publishes whether ANY split handle is being
+/// dragged. Individual panes subscribe via `.blursWhileResizing()` so both the
+/// main content and the resizable content can fade in a blur overlay without
+/// the overlay covering the handle itself.
+@MainActor
+@Observable
+final class ResizeInteractionState {
+  static let shared = ResizeInteractionState()
+
+  /// Number of concurrent active drags. `isResizing` is `true` when > 0.
+  /// Tracked as a counter so nested / overlapping drags all release cleanly.
+  private var activeCount: Int = 0
+
+  var isResizing: Bool { activeCount > 0 }
+
+  fileprivate func beginResize() { activeCount += 1 }
+  fileprivate func endResize() { activeCount = max(0, activeCount - 1) }
+
+  private init() {}
+}
+
+extension View {
+  /// Fades a blurred material overlay in while any descendant (or sibling)
+  /// `ResizablePanelContainer` is being dragged. Apply to each pane that should
+  /// blur. The handle itself is deliberately NOT wrapped so the preview guide +
+  /// width readout stay sharp on top.
+  func blursWhileResizing() -> some View {
+    modifier(BlurWhileResizingModifier())
+  }
+}
+
+private struct BlurWhileResizingModifier: ViewModifier {
+  @State private var state = ResizeInteractionState.shared
+
+  /// Peak opacity of the material overlay during a drag. `.ultraThinMaterial`
+  /// is already the lightest system material — lowering the opacity further
+  /// makes the blur very subtle so the underlying content stays readable.
+  private static let peakOpacity: Double = 0.75
+
+  func body(content: Content) -> some View {
+    let isResizing = state.isResizing
+    content
+      .overlay {
+        Rectangle()
+          .fill(.ultraThinMaterial)
+          .opacity(isResizing ? Self.peakOpacity : 0)
+          .animation(.easeInOut(duration: 0.2), value: isResizing)
+          .allowsHitTesting(false)
+      }
+  }
+}
+
 // MARK: - ResizablePanelContainer
 
 /// A self-contained split pane whose width state lives entirely inside this view.
@@ -75,13 +129,21 @@ struct ResizablePanelContainer<Content: View>: View {
       if side == .trailing {
         handle
           .zIndex(2)
-        content.frame(width: resolvedWidth)
+        resizableContent
       } else {
-        content.frame(width: resolvedWidth)
+        resizableContent
         handle
           .zIndex(2)
       }
     }
+  }
+
+  /// The resizable pane itself, blurred while this (or any sibling) handle is
+  /// being dragged. The handle is rendered separately so it stays sharp.
+  private var resizableContent: some View {
+    content
+      .frame(width: resolvedWidth)
+      .blursWhileResizing()
   }
 
   private var handle: some View {
@@ -165,7 +227,10 @@ struct ResizableSplitHandle: View {
     .help("Drag to resize. Double-click to reset.")
     .zIndex(isDragging ? 20 : 10)
     .onDisappear {
-      if isDragging { ResizeInteractionSuppression.shared.endResize() }
+      if isDragging {
+        ResizeInteractionSuppression.shared.endResize()
+        ResizeInteractionState.shared.endResize()
+      }
       isDragging = false
       previewWidth = nil
       updateCursor(isHovering: false)
@@ -204,6 +269,7 @@ struct ResizableSplitHandle: View {
           isDragging = true
           widthAtDragStart = resolvedWidth
           ResizeInteractionSuppression.shared.beginResize()
+          ResizeInteractionState.shared.beginResize()
         }
 
         let translatedWidth: CGFloat
@@ -222,6 +288,7 @@ struct ResizableSplitHandle: View {
         isDragging = false
         previewWidth = nil
         ResizeInteractionSuppression.shared.endResize()
+        ResizeInteractionState.shared.endResize()
         onDragEnd?(finalWidth)
       }
   }

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/WebPreviewView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/WebPreviewView.swift
@@ -157,6 +157,13 @@ public struct WebPreviewView: View {
   @AppStorage(AgentHubDefaults.webPreviewAdvancedEditingEnabled)
   private var webPreviewAdvancedEditingEnabled: Bool = true
 
+  @Environment(\.colorScheme) private var colorScheme
+  @Environment(\.runtimeTheme) private var runtimeTheme
+
+  private var headerBackground: Color {
+    Color.adaptiveExpandedContentBackground(for: colorScheme, theme: runtimeTheme)
+  }
+
   /// Uses session ID as key for DevServerManager to support multiple sessions
   private var serverKey: String { session.id }
 
@@ -369,9 +376,9 @@ public struct WebPreviewView: View {
       // Controls
       headerControls
     }
-    .padding(.horizontal)
-    .padding(.vertical, 8)
-    .background(Color.surfaceElevated)
+    .padding(.horizontal, DesignTokens.Spacing.sm)
+    .frame(height: AgentHubLayout.topBarHeight)
+    .background(headerBackground)
   }
 
   // MARK: - Center Indicator
@@ -551,6 +558,7 @@ public struct WebPreviewView: View {
       Button("Close") {
         onDismiss()
       }
+      .controlSize(.small)
     }
     .overlay {
       // Hidden keyboard shortcuts — kept outside HStack layout to avoid phantom spacing

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/WebPreviewView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/WebPreviewView.swift
@@ -599,6 +599,7 @@ public struct WebPreviewView: View {
     HStack(spacing: 0) {
       previewContent
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .blursWhileResizing()
 
       if showsInspectorRail {
         ResizablePanelContainer(

--- a/app/modules/AgentHubGitHub/Sources/AgentHubGitHub/ViewModels/GitHubViewModel.swift
+++ b/app/modules/AgentHubGitHub/Sources/AgentHubGitHub/ViewModels/GitHubViewModel.swift
@@ -29,15 +29,19 @@ public enum GitHubTab: String, CaseIterable, Identifiable, Sendable {
 /// Filter for PR list state
 public enum GitHubPRFilter: String, CaseIterable, Identifiable, Sendable {
   case open = "Open"
+  case draft = "Draft"
+  case merged = "Merged"
   case closed = "Closed"
   case all = "All"
 
   public var id: String { rawValue }
 
+  /// gh CLI state used when querying the API.
+  /// Draft is a client-side refinement over open; merged is a client-side refinement over closed.
   var ghState: String {
     switch self {
-    case .open: return "open"
-    case .closed: return "closed"
+    case .open, .draft: return "open"
+    case .merged, .closed: return "closed"
     case .all: return "all"
     }
   }
@@ -192,18 +196,44 @@ public final class GitHubViewModel {
     prLoadingState = .loading
 
     do {
-      pullRequests = try await service.listPullRequests(
+      let raw = try await service.listPullRequests(
         at: repoPath,
         state: prFilter.ghState,
         limit: 30,
         authoredByMe: showOnlyMyPRs,
         labels: Array(selectedLabels)
       )
+      pullRequests = applyClientSideFilter(raw, filter: prFilter)
       prLoadingState = .loaded
     } catch {
       prLoadingState = .error(error.localizedDescription)
       GitHubLogger.github.error("Failed to load PRs: \(error.localizedDescription)")
     }
+  }
+
+  /// Refines the raw list returned by `gh` for filters that can't be expressed in the query.
+  /// - `.draft`: open PRs with `isDraft == true`
+  /// - `.open`:  open PRs with `isDraft == false` (so the draft chip isn't double-counted)
+  /// - `.merged`: closed PRs that were merged
+  /// - `.closed`: closed PRs that were not merged
+  /// - `.all`: no refinement
+  private func applyClientSideFilter(
+    _ prs: [GitHubPullRequest],
+    filter: GitHubPRFilter
+  ) -> [GitHubPullRequest] {
+    switch filter {
+    case .draft:  return prs.filter { $0.isDraft }
+    case .open:   return prs.filter { !$0.isDraft }
+    case .merged: return prs.filter { $0.stateKind == .merged }
+    case .closed: return prs.filter { $0.stateKind == .closed }
+    case .all:    return prs
+    }
+  }
+
+  /// Count of loaded PRs that fall into a given filter. Used for the filter chip badges.
+  /// Note: counts reflect the currently loaded set, not the full remote state.
+  public func filterCount(_ filter: GitHubPRFilter) -> Int {
+    applyClientSideFilter(pullRequests, filter: filter).count
   }
 
   /// Loads repository labels if not already loaded


### PR DESCRIPTION
## Summary
- Redesigns the GitHub panel: segmented tab bar with counts, sectioned PR list (Current Branch / Open / Draft / Recently Merged / Closed), clean flat rows via `agentHubFlatRow`, restyled stat cards, and a `Filter /` menu hosting Labels + Mine toggles.
- Extends `GitHubPRFilter` with `.draft` + `.merged` cases and adds `filterCount(_:)` for chip badges.
- Themes the panel end-to-end — `panelBackground` / `headerBackground` call `adaptiveBackground` / `adaptiveExpandedContentBackground`; accents, dividers, avatars, and segmented tabs use `brandPrimary(from: theme)`.
- Forwards `runtimeTheme` + `agentHub` through `ModalPanelModifier` so popped-out GitHub NSPanels inherit the active theme.
- Introduces `AgentHubLayout.topBarHeight` (34) and `subBarHeight` (30) and aligns MonitoringCard, GitHub, FileExplorer, GitDiff, PlanView, and WebPreview headers/sub-bars to them. Standardizes close buttons as `Button("Close")` + `.controlSize(.small)`.
- Adds `transparent` option to `MarkdownCardView` and `agentHubCard` so PR/Issue Overview + PlanView bodies keep the rounded border + shadow without a filled surface.
- New animated blur on split resize: `@Observable ResizeInteractionState` drives a `.blursWhileResizing()` modifier that fades an `.ultraThinMaterial` overlay (0 → 0.75, 0.2s ease-in/out) over each pane while a handle is being dragged. The handle, preview guide, and width readout stay sharp on top.

## Test plan
- [ ] Launch AgentHub, open the GitHub panel on `jamesrochabrun/AgentHub` and confirm the sectioned PR list, filter chips with counts, and Filter menu (Labels + Mine) work.
- [ ] Switch YAML themes (Claude / Codex / Bat / Xcode) and verify the GitHub panel + all fixed headers follow the theme for backgrounds and accent colors.
- [ ] Pop out the GitHub panel via the header button; theme should still apply in the standalone NSPanel window.
- [ ] Open PR detail → Overview: description card shows border + shadow but no filled interior; Issue Overview + Plan view markdown cards match.
- [ ] Place MonitoringCard + GitHub / FileExplorer / GitDiff / PlanView / WebPreview side by side; top bars align at 34pt and segmented/tab sub-bars at 30pt.
- [ ] Drag a split handle (single-mode side panel, WebPreview inspector, FileExplorer sidebar); both panes fade a subtle blur in and back out on release while the handle + width readout stay sharp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)