### PR TITLE
Fix character-wrap overflow in CollapsibleSessionRow metadata

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/CollapsibleSessionRow.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/CollapsibleSessionRow.swift
@@ -88,16 +88,22 @@ struct CollapsibleSessionRow: View {
           Text(providerKind.rawValue)
             .font(.secondaryCaption)
             .foregroundColor(isPrimary ? .white : .brandPrimary(for: providerKind).opacity(0.8))
+            .lineLimit(1)
+            .fixedSize(horizontal: true, vertical: false)
 
           Spacer(minLength: 4)
 
           statusLabel
+            .lineLimit(1)
+            .fixedSize(horizontal: true, vertical: false)
             .animation(.easeInOut(duration: 0.3), value: isPending)
             .animation(.easeInOut(duration: 0.3), value: sessionStatus)
 
           Text(timestamp.timeAgoDisplay())
             .font(.secondaryCaption)
             .foregroundColor(.secondary.opacity(0.7))
+            .lineLimit(1)
+            .fixedSize(horizontal: true, vertical: false)
         }
 
         // Row 2: message + actions


### PR DESCRIPTION
## Summary
- Trailing metadata (`providerKind`, `statusLabel`, `timeAgoDisplay`) in `CollapsibleSessionRow` lacked `lineLimit(1)`, so a long session name combined with a narrow container caused each label to wrap per-character (e.g. `Claude` → `C / l / a / u / d / e`) and grew the row's height.
- Add `.lineLimit(1)` and `.fixedSize(horizontal: true, vertical: false)` to the three trailing views so they keep their intrinsic width on a single line.
- `displayName` already has `layoutPriority(1)` + `lineLimit(1)`, so it correctly truncates with an ellipsis when space is tight.

## Test plan
- [ ] Build passes (`xcodebuild … build`)
- [ ] Open `CollapsibleSessionRow` SwiftUI preview — all states (thinking/executing/idle/waitingForUser/awaitingApproval/pending) stay on one line
- [ ] Narrow the sidebar / selected-sessions panel to min column width (300pt) — rows stay a fixed height, long names truncate with `…`, trailing labels remain intact
- [ ] Verify sidebar usage in `MultiProviderSessionsListView` renders correctly