### PR TITLE
Fix terminal file opens from CLI sessions

### DIFF
--- a/app/AgentHub.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/app/AgentHub.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "eab8200f5c9d1f95fc7f9892307fd756c56c22d956e5328233b0e91a21389520",
+  "originHash" : "0902c7a92d5daddf48b1355b43dd3d941d9c296fc8885595c4e2aa07c311d27d",
   "pins" : [
     {
       "identity" : "beautiful-mermaid-swift",
@@ -141,8 +141,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/jamesrochabrun/SwiftTerm",
       "state" : {
-        "branch" : "agenthub",
-        "revision" : "d03ad83eecfe5b19f911408c7845ccd11ba2bf4f"
+        "revision" : "287a410162ca653e43b1c571faefc0320ae2f51b",
+        "version" : "1.13.0-agenthub.1"
       }
     },
     {

--- a/app/modules/AgentHubCore/Package.resolved
+++ b/app/modules/AgentHubCore/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "2929b57e1e88ace276de95b5aba8cc10118deb51a28af42ac44c558c70f34bf2",
+  "originHash" : "32e8e7d8d421e004d73399341fe6d495069b00bf10cf72b6371b3e8c467e7a38",
   "pins" : [
     {
       "identity" : "beautiful-mermaid-swift",
@@ -132,8 +132,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/jamesrochabrun/SwiftTerm",
       "state" : {
-        "branch" : "agenthub",
-        "revision" : "d03ad83eecfe5b19f911408c7845ccd11ba2bf4f"
+        "revision" : "287a410162ca653e43b1c571faefc0320ae2f51b",
+        "version" : "1.13.0-agenthub.1"
       }
     },
     {

--- a/app/modules/AgentHubCore/Package.swift
+++ b/app/modules/AgentHubCore/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
     .package(path: "../AgentHubGitHub"),
     .package(url: "https://github.com/jamesrochabrun/Canvas", from: "1.2.0"),
     .package(url: "https://github.com/jamesrochabrun/PierreDiffsSwift", exact: "1.1.7"),
-    .package(url: "https://github.com/jamesrochabrun/SwiftTerm", branch: "agenthub"),
+    .package(url: "https://github.com/jamesrochabrun/SwiftTerm", exact: "1.13.0-agenthub.1"),
     .package(url: "https://github.com/gonzalezreal/swift-markdown-ui", from: "2.0.0"),
     .package(url: "https://github.com/groue/GRDB.swift", from: "6.24.0"),
     .package(url: "https://github.com/appstefan/HighlightSwift", from: "1.1.0"),

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/ManagedLocalProcessTerminalView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/ManagedLocalProcessTerminalView.swift
@@ -40,6 +40,7 @@ public protocol ManagedLocalProcessTerminalViewDelegate: AnyObject {
 /// Local-process terminal view with explicit process control.
 open class ManagedLocalProcessTerminalView: TerminalView, TerminalViewDelegate, LocalProcessDelegate {
   private var process: LocalProcess!
+  private static let fileOpenLogPrefix = "[AH-OPEN][AgentHub]"
 
   /// Delegate for process-related events.
   public weak var processDelegate: ManagedLocalProcessTerminalViewDelegate?
@@ -115,6 +116,24 @@ open class ManagedLocalProcessTerminalView: TerminalView, TerminalViewDelegate, 
 
   open func rangeChanged(source: TerminalView, startY: Int, endY: Int) {}
 
+  public func requestOpenLink(source: TerminalView, link: String, params: [String: String]) {
+    Self.logFileOpen("requestOpenLink link=\"\(link)\" params=\(params)")
+
+    if let fileLink = Self.filePathFromImplicitLink(link) {
+      Self.logFileOpen("redirect implicit file link to requestOpenFile path=\"\(fileLink.path)\" line=\(fileLink.lineNumber.map(String.init) ?? "nil")")
+      requestOpenFile(source: source, path: fileLink.path, lineNumber: fileLink.lineNumber)
+      return
+    }
+
+    guard let url = URL(string: link), url.scheme != nil else {
+      Self.logFileOpen("abort link is neither file path nor absolute URL link=\"\(link)\"")
+      return
+    }
+
+    let opened = NSWorkspace.shared.open(url)
+    Self.logFileOpen("dispatch=ExternalURL opened=\(opened) url=\"\(url.absoluteString)\"")
+  }
+
   // MARK: - File Path Opening
 
   /// The project path for resolving relative file paths. Set by TerminalContainerView.
@@ -124,6 +143,8 @@ open class ManagedLocalProcessTerminalView: TerminalView, TerminalViewDelegate, 
   public var onOpenFile: ((String, Int?) -> Void)?
 
   public func requestOpenFile(source: TerminalView, path: String, lineNumber: Int?) {
+    Self.logFileOpen("requestOpenFile rawPath=\"\(path)\" line=\(lineNumber.map(String.init) ?? "nil") projectPath=\"\(projectPath ?? "nil")\"")
+
     let resolvedPath: String
     if path.hasPrefix("/") || path.hasPrefix("~") {
       resolvedPath = (path as NSString).expandingTildeInPath
@@ -133,14 +154,23 @@ open class ManagedLocalProcessTerminalView: TerminalView, TerminalViewDelegate, 
       resolvedPath = (NSHomeDirectory() as NSString).appendingPathComponent(path)
     }
 
-    guard FileManager.default.fileExists(atPath: resolvedPath) else { return }
+    var isDirectory: ObjCBool = false
+    let exists = FileManager.default.fileExists(atPath: resolvedPath, isDirectory: &isDirectory)
+    Self.logFileOpen("resolvedPath=\"\(resolvedPath)\" exists=\(exists) isDirectory=\(isDirectory.boolValue)")
+    guard exists else {
+      Self.logFileOpen("abort missing resolvedPath=\"\(resolvedPath)\"")
+      return
+    }
 
+    let rawEditor = UserDefaults.standard.integer(forKey: AgentHubDefaults.terminalFileOpenEditor)
     let editor = FileOpenEditor(
-      rawValue: UserDefaults.standard.integer(forKey: AgentHubDefaults.terminalFileOpenEditor)
+      rawValue: rawEditor
     ) ?? .agentHub
+    Self.logFileOpen("editor rawValue=\(rawEditor) resolved=\(editor.label) onOpenFileSet=\(onOpenFile != nil)")
 
     switch editor {
     case .agentHub:
+      Self.logFileOpen("dispatch=AgentHubInline path=\"\(resolvedPath)\" line=\(lineNumber.map(String.init) ?? "nil")")
       onOpenFile?(resolvedPath, lineNumber)
     case .vscode:
       Self.openInVSCode(path: resolvedPath, line: lineNumber)
@@ -156,20 +186,60 @@ open class ManagedLocalProcessTerminalView: TerminalView, TerminalViewDelegate, 
       "/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code"
     ]
     guard let codePath = codePaths.first(where: { FileManager.default.isExecutableFile(atPath: $0) }) else {
-      NSWorkspace.shared.open(URL(fileURLWithPath: path))
+      let opened = NSWorkspace.shared.open(URL(fileURLWithPath: path))
+      logFileOpen("VSCode not found; fallback=NSWorkspace.open opened=\(opened) path=\"\(path)\"")
       return
     }
     let task = Process()
     task.executableURL = URL(fileURLWithPath: codePath)
     task.arguments = ["--goto", line != nil ? "\(path):\(line!)" : path]
-    try? task.run()
+    do {
+      try task.run()
+      logFileOpen("dispatch=VSCode executable=\"\(codePath)\" args=\(task.arguments ?? []) pid=\(task.processIdentifier)")
+    } catch {
+      logFileOpen("dispatch=VSCode failed executable=\"\(codePath)\" error=\"\(error.localizedDescription)\"")
+    }
   }
 
   private static func openInXcode(path: String, line: Int?) {
     let task = Process()
     task.executableURL = URL(fileURLWithPath: "/usr/bin/xed")
     task.arguments = line != nil ? ["--line", "\(line!)", path] : [path]
-    try? task.run()
+    do {
+      try task.run()
+      logFileOpen("dispatch=Xcode executable=\"/usr/bin/xed\" args=\(task.arguments ?? []) pid=\(task.processIdentifier)")
+    } catch {
+      logFileOpen("dispatch=Xcode failed executable=\"/usr/bin/xed\" error=\"\(error.localizedDescription)\"")
+    }
+  }
+
+  private static func logFileOpen(_ message: @autoclosure () -> String) {
+    print("\(fileOpenLogPrefix) \(message())")
+  }
+
+  private static func filePathFromImplicitLink(_ link: String) -> (path: String, lineNumber: Int?)? {
+    let trimmed = link.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty,
+          !trimmed.contains("://"),
+          URLComponents(string: trimmed)?.scheme == nil,
+          trimmed.contains("/")
+            || trimmed.hasPrefix("~")
+            || trimmed.hasPrefix(".")
+            || trimmed.hasPrefix("/")
+    else {
+      return nil
+    }
+
+    var path = trimmed
+    var lineNumber: Int?
+    if let suffixRange = path.range(of: #":\d+(?::\d+)?$"#, options: .regularExpression) {
+      let suffix = String(path[suffixRange])
+      let parts = suffix.dropFirst().split(separator: ":")
+      lineNumber = parts.first.flatMap { Int($0) }
+      path = String(path[..<suffixRange.lowerBound])
+    }
+
+    return path.isEmpty ? nil : (path, lineNumber)
   }
 
   // MARK: - Process Control

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderMonitoringPanelView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderMonitoringPanelView.swift
@@ -322,18 +322,11 @@ public struct MultiProviderMonitoringPanelView: View {
     .onChange(of: isAuxiliaryShellVisible) { _, _ in
       syncAuxiliaryShellDockState()
     }
-    .onChange(of: claudeViewModel.pendingFileOpen?.filePath) { _, filePath in
-      guard let pending = claudeViewModel.pendingFileOpen, let filePath else { return }
-      if let session = claudeViewModel.allSessions.first(where: { $0.id == pending.sessionId }) {
-        sidePanelContent = .fileExplorer(
-          sessionId: session.id,
-          session: session,
-          projectPath: session.projectPath,
-          initialFilePath: filePath,
-          navigationId: UUID()
-        )
-      }
-      claudeViewModel.pendingFileOpen = nil
+    .onChange(of: claudeViewModel.pendingFileOpen?.filePath) { _, _ in
+      consumePendingFileOpen(from: claudeViewModel, providerKind: .claude)
+    }
+    .onChange(of: codexViewModel.pendingFileOpen?.filePath) { _, _ in
+      consumePendingFileOpen(from: codexViewModel, providerKind: .codex)
     }
     .overlay {
       // Hidden Shift+P trigger for QuickFilePicker
@@ -426,6 +419,10 @@ public struct MultiProviderMonitoringPanelView: View {
       if currentSidePanelContent.isFileExplorer, let newId {
         if let item = allItems.first(where: { $0.id == newId }),
            case .monitored(_, _, let session, _) = item {
+          if case .fileExplorer(let currentSessionId, _, _, _, _) = currentSidePanelContent,
+             currentSessionId == session.id {
+            return
+          }
           sidePanelContent = .fileExplorer(
             sessionId: session.id,
             session: session,
@@ -1247,6 +1244,46 @@ public struct MultiProviderMonitoringPanelView: View {
         content: content
       )
     }
+  }
+
+  private func consumePendingFileOpen(
+    from viewModel: CLISessionsViewModel,
+    providerKind: SessionProviderKind
+  ) {
+    guard let pending = viewModel.pendingFileOpen else { return }
+    defer {
+      viewModel.pendingFileOpen = nil
+    }
+
+    guard let session = viewModel.allSessions.first(where: { $0.id == pending.sessionId })
+      ?? viewModel.monitoredSessions.first(where: { $0.session.id == pending.sessionId })?.session
+    else {
+      Self.logFileOpen(
+        "abort pendingFileOpen provider=\(providerKind.rawValue) missing session=\(pending.sessionId) file=\"\(pending.filePath)\""
+      )
+      return
+    }
+
+    let fileExplorerProjectPath = TerminalFileOpenProjectResolver.projectPath(
+      forFile: pending.filePath,
+      sessionProjectPath: session.projectPath,
+      repositories: allSelectedRepositories
+    )
+    Self.logFileOpen(
+      "consume pendingFileOpen provider=\(providerKind.rawValue) session=\(session.id) file=\"\(pending.filePath)\" sessionProject=\"\(session.projectPath)\" explorerProject=\"\(fileExplorerProjectPath)\""
+    )
+
+    sidePanelContent = .fileExplorer(
+      sessionId: session.id,
+      session: session,
+      projectPath: fileExplorerProjectPath,
+      initialFilePath: pending.filePath,
+      navigationId: UUID()
+    )
+  }
+
+  private static func logFileOpen(_ message: @autoclosure () -> String) {
+    print("[AH-OPEN][AgentHub] \(message())")
   }
 
   private func ensurePrimarySelection() {

--- a/app/modules/AgentHubCore/Sources/AgentHub/Utils/TerminalFileOpenProjectResolver.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Utils/TerminalFileOpenProjectResolver.swift
@@ -1,0 +1,88 @@
+//
+//  TerminalFileOpenProjectResolver.swift
+//  AgentHub
+//
+//  Resolves the project root used by the inline file explorer for terminal
+//  Cmd+Click file opens.
+//
+
+import Foundation
+
+enum TerminalFileOpenProjectResolver {
+  static func projectPath(
+    forFile filePath: String,
+    sessionProjectPath: String,
+    repositories: [SelectedRepository],
+    fileManager: FileManager = .default
+  ) -> String {
+    let resolvedFilePath = normalize(filePath)
+    let resolvedSessionProjectPath = normalize(sessionProjectPath)
+
+    if isPath(resolvedFilePath, within: resolvedSessionProjectPath) {
+      return resolvedSessionProjectPath
+    }
+
+    if let selectedRoot = selectedProjectRoot(
+      containing: resolvedFilePath,
+      repositories: repositories
+    ) {
+      return selectedRoot
+    }
+
+    if let gitRoot = gitRoot(containing: resolvedFilePath, fileManager: fileManager) {
+      return gitRoot
+    }
+
+    return URL(fileURLWithPath: resolvedFilePath)
+      .deletingLastPathComponent()
+      .standardizedFileURL
+      .path
+  }
+
+  private static func selectedProjectRoot(
+    containing filePath: String,
+    repositories: [SelectedRepository]
+  ) -> String? {
+    let candidates = repositories.flatMap { repository in
+      [repository.path] + repository.worktrees.map(\.path)
+    }
+    .map(normalize)
+    .filter { isPath(filePath, within: $0) }
+
+    return candidates.max { $0.count < $1.count }
+  }
+
+  private static func gitRoot(containing filePath: String, fileManager: FileManager) -> String? {
+    var isDirectory: ObjCBool = false
+    let exists = fileManager.fileExists(atPath: filePath, isDirectory: &isDirectory)
+    var current = exists && isDirectory.boolValue
+      ? filePath
+      : URL(fileURLWithPath: filePath).deletingLastPathComponent().path
+
+    while !current.isEmpty {
+      let gitPath = (current as NSString).appendingPathComponent(".git")
+      if fileManager.fileExists(atPath: gitPath) {
+        return normalize(current)
+      }
+
+      let parent = URL(fileURLWithPath: current).deletingLastPathComponent().path
+      if parent == current {
+        return nil
+      }
+      current = parent
+    }
+
+    return nil
+  }
+
+  private static func normalize(_ path: String) -> String {
+    URL(fileURLWithPath: path)
+      .standardizedFileURL
+      .resolvingSymlinksInPath()
+      .path
+  }
+
+  private static func isPath(_ path: String, within rootPath: String) -> Bool {
+    path == rootPath || path.hasPrefix(rootPath + "/")
+  }
+}

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/TerminalFileOpenProjectResolverTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/TerminalFileOpenProjectResolverTests.swift
@@ -1,0 +1,89 @@
+//
+//  TerminalFileOpenProjectResolverTests.swift
+//  AgentHubTests
+//
+
+import Foundation
+import Testing
+
+@testable import AgentHubCore
+
+struct TerminalFileOpenProjectResolverTests {
+  @Test func usesSessionProjectWhenFileIsInsideSessionProject() {
+    let projectPath = "/tmp/AgentHubResolver/project"
+    let filePath = projectPath + "/Sources/App.swift"
+
+    let resolved = TerminalFileOpenProjectResolver.projectPath(
+      forFile: filePath,
+      sessionProjectPath: projectPath,
+      repositories: []
+    )
+
+    #expect(resolved == projectPath)
+  }
+
+  @Test func usesSelectedWorktreeContainingExternalFile() {
+    let sessionProjectPath = "/tmp/AgentHubResolver/Easel"
+    let worktreePath = "/tmp/AgentHubResolver/agenthub-buenos-aires-692130"
+    let filePath = worktreePath + "/app/modules/AgentHubCore/Sources/AgentHub/Intelligence/WorktreeOrchestrationTool.swift"
+    let repositories = [
+      SelectedRepository(
+        path: "/tmp/AgentHubResolver/agenthub",
+        worktrees: [
+          WorktreeBranch(
+            name: "agenthub-buenos-aires-692130",
+            path: worktreePath,
+            isWorktree: true
+          )
+        ]
+      )
+    ]
+
+    let resolved = TerminalFileOpenProjectResolver.projectPath(
+      forFile: filePath,
+      sessionProjectPath: sessionProjectPath,
+      repositories: repositories
+    )
+
+    #expect(resolved == worktreePath)
+  }
+
+  @Test func fallsBackToNearestGitRootForUntrackedProject() throws {
+    let root = try makeTemporaryDirectory()
+    let gitDirectory = root.appendingPathComponent(".git", isDirectory: true)
+    let nestedDirectory = root.appendingPathComponent("Sources/App", isDirectory: true)
+    let file = nestedDirectory.appendingPathComponent("Feature.swift")
+    try FileManager.default.createDirectory(at: gitDirectory, withIntermediateDirectories: true)
+    try FileManager.default.createDirectory(at: nestedDirectory, withIntermediateDirectories: true)
+    FileManager.default.createFile(atPath: file.path, contents: Data())
+
+    let resolved = TerminalFileOpenProjectResolver.projectPath(
+      forFile: file.path,
+      sessionProjectPath: "/tmp/AgentHubResolver/Easel",
+      repositories: []
+    )
+
+    #expect(resolved == root.path)
+  }
+
+  @Test func fallsBackToParentDirectoryWhenNoKnownRootContainsFile() throws {
+    let root = try makeTemporaryDirectory()
+    let file = root.appendingPathComponent("LooseFile.swift")
+    FileManager.default.createFile(atPath: file.path, contents: Data())
+
+    let resolved = TerminalFileOpenProjectResolver.projectPath(
+      forFile: file.path,
+      sessionProjectPath: "/tmp/AgentHubResolver/Easel",
+      repositories: []
+    )
+
+    #expect(resolved == root.path)
+  }
+
+  private func makeTemporaryDirectory() throws -> URL {
+    let url = FileManager.default.temporaryDirectory
+      .appendingPathComponent("AgentHubResolver-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+    return url
+  }
+}


### PR DESCRIPTION
## Summary
- pin AgentHubCore to SwiftTerm fork release `1.13.0-agenthub.1` at `287a410162ca653e43b1c571faefc0320ae2f51b`
- route implicit terminal file links through the AgentHub file-open path while keeping external URLs opening normally
- resolve inline file explorer roots from the clicked file, including selected worktrees and nearest git roots

## Tests
- `swift test --filter TerminalFileOpenProjectResolverTests` from a clean temporary worktree