### PR TITLE
Always present right-side monitoring panels inline

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringCardView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringCardView.swift
@@ -9,49 +9,6 @@ import AgentHubGitHub
 import SwiftUI
 import UniformTypeIdentifiers
 
-// MARK: - GitDiffSheetItem
-
-/// Identifiable wrapper for git diff sheet - captures session and project path
-private struct GitDiffSheetItem: Identifiable {
-  let id = UUID()
-  let session: CLISession
-  let projectPath: String
-}
-
-// MARK: - PlanSheetItem
-
-/// Identifiable wrapper for plan sheet - captures session and plan state
-private struct PlanSheetItem: Identifiable {
-  let id = UUID()
-  let session: CLISession
-  let planState: PlanState
-}
-
-// MARK: - PendingChangesSheetItem
-
-/// Identifiable wrapper for pending changes preview sheet
-private struct PendingChangesSheetItem: Identifiable {
-  let id = UUID()
-  let session: CLISession
-  let pendingToolUse: PendingToolUse
-}
-
-/// Identifiable wrapper for web preview sheet
-private struct WebPreviewSheetItem: Identifiable {
-  let id = UUID()
-  let session: CLISession
-  let projectPath: String
-  var agentLocalhostURL: URL?
-  var monitorState: SessionMonitorState?
-}
-
-/// Identifiable wrapper for GitHub panel sheet
-private struct GitHubSheetItem: Identifiable {
-  let id = UUID()
-  let session: CLISession
-  let projectPath: String
-}
-
 // MARK: - MonitoringCardView
 
 /// Card view for displaying a monitored session in the monitoring panel
@@ -81,6 +38,7 @@ public struct MonitoringCardView: View {
   let onShowWebPreview: ((CLISession, String) -> Void)?
   let onShowMermaid: ((CLISession) -> Void)?
   let onShowGitHub: ((CLISession, String) -> Void)?
+  let onShowPendingChanges: ((CLISession, PendingToolUse) -> Void)?
   let onPromptConsumed: (() -> Void)?
   let onTerminalInteraction: (() -> Void)?
   let onRequestShowEditor: (() -> Void)?
@@ -92,13 +50,7 @@ public struct MonitoringCardView: View {
   @Binding private var contentMode: MonitoringCardContentMode
   @Binding private var selectedEditorFilePath: String?
 
-  @State private var gitDiffSheetItem: GitDiffSheetItem?
-  @State private var planSheetItem: PlanSheetItem?
-  @State private var pendingChangesSheetItem: PendingChangesSheetItem?
-  @State private var webPreviewSheetItem: WebPreviewSheetItem?
-  @State private var mermaidSheetSession: CLISession?
   @State private var simulatorSheetSession: CLISession?
-  @State private var gitHubSheetItem: GitHubSheetItem?
   @State private var sessionGitHubQuickAccessViewModel = SessionGitHubQuickAccessViewModel()
   @State private var isDragging = false
   @State private var showingActionsPopover = false
@@ -136,6 +88,7 @@ public struct MonitoringCardView: View {
     onShowWebPreview: ((CLISession, String) -> Void)? = nil,
     onShowMermaid: ((CLISession) -> Void)? = nil,
     onShowGitHub: ((CLISession, String) -> Void)? = nil,
+    onShowPendingChanges: ((CLISession, PendingToolUse) -> Void)? = nil,
     onPromptConsumed: (() -> Void)? = nil,
     onTerminalInteraction: (() -> Void)? = nil,
     onRequestShowEditor: (() -> Void)? = nil,
@@ -172,6 +125,7 @@ public struct MonitoringCardView: View {
     self.onShowWebPreview = onShowWebPreview
     self.onShowMermaid = onShowMermaid
     self.onShowGitHub = onShowGitHub
+    self.onShowPendingChanges = onShowPendingChanges
     self.onPromptConsumed = onPromptConsumed
     self.onTerminalInteraction = onTerminalInteraction
     self.onRequestShowEditor = onRequestShowEditor
@@ -308,65 +262,6 @@ public struct MonitoringCardView: View {
       handleDroppedFiles(providers)
       return true
     }
-    .modalPanel(
-      item: $gitDiffSheetItem,
-      title: "Git Diff",
-      autosaveName: "com.agenthub.panel.gitDiff"
-    ) { item in
-      GitDiffView(
-        session: item.session,
-        projectPath: item.projectPath,
-        onDismiss: { gitDiffSheetItem = nil },
-        cliConfiguration: cliConfiguration,
-        providerKind: providerKind,
-        onInlineRequestSubmit: onInlineRequestSubmit
-      )
-    }
-    .sheet(item: $planSheetItem) { item in
-      PlanView(
-        session: item.session,
-        planState: item.planState,
-        onDismiss: { planSheetItem = nil },
-        providerKind: providerKind,
-        onSendFeedback: { feedback, sess in
-          viewModel?.showTerminalWithPrompt(for: sess, prompt: feedback)
-        }
-      )
-    }
-    .sheet(item: $pendingChangesSheetItem) { item in
-      PendingChangesView(
-        session: item.session,
-        pendingToolUse: item.pendingToolUse,
-        onDismiss: { pendingChangesSheetItem = nil },
-        onApprovalResponse: { response, session in
-          viewModel?.showTerminalWithPrompt(for: session, prompt: response)
-        }
-      )
-    }
-    .sheet(item: $webPreviewSheetItem) { item in
-      WebPreviewView(
-        session: item.session,
-        projectPath: item.projectPath,
-        onDismiss: { webPreviewSheetItem = nil },
-        onInspectSubmit: { prompt, sess in
-          if viewModel?.sendPromptToActiveTerminal(forKey: sess.id, prompt: prompt) != true {
-            viewModel?.showTerminalWithPrompt(for: sess, prompt: prompt)
-          }
-        },
-        onQueuedSubmit: { prompt, sess in
-          viewModel?.sendPromptToActiveTerminal(forKey: sess.id, prompt: prompt) == true
-        },
-        viewModel: viewModel,
-        agentLocalhostURL: viewModel?.monitorStates[item.session.id]?.detectedLocalhostURL ?? item.agentLocalhostURL,
-        monitorState: viewModel?.monitorStates[item.session.id] ?? item.monitorState
-      )
-    }
-    .sheet(item: $mermaidSheetSession) { session in
-      MermaidDiagramView(
-        session: session,
-        onDismiss: { mermaidSheetSession = nil }
-      )
-    }
     .sheet(item: $simulatorSheetSession) { session in
       SimulatorPickerView(
         session: session,
@@ -375,22 +270,6 @@ public struct MonitoringCardView: View {
           guard let vm = viewModel else { return }
           vm.showTerminalWithPrompt(for: session, prompt: "Fix this build error:\n\(error)")
           simulatorSheetSession = nil
-        }
-      )
-    }
-    .modalPanel(
-      item: $gitHubSheetItem,
-      title: "GitHub",
-      autosaveName: "com.agenthub.panel.github"
-    ) { item in
-      GitHubPanelView(
-        projectPath: item.projectPath,
-        onDismiss: { gitHubSheetItem = nil },
-        isEmbedded: false,
-        session: item.session,
-        onSendToSession: { prompt, session in
-          viewModel?.showTerminalWithPrompt(for: session, prompt: prompt)
-          gitHubSheetItem = nil
         }
       )
     }
@@ -539,16 +418,7 @@ public struct MonitoringCardView: View {
   }
 
   private func presentWebPreview() {
-    if let onShowWebPreview {
-      onShowWebPreview(session, session.projectPath)
-    } else {
-      webPreviewSheetItem = WebPreviewSheetItem(
-        session: session,
-        projectPath: session.projectPath,
-        agentLocalhostURL: state?.detectedLocalhostURL,
-        monitorState: state
-      )
-    }
+    onShowWebPreview?(session, session.projectPath)
   }
 
   @MainActor
@@ -558,14 +428,7 @@ public struct MonitoringCardView: View {
   }
 
   private func presentGitHubPanel() {
-    if let onShowGitHub {
-      onShowGitHub(session, session.projectPath)
-    } else {
-      gitHubSheetItem = GitHubSheetItem(
-        session: session,
-        projectPath: session.projectPath
-      )
-    }
+    onShowGitHub?(session, session.projectPath)
   }
 
   // MARK: - Header
@@ -619,10 +482,7 @@ public struct MonitoringCardView: View {
         if let pendingToolUse = state?.pendingToolUse,
            pendingToolUse.isCodeChangeTool {
           Button(action: {
-            pendingChangesSheetItem = PendingChangesSheetItem(
-              session: session,
-              pendingToolUse: pendingToolUse
-            )
+            onShowPendingChanges?(session, pendingToolUse)
           }) {
             HStack(spacing: 4) {
               Image(systemName: "eye")
@@ -637,14 +497,7 @@ public struct MonitoringCardView: View {
         // Plan button
         if let planState = planState {
           Button(action: {
-            if let onShowPlan = onShowPlan {
-              onShowPlan(session, planState)
-            } else {
-              planSheetItem = PlanSheetItem(
-                session: session,
-                planState: planState
-              )
-            }
+            onShowPlan?(session, planState)
           }) {
             HStack(spacing: 4) {
               Image(systemName: "list.bullet.clipboard")
@@ -658,14 +511,7 @@ public struct MonitoringCardView: View {
 
         // Diff button
         Button(action: {
-          if let onShowDiff = onShowDiff {
-            onShowDiff(session, session.projectPath)
-          } else {
-            gitDiffSheetItem = GitDiffSheetItem(
-              session: session,
-              projectPath: session.projectPath
-            )
-          }
+          onShowDiff?(session, session.projectPath)
         }) {
           HStack(spacing: 4) {
             Image(systemName: "arrow.left.arrow.right")
@@ -698,11 +544,7 @@ public struct MonitoringCardView: View {
         // Mermaid diagram button (only visible when mermaid content is detected)
         if state?.hasMermaidContent == true {
           Button(action: {
-            if let onShowMermaid {
-              onShowMermaid(session)
-            } else {
-              mermaidSheetSession = session
-            }
+            onShowMermaid?(session)
           }) {
             HStack(spacing: 4) {
               Image(systemName: "chart.xyaxis.line")

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderMonitoringPanelView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderMonitoringPanelView.swift
@@ -18,6 +18,7 @@ private enum SidePanelContent: Equatable {
   case webPreview(sessionId: String, session: CLISession, projectPath: String)
   case mermaid(sessionId: String, session: CLISession)
   case gitHub(sessionId: String, session: CLISession, projectPath: String)
+  case edits(sessionId: String, session: CLISession, pendingToolUse: PendingToolUse)
 
   static func == (lhs: SidePanelContent, rhs: SidePanelContent) -> Bool {
     switch (lhs, rhs) {
@@ -31,6 +32,8 @@ private enum SidePanelContent: Equatable {
       return id1 == id2
     case (.gitHub(let id1, _, let p1), .gitHub(let id2, _, let p2)):
       return id1 == id2 && p1 == p2
+    case (.edits(let id1, _, let t1), .edits(let id2, _, let t2)):
+      return id1 == id2 && t1.toolUseId == t2.toolUseId
     default: return false
     }
   }
@@ -205,14 +208,6 @@ public struct MultiProviderMonitoringPanelView: View {
     get { LayoutMode(rawValue: layoutModeRawValue) ?? .single }
   }
 
-  private var canShowSidePanel: Bool {
-    availableDetailWidth >= minimumWidthForEmbeddedSidePanel
-  }
-
-  private var minimumWidthForEmbeddedSidePanel: CGFloat {
-    embeddedPrimaryContentMinWidth + embeddedSidePanelMinWidth + embeddedSidePanelHandleWidth
-  }
-
   private var allowedEmbeddedSidePanelWidth: CGFloat {
     let availablePanelWidth = availableDetailWidth - embeddedPrimaryContentMinWidth - embeddedSidePanelHandleWidth
     return min(
@@ -237,7 +232,6 @@ public struct MultiProviderMonitoringPanelView: View {
 
   private var isEmbeddedSidePanelVisible: Bool {
     wantsEmbeddedSidePanelPresentation
-      && canShowSidePanel
   }
 
   public init(
@@ -385,13 +379,6 @@ public struct MultiProviderMonitoringPanelView: View {
       guard let newId else { return }
       if let item = allItems.first(where: { $0.id == newId }) {
         item.viewModel.focusTerminal(forKey: item.sessionId)
-      }
-    }
-    .onChange(of: canShowSidePanel) { _, canShow in
-      if !canShow {
-        withAnimation(.easeInOut(duration: 0.25)) {
-          sidePanelContent = nil
-        }
       }
     }
   }
@@ -620,37 +607,39 @@ public struct MultiProviderMonitoringPanelView: View {
             onInlineRequestSubmit: { prompt, sess in
               viewModel.showTerminalWithPrompt(for: sess, prompt: prompt)
             },
-            onShowDiff: canShowSidePanel ? { session, projectPath in
-              if case .diff(let sid, _, _) = sidePanelContent, sid == session.id {
-                withAnimation(.easeInOut(duration: 0.25)) { sidePanelContent = nil }
-              } else {
-                sidePanelContent = .diff(sessionId: session.id, session: session, projectPath: projectPath)
-              }
-            } : nil,
-            onShowPlan: canShowSidePanel ? { session, planState in
-              if case .plan(let sid, _, _) = sidePanelContent, sid == session.id {
-                withAnimation(.easeInOut(duration: 0.25)) { sidePanelContent = nil }
-              } else {
-                sidePanelContent = .plan(sessionId: session.id, session: session, planState: planState)
-              }
-            } : nil,
+            onShowDiff: { session, projectPath in
+              toggleSidePanel(
+                .diff(sessionId: session.id, session: session, projectPath: projectPath),
+                forItemID: item.id
+              )
+            },
+            onShowPlan: { session, planState in
+              toggleSidePanel(
+                .plan(sessionId: session.id, session: session, planState: planState),
+                forItemID: item.id
+              )
+            },
             onShowWebPreview: { session, projectPath in
               presentWebPreviewInSidePanel(forItemID: item.id, session: session, projectPath: projectPath)
             },
-            onShowMermaid: canShowSidePanel ? { session in
-              if case .mermaid(let sid, _) = sidePanelContent, sid == session.id {
-                withAnimation(.easeInOut(duration: 0.25)) { sidePanelContent = nil }
-              } else {
-                sidePanelContent = .mermaid(sessionId: session.id, session: session)
-              }
-            } : nil,
-            onShowGitHub: canShowSidePanel ? { session, projectPath in
-              if case .gitHub(let sid, _, _) = sidePanelContent, sid == session.id {
-                withAnimation(.easeInOut(duration: 0.25)) { sidePanelContent = nil }
-              } else {
-                sidePanelContent = .gitHub(sessionId: session.id, session: session, projectPath: projectPath)
-              }
-            } : nil,
+            onShowMermaid: { session in
+              toggleSidePanel(
+                .mermaid(sessionId: session.id, session: session),
+                forItemID: item.id
+              )
+            },
+            onShowGitHub: { session, projectPath in
+              toggleSidePanel(
+                .gitHub(sessionId: session.id, session: session, projectPath: projectPath),
+                forItemID: item.id
+              )
+            },
+            onShowPendingChanges: { session, pendingToolUse in
+              toggleSidePanel(
+                .edits(sessionId: session.id, session: session, pendingToolUse: pendingToolUse),
+                forItemID: item.id
+              )
+            },
             onPromptConsumed: {
               viewModel.clearPendingPrompt(for: session.id)
             },
@@ -697,8 +686,15 @@ public struct MultiProviderMonitoringPanelView: View {
   }
 
   private func presentWebPreviewInSidePanel(forItemID itemID: String, session: CLISession, projectPath: String) {
-    // TODO: Standardize this with the other auxiliary panel flows once web preview
-    // selections can route context back into the main terminal across all layouts.
+    toggleSidePanel(
+      .webPreview(sessionId: session.id, session: session, projectPath: projectPath),
+      forItemID: itemID
+    )
+  }
+
+  /// Ensures the single-mode inline layout is active for `itemID`, then toggles the requested
+  /// side panel content (open if not already presenting it; close if re-selected).
+  private func toggleSidePanel(_ content: SidePanelContent, forItemID itemID: String) {
     withAnimation(.easeInOut(duration: 0.25)) {
       if primarySessionId != itemID {
         primarySessionId = itemID
@@ -710,14 +706,10 @@ public struct MultiProviderMonitoringPanelView: View {
         maximizedSessionId = nil
       }
     }
-    toggleWebPreviewSidePanel(for: session, projectPath: projectPath)
-  }
-
-  private func toggleWebPreviewSidePanel(for session: CLISession, projectPath: String) {
-    if case .webPreview(let sessionId, _, _) = sidePanelContent, sessionId == session.id {
+    if sidePanelContent == content {
       closeEmbeddedSidePanel()
     } else {
-      openEmbeddedSidePanel(.webPreview(sessionId: session.id, session: session, projectPath: projectPath))
+      openEmbeddedSidePanel(content)
     }
   }
 
@@ -791,6 +783,16 @@ public struct MultiProviderMonitoringPanelView: View {
         onPopOut: {
           withAnimation(.easeInOut(duration: 0.25)) { sidePanelContent = nil }
           gitHubPopOutItem = GitHubPopOutItem(session: session, projectPath: projectPath)
+        }
+      )
+    case .edits(_, let session, let pendingToolUse):
+      PendingChangesView(
+        session: session,
+        pendingToolUse: pendingToolUse,
+        onDismiss: { withAnimation(.easeInOut(duration: 0.25)) { sidePanelContent = nil } },
+        isEmbedded: true,
+        onApprovalResponse: { response, sess in
+          viewModel.showTerminalWithPrompt(for: sess, prompt: response)
         }
       )
     }
@@ -879,8 +881,38 @@ public struct MultiProviderMonitoringPanelView: View {
         onInlineRequestSubmit: { prompt, sess in
           viewModel.showTerminalWithPrompt(for: sess, prompt: prompt)
         },
+        onShowDiff: { session, projectPath in
+          toggleSidePanel(
+            .diff(sessionId: session.id, session: session, projectPath: projectPath),
+            forItemID: item.id
+          )
+        },
+        onShowPlan: { session, planState in
+          toggleSidePanel(
+            .plan(sessionId: session.id, session: session, planState: planState),
+            forItemID: item.id
+          )
+        },
         onShowWebPreview: { session, projectPath in
           presentWebPreviewInSidePanel(forItemID: item.id, session: session, projectPath: projectPath)
+        },
+        onShowMermaid: { session in
+          toggleSidePanel(
+            .mermaid(sessionId: session.id, session: session),
+            forItemID: item.id
+          )
+        },
+        onShowGitHub: { session, projectPath in
+          toggleSidePanel(
+            .gitHub(sessionId: session.id, session: session, projectPath: projectPath),
+            forItemID: item.id
+          )
+        },
+        onShowPendingChanges: { session, pendingToolUse in
+          toggleSidePanel(
+            .edits(sessionId: session.id, session: session, pendingToolUse: pendingToolUse),
+            forItemID: item.id
+          )
         },
         onPromptConsumed: {
           viewModel.clearPendingPrompt(for: session.id)
@@ -1039,8 +1071,38 @@ public struct MultiProviderMonitoringPanelView: View {
           onInlineRequestSubmit: { prompt, sess in
             viewModel.showTerminalWithPrompt(for: sess, prompt: prompt)
           },
+          onShowDiff: { session, projectPath in
+            toggleSidePanel(
+              .diff(sessionId: session.id, session: session, projectPath: projectPath),
+              forItemID: itemId
+            )
+          },
+          onShowPlan: { session, planState in
+            toggleSidePanel(
+              .plan(sessionId: session.id, session: session, planState: planState),
+              forItemID: itemId
+            )
+          },
           onShowWebPreview: { session, projectPath in
             presentWebPreviewInSidePanel(forItemID: itemId, session: session, projectPath: projectPath)
+          },
+          onShowMermaid: { session in
+            toggleSidePanel(
+              .mermaid(sessionId: session.id, session: session),
+              forItemID: itemId
+            )
+          },
+          onShowGitHub: { session, projectPath in
+            toggleSidePanel(
+              .gitHub(sessionId: session.id, session: session, projectPath: projectPath),
+              forItemID: itemId
+            )
+          },
+          onShowPendingChanges: { session, pendingToolUse in
+            toggleSidePanel(
+              .edits(sessionId: session.id, session: session, pendingToolUse: pendingToolUse),
+              forItemID: itemId
+            )
           },
           onPromptConsumed: {
             viewModel.clearPendingPrompt(for: session.id)

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/PendingChangesView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/PendingChangesView.swift
@@ -16,6 +16,7 @@ public struct PendingChangesView: View {
   let session: CLISession
   let pendingToolUse: PendingToolUse
   let onDismiss: () -> Void
+  var isEmbedded: Bool = false
   let onApprovalResponse: ((String, CLISession) -> Void)?
 
   @State private var previewResult: PendingChangesPreviewService.PreviewResult?
@@ -48,11 +49,13 @@ public struct PendingChangesView: View {
     session: CLISession,
     pendingToolUse: PendingToolUse,
     onDismiss: @escaping () -> Void,
+    isEmbedded: Bool = false,
     onApprovalResponse: ((String, CLISession) -> Void)? = nil
   ) {
     self.session = session
     self.pendingToolUse = pendingToolUse
     self.onDismiss = onDismiss
+    self.isEmbedded = isEmbedded
     self.onApprovalResponse = onApprovalResponse
   }
 
@@ -64,8 +67,10 @@ public struct PendingChangesView: View {
       Divider()
       actionBar
     }
-    .frame(minWidth: 1000, idealWidth: 1200, maxWidth: .infinity,
-           minHeight: 600, idealHeight: 800, maxHeight: .infinity)
+    .frame(
+      minWidth: isEmbedded ? 300 : 1000, idealWidth: isEmbedded ? .infinity : 1200, maxWidth: .infinity,
+      minHeight: isEmbedded ? 300 : 600, idealHeight: isEmbedded ? .infinity : 800, maxHeight: .infinity
+    )
     .task {
       await loadPreview()
     }


### PR DESCRIPTION
## Summary
- Remove the size-based sheet fallback for Diff, Plan, WebPreview, Mermaid, GitHub, and the new Edits (pending changes) panel.
- Clicking any panel button from List, 2-Column, or a maximized card now auto-switches to Single layout and opens the resizable inline side panel — matching the existing Web Preview flow.
- Add `isEmbedded` support to `PendingChangesView`; collapse redundant sheet state in `MonitoringCardView`.

## Test plan
- [ ] Single layout, wide window: Diff / Plan / GitHub / Mermaid / Web Preview / Edits each open as an inline right-side panel and toggle closed on re-click.
- [ ] Single layout, narrow window (<878pt): panels still open inline; primary content squeezes, no sheet.
- [ ] List & 2-Column layouts: clicking any panel button auto-switches to Single and opens the inline panel.
- [ ] Maximized card: panel buttons restore to Single and show the inline panel.
- [ ] Edits approval flow: Accept / Reject still route through `onApprovalResponse`.
- [ ] GitHub pop-out from the inline panel still opens a separate window.