### PR TITLE
Shell-quote hook script path so /bin/sh -c doesn't word-split

### DIFF
--- a/app/AgentHubTests/ClaudeHookInstallerTests.swift
+++ b/app/AgentHubTests/ClaudeHookInstallerTests.swift
@@ -71,9 +71,13 @@ struct ClaudeHookInstallerTests {
     }
 
     func hasAgentHubEntry(in entries: [[String: Any]], scriptPath: String) -> Bool {
-      entries.contains { entry in
+      let quoted = ClaudeHookInstaller.shellQuoted(scriptPath)
+      return entries.contains { entry in
         let inner = entry["hooks"] as? [[String: Any]] ?? []
-        return inner.contains { ($0["command"] as? String) == scriptPath }
+        return inner.contains {
+          let cmd = $0["command"] as? String
+          return cmd == scriptPath || cmd == quoted
+        }
       }
     }
   }
@@ -148,9 +152,13 @@ struct ClaudeHookInstallerTests {
 
     let settings = try fx.readSettings(at: fx.settingsLocal(for: fx.projectA))
     let entries = fx.preEntries(in: settings)
+    let quoted = ClaudeHookInstaller.shellQuoted(fx.sharedScriptURL.path)
     let matches = entries.filter { entry in
       let inner = entry["hooks"] as? [[String: Any]] ?? []
-      return inner.contains { ($0["command"] as? String) == fx.sharedScriptURL.path }
+      return inner.contains {
+        let cmd = $0["command"] as? String
+        return cmd == fx.sharedScriptURL.path || cmd == quoted
+      }
     }
     #expect(matches.count == 1)
   }
@@ -232,6 +240,80 @@ struct ClaudeHookInstallerTests {
     #expect(FileManager.default.fileExists(atPath: fx.settingsLocal(for: fx.projectA).path))
 
     await fx.installer.reconcileOnLaunch(expectedPaths: [])
+
+    let url = fx.settingsLocal(for: fx.projectA)
+    if FileManager.default.fileExists(atPath: url.path) {
+      let settings = try fx.readSettings(at: url)
+      #expect(!fx.hasAgentHubEntry(in: fx.preEntries(in: settings), scriptPath: fx.sharedScriptURL.path))
+    }
+  }
+
+  @Test("written command is shell-quoted so /bin/sh -c doesn't word-split on spaces in the path")
+  func writtenCommandIsShellQuoted() async throws {
+    let fx = try Fixture(name: "shellQuoted")
+    defer { fx.teardown() }
+
+    await fx.installer.syncInstalledPaths([fx.projectA.path])
+
+    let settings = try fx.readSettings(at: fx.settingsLocal(for: fx.projectA))
+    let entries = fx.preEntries(in: settings)
+    let inner = entries.first?["hooks"] as? [[String: Any]] ?? []
+    let cmd = inner.first?["command"] as? String
+    #expect(cmd == ClaudeHookInstaller.shellQuoted(fx.sharedScriptURL.path))
+    #expect(cmd?.hasPrefix("'") == true)
+    #expect(cmd?.hasSuffix("'") == true)
+  }
+
+  @Test("sync replaces a legacy unquoted entry with the quoted form")
+  func syncReplacesLegacyUnquotedEntry() async throws {
+    let fx = try Fixture(name: "migrateUnquoted")
+    defer { fx.teardown() }
+
+    let legacy: [String: Any] = [
+      "hooks": [
+        "PreToolUse": [
+          ["matcher": "*", "hooks": [["type": "command", "command": fx.sharedScriptURL.path]]]
+        ]
+      ],
+    ]
+    try FileManager.default.createDirectory(
+      at: fx.settingsLocal(for: fx.projectA).deletingLastPathComponent(),
+      withIntermediateDirectories: true
+    )
+    try JSONSerialization.data(withJSONObject: legacy).write(to: fx.settingsLocal(for: fx.projectA))
+
+    await fx.installer.syncInstalledPaths([fx.projectA.path])
+
+    let entries = fx.preEntries(in: try fx.readSettings(at: fx.settingsLocal(for: fx.projectA)))
+    #expect(entries.count == 1)
+    let cmd = (entries.first?["hooks"] as? [[String: Any]])?.first?["command"] as? String
+    #expect(cmd == ClaudeHookInstaller.shellQuoted(fx.sharedScriptURL.path))
+  }
+
+  @Test("uninstall removes a legacy unquoted entry")
+  func uninstallRemovesLegacyUnquotedEntry() async throws {
+    let fx = try Fixture(name: "uninstallUnquoted")
+    defer { fx.teardown() }
+
+    let legacy: [String: Any] = [
+      "hooks": [
+        "PreToolUse": [
+          ["matcher": "*", "hooks": [["type": "command", "command": fx.sharedScriptURL.path]]]
+        ],
+        "PostToolUse": [
+          ["matcher": "*", "hooks": [["type": "command", "command": fx.sharedScriptURL.path]]]
+        ],
+      ],
+    ]
+    try FileManager.default.createDirectory(
+      at: fx.settingsLocal(for: fx.projectA).deletingLastPathComponent(),
+      withIntermediateDirectories: true
+    )
+    try JSONSerialization.data(withJSONObject: legacy).write(to: fx.settingsLocal(for: fx.projectA))
+    // Pretend installer had previously written this path so uninstall sees it.
+    fx.defaults.set([fx.projectA.path], forKey: ClaudeHookInstaller.installedPathsKey)
+
+    await fx.installer.syncInstalledPaths([])
 
     let url = fx.settingsLocal(for: fx.projectA)
     if FileManager.default.fileExists(atPath: url.path) {

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/ClaudeHookInstaller.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/ClaudeHookInstaller.swift
@@ -243,14 +243,14 @@ public actor ClaudeHookInstaller: ClaudeHookInstallerProtocol {
     var entries = result[event] as? [[String: Any]] ?? []
     entries.removeAll { entry in
       guard let inner = entry["hooks"] as? [[String: Any]] else { return false }
-      return inner.contains { ($0["command"] as? String) == scriptPath }
+      return inner.contains { isOurCommand($0["command"] as? String, scriptPath: scriptPath) }
     }
     entries.append([
       "matcher": "*",
       "hooks": [
         [
           "type": "command",
-          "command": scriptPath,
+          "command": Self.shellQuoted(scriptPath),
         ] as [String: Any],
       ],
     ])
@@ -267,7 +267,7 @@ public actor ClaudeHookInstaller: ClaudeHookInstallerProtocol {
     guard var entries = result[event] as? [[String: Any]] else { return result }
     entries.removeAll { entry in
       guard let inner = entry["hooks"] as? [[String: Any]] else { return false }
-      return inner.contains { ($0["command"] as? String) == scriptPath }
+      return inner.contains { isOurCommand($0["command"] as? String, scriptPath: scriptPath) }
     }
     if entries.isEmpty {
       result.removeValue(forKey: event)
@@ -275,6 +275,20 @@ public actor ClaudeHookInstaller: ClaudeHookInstallerProtocol {
       result[event] = entries
     }
     return result
+  }
+
+  /// Matches both the current shell-quoted form and the legacy unquoted form
+  /// so that older installations get cleanly upgraded on the next sync.
+  private func isOurCommand(_ command: String?, scriptPath: String) -> Bool {
+    guard let command else { return false }
+    return command == scriptPath || command == Self.shellQuoted(scriptPath)
+  }
+
+  /// Wraps a path in single quotes so `/bin/sh -c` doesn't word-split on
+  /// embedded spaces (e.g. `~/Library/Application Support/...`). Embedded
+  /// single quotes are escaped as `'\''`.
+  static func shellQuoted(_ path: String) -> String {
+    "'" + path.replacingOccurrences(of: "'", with: "'\\''") + "'"
   }
 
   private func writeJSON(_ object: [String: Any], to url: URL) throws {


### PR DESCRIPTION
## Summary
- Hook entries written to each project's `.claude/settings.local.json` were storing the raw shared-script path. Claude Code passes the command to `/bin/sh -c`, which word-split on the space in `~/Library/Application Support/...` and produced `/bin/sh: /Users/<user>/Library/Application: No such file or directory` for every Pre/PostToolUse on tracked sessions.
- Wrap the path in single quotes (escaping any embedded `'` as `'\''`) when writing the hook command.
- Dedupe and uninstall now accept either the quoted or legacy unquoted form, so existing broken entries get repaired automatically on the next `syncInstalledPaths` call.

## Test plan
- [x] `xcodebuild ... -only-testing:AgentHubTests/ClaudeHookInstallerTests test` — all 12 tests pass, including 3 new ones:
  - `writtenCommandIsShellQuoted` — asserts the persisted command is `'…'`-wrapped.
  - `syncReplacesLegacyUnquotedEntry` — asserts an existing unquoted entry is replaced (no duplicate).
  - `uninstallRemovesLegacyUnquotedEntry` — asserts uninstall finds and removes the legacy form.
- [ ] Manual: launch app against a project with the hook enabled, run a Bash tool call in Claude Code, confirm no more `PreToolUse:Bash hook error` lines.