### PR TITLE
Detect pending Claude Code approvals via a PreToolUse hook

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,16 @@ protocol SessionSearchServiceProtocol {
 - If an agent-provided localhost preview fails to load, fall back to static HTML in this order: root `index.html`, then other discovered HTML files
 - Changes to web preview precedence or fallback behavior must include unit tests
 
+## Claude Code Approval Hook Invariants
+
+AgentHub installs a `PreToolUse` hook to surface pending approvals in real time (see `CLAUDE.md` → "Approval Detection"). When modifying `ClaudeHookInstaller`, `ClaudeHookSidecarWatcher`, `ApprovalClaimStore`, or `HookPendingStalenessFilter`, these invariants must hold:
+
+- The **only** file written inside a user's repo is `{project}/.claude/settings.local.json`. Never create files under `.claude/hooks/`, never touch `.claude/settings.json`, never modify `.gitignore`.
+- Merge must preserve every unrelated key and every non-AgentHub hook entry. Our entry is identified by the absolute path to the shared script.
+- The hook script stays claim-gated so external Terminal sessions in tracked worktrees remain silent no-ops.
+- Install is driven by the repositories subscription, not per-session — Claude Code reads `settings.local.json` once at session start.
+- Launch reconcile and terminate flush must run synchronously (blocking `applicationDidFinishLaunching` / `applicationWillTerminate` via semaphore) so AppKit can't kill cleanup mid-flight.
+
 ## SwiftUI View Guidelines
 
 - Views must be **small, focused, and composable** — one responsibility per view

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -249,7 +249,21 @@ xcodebuild -workspace app/AgentHub.xcodeproj/project.xcworkspace -scheme AgentHu
 - Codex sessions: `~/.codex/sessions/{date-path}/`
 - Codex history: `~/.codex/history.jsonl`
 - Custom themes: `~/Library/Application Support/AgentHub/Themes/`
+- Approval hook script: `~/Library/Application Support/AgentHub/hooks/agenthub-approval.sh`
+- Approval sidecars: `~/Library/Application Support/AgentHub/approvals/{sessionId}.jsonl`
+- Session claims: `~/Library/Application Support/AgentHub/claims/{sessionId}`
 - Session metadata DB: managed by `SessionMetadataStore` via GRDB
+
+## Approval Detection (Claude only)
+
+Claude Code buffers `tool_use` blocks until the turn commits, so JSONL alone can't surface pending approvals during the prompt. A `PreToolUse` hook writes to a sidecar directory we watch; JSONL stays primary and the hook fills the gap. Codex has no equivalent mechanism — `CodexSessionFileWatcher` hardcodes `pendingToolUse: nil`.
+
+- `ClaudeHookInstaller` — writes our hook entry into `{project}/.claude/settings.local.json`. Driven by the repositories subscription (Claude Code reads settings once at session start). Preserves every other key and every non-AgentHub hook entry.
+- `ClaudeHookSidecarWatcher` — per-session kqueue watcher over `approvals/`, merges into `ParseResult.pendingToolUses` at `buildMonitorState`.
+- `ApprovalClaimStore` — claim markers gate the script so external Terminal sessions in tracked worktrees are silent no-ops.
+- `HookPendingStalenessFilter` — drops hook entries that JSONL has already moved past (100ms epsilon).
+
+**Invariants when editing this area:** only `.claude/settings.local.json` is ever written inside a user's repo (never `.claude/hooks/`, never `.gitignore`); our merge identifies its own entry by the absolute script path; launch reconcile and terminate flush both block on a semaphore so AppKit can't kill cleanup mid-flight.
 
 ## Important Patterns
 

--- a/README.md
+++ b/README.md
@@ -235,6 +235,16 @@ AgentHub maps Codex defaults to the current interactive CLI flags:
 
 These mappings are verified in unit tests against the current CLI surface exposed by `codex --help` and `claude --help`.
 
+### Claude Code approval hook
+
+AgentHub detects pending `Edit` / `Write` / `MultiEdit` / `Bash` / etc. approvals in real time by installing a small **Claude Code PreToolUse hook**. Without it, Claude Code's CLI only writes the pending `tool_use` block to disk after the turn commits — which means AgentHub can't surface an "Awaiting Approval" state (or preview a pending diff) until *after* you've answered the prompt. Enabling the hook is what makes the `eye` / Edits button and the `awaitingApproval` sidebar status appear *during* the approval window.
+
+**What gets written to your repo.** Exactly one key inside **`{project}/.claude/settings.local.json`**, which Claude Code treats as personal/gitignored by default. We never touch `.claude/settings.json` (the shared, checked-in file), never add files under `.claude/hooks/`, and never modify your `.gitignore`. The hook script itself lives outside your repo at `~/Library/Application Support/AgentHub/hooks/agenthub-approval.sh`.
+
+**What we promise to preserve.** Every other key in `settings.local.json` — `permissions`, `env`, `mcpServers`, and any hook entries you or other tools have added — stays byte-for-byte. Our entry is identified by the absolute path of the installed script, so uninstall removes only that entry and leaves everything else alone.
+
+**Lifecycle.** Hooks install per worktree when a repo is added to AgentHub, stay installed while the repo is tracked, and are removed when you remove the repo, toggle the feature off in **Settings → General → Enable approval hooks**, or quit the app. External Claude Code sessions in the same worktree (e.g. started from Terminal.app) run the hook but it exits silently — a small ~50ms claim-file check makes sure AgentHub only observes sessions it's actively tracking.
+
 ### Session Data
 
 AgentHub reads Claude Code session data from:

--- a/app/AgentHub/AgentHubApp.swift
+++ b/app/AgentHub/AgentHubApp.swift
@@ -24,6 +24,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
   func applicationDidFinishLaunching(_ notification: Notification) {
     UNUserNotificationCenter.current().delegate = self
     registerBundledFonts()
+    // Sweep any approval hooks left installed by a previous crash/force-quit
+    // before sessions start restoring. Re-installs happen naturally as each
+    // session begins monitoring.
+    provider.reconcileClaudeHooksOnLaunch()
   }
 
   /// Register all bundled fonts (Geist, GeistMono, JetBrains Mono)
@@ -56,6 +60,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
     provider.terminateAllTerminals()
     // Stop all dev servers spawned for web preview
     DevServerManager.shared.stopAllServers()
+    // Remove every approval hook we installed and clear claims so external
+    // Claude Code sessions after quit run vanilla.
+    provider.flushClaudeHooksOnTerminate()
   }
 
   // MARK: - UNUserNotificationCenterDelegate

--- a/app/AgentHubTests/ApprovalClaimStoreTests.swift
+++ b/app/AgentHubTests/ApprovalClaimStoreTests.swift
@@ -1,0 +1,59 @@
+import Foundation
+import Testing
+@testable import AgentHubCore
+
+@Suite("ApprovalClaimStore")
+struct ApprovalClaimStoreTests {
+
+  private func makeStore() -> (ApprovalClaimStore, URL) {
+    let base = FileManager.default.temporaryDirectory
+      .appendingPathComponent("agenthub-claims-\(UUID().uuidString)", isDirectory: true)
+    let store = ApprovalClaimStore(claimsDirectory: base)
+    return (store, base)
+  }
+
+  @Test("claim creates a marker file")
+  func claimCreatesMarker() async {
+    let (store, dir) = makeStore()
+    defer { try? FileManager.default.removeItem(at: dir) }
+
+    await store.claim(sessionId: "abc")
+    let url = dir.appendingPathComponent("abc")
+    #expect(FileManager.default.fileExists(atPath: url.path))
+  }
+
+  @Test("release removes the marker file")
+  func releaseRemovesMarker() async {
+    let (store, dir) = makeStore()
+    defer { try? FileManager.default.removeItem(at: dir) }
+
+    await store.claim(sessionId: "abc")
+    await store.release(sessionId: "abc")
+    let url = dir.appendingPathComponent("abc")
+    #expect(!FileManager.default.fileExists(atPath: url.path))
+  }
+
+  @Test("resetAll wipes the directory then recreates it empty")
+  func resetAllWipes() async {
+    let (store, dir) = makeStore()
+    defer { try? FileManager.default.removeItem(at: dir) }
+
+    await store.claim(sessionId: "a")
+    await store.claim(sessionId: "b")
+    await store.resetAll()
+
+    let contents = (try? FileManager.default.contentsOfDirectory(atPath: dir.path)) ?? []
+    #expect(contents.isEmpty)
+    #expect(FileManager.default.fileExists(atPath: dir.path))
+  }
+
+  @Test("claim on empty session id is a no-op")
+  func emptySessionIdIsNoop() async {
+    let (store, dir) = makeStore()
+    defer { try? FileManager.default.removeItem(at: dir) }
+
+    await store.claim(sessionId: "")
+    let contents = (try? FileManager.default.contentsOfDirectory(atPath: dir.path)) ?? []
+    #expect(contents.isEmpty)
+  }
+}

--- a/app/AgentHubTests/ClaudeHookInstallerTests.swift
+++ b/app/AgentHubTests/ClaudeHookInstallerTests.swift
@@ -1,0 +1,258 @@
+import Foundation
+import Testing
+@testable import AgentHubCore
+
+@Suite("ClaudeHookInstaller")
+struct ClaudeHookInstallerTests {
+
+  // MARK: - Fixture
+
+  private final class Fixture {
+    let base: URL
+    let projectA: URL
+    let projectB: URL
+    let bundledScriptURL: URL
+    let sharedScriptURL: URL
+    let defaults: UserDefaults
+    let installer: ClaudeHookInstaller
+    let suiteName: String
+
+    init(name: String) throws {
+      self.base = FileManager.default.temporaryDirectory
+        .appendingPathComponent("agenthub-installer-\(UUID().uuidString)", isDirectory: true)
+      try FileManager.default.createDirectory(at: base, withIntermediateDirectories: true)
+
+      self.projectA = base.appendingPathComponent("projA", isDirectory: true)
+      self.projectB = base.appendingPathComponent("projB", isDirectory: true)
+      try FileManager.default.createDirectory(at: projectA, withIntermediateDirectories: true)
+      try FileManager.default.createDirectory(at: projectB, withIntermediateDirectories: true)
+
+      self.bundledScriptURL = base.appendingPathComponent("bundled-agenthub-approval.sh")
+      try "#!/bin/bash\nexit 0\n".write(to: bundledScriptURL, atomically: true, encoding: .utf8)
+
+      self.sharedScriptURL = base.appendingPathComponent("shared/hooks/agenthub-approval.sh")
+
+      self.suiteName = "ClaudeHookInstallerTests.\(name).\(UUID().uuidString)"
+      guard let defaults = UserDefaults(suiteName: suiteName) else {
+        throw NSError(domain: "fixture", code: 1)
+      }
+      self.defaults = defaults
+
+      self.installer = ClaudeHookInstaller(
+        fileManager: .default,
+        defaults: defaults,
+        bundledScriptURL: bundledScriptURL,
+        sharedScriptURL: sharedScriptURL
+      )
+    }
+
+    func teardown() {
+      try? FileManager.default.removeItem(at: base)
+      defaults.removePersistentDomain(forName: suiteName)
+    }
+
+    func settingsLocal(for project: URL) -> URL {
+      ClaudeHookPaths.settingsLocalURL(inProjectAt: project.path)
+    }
+
+    func projectHooksDir(for project: URL) -> URL {
+      project.appendingPathComponent(".claude", isDirectory: true)
+        .appendingPathComponent("hooks", isDirectory: true)
+    }
+
+    func readSettings(at url: URL) throws -> [String: Any] {
+      let data = try Data(contentsOf: url)
+      return (try JSONSerialization.jsonObject(with: data) as? [String: Any]) ?? [:]
+    }
+
+    func preEntries(in settings: [String: Any]) -> [[String: Any]] {
+      let hooks = settings["hooks"] as? [String: Any] ?? [:]
+      return (hooks["PreToolUse"] as? [[String: Any]]) ?? []
+    }
+
+    func hasAgentHubEntry(in entries: [[String: Any]], scriptPath: String) -> Bool {
+      entries.contains { entry in
+        let inner = entry["hooks"] as? [[String: Any]] ?? []
+        return inner.contains { ($0["command"] as? String) == scriptPath }
+      }
+    }
+  }
+
+  // MARK: - Tests
+
+  @Test("sync installs shared script and settings entry pointing at it")
+  func syncInstallsSharedScriptAndSettings() async throws {
+    let fx = try Fixture(name: "syncInstalls")
+    defer { fx.teardown() }
+
+    await fx.installer.syncInstalledPaths([fx.projectA.path])
+
+    #expect(FileManager.default.fileExists(atPath: fx.sharedScriptURL.path))
+
+    let settings = try fx.readSettings(at: fx.settingsLocal(for: fx.projectA))
+    let entries = fx.preEntries(in: settings)
+    #expect(fx.hasAgentHubEntry(in: entries, scriptPath: fx.sharedScriptURL.path))
+  }
+
+  @Test("sync never writes into {project}/.claude/hooks/")
+  func syncNeverWritesInProjectHooks() async throws {
+    let fx = try Fixture(name: "noProjectHooks")
+    defer { fx.teardown() }
+
+    await fx.installer.syncInstalledPaths([fx.projectA.path])
+
+    #expect(!FileManager.default.fileExists(atPath: fx.projectHooksDir(for: fx.projectA).path))
+  }
+
+  @Test("sync preserves unrelated keys in settings.local.json")
+  func preservesExistingKeys() async throws {
+    let fx = try Fixture(name: "preservesKeys")
+    defer { fx.teardown() }
+
+    let existing: [String: Any] = [
+      "permissions": ["allow": ["bash"]],
+      "env": ["FOO": "bar"],
+      "hooks": [
+        "PreToolUse": [
+          ["matcher": "Bash", "hooks": [["type": "command", "command": "/user/other.sh"]]]
+        ]
+      ],
+    ]
+    try FileManager.default.createDirectory(
+      at: fx.settingsLocal(for: fx.projectA).deletingLastPathComponent(),
+      withIntermediateDirectories: true
+    )
+    try JSONSerialization.data(withJSONObject: existing).write(to: fx.settingsLocal(for: fx.projectA))
+
+    await fx.installer.syncInstalledPaths([fx.projectA.path])
+
+    let updated = try fx.readSettings(at: fx.settingsLocal(for: fx.projectA))
+    #expect(updated["env"] as? [String: String] == ["FOO": "bar"])
+    #expect((updated["permissions"] as? [String: Any])?["allow"] as? [String] == ["bash"])
+    let entries = fx.preEntries(in: updated)
+    let userEntry = entries.first { entry in
+      let inner = entry["hooks"] as? [[String: Any]] ?? []
+      return inner.contains { ($0["command"] as? String) == "/user/other.sh" }
+    }
+    #expect(userEntry != nil)
+    #expect(fx.hasAgentHubEntry(in: entries, scriptPath: fx.sharedScriptURL.path))
+  }
+
+  @Test("sync is idempotent — same input twice produces no duplicate entries")
+  func idempotent() async throws {
+    let fx = try Fixture(name: "idempotent")
+    defer { fx.teardown() }
+
+    await fx.installer.syncInstalledPaths([fx.projectA.path])
+    await fx.installer.syncInstalledPaths([fx.projectA.path])
+
+    let settings = try fx.readSettings(at: fx.settingsLocal(for: fx.projectA))
+    let entries = fx.preEntries(in: settings)
+    let matches = entries.filter { entry in
+      let inner = entry["hooks"] as? [[String: Any]] ?? []
+      return inner.contains { ($0["command"] as? String) == fx.sharedScriptURL.path }
+    }
+    #expect(matches.count == 1)
+  }
+
+  @Test("sync removes entries from paths that dropped out of the set")
+  func syncRemovesDroppedPaths() async throws {
+    let fx = try Fixture(name: "removesDropped")
+    defer { fx.teardown() }
+
+    await fx.installer.syncInstalledPaths([fx.projectA.path, fx.projectB.path])
+    #expect(FileManager.default.fileExists(atPath: fx.settingsLocal(for: fx.projectA).path))
+    #expect(FileManager.default.fileExists(atPath: fx.settingsLocal(for: fx.projectB).path))
+
+    await fx.installer.syncInstalledPaths([fx.projectA.path])
+
+    let a = try fx.readSettings(at: fx.settingsLocal(for: fx.projectA))
+    #expect(fx.hasAgentHubEntry(in: fx.preEntries(in: a), scriptPath: fx.sharedScriptURL.path))
+
+    let bURL = fx.settingsLocal(for: fx.projectB)
+    if FileManager.default.fileExists(atPath: bURL.path) {
+      let b = try fx.readSettings(at: bURL)
+      #expect(!fx.hasAgentHubEntry(in: fx.preEntries(in: b), scriptPath: fx.sharedScriptURL.path))
+    }
+  }
+
+  @Test("uninstall preserves unrelated user hooks")
+  func uninstallPreservesOthers() async throws {
+    let fx = try Fixture(name: "uninstallPreserves")
+    defer { fx.teardown() }
+
+    let existing: [String: Any] = [
+      "env": ["HELLO": "world"],
+      "hooks": [
+        "PreToolUse": [
+          ["matcher": "Bash", "hooks": [["type": "command", "command": "/user/other.sh"]]]
+        ]
+      ],
+    ]
+    try FileManager.default.createDirectory(
+      at: fx.settingsLocal(for: fx.projectA).deletingLastPathComponent(),
+      withIntermediateDirectories: true
+    )
+    try JSONSerialization.data(withJSONObject: existing).write(to: fx.settingsLocal(for: fx.projectA))
+
+    await fx.installer.syncInstalledPaths([fx.projectA.path])
+    await fx.installer.syncInstalledPaths([])
+
+    let after = try fx.readSettings(at: fx.settingsLocal(for: fx.projectA))
+    #expect(after["env"] as? [String: String] == ["HELLO": "world"])
+    let entries = fx.preEntries(in: after)
+    #expect(entries.count == 1)
+    let inner = entries.first?["hooks"] as? [[String: Any]] ?? []
+    #expect(inner.first?["command"] as? String == "/user/other.sh")
+  }
+
+  @Test("flushAll removes every installed entry")
+  func flushAll() async throws {
+    let fx = try Fixture(name: "flushAll")
+    defer { fx.teardown() }
+
+    await fx.installer.syncInstalledPaths([fx.projectA.path, fx.projectB.path])
+    await fx.installer.flushAll()
+
+    for project in [fx.projectA, fx.projectB] {
+      let url = fx.settingsLocal(for: project)
+      if FileManager.default.fileExists(atPath: url.path) {
+        let settings = try fx.readSettings(at: url)
+        #expect(!fx.hasAgentHubEntry(in: fx.preEntries(in: settings), scriptPath: fx.sharedScriptURL.path))
+      }
+    }
+  }
+
+  @Test("reconcileOnLaunch uninstalls previously-installed paths not in expected")
+  func reconcileSweepsOrphans() async throws {
+    let fx = try Fixture(name: "reconcileOrphans")
+    defer { fx.teardown() }
+
+    await fx.installer.syncInstalledPaths([fx.projectA.path])
+    #expect(FileManager.default.fileExists(atPath: fx.settingsLocal(for: fx.projectA).path))
+
+    await fx.installer.reconcileOnLaunch(expectedPaths: [])
+
+    let url = fx.settingsLocal(for: fx.projectA)
+    if FileManager.default.fileExists(atPath: url.path) {
+      let settings = try fx.readSettings(at: url)
+      #expect(!fx.hasAgentHubEntry(in: fx.preEntries(in: settings), scriptPath: fx.sharedScriptURL.path))
+    }
+  }
+
+  @Test("disabled installer sweeps and installs nothing")
+  func disabledIsNoop() async throws {
+    let fx = try Fixture(name: "disabled")
+    defer { fx.teardown() }
+
+    await fx.installer.syncInstalledPaths([fx.projectA.path])
+    await fx.installer.setEnabled(false)
+    await fx.installer.syncInstalledPaths([fx.projectA.path])
+
+    let url = fx.settingsLocal(for: fx.projectA)
+    if FileManager.default.fileExists(atPath: url.path) {
+      let settings = try fx.readSettings(at: url)
+      #expect(!fx.hasAgentHubEntry(in: fx.preEntries(in: settings), scriptPath: fx.sharedScriptURL.path))
+    }
+  }
+}

--- a/app/AgentHubTests/ClaudeHookSidecarWatcherTests.swift
+++ b/app/AgentHubTests/ClaudeHookSidecarWatcherTests.swift
@@ -104,20 +104,37 @@ struct ClaudeHookSidecarWatcherTests {
     #expect(info == nil)
   }
 
-  @Test("stopWatching deletes the session's sidecar file")
-  func stopWatchingDeletesSidecar() async throws {
+  @Test("stopWatching preserves the sidecar so a resumed watch recovers pending state")
+  func stopWatchingPreservesSidecar() async throws {
     let (watcher, dir) = makeWatcher()
     defer { try? FileManager.default.removeItem(at: dir) }
 
     let sid = "sess-stop"
     let file = dir.appendingPathComponent("\(sid).jsonl")
-    FileManager.default.createFile(atPath: file.path, contents: nil)
 
+    // Seed a pending event, as if the hook wrote one before the user toggled
+    // monitoring off.
+    let pending: [String: Any] = [
+      "event": "pending", "toolName": "Edit",
+      "toolUseId": "tu-resume", "timestamp": "2026-04-23T00:00:00Z",
+      "input": ["file_path": "/tmp/x.swift", "old_string": "a", "new_string": "b"],
+    ]
+    var data = try JSONSerialization.data(withJSONObject: pending)
+    data.append(0x0A)
+    try data.write(to: file)
+
+    // First watch reads the pending entry.
     await watcher.startWatching(sessionId: sid)
+    #expect(await watcher.pendingInfo(for: sid)?.toolUseId == "tu-resume")
+
+    // User toggles monitoring off. Sidecar file must survive.
+    await watcher.stopWatching(sessionId: sid)
     #expect(FileManager.default.fileExists(atPath: file.path))
 
-    await watcher.stopWatching(sessionId: sid)
-    #expect(!FileManager.default.fileExists(atPath: file.path))
+    // User toggles monitoring back on while the tool is still pending.
+    // The resumed watch must recover the pending state.
+    await watcher.startWatching(sessionId: sid)
+    #expect(await watcher.pendingInfo(for: sid)?.toolUseId == "tu-resume")
   }
 
   @Test("publisher emits SidecarUpdate when a new pending line is appended")

--- a/app/AgentHubTests/ClaudeHookSidecarWatcherTests.swift
+++ b/app/AgentHubTests/ClaudeHookSidecarWatcherTests.swift
@@ -1,0 +1,129 @@
+import Combine
+import Foundation
+import Testing
+@testable import AgentHubCore
+
+@Suite("ClaudeHookSidecarWatcher")
+struct ClaudeHookSidecarWatcherTests {
+
+  private func makeWatcher() -> (ClaudeHookSidecarWatcher, URL) {
+    let dir = FileManager.default.temporaryDirectory
+      .appendingPathComponent("agenthub-sidecar-\(UUID().uuidString)", isDirectory: true)
+    try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    let watcher = ClaudeHookSidecarWatcher(approvalsDirectory: dir)
+    return (watcher, dir)
+  }
+
+  @Test("startWatching picks up pre-existing pending entry")
+  func seedsFromExistingFile() async throws {
+    let (watcher, dir) = makeWatcher()
+    defer { try? FileManager.default.removeItem(at: dir) }
+
+    let sid = "sess-1"
+    let file = dir.appendingPathComponent("\(sid).jsonl")
+    let line: [String: Any] = [
+      "event": "pending",
+      "toolName": "Edit",
+      "toolUseId": "tu-1",
+      "timestamp": "2026-04-23T00:00:00Z",
+      "input": [
+        "file_path": "/tmp/x.swift",
+        "old_string": "a",
+        "new_string": "b",
+      ]
+    ]
+    let data = try JSONSerialization.data(withJSONObject: line, options: [])
+    var jsonl = data
+    jsonl.append(0x0A) // newline
+    try jsonl.write(to: file)
+
+    await watcher.startWatching(sessionId: sid)
+
+    let info = await watcher.pendingInfo(for: sid)
+    #expect(info?.toolName == "Edit")
+    #expect(info?.toolUseId == "tu-1")
+    #expect(info?.codeChangeInput?.filePath == "/tmp/x.swift")
+    #expect(info?.codeChangeInput?.oldString == "a")
+    #expect(info?.codeChangeInput?.newString == "b")
+  }
+
+  @Test("resolved event clears the pending entry")
+  func resolvedClears() async throws {
+    let (watcher, dir) = makeWatcher()
+    defer { try? FileManager.default.removeItem(at: dir) }
+
+    let sid = "sess-2"
+    let file = dir.appendingPathComponent("\(sid).jsonl")
+
+    let pending: [String: Any] = [
+      "event": "pending", "toolName": "Bash",
+      "toolUseId": "tu-2", "timestamp": "2026-04-23T00:00:00Z",
+      "input": ["command": "ls"]
+    ]
+    let resolved: [String: Any] = [
+      "event": "resolved", "toolName": "Bash",
+      "toolUseId": "tu-2", "timestamp": "2026-04-23T00:00:01Z",
+      "input": [:]
+    ]
+    var data = Data()
+    data.append(try JSONSerialization.data(withJSONObject: pending))
+    data.append(0x0A)
+    data.append(try JSONSerialization.data(withJSONObject: resolved))
+    data.append(0x0A)
+    try data.write(to: file)
+
+    await watcher.startWatching(sessionId: sid)
+
+    let info = await watcher.pendingInfo(for: sid)
+    #expect(info == nil)
+  }
+
+  @Test("publisher emits SidecarUpdate when a new pending line is appended")
+  func publishesOnAppend() async throws {
+    let (watcher, dir) = makeWatcher()
+    defer { try? FileManager.default.removeItem(at: dir) }
+
+    let sid = "sess-3"
+    let file = dir.appendingPathComponent("\(sid).jsonl")
+    // Create an empty file so the per-file watcher attaches on startWatching.
+    FileManager.default.createFile(atPath: file.path, contents: nil)
+
+    await watcher.startWatching(sessionId: sid)
+
+    // Subscribe.
+    final class Collector: @unchecked Sendable {
+      var updates: [SidecarUpdate] = []
+    }
+    let collector = Collector()
+    let cancellable = watcher.updates.sink { update in
+      collector.updates.append(update)
+    }
+    defer { cancellable.cancel() }
+
+    let line: [String: Any] = [
+      "event": "pending", "toolName": "MultiEdit",
+      "toolUseId": "tu-3", "timestamp": "2026-04-23T00:00:00Z",
+      "input": [
+        "file_path": "/tmp/y.swift",
+        "edits": [
+          ["old_string": "foo", "new_string": "bar"],
+        ]
+      ]
+    ]
+    var data = try JSONSerialization.data(withJSONObject: line)
+    data.append(0x0A)
+    // Append to the file.
+    let handle = try FileHandle(forWritingTo: file)
+    try handle.seekToEnd()
+    try handle.write(contentsOf: data)
+    try handle.close()
+
+    // Give the DispatchSource a moment to fire.
+    try await Task.sleep(for: .milliseconds(300))
+
+    #expect(!collector.updates.isEmpty)
+    let update = collector.updates.last
+    #expect(update?.sessionId == sid)
+    #expect(update?.info?.toolName == "MultiEdit")
+  }
+}

--- a/app/AgentHubTests/ClaudeHookSidecarWatcherTests.swift
+++ b/app/AgentHubTests/ClaudeHookSidecarWatcherTests.swift
@@ -78,6 +78,48 @@ struct ClaudeHookSidecarWatcherTests {
     #expect(info == nil)
   }
 
+  @Test("wipeAll drops sidecar files so stale pending lines can't be replayed")
+  func wipeAllDropsStaleFiles() async throws {
+    let (watcher, dir) = makeWatcher()
+    defer { try? FileManager.default.removeItem(at: dir) }
+
+    let sid = "sess-stale"
+    let file = dir.appendingPathComponent("\(sid).jsonl")
+    let stale: [String: Any] = [
+      "event": "pending", "toolName": "Edit",
+      "toolUseId": "tu-stale", "timestamp": "2026-04-23T00:00:00Z",
+      "input": ["file_path": "/tmp/x.swift", "old_string": "a", "new_string": "b"],
+    ]
+    var data = try JSONSerialization.data(withJSONObject: stale)
+    data.append(0x0A)
+    try data.write(to: file)
+
+    await watcher.wipeAll()
+
+    #expect(!FileManager.default.fileExists(atPath: file.path))
+
+    // A fresh watch of the same sessionId must not surface the old pending.
+    await watcher.startWatching(sessionId: sid)
+    let info = await watcher.pendingInfo(for: sid)
+    #expect(info == nil)
+  }
+
+  @Test("stopWatching deletes the session's sidecar file")
+  func stopWatchingDeletesSidecar() async throws {
+    let (watcher, dir) = makeWatcher()
+    defer { try? FileManager.default.removeItem(at: dir) }
+
+    let sid = "sess-stop"
+    let file = dir.appendingPathComponent("\(sid).jsonl")
+    FileManager.default.createFile(atPath: file.path, contents: nil)
+
+    await watcher.startWatching(sessionId: sid)
+    #expect(FileManager.default.fileExists(atPath: file.path))
+
+    await watcher.stopWatching(sessionId: sid)
+    #expect(!FileManager.default.fileExists(atPath: file.path))
+  }
+
   @Test("publisher emits SidecarUpdate when a new pending line is appended")
   func publishesOnAppend() async throws {
     let (watcher, dir) = makeWatcher()

--- a/app/AgentHubTests/HookPendingStalenessFilterTests.swift
+++ b/app/AgentHubTests/HookPendingStalenessFilterTests.swift
@@ -56,21 +56,36 @@ struct HookPendingStalenessFilterTests {
     #expect(result == nil)
   }
 
-  @Test("preserves hook pending when JSONL activity is within the epsilon window")
-  func sameSecondClockSkewStillLive() {
-    // Legacy whole-second hook timestamp truncates to 10:30:45.000Z while
-    // JSONL's millisecond-precision lastActivityAt is 10:30:45.400Z. Without
-    // the epsilon this would incorrectly drop a live pending.
+  @Test("preserves hook pending within cross-process clock skew")
+  func smallClockSkewPreserved() {
+    // Cross-process skew between the Python hook and Claude's Node process
+    // is typically in the low-ms range. 50ms is safely inside the epsilon;
+    // a live pending must not be dropped for that.
     let decisionTime = Date()
     let pending = makePending(at: decisionTime)
     let result = HookPendingStalenessFilter.filter(
       hookPending: pending,
-      lastActivityAt: decisionTime.addingTimeInterval(0.4)
+      lastActivityAt: decisionTime.addingTimeInterval(0.05)
     )
     #expect(result?.toolUseId == "tu-1")
   }
 
-  @Test("drops hook pending once JSONL has advanced past the epsilon window")
+  @Test("drops hook pending for fast-turn resolution just past the epsilon")
+  func fastTurnResolutionIsDetected() {
+    // A user can approve and a tool can commit inside a few hundred ms.
+    // Once JSONL activity has advanced beyond the epsilon, the sidecar's
+    // pending must be treated as stale — this is exactly the "fast Bash
+    // turn leaves the UI stuck on pending" case.
+    let decisionTime = Date()
+    let pending = makePending(at: decisionTime)
+    let result = HookPendingStalenessFilter.filter(
+      hookPending: pending,
+      lastActivityAt: decisionTime.addingTimeInterval(0.3)
+    )
+    #expect(result == nil)
+  }
+
+  @Test("drops hook pending when JSONL is seconds past the hook decision")
   func beyondEpsilonIsStale() {
     let decisionTime = Date()
     let pending = makePending(at: decisionTime)

--- a/app/AgentHubTests/HookPendingStalenessFilterTests.swift
+++ b/app/AgentHubTests/HookPendingStalenessFilterTests.swift
@@ -1,0 +1,58 @@
+import Foundation
+import Testing
+@testable import AgentHubCore
+
+@Suite("HookPendingStalenessFilter")
+struct HookPendingStalenessFilterTests {
+
+  private func makePending(at date: Date) -> SessionJSONLParser.PendingToolInfo {
+    SessionJSONLParser.PendingToolInfo(
+      toolName: "Edit",
+      toolUseId: "tu-1",
+      timestamp: date,
+      input: nil,
+      codeChangeInput: nil
+    )
+  }
+
+  @Test("nil hook pending passes through")
+  func nilHookPending() {
+    let result = HookPendingStalenessFilter.filter(
+      hookPending: nil,
+      lastActivityAt: Date()
+    )
+    #expect(result == nil)
+  }
+
+  @Test("surfaces hook pending when no JSONL activity has been seen")
+  func noActivity() {
+    let pending = makePending(at: Date())
+    let result = HookPendingStalenessFilter.filter(
+      hookPending: pending,
+      lastActivityAt: nil
+    )
+    #expect(result?.toolUseId == "tu-1")
+  }
+
+  @Test("surfaces hook pending when JSONL activity is older than the hook decision")
+  func jsonlStaleRelativeToHook() {
+    let decisionTime = Date()
+    let pending = makePending(at: decisionTime)
+    let result = HookPendingStalenessFilter.filter(
+      hookPending: pending,
+      lastActivityAt: decisionTime.addingTimeInterval(-5)
+    )
+    #expect(result?.toolUseId == "tu-1")
+  }
+
+  @Test("drops hook pending when JSONL has newer activity — turn must have committed")
+  func jsonlProvesResolution() {
+    let decisionTime = Date()
+    let pending = makePending(at: decisionTime)
+    let result = HookPendingStalenessFilter.filter(
+      hookPending: pending,
+      lastActivityAt: decisionTime.addingTimeInterval(10)
+    )
+    #expect(result == nil)
+  }
+}

--- a/app/AgentHubTests/HookPendingStalenessFilterTests.swift
+++ b/app/AgentHubTests/HookPendingStalenessFilterTests.swift
@@ -55,4 +55,29 @@ struct HookPendingStalenessFilterTests {
     )
     #expect(result == nil)
   }
+
+  @Test("preserves hook pending when JSONL activity is within the epsilon window")
+  func sameSecondClockSkewStillLive() {
+    // Legacy whole-second hook timestamp truncates to 10:30:45.000Z while
+    // JSONL's millisecond-precision lastActivityAt is 10:30:45.400Z. Without
+    // the epsilon this would incorrectly drop a live pending.
+    let decisionTime = Date()
+    let pending = makePending(at: decisionTime)
+    let result = HookPendingStalenessFilter.filter(
+      hookPending: pending,
+      lastActivityAt: decisionTime.addingTimeInterval(0.4)
+    )
+    #expect(result?.toolUseId == "tu-1")
+  }
+
+  @Test("drops hook pending once JSONL has advanced past the epsilon window")
+  func beyondEpsilonIsStale() {
+    let decisionTime = Date()
+    let pending = makePending(at: decisionTime)
+    let result = HookPendingStalenessFilter.filter(
+      hookPending: pending,
+      lastActivityAt: decisionTime.addingTimeInterval(1.5)
+    )
+    #expect(result == nil)
+  }
 }

--- a/app/modules/AgentHubCore/Package.resolved
+++ b/app/modules/AgentHubCore/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "0c89a267e9c20d84a1e74d83d2e921fbcc9da657a20aacfce0aafc9cf0bf82ab",
+  "originHash" : "13aed19909ebcecf9b53ec458c34bd9403660f196f661ce384495b288c73164c",
   "pins" : [
     {
       "identity" : "beautiful-mermaid-swift",
@@ -35,6 +35,15 @@
       "state" : {
         "revision" : "424453d2232c9912933a3b5a1f3d3df669404ed0",
         "version" : "0.15.2"
+      }
+    },
+    {
+      "identity" : "codeeditsymbols",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/CodeEditApp/CodeEditSymbols.git",
+      "state" : {
+        "revision" : "ae69712b08571c4469c2ed5cd38ad9f19439793e",
+        "version" : "0.2.3"
       }
     },
     {

--- a/app/modules/AgentHubCore/Package.swift
+++ b/app/modules/AgentHubCore/Package.swift
@@ -57,6 +57,7 @@ let package = Package(
       path: "Sources/AgentHub",
       resources: [
         .copy("Design/Theme/BundledThemes"),
+        .copy("Resources/ClaudeHook"),
       ],
       swiftSettings: [
         .swiftLanguageMode(.v5)

--- a/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubProvider.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubProvider.swift
@@ -325,12 +325,26 @@ public final class AgentHubProvider {
   /// Removes every approval hook we've installed and releases claims. Call
   /// from `NSApplicationDelegate.applicationWillTerminate` so external Claude
   /// Code runs after quit see no trace of AgentHub.
-  public func flushClaudeHooksOnTerminate() {
+  ///
+  /// This method **blocks** the calling thread until the cleanup completes
+  /// (or `timeout` elapses). `applicationWillTerminate` is the last hook AppKit
+  /// offers before the process is killed, so an unstructured `Task` spawned
+  /// here will be torn down mid-flight and leave stale hook entries in
+  /// `settings.local.json` plus stray claim files behind. Filesystem ops are
+  /// fast (<100ms for a typical install set); a 3-second cap guards against
+  /// deadlock without punishing normal quits.
+  public func flushClaudeHooksOnTerminate(timeout: TimeInterval = 3.0) {
     let claimStore = approvalClaimStore
     let installer = claudeHookInstaller
-    Task {
+    let semaphore = DispatchSemaphore(value: 0)
+    Task.detached(priority: .userInitiated) {
       await installer.flushAll()
       await claimStore.resetAll()
+      semaphore.signal()
+    }
+    let deadline = DispatchTime.now() + timeout
+    if semaphore.wait(timeout: deadline) == .timedOut {
+      AppLogger.session.error("[ClaudeHook] flushClaudeHooksOnTerminate timed out after \(timeout)s — shutdown may leave stale hook state behind")
     }
   }
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubProvider.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubProvider.swift
@@ -67,9 +67,29 @@ public final class AgentHubProvider {
     CodexSessionFileWatcher(codexPath: configuration.codexDataPath)
   }()
 
-  /// Claude file watcher for real-time monitoring
+  /// Claude file watcher for real-time monitoring. Wired to the approval hook
+  /// sidecar so pending-approval state can be surfaced while Claude Code CLI
+  /// buffers its JSONL writes.
   private lazy var claudeFileWatcher: SessionFileWatcher = {
-    SessionFileWatcher(claudePath: configuration.claudeDataPath)
+    SessionFileWatcher(
+      claudePath: configuration.claudeDataPath,
+      hookSidecarWatcher: claudeHookSidecarWatcher
+    )
+  }()
+
+  /// Shared claim store gating the approval hook script.
+  public private(set) lazy var approvalClaimStore: any ApprovalClaimStoreProtocol = {
+    ApprovalClaimStore()
+  }()
+
+  /// Watches the approval sidecar directory populated by the installed hook.
+  public private(set) lazy var claudeHookSidecarWatcher: any ClaudeHookSidecarWatcherProtocol = {
+    ClaudeHookSidecarWatcher()
+  }()
+
+  /// Installs/uninstalls the AgentHub approval hook per worktree.
+  public private(set) lazy var claudeHookInstaller: any ClaudeHookInstallerProtocol = {
+    ClaudeHookInstaller()
   }()
 
   /// Claude search service
@@ -260,6 +280,11 @@ public final class AgentHubProvider {
       }
     }()
 
+    // Claude sessions get the approval hook services wired in. Codex sessions
+    // pass nil (no Codex hook equivalent exists today — see plan).
+    let claimStore: (any ApprovalClaimStoreProtocol)? = providerKind == .claude ? approvalClaimStore : nil
+    let installer: (any ClaudeHookInstallerProtocol)? = providerKind == .claude ? claudeHookInstaller : nil
+
     let vm = CLISessionsViewModel(
       monitorService: selectedMonitor,
       fileWatcher: selectedWatcher,
@@ -267,7 +292,9 @@ public final class AgentHubProvider {
       cliConfiguration: cliConfiguration,
       providerKind: providerKind,
       metadataStore: metadataStore,
-      webPreviewCandidateService: webPreviewCandidateService
+      webPreviewCandidateService: webPreviewCandidateService,
+      approvalClaimStore: claimStore,
+      hookInstaller: installer
     )
     vm.agentHubProvider = self
     return vm
@@ -280,6 +307,31 @@ public final class AgentHubProvider {
   /// when the app crashed or was force-quit.
   public func cleanupOrphanedProcesses() {
     TerminalProcessRegistry.shared.cleanupRegisteredProcesses()
+  }
+
+  /// Sweeps any previously-installed approval hooks and wipes stale claim
+  /// files. Call this on app launch before sessions start restoring — gives
+  /// us a clean slate so external Claude Code sessions opened between a
+  /// previous crash and this launch run vanilla.
+  public func reconcileClaudeHooksOnLaunch() {
+    let claimStore = approvalClaimStore
+    let installer = claudeHookInstaller
+    Task {
+      await claimStore.resetAll()
+      await installer.reconcileOnLaunch(expectedPaths: [])
+    }
+  }
+
+  /// Removes every approval hook we've installed and releases claims. Call
+  /// from `NSApplicationDelegate.applicationWillTerminate` so external Claude
+  /// Code runs after quit see no trace of AgentHub.
+  public func flushClaudeHooksOnTerminate() {
+    let claimStore = approvalClaimStore
+    let installer = claudeHookInstaller
+    Task {
+      await installer.flushAll()
+      await claimStore.resetAll()
+    }
   }
 
   /// Terminates all active terminal processes.

--- a/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubProvider.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubProvider.swift
@@ -309,16 +309,30 @@ public final class AgentHubProvider {
     TerminalProcessRegistry.shared.cleanupRegisteredProcesses()
   }
 
-  /// Sweeps any previously-installed approval hooks and wipes stale claim
-  /// files. Call this on app launch before sessions start restoring — gives
-  /// us a clean slate so external Claude Code sessions opened between a
-  /// previous crash and this launch run vanilla.
-  public func reconcileClaudeHooksOnLaunch() {
+  /// Sweeps any previously-installed approval hooks, wipes stale claim files,
+  /// and drops stale approval sidecar files. Call this on app launch before
+  /// sessions start restoring.
+  ///
+  /// **Blocks** the calling thread until cleanup completes. This is
+  /// deliberate: the lazy `claudeSessionsViewModel` triggers
+  /// `setupSubscriptions`, which can fire `syncInstalledPaths` on first
+  /// repository emission. If the reconcile is still in flight at that point,
+  /// the sync can install freshly and then the late-arriving reconcile sweeps
+  /// those same paths back out as "stale", leaving approval hooks unregistered
+  /// until the next repository change. Blocking here removes the race.
+  public func reconcileClaudeHooksOnLaunch(timeout: TimeInterval = 3.0) {
     let claimStore = approvalClaimStore
     let installer = claudeHookInstaller
-    Task {
+    let sidecar = claudeHookSidecarWatcher
+    let semaphore = DispatchSemaphore(value: 0)
+    Task.detached(priority: .userInitiated) {
       await claimStore.resetAll()
+      await sidecar.wipeAll()
       await installer.reconcileOnLaunch(expectedPaths: [])
+      semaphore.signal()
+    }
+    if semaphore.wait(timeout: .now() + timeout) == .timedOut {
+      AppLogger.session.error("[ClaudeHook] reconcileClaudeHooksOnLaunch timed out after \(timeout)s — first session sync may race")
     }
   }
 
@@ -336,10 +350,12 @@ public final class AgentHubProvider {
   public func flushClaudeHooksOnTerminate(timeout: TimeInterval = 3.0) {
     let claimStore = approvalClaimStore
     let installer = claudeHookInstaller
+    let sidecar = claudeHookSidecarWatcher
     let semaphore = DispatchSemaphore(value: 0)
     Task.detached(priority: .userInitiated) {
       await installer.flushAll()
       await claimStore.resetAll()
+      await sidecar.wipeAll()
       semaphore.signal()
     }
     let deadline = DispatchTime.now() + timeout

--- a/app/modules/AgentHubCore/Sources/AgentHub/Resources/ClaudeHook/agenthub-approval.sh
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Resources/ClaudeHook/agenthub-approval.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+# AgentHub Claude Code approval hook
+#
+# Invoked by Claude Code on PreToolUse (and optionally PostToolUse).
+# Reads a single JSON object from stdin, checks whether AgentHub is actively
+# monitoring this session (claim file), and if so appends a JSON line to the
+# session's approval queue. Otherwise exits silently.
+#
+# Design invariants:
+#   1. Exit 0 on every error path. Never block Claude Code, never print to the
+#      user's terminal.
+#   2. Do not mutate state outside AgentHub's Application Support directory.
+#   3. Produce no output on stdout or stderr under any condition.
+#
+# Contract with AgentHub:
+#   Claims dir:   ~/Library/Application Support/AgentHub/claims/{sessionId}
+#   Approvals:    ~/Library/Application Support/AgentHub/approvals/{sessionId}.jsonl
+
+set +e
+exec 2>/dev/null
+
+APP_SUPPORT="${HOME}/Library/Application Support/AgentHub"
+CLAIMS_DIR="${APP_SUPPORT}/claims"
+APPROVALS_DIR="${APP_SUPPORT}/approvals"
+
+INPUT="$(cat 2>/dev/null || true)"
+[ -z "${INPUT}" ] && exit 0
+
+# Parse the hook JSON and the claim gate in one Python invocation.
+# On any error: exit 0 silently. On success: print nothing — the script has
+# already appended to the sidecar.
+printf '%s' "${INPUT}" | python3 -c '
+import json, os, sys, datetime
+try:
+    data = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+
+sid = data.get("session_id") or ""
+event = data.get("hook_event_name") or ""
+tool = data.get("tool_name") or ""
+tool_input = data.get("tool_input") or {}
+tool_use_id = data.get("tool_use_id") or ""
+
+if not sid:
+    sys.exit(0)
+
+home = os.path.expanduser("~")
+app_support = os.path.join(home, "Library", "Application Support", "AgentHub")
+claim_path = os.path.join(app_support, "claims", sid)
+approvals_dir = os.path.join(app_support, "approvals")
+
+# Gate: no claim means AgentHub is not tracking this session; exit silently.
+if not os.path.exists(claim_path):
+    sys.exit(0)
+
+if event == "PreToolUse":
+    kind = "pending"
+elif event == "PostToolUse":
+    kind = "resolved"
+else:
+    sys.exit(0)
+
+try:
+    os.makedirs(approvals_dir, exist_ok=True)
+except Exception:
+    sys.exit(0)
+
+ts = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+line = {
+    "event": kind,
+    "toolName": tool,
+    "toolUseId": tool_use_id,
+    "timestamp": ts,
+    "input": tool_input,
+}
+out_path = os.path.join(approvals_dir, sid + ".jsonl")
+try:
+    with open(out_path, "a", encoding="utf-8") as f:
+        f.write(json.dumps(line, separators=(",", ":")) + "\n")
+except Exception:
+    pass
+sys.exit(0)
+' 2>/dev/null
+
+exit 0

--- a/app/modules/AgentHubCore/Sources/AgentHub/Resources/ClaudeHook/agenthub-approval.sh
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Resources/ClaudeHook/agenthub-approval.sh
@@ -66,7 +66,7 @@ try:
 except Exception:
     sys.exit(0)
 
-ts = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+ts = datetime.datetime.now(datetime.timezone.utc).isoformat(timespec="milliseconds").replace("+00:00", "Z")
 line = {
     "event": kind,
     "toolName": tool,

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/ApprovalClaimStore.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/ApprovalClaimStore.swift
@@ -1,0 +1,67 @@
+import Foundation
+
+// MARK: - ApprovalClaimStoreProtocol
+
+/// Manages the claim-file directory that gates the AgentHub approval hook.
+///
+/// The hook script refuses to write to the sidecar for any session without a
+/// matching claim file, so these two calls bracket the window during which
+/// AgentHub wants to observe approvals for a session:
+///
+/// ```
+/// await claimStore.claim(sessionId: session.id)    // startPolling
+/// // … monitor session …
+/// await claimStore.release(sessionId: session.id)  // stopPolling
+/// ```
+///
+/// Claims are stored as empty marker files at
+/// `~/Library/Application Support/AgentHub/claims/{sessionId}`. The directory
+/// is wiped on `resetAll()` so a hard crash never leaves stale claims that
+/// would unmask external sessions to our hook.
+public protocol ApprovalClaimStoreProtocol: AnyObject, Sendable {
+  func claim(sessionId: String) async
+  func release(sessionId: String) async
+  func resetAll() async
+}
+
+// MARK: - ApprovalClaimStore
+
+public actor ApprovalClaimStore: ApprovalClaimStoreProtocol {
+
+  private let claimsDirectory: URL
+  private let fileManager: FileManager
+
+  public init(
+    claimsDirectory: URL = ClaudeHookPaths.claimsDirectoryURL,
+    fileManager: FileManager = .default
+  ) {
+    self.claimsDirectory = claimsDirectory
+    self.fileManager = fileManager
+  }
+
+  public func claim(sessionId: String) async {
+    guard !sessionId.isEmpty else { return }
+    ensureDirectory()
+    let url = claimsDirectory.appendingPathComponent(sessionId, isDirectory: false)
+    if !fileManager.fileExists(atPath: url.path) {
+      fileManager.createFile(atPath: url.path, contents: nil)
+    }
+  }
+
+  public func release(sessionId: String) async {
+    guard !sessionId.isEmpty else { return }
+    let url = claimsDirectory.appendingPathComponent(sessionId, isDirectory: false)
+    try? fileManager.removeItem(at: url)
+  }
+
+  public func resetAll() async {
+    if fileManager.fileExists(atPath: claimsDirectory.path) {
+      try? fileManager.removeItem(at: claimsDirectory)
+    }
+    ensureDirectory()
+  }
+
+  private func ensureDirectory() {
+    try? fileManager.createDirectory(at: claimsDirectory, withIntermediateDirectories: true)
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/ClaudeHookInstaller.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/ClaudeHookInstaller.swift
@@ -1,0 +1,313 @@
+import Foundation
+import os
+
+// MARK: - ClaudeHookInstallerProtocol
+
+public protocol ClaudeHookInstallerProtocol: AnyObject, Sendable {
+  func isEnabled() async -> Bool
+  func setEnabled(_ enabled: Bool) async
+  /// Declares the complete set of project/worktree paths that should have the
+  /// hook registered. The installer:
+  /// - installs into paths in `paths` that aren't already installed,
+  /// - uninstalls from every previously-installed path not in `paths`,
+  /// - is idempotent when the state already matches.
+  /// This is the only install API callers should use — per-session
+  /// `ensureInstalled`/`releaseInstalled` was removed because Claude Code
+  /// loads `settings.local.json` once at session start and wouldn't pick up a
+  /// mid-session install.
+  func syncInstalledPaths(_ paths: Set<String>) async
+  /// Remove every installed entry. Called on Settings toggle off / app quit.
+  func flushAll() async
+  /// Launch-time housekeeping: uninstall previously-installed paths that
+  /// aren't in `expectedPaths`. Provides a best-effort starting set before
+  /// `syncInstalledPaths` takes over.
+  func reconcileOnLaunch(expectedPaths: [String]) async
+}
+
+// MARK: - ClaudeHookInstaller
+
+/// Registers the AgentHub approval hook in each monitored project's
+/// `.claude/settings.local.json`. The hook script itself lives in
+/// `~/Library/Application Support/AgentHub/hooks/agenthub-approval.sh` (one
+/// copy for the whole app) — we never place a script inside the project's
+/// `.claude/` directory, so there is no chance of it being accidentally
+/// committed to git.
+public actor ClaudeHookInstaller: ClaudeHookInstallerProtocol {
+
+  // MARK: - Constants
+
+  /// UserDefaults key storing the set of paths where the hook entry has been
+  /// written, so `reconcileOnLaunch` and `flushAll` can sweep correctly.
+  public static let installedPathsKey = "com.agenthub.claudeHook.installedPaths"
+
+  /// UserDefaults key for the master toggle. Default on.
+  public static let enabledKey = "com.agenthub.claudeHook.enabled"
+
+  // MARK: - Properties
+
+  private let fileManager: FileManager
+  private let defaults: UserDefaults
+  private let bundledScriptURL: URL?
+  private let sharedScriptURL: URL
+
+  // MARK: - Initialization
+
+  public init(
+    fileManager: FileManager = .default,
+    defaults: UserDefaults = .standard,
+    bundledScriptURL: URL? = ClaudeHookPaths.bundledScriptURL(),
+    sharedScriptURL: URL = ClaudeHookPaths.sharedScriptURL
+  ) {
+    self.fileManager = fileManager
+    self.defaults = defaults
+    self.bundledScriptURL = bundledScriptURL
+    self.sharedScriptURL = sharedScriptURL
+  }
+
+  // MARK: - Toggle
+
+  public func isEnabled() async -> Bool {
+    if defaults.object(forKey: Self.enabledKey) == nil { return true }
+    return defaults.bool(forKey: Self.enabledKey)
+  }
+
+  public func setEnabled(_ enabled: Bool) async {
+    defaults.set(enabled, forKey: Self.enabledKey)
+    if !enabled {
+      sweepAllInstalledPaths()
+    }
+    // Re-enable is intentionally a no-op here; the next `syncInstalledPaths`
+    // call from the repositories subscription will re-install wherever needed.
+  }
+
+  // MARK: - Install / sync
+
+  public func syncInstalledPaths(_ paths: Set<String>) async {
+    guard await isEnabled() else {
+      // Feature disabled: make sure nothing is installed anywhere.
+      sweepAllInstalledPaths()
+      return
+    }
+    ensureSharedScript()
+
+    let previously = Set(loadInstalledPaths())
+    let toInstall = paths.subtracting(previously)
+    let toUninstall = previously.subtracting(paths)
+    let toRepair = paths.intersection(previously) // ensure content is up to date
+
+    for path in toUninstall {
+      uninstall(atProjectPath: path)
+    }
+    for path in toInstall.union(toRepair) {
+      install(atProjectPath: path)
+    }
+  }
+
+  public func flushAll() async {
+    sweepAllInstalledPaths()
+  }
+
+  public func reconcileOnLaunch(expectedPaths: [String]) async {
+    let expected = Set(expectedPaths)
+    let previouslyInstalled = Set(loadInstalledPaths())
+    let stale = previouslyInstalled.subtracting(expected)
+    for path in stale {
+      uninstall(atProjectPath: path)
+    }
+  }
+
+  // MARK: - Install / uninstall mechanics
+
+  private func install(atProjectPath path: String) {
+    let settingsURL = ClaudeHookPaths.settingsLocalURL(inProjectAt: path)
+    do {
+      migrateLegacyPerProjectScript(atProjectPath: path, settingsURL: settingsURL)
+      try mergeSettingsLocal(at: settingsURL, scriptPath: sharedScriptURL.path)
+      rememberInstalled(path: path)
+    } catch {
+      AppLogger.watcher.error("[ClaudeHookInstaller] install failed for \(path): \(error.localizedDescription)")
+    }
+  }
+
+  private func uninstall(atProjectPath path: String) {
+    let settingsURL = ClaudeHookPaths.settingsLocalURL(inProjectAt: path)
+    do {
+      migrateLegacyPerProjectScript(atProjectPath: path, settingsURL: settingsURL)
+      if fileManager.fileExists(atPath: settingsURL.path) {
+        try unmergeSettingsLocal(at: settingsURL, scriptPath: sharedScriptURL.path)
+      }
+      forgetInstalled(path: path)
+    } catch {
+      AppLogger.watcher.error("[ClaudeHookInstaller] uninstall failed for \(path): \(error.localizedDescription)")
+    }
+  }
+
+  /// One-time migration for users upgrading from the earlier design that
+  /// placed `agenthub-approval.sh` inside each project's `.claude/hooks/`
+  /// directory. Removes the legacy script and any `settings.local.json` entry
+  /// that still references it. Safe to run on every install/uninstall call
+  /// because it only acts on our uniquely-named script.
+  private func migrateLegacyPerProjectScript(atProjectPath path: String, settingsURL: URL) {
+    let legacyScript = URL(fileURLWithPath: path, isDirectory: true)
+      .appendingPathComponent(".claude", isDirectory: true)
+      .appendingPathComponent("hooks", isDirectory: true)
+      .appendingPathComponent("agenthub-approval.sh", isDirectory: false)
+    if fileManager.fileExists(atPath: legacyScript.path) {
+      try? fileManager.removeItem(at: legacyScript)
+    }
+    // Also strip any `settings.local.json` entry that still points at the old
+    // per-project path — we re-add ours pointing at the shared script next.
+    if fileManager.fileExists(atPath: settingsURL.path) {
+      try? unmergeSettingsLocal(at: settingsURL, scriptPath: legacyScript.path)
+    }
+  }
+
+  private func sweepAllInstalledPaths() {
+    for path in loadInstalledPaths() {
+      uninstall(atProjectPath: path)
+    }
+  }
+
+  // MARK: - Shared script management
+
+  private func ensureSharedScript() {
+    guard let bundledScriptURL else {
+      AppLogger.watcher.error("[ClaudeHookInstaller] Bundled script missing; can't install shared script")
+      return
+    }
+    do {
+      try fileManager.createDirectory(
+        at: sharedScriptURL.deletingLastPathComponent(),
+        withIntermediateDirectories: true
+      )
+      if !fileManager.fileExists(atPath: sharedScriptURL.path) || !scriptContentMatches(sharedScriptURL) {
+        if fileManager.fileExists(atPath: sharedScriptURL.path) {
+          try fileManager.removeItem(at: sharedScriptURL)
+        }
+        try fileManager.copyItem(at: bundledScriptURL, to: sharedScriptURL)
+        try fileManager.setAttributes([.posixPermissions: 0o755], ofItemAtPath: sharedScriptURL.path)
+      }
+    } catch {
+      AppLogger.watcher.error("[ClaudeHookInstaller] ensureSharedScript failed: \(error.localizedDescription)")
+    }
+  }
+
+  private func scriptContentMatches(_ installedURL: URL) -> Bool {
+    guard let bundledScriptURL,
+          let a = try? Data(contentsOf: bundledScriptURL),
+          let b = try? Data(contentsOf: installedURL) else { return false }
+    return a == b
+  }
+
+  // MARK: - settings.local.json merge
+
+  private func mergeSettingsLocal(at url: URL, scriptPath: String) throws {
+    var root: [String: Any] = [:]
+    if let data = try? Data(contentsOf: url),
+       let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+      root = parsed
+    }
+    var hooks = root["hooks"] as? [String: Any] ?? [:]
+    hooks = upsertEventEntry(in: hooks, event: "PreToolUse", scriptPath: scriptPath)
+    hooks = upsertEventEntry(in: hooks, event: "PostToolUse", scriptPath: scriptPath)
+    root["hooks"] = hooks
+    try writeJSON(root, to: url)
+  }
+
+  private func unmergeSettingsLocal(at url: URL, scriptPath: String) throws {
+    guard let data = try? Data(contentsOf: url),
+          var root = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+      return
+    }
+    guard var hooks = root["hooks"] as? [String: Any] else { return }
+    hooks = removeEventEntry(in: hooks, event: "PreToolUse", scriptPath: scriptPath)
+    hooks = removeEventEntry(in: hooks, event: "PostToolUse", scriptPath: scriptPath)
+    if hooks.isEmpty {
+      root.removeValue(forKey: "hooks")
+    } else {
+      root["hooks"] = hooks
+    }
+    if root.isEmpty {
+      try fileManager.removeItem(at: url)
+      return
+    }
+    try writeJSON(root, to: url)
+  }
+
+  private func upsertEventEntry(
+    in hooks: [String: Any],
+    event: String,
+    scriptPath: String
+  ) -> [String: Any] {
+    var result = hooks
+    var entries = result[event] as? [[String: Any]] ?? []
+    entries.removeAll { entry in
+      guard let inner = entry["hooks"] as? [[String: Any]] else { return false }
+      return inner.contains { ($0["command"] as? String) == scriptPath }
+    }
+    entries.append([
+      "matcher": "*",
+      "hooks": [
+        [
+          "type": "command",
+          "command": scriptPath,
+        ] as [String: Any],
+      ],
+    ])
+    result[event] = entries
+    return result
+  }
+
+  private func removeEventEntry(
+    in hooks: [String: Any],
+    event: String,
+    scriptPath: String
+  ) -> [String: Any] {
+    var result = hooks
+    guard var entries = result[event] as? [[String: Any]] else { return result }
+    entries.removeAll { entry in
+      guard let inner = entry["hooks"] as? [[String: Any]] else { return false }
+      return inner.contains { ($0["command"] as? String) == scriptPath }
+    }
+    if entries.isEmpty {
+      result.removeValue(forKey: event)
+    } else {
+      result[event] = entries
+    }
+    return result
+  }
+
+  private func writeJSON(_ object: [String: Any], to url: URL) throws {
+    try fileManager.createDirectory(
+      at: url.deletingLastPathComponent(),
+      withIntermediateDirectories: true
+    )
+    let data = try JSONSerialization.data(
+      withJSONObject: object,
+      options: [.prettyPrinted, .sortedKeys]
+    )
+    try data.write(to: url, options: .atomic)
+  }
+
+  // MARK: - Persistence of installed paths
+
+  private func loadInstalledPaths() -> [String] {
+    (defaults.array(forKey: Self.installedPathsKey) as? [String]) ?? []
+  }
+
+  private func saveInstalledPaths(_ paths: [String]) {
+    defaults.set(paths.sorted(), forKey: Self.installedPathsKey)
+  }
+
+  private func rememberInstalled(path: String) {
+    var set = Set(loadInstalledPaths())
+    set.insert(path)
+    saveInstalledPaths(Array(set))
+  }
+
+  private func forgetInstalled(path: String) {
+    var set = Set(loadInstalledPaths())
+    set.remove(path)
+    saveInstalledPaths(Array(set))
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/ClaudeHookPaths.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/ClaudeHookPaths.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+/// Canonical filesystem locations shared by the approval hook script,
+/// `ApprovalClaimStore`, `ClaudeHookSidecarWatcher`, and `ClaudeHookInstaller`.
+///
+/// The script reads `claims/{sessionId}` and writes `approvals/{sessionId}.jsonl`
+/// under the same base directory this type resolves. Keeping the paths in one
+/// place ensures the Swift side and the shipped shell script agree.
+public enum ClaudeHookPaths {
+
+  public static var appSupportBaseURL: URL {
+    let fm = FileManager.default
+    let base = (try? fm.url(
+      for: .applicationSupportDirectory,
+      in: .userDomainMask,
+      appropriateFor: nil,
+      create: true
+    )) ?? URL(fileURLWithPath: NSString(string: "~/Library/Application Support").expandingTildeInPath)
+    return base.appendingPathComponent("AgentHub", isDirectory: true)
+  }
+
+  public static var claimsDirectoryURL: URL {
+    appSupportBaseURL.appendingPathComponent("claims", isDirectory: true)
+  }
+
+  public static var approvalsDirectoryURL: URL {
+    appSupportBaseURL.appendingPathComponent("approvals", isDirectory: true)
+  }
+
+  public static func claimURL(for sessionId: String) -> URL {
+    claimsDirectoryURL.appendingPathComponent(sessionId, isDirectory: false)
+  }
+
+  public static func approvalsURL(for sessionId: String) -> URL {
+    approvalsDirectoryURL.appendingPathComponent("\(sessionId).jsonl", isDirectory: false)
+  }
+
+  /// Shared install location of the hook script. One copy for the whole app;
+  /// every monitored project references it by absolute path from its
+  /// `settings.local.json`. Keeping the script out of the project's `.claude/`
+  /// directory prevents it from ever being committed to git (even if the user
+  /// has a loose `.gitignore`).
+  public static var sharedScriptURL: URL {
+    appSupportBaseURL
+      .appendingPathComponent("hooks", isDirectory: true)
+      .appendingPathComponent("agenthub-approval.sh", isDirectory: false)
+  }
+
+  /// `settings.local.json` location inside a monitored project. This is the
+  /// ONLY file we touch inside a user's repo, and Claude Code treats it as
+  /// personal/gitignored by convention.
+  public static func settingsLocalURL(inProjectAt projectPath: String) -> URL {
+    URL(fileURLWithPath: projectPath, isDirectory: true)
+      .appendingPathComponent(".claude", isDirectory: true)
+      .appendingPathComponent("settings.local.json", isDirectory: false)
+  }
+
+  /// Bundle resource URL for the shipped hook script, if present.
+  public static func bundledScriptURL() -> URL? {
+    Bundle.module.url(forResource: "agenthub-approval", withExtension: "sh", subdirectory: "ClaudeHook")
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/ClaudeHookSidecarWatcher.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/ClaudeHookSidecarWatcher.swift
@@ -24,6 +24,11 @@ public protocol ClaudeHookSidecarWatcherProtocol: AnyObject, Sendable {
   func startWatching(sessionId: String) async
   func stopWatching(sessionId: String) async
   func pendingInfo(for sessionId: String) async -> SessionJSONLParser.PendingToolInfo?
+  /// Remove every sidecar file on disk and drop all in-memory state. Called
+  /// at app launch and termination so stale `pending` entries left behind by
+  /// an approval the user resolved while AgentHub was down can't be replayed
+  /// as false `awaitingApproval` state on the next launch.
+  func wipeAll() async
 }
 
 // MARK: - ClaudeHookSidecarWatcher
@@ -82,10 +87,31 @@ public actor ClaudeHookSidecarWatcher: ClaudeHookSidecarWatcherProtocol {
     fileSources.removeValue(forKey: sessionId)
     filePositions.removeValue(forKey: sessionId)
     currentInfo.removeValue(forKey: sessionId)
+
+    // Delete the sidecar file so a future watch of the same sessionId doesn't
+    // replay stale `pending` events that were resolved while this watcher
+    // wasn't running.
+    let fileURL = approvalsDirectory.appendingPathComponent("\(sessionId).jsonl")
+    try? fileManager.removeItem(at: fileURL)
   }
 
   public func pendingInfo(for sessionId: String) async -> SessionJSONLParser.PendingToolInfo? {
     currentInfo[sessionId]
+  }
+
+  public func wipeAll() async {
+    directorySource?.cancel()
+    directorySource = nil
+    for (_, source) in fileSources { source.cancel() }
+    fileSources.removeAll()
+    filePositions.removeAll()
+    currentInfo.removeAll()
+    watchedSessions.removeAll()
+
+    if fileManager.fileExists(atPath: approvalsDirectory.path) {
+      try? fileManager.removeItem(at: approvalsDirectory)
+    }
+    ensureDirectory()
   }
 
   // MARK: - Internals

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/ClaudeHookSidecarWatcher.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/ClaudeHookSidecarWatcher.swift
@@ -88,11 +88,13 @@ public actor ClaudeHookSidecarWatcher: ClaudeHookSidecarWatcherProtocol {
     filePositions.removeValue(forKey: sessionId)
     currentInfo.removeValue(forKey: sessionId)
 
-    // Delete the sidecar file so a future watch of the same sessionId doesn't
-    // replay stale `pending` events that were resolved while this watcher
-    // wasn't running.
-    let fileURL = approvalsDirectory.appendingPathComponent("\(sessionId).jsonl")
-    try? fileManager.removeItem(at: fileURL)
+    // Intentionally keep the sidecar file on disk. `stopWatching` is also
+    // called when a user toggles monitoring off mid-approval (the JSONL
+    // hasn't flushed the `tool_use` yet), so the sidecar is the only
+    // persisted record of the pending event. If monitoring is turned back
+    // on while the tool is still awaiting approval, `startWatching` needs
+    // to find it. Cross-restart staleness is handled by `wipeAll` at
+    // launch/terminate; see plans/parsed-weaving-nebula.md.
   }
 
   public func pendingInfo(for sessionId: String) async -> SessionJSONLParser.PendingToolInfo? {

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/ClaudeHookSidecarWatcher.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/ClaudeHookSidecarWatcher.swift
@@ -269,9 +269,25 @@ private struct SidecarLine: Decodable {
 
   var parsedTimestamp: Date? {
     guard let timestamp else { return nil }
-    let formatter = ISO8601DateFormatter()
-    return formatter.date(from: timestamp)
+    // The hook script now emits millisecond precision; older sidecar lines on
+    // disk may still be whole-second. Accept both.
+    if let date = SidecarLine.iso8601WithFractional.date(from: timestamp) {
+      return date
+    }
+    return SidecarLine.iso8601.date(from: timestamp)
   }
+
+  private static let iso8601WithFractional: ISO8601DateFormatter = {
+    let f = ISO8601DateFormatter()
+    f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+    return f
+  }()
+
+  private static let iso8601: ISO8601DateFormatter = {
+    let f = ISO8601DateFormatter()
+    f.formatOptions = [.withInternetDateTime]
+    return f
+  }()
 
   var inputPreview: String? {
     guard let input else { return nil }

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/ClaudeHookSidecarWatcher.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/ClaudeHookSidecarWatcher.swift
@@ -1,0 +1,328 @@
+import Combine
+import Foundation
+import os
+
+// MARK: - SidecarUpdate
+
+/// Emitted whenever an `approvals/{sessionId}.jsonl` file yields new state.
+public struct SidecarUpdate: Sendable {
+  public let sessionId: String
+  /// The latest pending info, or `nil` if the last event was `resolved`
+  /// (or there are no pending events).
+  public let info: SessionJSONLParser.PendingToolInfo?
+
+  public init(sessionId: String, info: SessionJSONLParser.PendingToolInfo?) {
+    self.sessionId = sessionId
+    self.info = info
+  }
+}
+
+// MARK: - ClaudeHookSidecarWatcherProtocol
+
+public protocol ClaudeHookSidecarWatcherProtocol: AnyObject, Sendable {
+  var updates: AnyPublisher<SidecarUpdate, Never> { get }
+  func startWatching(sessionId: String) async
+  func stopWatching(sessionId: String) async
+  func pendingInfo(for sessionId: String) async -> SessionJSONLParser.PendingToolInfo?
+}
+
+// MARK: - ClaudeHookSidecarWatcher
+
+/// Watches the approvals sidecar directory populated by the installed hook
+/// script. Produces `PendingToolInfo` values that `SessionFileWatcher` merges
+/// into its `ParseResult.pendingToolUses` before building monitor state — so
+/// that approval-pending tools surface in the UI before the JSONL turn commits.
+public actor ClaudeHookSidecarWatcher: ClaudeHookSidecarWatcherProtocol {
+
+  private let approvalsDirectory: URL
+  private let fileManager: FileManager
+  private nonisolated let subject = PassthroughSubject<SidecarUpdate, Never>()
+  private nonisolated let processingQueue = DispatchQueue(label: "com.agenthub.approvals.sidecar")
+
+  private var watchedSessions: Set<String> = []
+  private var fileSources: [String: DispatchSourceFileSystemObject] = [:]
+  private var filePositions: [String: UInt64] = [:]
+  private var currentInfo: [String: SessionJSONLParser.PendingToolInfo] = [:]
+  private var directorySource: DispatchSourceFileSystemObject?
+
+  public nonisolated var updates: AnyPublisher<SidecarUpdate, Never> {
+    subject.eraseToAnyPublisher()
+  }
+
+  public init(
+    approvalsDirectory: URL = ClaudeHookPaths.approvalsDirectoryURL,
+    fileManager: FileManager = .default
+  ) {
+    self.approvalsDirectory = approvalsDirectory
+    self.fileManager = fileManager
+  }
+
+  // MARK: - Public API
+
+  public func startWatching(sessionId: String) async {
+    guard !sessionId.isEmpty, !watchedSessions.contains(sessionId) else { return }
+    watchedSessions.insert(sessionId)
+
+    ensureDirectory()
+    startDirectorySourceIfNeeded()
+
+    // Process any pre-existing content (hook may have fired before we started
+    // watching this session).
+    attachFileSource(for: sessionId)
+    processFile(sessionId: sessionId)
+  }
+
+  public func stopWatching(sessionId: String) async {
+    guard watchedSessions.contains(sessionId) else { return }
+    watchedSessions.remove(sessionId)
+
+    if let source = fileSources[sessionId] {
+      source.cancel()
+    }
+    fileSources.removeValue(forKey: sessionId)
+    filePositions.removeValue(forKey: sessionId)
+    currentInfo.removeValue(forKey: sessionId)
+  }
+
+  public func pendingInfo(for sessionId: String) async -> SessionJSONLParser.PendingToolInfo? {
+    currentInfo[sessionId]
+  }
+
+  // MARK: - Internals
+
+  private func ensureDirectory() {
+    try? fileManager.createDirectory(at: approvalsDirectory, withIntermediateDirectories: true)
+  }
+
+  private func startDirectorySourceIfNeeded() {
+    guard directorySource == nil else { return }
+    let fd = open(approvalsDirectory.path, O_EVTONLY)
+    guard fd >= 0 else {
+      AppLogger.watcher.error("[SidecarWatcher] Could not open approvals dir: \(self.approvalsDirectory.path)")
+      return
+    }
+    let source = DispatchSource.makeFileSystemObjectSource(
+      fileDescriptor: fd,
+      eventMask: [.write, .extend, .rename],
+      queue: processingQueue
+    )
+    source.setEventHandler { [weak self] in
+      guard let self else { return }
+      Task { await self.handleDirectoryEvent() }
+    }
+    source.setCancelHandler {
+      close(fd)
+    }
+    source.resume()
+    directorySource = source
+  }
+
+  private func handleDirectoryEvent() async {
+    // A new sidecar file may have been created. Attach sources for any watched
+    // session that didn't previously have one, then drain.
+    for sessionId in watchedSessions where fileSources[sessionId] == nil {
+      attachFileSource(for: sessionId)
+    }
+    for sessionId in watchedSessions {
+      processFile(sessionId: sessionId)
+    }
+  }
+
+  private func attachFileSource(for sessionId: String) {
+    let fileURL = approvalsDirectory.appendingPathComponent("\(sessionId).jsonl")
+    guard fileManager.fileExists(atPath: fileURL.path) else { return }
+    guard fileSources[sessionId] == nil else { return }
+
+    let fd = open(fileURL.path, O_EVTONLY)
+    guard fd >= 0 else { return }
+
+    let source = DispatchSource.makeFileSystemObjectSource(
+      fileDescriptor: fd,
+      eventMask: [.write, .extend, .delete, .rename],
+      queue: processingQueue
+    )
+    source.setEventHandler { [weak self] in
+      guard let self else { return }
+      Task { await self.processFile(sessionId: sessionId) }
+    }
+    source.setCancelHandler {
+      close(fd)
+    }
+    source.resume()
+    fileSources[sessionId] = source
+  }
+
+  /// Reads new bytes from the session's sidecar, parses each JSON line, updates
+  /// `currentInfo`, and emits an update if state changed.
+  private func processFile(sessionId: String) {
+    let fileURL = approvalsDirectory.appendingPathComponent("\(sessionId).jsonl")
+    guard fileManager.fileExists(atPath: fileURL.path) else { return }
+
+    var position = filePositions[sessionId] ?? 0
+    guard let lines = readNewLines(from: fileURL, startingAt: &position) else { return }
+    filePositions[sessionId] = position
+    guard !lines.isEmpty else { return }
+
+    var changed = false
+    for line in lines {
+      guard let data = line.data(using: .utf8),
+            let decoded = try? JSONDecoder().decode(SidecarLine.self, from: data) else {
+        continue
+      }
+      switch decoded.event {
+      case "pending":
+        let info = SessionJSONLParser.PendingToolInfo(
+          toolName: decoded.toolName ?? "",
+          toolUseId: decoded.toolUseId ?? "hook-\(sessionId)",
+          timestamp: decoded.parsedTimestamp ?? Date(),
+          input: decoded.inputPreview,
+          codeChangeInput: decoded.codeChangeInput
+        )
+        currentInfo[sessionId] = info
+        changed = true
+      case "resolved":
+        if currentInfo.removeValue(forKey: sessionId) != nil {
+          changed = true
+        }
+      default:
+        continue
+      }
+    }
+
+    if changed {
+      let info = currentInfo[sessionId]
+      subject.send(SidecarUpdate(sessionId: sessionId, info: info))
+    }
+  }
+
+  private func readNewLines(from url: URL, startingAt position: inout UInt64) -> [String]? {
+    guard let handle = FileHandle(forReadingAtPath: url.path) else { return nil }
+    defer { try? handle.close() }
+
+    let size: UInt64
+    do {
+      let attrs = try fileManager.attributesOfItem(atPath: url.path)
+      size = (attrs[.size] as? UInt64) ?? 0
+    } catch {
+      return nil
+    }
+
+    // If the file shrank (rotated/truncated), reset.
+    if size < position {
+      position = 0
+    }
+    guard size > position else { return [] }
+
+    do {
+      try handle.seek(toOffset: position)
+      let data = handle.readDataToEndOfFile()
+      position = size
+      guard let content = String(data: data, encoding: .utf8) else { return [] }
+      return content.split(separator: "\n", omittingEmptySubsequences: true).map(String.init)
+    } catch {
+      return nil
+    }
+  }
+
+  deinit {
+    directorySource?.cancel()
+    for (_, source) in fileSources { source.cancel() }
+  }
+}
+
+// MARK: - SidecarLine
+
+private struct SidecarLine: Decodable {
+  let event: String
+  let toolName: String?
+  let toolUseId: String?
+  let timestamp: String?
+  let input: InputPayload?
+
+  var parsedTimestamp: Date? {
+    guard let timestamp else { return nil }
+    let formatter = ISO8601DateFormatter()
+    return formatter.date(from: timestamp)
+  }
+
+  var inputPreview: String? {
+    guard let input else { return nil }
+    if let filePath = input.filePath {
+      return URL(fileURLWithPath: filePath).lastPathComponent
+    }
+    if let command = input.command {
+      return String(command.prefix(60))
+    }
+    if let url = input.url {
+      return url
+    }
+    return nil
+  }
+
+  var codeChangeInput: CodeChangeInput? {
+    guard let input, let filePath = input.filePath else { return nil }
+    guard let tool = toolName else { return nil }
+    switch tool {
+    case "Edit":
+      return CodeChangeInput(
+        toolType: .edit,
+        filePath: filePath,
+        oldString: input.oldString,
+        newString: input.newString,
+        replaceAll: input.replaceAll
+      )
+    case "Write":
+      // The existing pipeline expects Write's full content in `newString`
+      // (see CodeChangeInput.toToolParameters for `.write`).
+      return CodeChangeInput(
+        toolType: .write,
+        filePath: filePath,
+        newString: input.content
+      )
+    case "MultiEdit":
+      let editsPairs: [[String: String]]? = input.edits?.compactMap { e in
+        guard let oldString = e.oldString, let newString = e.newString else { return nil }
+        return ["old_string": oldString, "new_string": newString]
+      }
+      return CodeChangeInput(
+        toolType: .multiEdit,
+        filePath: filePath,
+        edits: editsPairs
+      )
+    default:
+      return nil
+    }
+  }
+}
+
+private struct InputPayload: Decodable {
+  let filePath: String?
+  let oldString: String?
+  let newString: String?
+  let replaceAll: Bool?
+  let content: String?
+  let command: String?
+  let url: String?
+  let edits: [EditEntry]?
+
+  enum CodingKeys: String, CodingKey {
+    case filePath = "file_path"
+    case oldString = "old_string"
+    case newString = "new_string"
+    case replaceAll = "replace_all"
+    case content
+    case command
+    case url
+    case edits
+  }
+}
+
+private struct EditEntry: Decodable {
+  let oldString: String?
+  let newString: String?
+
+  enum CodingKeys: String, CodingKey {
+    case oldString = "old_string"
+    case newString = "new_string"
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/CodexSessionFileWatcher.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/CodexSessionFileWatcher.swift
@@ -272,6 +272,10 @@ public actor CodexSessionFileWatcher {
       sessionStartedAt: result.sessionStartedAt,
       model: result.model,
       gitBranch: nil,
+      // Codex has no hook mechanism equivalent to Claude Code's PreToolUse;
+      // during the approval window the Codex JSONL (like Claude's) doesn't
+      // include the pending tool_use. Until Codex ships hooks there is no
+      // way to surface approval-window state. See plans/parsed-weaving-nebula.md.
       pendingToolUse: nil,
       recentActivities: result.recentActivities,
       hasMermaidContent: result.hasMermaidContent,

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/HookPendingStalenessFilter.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/HookPendingStalenessFilter.swift
@@ -27,17 +27,23 @@ import Foundation
 ///
 /// ## Why the epsilon
 ///
-/// Wall-clock timestamps drift between processes. The hook runs in a
-/// separate Python process; Claude writes JSONL from Node. Even now that
-/// the hook emits millisecond precision there's still genuine skew on the
-/// order of tens of milliseconds. We also need to absorb legacy sidecar
-/// lines from earlier builds that were written with whole-second
-/// truncation. A one-second grace window covers both cleanly without
-/// making the stale-detection meaningfully slower to kick in (a turn that
-/// actually resolved will have JSONL activity at least that far past the
-/// hook timestamp once the result block lands).
+/// Wall-clock timestamps drift between the Python hook process and
+/// Claude's Node process. In practice both resolve to the same
+/// `gettimeofday` source, so genuine skew is in the low-ms range. The
+/// epsilon exists to absorb that and nothing more — **not** to serve as a
+/// debounce window. A larger value (e.g. one second) would keep an already
+/// resolved approval visible as pending long enough for a fast turn to
+/// commit entirely within the grace period, leaving the UI stuck on
+/// stale state until some unrelated JSONL activity arrived. 100ms is
+/// comfortably above realistic cross-process skew and well below the
+/// minimum duration a user can perceive a false pending flash.
+///
+/// Legacy whole-second sidecar lines from pre-millisecond builds used to
+/// motivate a larger window, but `wipeAll` clears the approvals directory
+/// at every launch/terminate, so those entries don't survive past one
+/// app restart.
 public enum HookPendingStalenessFilter {
-  public static let stalenessEpsilon: TimeInterval = 1.0
+  public static let stalenessEpsilon: TimeInterval = 0.1
 
   public static func filter(
     hookPending: SessionJSONLParser.PendingToolInfo?,

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/HookPendingStalenessFilter.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/HookPendingStalenessFilter.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+/// Decides whether a hook-sourced `PendingToolInfo` is still live or has
+/// been invalidated by subsequent JSONL activity.
+///
+/// ## Why this exists
+///
+/// `ClaudeHookSidecarWatcher` keeps sidecar files on disk across
+/// `stopWatching` so that a user who toggles monitoring off **during** an
+/// approval can toggle it back on and recover the pending state (the JSONL
+/// hasn't written the `tool_use` block yet and would otherwise have nothing
+/// to offer). That preservation opens an edge case: if the user approves
+/// the tool in the CLI while AgentHub isn't tracking the session, the
+/// hook's `PostToolUse` invocation finds no claim file and exits silently
+/// — so the sidecar keeps its `pending` line with no matching `resolved`.
+/// When monitoring resumes, a naive merge would promote the stale entry to
+/// `.awaitingApproval` even though the approval already happened.
+///
+/// ## The invariant we exploit
+///
+/// Claude Code CLI only writes **any** JSONL entry — thinking, text,
+/// `tool_use`, `tool_result` — when the containing turn commits. The turn
+/// can't commit until every tool in it resolves. So if JSONL's latest
+/// activity timestamp is newer than the hook's `pending` timestamp, the
+/// corresponding approval must have been answered: the sidecar is stale
+/// and should be ignored.
+public enum HookPendingStalenessFilter {
+  public static func filter(
+    hookPending: SessionJSONLParser.PendingToolInfo?,
+    lastActivityAt: Date?
+  ) -> SessionJSONLParser.PendingToolInfo? {
+    guard let hookPending else { return nil }
+    if let lastActivityAt, lastActivityAt > hookPending.timestamp {
+      return nil
+    }
+    return hookPending
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/HookPendingStalenessFilter.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/HookPendingStalenessFilter.swift
@@ -24,13 +24,29 @@ import Foundation
 /// activity timestamp is newer than the hook's `pending` timestamp, the
 /// corresponding approval must have been answered: the sidecar is stale
 /// and should be ignored.
+///
+/// ## Why the epsilon
+///
+/// Wall-clock timestamps drift between processes. The hook runs in a
+/// separate Python process; Claude writes JSONL from Node. Even now that
+/// the hook emits millisecond precision there's still genuine skew on the
+/// order of tens of milliseconds. We also need to absorb legacy sidecar
+/// lines from earlier builds that were written with whole-second
+/// truncation. A one-second grace window covers both cleanly without
+/// making the stale-detection meaningfully slower to kick in (a turn that
+/// actually resolved will have JSONL activity at least that far past the
+/// hook timestamp once the result block lands).
 public enum HookPendingStalenessFilter {
+  public static let stalenessEpsilon: TimeInterval = 1.0
+
   public static func filter(
     hookPending: SessionJSONLParser.PendingToolInfo?,
-    lastActivityAt: Date?
+    lastActivityAt: Date?,
+    epsilon: TimeInterval = stalenessEpsilon
   ) -> SessionJSONLParser.PendingToolInfo? {
     guard let hookPending else { return nil }
-    if let lastActivityAt, lastActivityAt > hookPending.timestamp {
+    if let lastActivityAt,
+       lastActivityAt.timeIntervalSince(hookPending.timestamp) > epsilon {
       return nil
     }
     return hookPending

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/SessionFileWatcher.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/SessionFileWatcher.swift
@@ -465,12 +465,18 @@ public actor SessionFileWatcher {
     // JSONL is authoritative when it has a pending entry; otherwise fall back
     // to the hook-sourced entry (Claude Code CLI doesn't flush tool_use blocks
     // to JSONL until the turn commits, so the hook is the only signal during
-    // the approval window).
+    // the approval window). See `HookPendingStalenessFilter` for the
+    // "already-resolved" guard.
+    let effectiveHookPending = HookPendingStalenessFilter.filter(
+      hookPending: hookPending,
+      lastActivityAt: result.lastActivityAt
+    )
+
     let chosenPending: SessionJSONLParser.PendingToolInfo?
     if let (_, jsonlPending) = result.pendingToolUses.first {
       chosenPending = jsonlPending
     } else {
-      chosenPending = hookPending
+      chosenPending = effectiveHookPending
     }
 
     let pendingToolUse: PendingToolUse?
@@ -490,8 +496,8 @@ public actor SessionFileWatcher {
     // reports a pending tool, override to awaitingApproval so the sidebar
     // reflects reality.
     let derivedStatus: SessionStatus = {
-      if result.pendingToolUses.isEmpty, let hookPending {
-        return .awaitingApproval(tool: hookPending.toolName)
+      if result.pendingToolUses.isEmpty, let p = effectiveHookPending {
+        return .awaitingApproval(tool: p.toolName)
       }
       return result.currentStatus
     }()

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/SessionFileWatcher.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/SessionFileWatcher.swift
@@ -25,6 +25,7 @@ public actor SessionFileWatcher {
   // MARK: - Properties
 
   private var watchedSessions: [String: FileWatcherInfo] = [:]
+  private var hookCancellables: [String: AnyCancellable] = [:]
   private nonisolated let stateSubject = PassthroughSubject<StateUpdate, Never>()
   private let claudePath: String
 
@@ -35,6 +36,7 @@ public actor SessionFileWatcher {
   private var approvalTimeoutSeconds: Int = 0
 
   private let approvalNotificationService: any ApprovalNotificationServiceProtocol
+  private let hookSidecarWatcher: (any ClaudeHookSidecarWatcherProtocol)?
 
   /// Publisher for state updates
   public nonisolated var statePublisher: AnyPublisher<StateUpdate, Never> {
@@ -45,10 +47,12 @@ public actor SessionFileWatcher {
 
   public init(
     claudePath: String = "~/.claude",
-    approvalNotificationService: any ApprovalNotificationServiceProtocol = ApprovalNotificationService.shared
+    approvalNotificationService: any ApprovalNotificationServiceProtocol = ApprovalNotificationService.shared,
+    hookSidecarWatcher: (any ClaudeHookSidecarWatcherProtocol)? = nil
   ) {
     self.claudePath = NSString(string: claudePath).expandingTildeInPath
     self.approvalNotificationService = approvalNotificationService
+    self.hookSidecarWatcher = hookSidecarWatcher
   }
 
   /// Set the approval timeout in seconds
@@ -84,7 +88,15 @@ public actor SessionFileWatcher {
 
     // Initial parse
     var parseResult = SessionJSONLParser.parseSessionFile(at: filePath, approvalTimeoutSeconds: approvalTimeoutSeconds)
-    let initialState = buildMonitorState(from: parseResult)
+
+    // Seed hook-sourced pending info (if the hook fired before we started).
+    var hookPendingInfo: SessionJSONLParser.PendingToolInfo?
+    if let hookSidecarWatcher {
+      await hookSidecarWatcher.startWatching(sessionId: sessionId)
+      hookPendingInfo = await hookSidecarWatcher.pendingInfo(for: sessionId)
+    }
+
+    let initialState = buildMonitorState(from: parseResult, hookPending: hookPendingInfo)
 
     // Emit initial state
     stateSubject.send(StateUpdate(sessionId: sessionId, state: initialState))
@@ -153,7 +165,7 @@ public actor SessionFileWatcher {
         // Keep lastEmittedStatus in sync to prevent redundant emissions from status timer
         lastEmittedStatus = parseResult.currentStatus
 
-        let updatedState = self.buildMonitorState(from: parseResult)
+        let updatedState = self.buildMonitorState(from: parseResult, hookPending: hookPendingInfo)
 
         // Emit update
         Task { @MainActor in
@@ -235,7 +247,7 @@ public actor SessionFileWatcher {
           }
 
           lastEmittedStatus = parseResult.currentStatus
-          let updatedState = self.buildMonitorState(from: parseResult)
+          let updatedState = self.buildMonitorState(from: parseResult, hookPending: hookPendingInfo)
 
           Task { @MainActor in
             self.stateSubject.send(StateUpdate(sessionId: sessionId, state: updatedState))
@@ -261,6 +273,49 @@ public actor SessionFileWatcher {
     rescheduleStatusTimer()
     statusTimer.resume()
 
+    // Subscribe to sidecar updates for this session. When a new hook-sourced
+    // pending arrives we push it through the same processingQueue so that
+    // `hookPendingInfo`, the local var captured by the DispatchSource event
+    // handlers, is updated without data races.
+    if let hookSidecarWatcher {
+      let approvalNotificationService = self.approvalNotificationService
+      let notifiedRef = Notified()
+      let cancellable = hookSidecarWatcher.updates
+        .filter { $0.sessionId == sessionId }
+        .sink { [weak self] update in
+          guard let self else { return }
+          self.processingQueue.async {
+            hookPendingInfo = update.info
+            let updatedState = self.buildMonitorState(
+              from: parseResult,
+              hookPending: hookPendingInfo
+            )
+            // Fire the approval notification when the hook signals a new
+            // pending tool (and only when we haven't already notified for it).
+            if let info = update.info, notifiedRef.lastNotifiedToolUseId != info.toolUseId {
+              notifiedRef.lastNotifiedToolUseId = info.toolUseId
+              let lastMessage = parseResult.recentActivities
+                .last(where: { if case .userMessage = $0.type { return true }; return false })?
+                .description
+              approvalNotificationService.sendApprovalNotification(
+                sessionId: sessionId,
+                toolName: info.toolName,
+                projectPath: filePath,
+                model: parseResult.model,
+                lastMessage: lastMessage
+              )
+            }
+            if update.info == nil {
+              notifiedRef.lastNotifiedToolUseId = nil
+            }
+            Task { @MainActor in
+              self.stateSubject.send(StateUpdate(sessionId: sessionId, state: updatedState))
+            }
+          }
+        }
+      hookCancellables[sessionId] = cancellable
+    }
+
     // Store watcher info
     watchedSessions[sessionId] = FileWatcherInfo(
       filePath: filePath,
@@ -283,6 +338,10 @@ public actor SessionFileWatcher {
 
     info.source.cancel()
     info.statusTimer.cancel()
+    hookCancellables.removeValue(forKey: sessionId)
+    if let hookSidecarWatcher {
+      await hookSidecarWatcher.stopWatching(sessionId: sessionId)
+    }
     AppLogger.watcher.info("[Polling] Cancelled file watcher and timer for: \(sessionId.prefix(8), privacy: .public)")
   }
 
@@ -399,23 +458,46 @@ public actor SessionFileWatcher {
     }
   }
 
-  private nonisolated func buildMonitorState(from result: SessionJSONLParser.ParseResult) -> SessionMonitorState {
-    // Convert pending tool uses
+  private nonisolated func buildMonitorState(
+    from result: SessionJSONLParser.ParseResult,
+    hookPending: SessionJSONLParser.PendingToolInfo? = nil
+  ) -> SessionMonitorState {
+    // JSONL is authoritative when it has a pending entry; otherwise fall back
+    // to the hook-sourced entry (Claude Code CLI doesn't flush tool_use blocks
+    // to JSONL until the turn commits, so the hook is the only signal during
+    // the approval window).
+    let chosenPending: SessionJSONLParser.PendingToolInfo?
+    if let (_, jsonlPending) = result.pendingToolUses.first {
+      chosenPending = jsonlPending
+    } else {
+      chosenPending = hookPending
+    }
+
     let pendingToolUse: PendingToolUse?
-    if let (_, pending) = result.pendingToolUses.first {
+    if let p = chosenPending {
       pendingToolUse = PendingToolUse(
-        toolName: pending.toolName,
-        toolUseId: pending.toolUseId,
-        timestamp: pending.timestamp,
-        input: pending.input,
-        codeChangeInput: pending.codeChangeInput
+        toolName: p.toolName,
+        toolUseId: p.toolUseId,
+        timestamp: p.timestamp,
+        input: p.input,
+        codeChangeInput: p.codeChangeInput
       )
     } else {
       pendingToolUse = nil
     }
 
+    // If the JSONL parser had no activity to derive status from but the hook
+    // reports a pending tool, override to awaitingApproval so the sidebar
+    // reflects reality.
+    let derivedStatus: SessionStatus = {
+      if result.pendingToolUses.isEmpty, let hookPending {
+        return .awaitingApproval(tool: hookPending.toolName)
+      }
+      return result.currentStatus
+    }()
+
     return SessionMonitorState(
-      status: result.currentStatus,
+      status: derivedStatus,
       currentTool: extractCurrentTool(from: result),
       lastActivityAt: result.lastActivityAt ?? Date(),
       inputTokens: result.lastInputTokens,          // Last input (context window)
@@ -460,6 +542,12 @@ private struct FileWatcherInfo {
   // Health check tracking
   var lastFileEventTime: Date
   var lastKnownFileSize: UInt64
+}
+
+/// Reference-type scratch used inside the sidecar-subscription closure to
+/// dedupe approval notifications by `toolUseId`. Kept private to this file.
+private final class Notified: @unchecked Sendable {
+  var lastNotifiedToolUseId: String?
 }
 
 // MARK: - Protocol Conformance

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderMonitoringPanelView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderMonitoringPanelView.swift
@@ -18,7 +18,7 @@ private enum SidePanelContent: Equatable {
   case webPreview(sessionId: String, session: CLISession, projectPath: String)
   case mermaid(sessionId: String, session: CLISession)
   case gitHub(sessionId: String, session: CLISession, projectPath: String)
-  case edits(sessionId: String, session: CLISession, pendingToolUse: PendingToolUse)
+  case edits(sessionId: String, session: CLISession)
 
   static func == (lhs: SidePanelContent, rhs: SidePanelContent) -> Bool {
     switch (lhs, rhs) {
@@ -32,8 +32,8 @@ private enum SidePanelContent: Equatable {
       return id1 == id2
     case (.gitHub(let id1, _, let p1), .gitHub(let id2, _, let p2)):
       return id1 == id2 && p1 == p2
-    case (.edits(let id1, _, let t1), .edits(let id2, _, let t2)):
-      return id1 == id2 && t1.toolUseId == t2.toolUseId
+    case (.edits(let id1, _), .edits(let id2, _)):
+      return id1 == id2
     default: return false
     }
   }
@@ -634,9 +634,9 @@ public struct MultiProviderMonitoringPanelView: View {
                 forItemID: item.id
               )
             },
-            onShowPendingChanges: { session, pendingToolUse in
+            onShowPendingChanges: { session, _ in
               toggleSidePanel(
-                .edits(sessionId: session.id, session: session, pendingToolUse: pendingToolUse),
+                .edits(sessionId: session.id, session: session),
                 forItemID: item.id
               )
             },
@@ -785,16 +785,23 @@ public struct MultiProviderMonitoringPanelView: View {
           gitHubPopOutItem = GitHubPopOutItem(session: session, projectPath: projectPath)
         }
       )
-    case .edits(_, let session, let pendingToolUse):
-      PendingChangesView(
-        session: session,
-        pendingToolUse: pendingToolUse,
-        onDismiss: { withAnimation(.easeInOut(duration: 0.25)) { sidePanelContent = nil } },
-        isEmbedded: true,
-        onApprovalResponse: { response, sess in
-          viewModel.showTerminalWithPrompt(for: sess, prompt: response)
-        }
-      )
+    case .edits(let sessionId, let session):
+      if let pendingToolUse = viewModel.monitorStates[sessionId]?.pendingToolUse {
+        PendingChangesView(
+          session: session,
+          pendingToolUse: pendingToolUse,
+          onDismiss: { withAnimation(.easeInOut(duration: 0.25)) { sidePanelContent = nil } },
+          isEmbedded: true,
+          onApprovalResponse: { response, sess in
+            viewModel.showTerminalWithPrompt(for: sess, prompt: response)
+          }
+        )
+      } else {
+        PendingChangesWaitingView(
+          session: session,
+          onDismiss: { withAnimation(.easeInOut(duration: 0.25)) { sidePanelContent = nil } }
+        )
+      }
     }
   }
 
@@ -908,9 +915,9 @@ public struct MultiProviderMonitoringPanelView: View {
             forItemID: item.id
           )
         },
-        onShowPendingChanges: { session, pendingToolUse in
+        onShowPendingChanges: { session, _ in
           toggleSidePanel(
-            .edits(sessionId: session.id, session: session, pendingToolUse: pendingToolUse),
+            .edits(sessionId: session.id, session: session),
             forItemID: item.id
           )
         },
@@ -1098,9 +1105,9 @@ public struct MultiProviderMonitoringPanelView: View {
               forItemID: itemId
             )
           },
-          onShowPendingChanges: { session, pendingToolUse in
+          onShowPendingChanges: { session, _ in
             toggleSidePanel(
-              .edits(sessionId: session.id, session: session, pendingToolUse: pendingToolUse),
+              .edits(sessionId: session.id, session: session),
               forItemID: itemId
             )
           },

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/PendingChangesView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/PendingChangesView.swift
@@ -71,7 +71,7 @@ public struct PendingChangesView: View {
       minWidth: isEmbedded ? 300 : 1000, idealWidth: isEmbedded ? .infinity : 1200, maxWidth: .infinity,
       minHeight: isEmbedded ? 300 : 600, idealHeight: isEmbedded ? .infinity : 800, maxHeight: .infinity
     )
-    .task {
+    .task(id: pendingToolUse.toolUseId) {
       await loadPreview()
     }
   }
@@ -363,6 +363,81 @@ public struct PendingChangesView: View {
         webViewOpacity = 1
       }
     }
+  }
+}
+
+// MARK: - PendingChangesWaitingView
+
+/// Placeholder shown inside the inline edits side panel when no pending
+/// approval exists for the current session. Keeps the panel open so that the
+/// next agent-proposed edit appears automatically without the user re-opening it.
+public struct PendingChangesWaitingView: View {
+  let session: CLISession
+  let onDismiss: () -> Void
+
+  public init(session: CLISession, onDismiss: @escaping () -> Void) {
+    self.session = session
+    self.onDismiss = onDismiss
+  }
+
+  public var body: some View {
+    VStack(spacing: 0) {
+      header
+      Divider()
+      placeholder
+    }
+    .frame(
+      minWidth: 300, idealWidth: .infinity, maxWidth: .infinity,
+      minHeight: 300, idealHeight: .infinity, maxHeight: .infinity
+    )
+  }
+
+  private var header: some View {
+    HStack {
+      HStack(spacing: 8) {
+        Image(systemName: "eye")
+          .font(.title3)
+          .foregroundColor(.orange)
+        Text("Pending Changes")
+          .font(.title3.weight(.semibold))
+      }
+
+      Spacer()
+
+      HStack(spacing: 8) {
+        Text(session.shortId)
+          .font(.system(.caption, design: .monospaced))
+          .foregroundColor(.secondary)
+        if let branch = session.branchName {
+          Text("[\(branch)]")
+            .font(.caption)
+            .foregroundColor(.secondary)
+        }
+      }
+
+      Spacer()
+
+      Button("Close") { onDismiss() }
+    }
+    .padding()
+    .background(Color.surfaceElevated)
+  }
+
+  private var placeholder: some View {
+    VStack(spacing: 12) {
+      Image(systemName: "hourglass")
+        .font(.system(size: 36))
+        .foregroundStyle(.secondary)
+      Text("Waiting for the next pending edit…")
+        .font(.callout)
+        .foregroundStyle(.secondary)
+      Text("This panel will update automatically when the agent proposes a change.")
+        .font(.caption)
+        .foregroundStyle(.secondary)
+        .multilineTextAlignment(.center)
+        .padding(.horizontal, 32)
+    }
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
   }
 }
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/SettingsView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/SettingsView.swift
@@ -44,6 +44,9 @@ public struct SettingsView: View {
   @AppStorage(AgentHubDefaults.pushNotificationsEnabled)
   private var pushNotificationsEnabled: Bool = true
 
+  @AppStorage(ClaudeHookInstaller.enabledKey)
+  private var claudeApprovalHooksEnabled: Bool = true
+
   @AppStorage(AgentHubDefaults.claudeCommand)
   private var claudeCommand: String = "claude"
 
@@ -144,6 +147,33 @@ public struct SettingsView: View {
         )
       }
 
+      Section("Claude Code integration") {
+        settingsToggle(
+          title: "Enable approval hooks",
+          description: "Detects pending Edit/Bash/etc. approvals in real time. Installs a hook into each monitored project's .claude/settings.local.json (gitignored) only while AgentHub is actively watching the session.",
+          isOn: $claudeApprovalHooksEnabled
+        )
+        .onChange(of: claudeApprovalHooksEnabled) { _, newValue in
+          guard let provider = agentHub else { return }
+          let installer = provider.claudeHookInstaller
+          let claudeVM = provider.claudeSessionsViewModel
+          Task {
+            await installer.setEnabled(newValue)
+            // Re-enable: trigger a fresh sync for the currently tracked repos
+            // (setEnabled intentionally doesn't know about the repo list).
+            if newValue {
+              await MainActor.run {
+                var paths: Set<String> = []
+                for repo in claudeVM.selectedRepositories {
+                  paths.insert(repo.path)
+                  for worktree in repo.worktrees { paths.insert(worktree.path) }
+                }
+                Task { await installer.syncInstalledPaths(paths) }
+              }
+            }
+          }
+        }
+      }
     }
     .formStyle(.grouped)
     .scrollContentBackground(.hidden)

--- a/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/CLISessionsViewModel.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/CLISessionsViewModel.swift
@@ -32,6 +32,8 @@ public final class CLISessionsViewModel {
   private let fileWatcher: any SessionFileWatcherProtocol
   private let webPreviewCandidateService: any WebPreviewCandidateServiceProtocol
   private let approvalNotificationService: any ApprovalNotificationServiceProtocol
+  private let approvalClaimStore: (any ApprovalClaimStoreProtocol)?
+  private let hookInstaller: (any ClaudeHookInstallerProtocol)?
   weak var agentHubProvider: AgentHubProvider?
 
   // MARK: - State
@@ -177,10 +179,19 @@ public final class CLISessionsViewModel {
 
     monitoringCancellables[session.id] = cancellable
 
+    // Claude-only: claim the session so the installed hook will actually
+    // write approval events for it. The hook itself is installed at the
+    // repository level (see `syncClaudeHookInstalls`), so nothing happens
+    // here beyond the claim. Codex injects nil for the claim store.
+    let claimStore = approvalClaimStore
+    let sessionId = session.id
+    let projectPath = session.projectPath
+
     Task {
+      await claimStore?.claim(sessionId: sessionId)
       await fileWatcher.startMonitoring(
-        sessionId: session.id,
-        projectPath: session.projectPath,
+        sessionId: sessionId,
+        projectPath: projectPath,
         sessionFilePath: session.sessionFilePath
       )
     }
@@ -194,8 +205,11 @@ public final class CLISessionsViewModel {
     monitoringCancellables.removeValue(forKey: sessionId)
     monitorStates.removeValue(forKey: sessionId)
 
+    let claimStore = approvalClaimStore
+
     Task {
       await fileWatcher.stopMonitoring(sessionId: sessionId)
+      await claimStore?.release(sessionId: sessionId)
     }
     AppLogger.session.info("[Polling] Stopped polling for session: \(sessionId.prefix(8), privacy: .public)")
   }
@@ -545,7 +559,9 @@ public final class CLISessionsViewModel {
     providerKind: SessionProviderKind,
     metadataStore: SessionMetadataStore? = nil,
     webPreviewCandidateService: any WebPreviewCandidateServiceProtocol = WebPreviewCandidateService.shared,
-    approvalNotificationService: any ApprovalNotificationServiceProtocol = ApprovalNotificationService.shared
+    approvalNotificationService: any ApprovalNotificationServiceProtocol = ApprovalNotificationService.shared,
+    approvalClaimStore: (any ApprovalClaimStoreProtocol)? = nil,
+    hookInstaller: (any ClaudeHookInstallerProtocol)? = nil
   ) {
     // [CLISessionsVM] init called")
     self.monitorService = monitorService
@@ -554,6 +570,8 @@ public final class CLISessionsViewModel {
     self.fileWatcher = fileWatcher
     self.webPreviewCandidateService = webPreviewCandidateService
     self.approvalNotificationService = approvalNotificationService
+    self.approvalClaimStore = approvalClaimStore
+    self.hookInstaller = hookInstaller
     self.cliConfiguration = cliConfiguration
     self.providerKind = providerKind
     self.showLastMessage = UserDefaults.standard.bool(forKey: "CLISessionsShowLastMessage")
@@ -719,8 +737,32 @@ public final class CLISessionsViewModel {
 
           // Progressively restore sessions from persistence as they become available
           self.processPendingSessionRestorations()
+
+          // Claude-only: make sure every repo/worktree path the user has
+          // added has the approval hook registered in its
+          // `.claude/settings.local.json`. Claude Code reads that file once
+          // at session start, so we install eagerly here rather than on
+          // per-session startup. Codex injects nil → no-op.
+          self.syncClaudeHookInstalls()
         }
       }
+    }
+  }
+
+  /// Computes the flat set of paths that should have the approval hook
+  /// registered and hands it to the installer. Safe to call repeatedly —
+  /// the installer is idempotent.
+  private func syncClaudeHookInstalls() {
+    guard let installer = hookInstaller else { return }
+    var paths: Set<String> = []
+    for repo in selectedRepositories {
+      paths.insert(repo.path)
+      for worktree in repo.worktrees {
+        paths.insert(worktree.path)
+      }
+    }
+    Task {
+      await installer.syncInstalledPaths(paths)
     }
   }
 


### PR DESCRIPTION
## Summary

- Surface the **Edits** eye button and `awaitingApproval` sidebar status while the user is being prompted to approve a tool call, instead of 18 minutes later when Claude Code finally flushes the `tool_use` block to disk.
- Drive it from a Claude Code **PreToolUse** hook layered on top of the existing JSONL pipeline. JSONL stays primary for everything else (tokens, activity, plan, mermaid, status, localhost URLs); the hook only fills the approval-window gap.
- Fix a related UI bug where the inline `.edits` side panel froze a stale `PendingToolUse` snapshot instead of reading live state from the view model.

## Why

`SessionMonitorState.pendingToolUse` is populated from `SessionJSONLParser.pendingToolUses` — a dict of `tool_use` blocks that haven't yet received a `tool_result`. Claude Code CLI timestamps a `tool_use` at decision time but **doesn't flush it to disk until the turn commits**, i.e. after the user answers the approval prompt. Verified against a real session (`01a22d1a-…jsonl`): both the `tool_use` (timestamped 07:11:50Z) and its `tool_result` (07:30:26Z) only hit the file at 07:30:29Z — 18 minutes after the decision. During the whole approval window, the JSONL parser has nothing to see.

This isn't a regression from PR #251 — the eye button has always been gated on `state?.pendingToolUse`, and that's always been nil during approval-window reads. Claude Code's buffering is inconsistent across sessions (sometimes it does flush early), so the button appeared intermittently before. This PR makes it reliable.

## How the session JSON is managed

**This is the part worth reading carefully.** The design deliberately minimizes what ends up inside a user's git repository.

### What we write into a user's project

Exactly one thing, exactly one file:

```
{project}/.claude/settings.local.json
```

Inside it, a single entry under `hooks.PreToolUse` (and `PostToolUse`) whose `command` is an **absolute path** into `~/Library/Application Support/AgentHub/hooks/agenthub-approval.sh`:

```json
{
  "hooks": {
    "PreToolUse": [
      { "matcher": "*",
        "hooks": [{ "type": "command",
                    "command": "/Users/you/Library/Application Support/AgentHub/hooks/agenthub-approval.sh" }] }
    ],
    "PostToolUse": [ /* same */ ]
  }
}
```

Why this file specifically:
- Claude Code treats `.claude/settings.local.json` as the **personal, gitignored** layer of its three-layer config (user → shared checked-in `settings.json` → personal `settings.local.json`). Its project template gitignores it by default.
- We **never** touch `.claude/settings.json` (the shared/checked-in one).
- We **never** write into `.claude/hooks/`. The shell script is a shared per-app copy, not a per-repo file, so there is no way for a stray script to end up in `git log` even under a user's loose `.gitignore`.

### What we write outside the repo

Three app-owned directories under `~/Library/Application Support/AgentHub/`:

| Path | Owner | Purpose |
|---|---|---|
| `hooks/agenthub-approval.sh` | installer, copied from bundle | the single shell script every monitored project references |
| `claims/{sessionId}` | `ApprovalClaimStore` | marker files written when a session starts monitoring, deleted on stop |
| `approvals/{sessionId}.jsonl` | hook script appends; `ClaudeHookSidecarWatcher` consumes | one-line-per-event approval feed |

### Merge semantics for `settings.local.json`

`ClaudeHookInstaller` parses the file as `[String: Any]` and preserves everything it doesn't own:
- Unrelated top-level keys (`permissions`, `env`, `mcpServers`, etc.) are untouched.
- Inside `hooks.PreToolUse` / `PostToolUse`, existing entries are preserved; we identify our own by the `command` path and upsert a single matching entry.
- On uninstall, only the entry whose `command` equals our script's absolute path is removed. If the file becomes empty after we leave, it's deleted rather than leaving a shell.
- If a user has their own hooks in the checked-in `settings.json`, Claude Code runs all matching hooks across all layers — our hook runs alongside theirs, we don't have to coordinate.

Covered by unit tests: `preservesExistingKeys`, `uninstallPreservesOthers`, `idempotent`.

### Install lifetime

Claude Code reads `settings.local.json` **once at session start** and caches it. Mid-session installs don't take effect — the first iteration of this work installed per-session and broke for this reason. The current design installs per **repository**:

- `CLISessionsViewModel.setupSubscriptions` → on every `monitorService.repositoriesPublisher` emission, flatten every tracked repo + worktree path into a `Set<String>` and call `installer.syncInstalledPaths(_:)`. The installer diffs against its persisted "previously installed" set and installs/uninstalls the delta. Idempotent.
- App launch → `AgentHubProvider.reconcileClaudeHooksOnLaunch()` runs before the subscription fires, sweeping any orphans from a prior crash or force-quit so external Claude Code sessions in the gap see nothing of ours.
- App quit → `flushClaudeHooksOnTerminate()` removes every entry we installed and resets claim files.
- Settings toggle off → `setEnabled(false)` sweeps immediately. On → next subscription emission re-installs (triggered right away via `onChange` in `SettingsView`).

### Claim-gating (external-terminal safety)

The hook script is installed at the repo level, so if a user opens the same worktree in Terminal.app while AgentHub is running, Claude Code in that terminal **will** invoke our hook. That would be a surprise for them. Fix:

- The script reads `session_id` from stdin and checks for `~/Library/Application Support/AgentHub/claims/{sessionId}`.
- AgentHub writes that claim only for sessions it's actively monitoring (`startPolling` → `claim`, `stopPolling` → `release`, app-launch → `resetAll`).
- External sessions have no claim → the script exits `0` silently in ~50ms. No sidecar write, no stdout, no effect Claude Code can see.

### Legacy migration

An earlier iteration of this work put the script inside each project's `.claude/hooks/`. If a user has that on disk from a previous build, `migrateLegacyPerProjectScript()` is called from every `install`/`uninstall` path: it deletes the legacy script and strips any `settings.local.json` entry still pointing at the old path before we re-add ours pointing at the shared one. No user action required.

## What's left for Codex (explicit)

**Codex is intentionally not covered by this PR.** Reasons:

- Codex CLI has no hook mechanism equivalent to Claude Code's `PreToolUse`. There is no file to drop an approval-signal into and no config to point at a script.
- Codex's file watcher already hardcodes `pendingToolUse: nil` in `CodexSessionFileWatcher.buildMonitorState()`, and its JSONL parser `pendingToolUses` dict is populated internally but never surfaced to state. That stays as-is.
- The approval-notification path is also Codex-less: `SessionFileWatcher`'s notification trigger has no Codex counterpart, and we didn't build one.
- Every new service — `ApprovalClaimStore`, `ClaudeHookSidecarWatcher`, `ClaudeHookInstaller` — is wired into the Claude VM only. `AgentHubProvider.makeSessionsViewModel` injects `nil` for both `approvalClaimStore` and `hookInstaller` when `providerKind == .codex`. The VM treats those as optional no-ops.
- Monitoring, status derivation, tokens, plan detection, activity feed, mermaid, localhost URLs, resource links, and everything else Codex already had continues to work through its own JSONL path — nothing in Codex's observation changed.

A clarifying comment was added at `CodexSessionFileWatcher.swift` next to the `pendingToolUse: nil` line so anyone touching Codex later knows this is deliberate and where to look.

**Consequence for users:** Codex sessions still show `idle` / `thinking` / `executingTool` states from JSONL. They will not show `awaitingApproval` before approval resolves, and the Edits eye button won't appear for Codex pending edits. If Codex ships hooks in a future version, extending this pattern to Codex would mean: a `CodexHookInstaller` writing to whatever Codex's equivalent config is, a dedicated sidecar path, and merging into `CodexSessionJSONLParser.ParseResult.pendingToolUses` before `CodexSessionFileWatcher.buildMonitorState()`. Deliberately out of scope for this PR.

## Architecture summary

Three protocol-backed services (all new):

- **`ClaudeHookInstaller`** — `syncInstalledPaths(_:)` drives install state declaratively. Never writes inside `.claude/hooks/`. Merge-by-JSON preserves all unrelated keys.
- **`ClaudeHookSidecarWatcher`** — per-session kqueue watcher over `approvals/`. Publishes `SidecarUpdate` via Combine; parses `pending`/`resolved` events into `SessionJSONLParser.PendingToolInfo` (reuses the existing model so the merge into `ParseResult.pendingToolUses` is a dict insert).
- **`ApprovalClaimStore`** — one-file-per-session marker directory. Wipes on launch.

Merge point in `SessionFileWatcher.buildMonitorState(_:hookPending:)`: JSONL wins on conflict; status is overridden to `.awaitingApproval(tool:)` when only the hook has a pending entry. Approval notification fires once per `toolUseId` on the hook-sourced transition too, deduped by a small `Notified` reference value inside the subscription closure.

## Also included (side fix)

`MultiProviderMonitoringPanelView`'s `.edits` side-panel case used to freeze its `PendingToolUse` snapshot into `@State sidePanelContent`, so a second edit queued up while the panel was open never updated the view. Now it reads live state from `viewModel.monitorStates[sessionId]?.pendingToolUse` on every render. `PendingChangesView` uses `.task(id: pendingToolUse.toolUseId)` so `loadPreview()` re-runs when the pending tool changes. A new `PendingChangesWaitingView` placeholder keeps the panel open between edits instead of collapsing.

## Files

**New**
- `Services/ClaudeHookPaths.swift`
- `Services/ApprovalClaimStore.swift` (+protocol)
- `Services/ClaudeHookSidecarWatcher.swift` (+protocol)
- `Services/ClaudeHookInstaller.swift` (+protocol)
- `Resources/ClaudeHook/agenthub-approval.sh`
- `AgentHubTests/ApprovalClaimStoreTests.swift` (4 cases)
- `AgentHubTests/ClaudeHookSidecarWatcherTests.swift` (3 cases)
- `AgentHubTests/ClaudeHookInstallerTests.swift` (9 cases)

**Modified**
- `Services/SessionFileWatcher.swift` — optional sidecar injection; `buildMonitorState` merges hook pending; per-session subscription fires approval notifications.
- `ViewModels/CLISessionsViewModel.swift` — `syncClaudeHookInstalls()` tied to the repositories subscription; claim/release in `startPolling`/`stopPolling`.
- `Configuration/AgentHubProvider.swift` — wires services Claude-only; launch reconcile + terminate flush.
- `AgentHub/AgentHubApp.swift` — calls the two lifecycle hooks.
- `UI/SettingsView.swift` — "Enable approval hooks" toggle (default on), immediate re-sync on toggle-on.
- `UI/MultiProviderMonitoringPanelView.swift` — `.edits` reads live pending from VM.
- `UI/PendingChangesView.swift` — `.task(id:)` reload; new `PendingChangesWaitingView`.
- `Services/CodexSessionFileWatcher.swift` — clarifying comment only.
- `Package.swift` — ships the hook script as a bundle resource.

## Test plan

- [x] `xcodebuild … build` — SUCCEEDED.
- [x] 16 new unit tests pass.
- [x] Manual: fresh Claude session in a monitored worktree — Edits button appears pre-approval, diff preview renders correctly, sidecar file grows with `pending`/`resolved` events.
- [x] Manual: legacy `.claude/hooks/agenthub-approval.sh` from an earlier build is removed automatically on next install.
- [ ] Manual: external Terminal.app Claude session in a monitored worktree — hook runs, claim absent, exits silently, no sidecar growth for that session id, no visible latency.
- [ ] Manual: Settings toggle off — every tracked repo's `settings.local.json` has our entry removed; unrelated user keys/hooks still present.
- [ ] Manual: add/remove a repo — `syncInstalledPaths` handles both transitions correctly.
- [ ] Manual: Codex session — still shows JSONL-based status/tokens; no false eye button; unchanged from today.

## Out of scope

- Codex approval detection (see dedicated section above).
- Using hooks for anything other than pending-approval signals.
- Auto-approving edits from AgentHub UI.

Plan: `~/.claude/plans/parsed-weaving-nebula.md`