### PR TITLE
Wire side-panel callbacks for pending sessions

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderMonitoringPanelView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderMonitoringPanelView.swift
@@ -552,8 +552,38 @@ public struct MultiProviderMonitoringPanelView: View {
             onCopySessionId: { },
             onOpenSessionFile: { },
             onRefreshTerminal: { },
+            onShowDiff: { session, projectPath in
+              toggleSidePanel(
+                .diff(sessionId: session.id, session: session, projectPath: projectPath),
+                forItemID: item.id
+              )
+            },
+            onShowPlan: { session, planState in
+              toggleSidePanel(
+                .plan(sessionId: session.id, session: session, planState: planState),
+                forItemID: item.id
+              )
+            },
             onShowWebPreview: { session, projectPath in
               presentWebPreviewInSidePanel(forItemID: item.id, session: session, projectPath: projectPath)
+            },
+            onShowMermaid: { session in
+              toggleSidePanel(
+                .mermaid(sessionId: session.id, session: session),
+                forItemID: item.id
+              )
+            },
+            onShowGitHub: { session, projectPath in
+              toggleSidePanel(
+                .gitHub(sessionId: session.id, session: session, projectPath: projectPath),
+                forItemID: item.id
+              )
+            },
+            onShowPendingChanges: { session, _ in
+              toggleSidePanel(
+                .edits(sessionId: session.id, session: session),
+                forItemID: item.id
+              )
             },
             onTerminalInteraction: { setPrimarySessionIfNeeded(item.id) },
             onRequestShowEditor: { setContentMode(.editor, for: item) },
@@ -833,8 +863,38 @@ public struct MultiProviderMonitoringPanelView: View {
         onCopySessionId: { },
         onOpenSessionFile: { },
         onRefreshTerminal: { },
+        onShowDiff: { session, projectPath in
+          toggleSidePanel(
+            .diff(sessionId: session.id, session: session, projectPath: projectPath),
+            forItemID: item.id
+          )
+        },
+        onShowPlan: { session, planState in
+          toggleSidePanel(
+            .plan(sessionId: session.id, session: session, planState: planState),
+            forItemID: item.id
+          )
+        },
         onShowWebPreview: { session, projectPath in
           presentWebPreviewInSidePanel(forItemID: item.id, session: session, projectPath: projectPath)
+        },
+        onShowMermaid: { session in
+          toggleSidePanel(
+            .mermaid(sessionId: session.id, session: session),
+            forItemID: item.id
+          )
+        },
+        onShowGitHub: { session, projectPath in
+          toggleSidePanel(
+            .gitHub(sessionId: session.id, session: session, projectPath: projectPath),
+            forItemID: item.id
+          )
+        },
+        onShowPendingChanges: { session, _ in
+          toggleSidePanel(
+            .edits(sessionId: session.id, session: session),
+            forItemID: item.id
+          )
         },
         onTerminalInteraction: { setPrimarySessionIfNeeded(item.id) },
         onRequestShowEditor: { setContentMode(.editor, for: item) },
@@ -1022,8 +1082,38 @@ public struct MultiProviderMonitoringPanelView: View {
           onCopySessionId: { },
           onOpenSessionFile: { },
           onRefreshTerminal: { },
+          onShowDiff: { session, projectPath in
+            toggleSidePanel(
+              .diff(sessionId: session.id, session: session, projectPath: projectPath),
+              forItemID: itemId
+            )
+          },
+          onShowPlan: { session, planState in
+            toggleSidePanel(
+              .plan(sessionId: session.id, session: session, planState: planState),
+              forItemID: itemId
+            )
+          },
           onShowWebPreview: { session, projectPath in
             presentWebPreviewInSidePanel(forItemID: itemId, session: session, projectPath: projectPath)
+          },
+          onShowMermaid: { session in
+            toggleSidePanel(
+              .mermaid(sessionId: session.id, session: session),
+              forItemID: itemId
+            )
+          },
+          onShowGitHub: { session, projectPath in
+            toggleSidePanel(
+              .gitHub(sessionId: session.id, session: session, projectPath: projectPath),
+              forItemID: itemId
+            )
+          },
+          onShowPendingChanges: { session, _ in
+            toggleSidePanel(
+              .edits(sessionId: session.id, session: session),
+              forItemID: itemId
+            )
           },
           onTerminalInteraction: { setPrimarySessionIfNeeded(itemId) },
           onRequestShowEditor: { setContentMode(.editor, for: item) },


### PR DESCRIPTION
## Summary
- On a fresh/pending session, the **Diff** and **GitHub** toolbar buttons (and Plan / Mermaid / Edits when they become visible) did nothing — clicking them never opened the side panel.
- Root cause: the three `.pending` branches in `MultiProviderMonitoringPanelView` (`singleModeContent`, `itemCardView`, `maximizedCardContent`) instantiated `MonitoringCardView` without passing `onShowDiff` / `onShowPlan` / `onShowMermaid` / `onShowGitHub` / `onShowPendingChanges`. The optional callbacks were `nil`, so the button actions (`onShowDiff?(...)`) were silent no-ops. The sibling `.monitored` branches wire them correctly — the pending ones just diverged.
- Fix: copy the same `toggleSidePanel(...)` closures from each `.monitored` branch into the matching `.pending` branch, using `pending.placeholderSession` (it already carries `id`, `projectPath` (= worktree path), and `branchName`, which is everything the `SidePanelContent` cases need). No guards, no model changes, no new state.

## Test plan
- [ ] Launch a fresh session (Cmd+N) in a git worktree without sending a prompt so it stays in the `.pending` state
- [ ] In single-panel layout: click **Diff** → `GitDiffView` opens; click again → closes
- [ ] Click **GitHub** → `GitHubPanelView` opens; click again → closes
- [ ] Verify **Simulator** (Xcode projects) still opens its sheet and **Refresh** stays a no-op on pending
- [ ] Repeat in list / 2-column / 3-column layouts (exercises `itemCardView`) and maximized view (exercises `maximizedCardContent`)
- [ ] Send a prompt so the session transitions `.pending` → `.monitored`; confirm side panel continues to work and doesn't flicker on transition
- [ ] Regression: on an existing monitored session, Diff / GitHub / Plan / Mermaid / Edits still toggle the side panel