### PR TITLE
Pin Needs Attention section to top of sessions sidebar

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
@@ -108,18 +108,18 @@ private enum SidebarGroupMode: String, CaseIterable {
 // MARK: - StatusGroupCategory
 
 private enum StatusGroupCategory: String, CaseIterable, Identifiable {
+  case needsAttention = "Needs Attention"
   case working = "Working"
   case ready = "Ready"
-  case needsAttention = "Needs Attention"
   case idle = "Idle"
 
   var id: String { rawValue }
 
   var color: Color {
     switch self {
+    case .needsAttention: return .yellow
     case .working: return .blue
     case .ready: return .green
-    case .needsAttention: return .yellow
     case .idle: return .gray
     }
   }


### PR DESCRIPTION
## Summary
- Reorder `StatusGroupCategory` cases in `MultiProviderSessionsListView.swift` so **Needs Attention** renders first when the sidebar is grouped by status.
- Order is now: Needs Attention → Working → Ready → Idle. Section order follows enum declaration order via `CaseIterable.allCases`.

## Test plan
- [ ] Launch AgentHub with sessions in multiple states and switch the sidebar grouping to Status
- [ ] Confirm Needs Attention is pinned to the top when any session is awaiting approval
- [ ] Confirm remaining sections render in the expected order (Working, Ready, Idle)