### PR TITLE
Add Storybook auto-detection and dedicated preview mode

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,10 @@ protocol SessionSearchServiceProtocol {
 - If an agent-provided localhost preview fails to load, fall back to static HTML in this order: root `index.html`, then other discovered HTML files
 - Changes to web preview precedence or fallback behavior must include unit tests
 
+### Storybook Mode
+
+Storybook-enabled projects swap the Preview button for a Storybook button (never both). `WebPreviewMode { .app, .storybook }` routes the preview pane; the storybook server runs at compound key `"{sessionId}:storybook"` in `DevServerManager` so it coexists with the primary app server. Read **Storybook** in `README.md` before editing this area.
+
 ## Claude Code Approval Hook Invariants
 
 AgentHub installs a `PreToolUse` hook to surface pending approvals in real time (see `CLAUDE.md` → "Approval Detection"). When modifying `ClaudeHookInstaller`, `ClaudeHookSidecarWatcher`, `ApprovalClaimStore`, or `HookPendingStalenessFilter`, these invariants must hold:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -183,6 +183,10 @@ In Single layout, a side panel can show: `GitDiffView` (split-pane diff), `PlanV
 - If that external localhost preview fails to load, fall back to static HTML: root `index.html` first, then other discovered HTML files
 - Changes to this behavior require unit tests
 
+### Storybook Mode
+
+When a project has Storybook configured, the Preview button is replaced with a Storybook button — never both. Routing is gated by `WebPreviewMode { .app, .storybook }`; the storybook server runs under the compound `DevServerManager` key `"{sessionId}:storybook"` alongside the primary app server. Detection lives in the standalone `Storybook` Swift module (`app/modules/Storybook/`, pure Foundation). See **Storybook** in `README.md` for detection rules, script-port handling, and the prompt auto-accept.
+
 ### Command Palette
 
 `CommandPaletteView` — Cmd+K for quick session/repository/action access.

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ https://github.com/user-attachments/assets/ee453a78-e417-488a-96c7-20732d1d1f60
 - **Mermaid diagrams** — Detects Mermaid diagram syntax in session output and renders it natively; diagrams can be exported as images
 - **Web preview** — Prefers agent-started localhost servers, recovers recent localhost URLs from session files when needed, and falls back to static HTML (`index.html` first) when no live preview is available
 - **Web preview batch updates** — Inspect elements or crop regions in the live web preview, queue multiple requested updates with structured context, and attach the batch to your next terminal message — no copy-paste needed
+- **Storybook support** — Auto-detects Storybook-enabled projects (`.storybook/` config, `storybook` npm script, or `@storybook/*` devDependencies) and replaces the Preview button with a one-click Storybook launcher; the dev server is started under a compound key so it can run alongside your primary app server
 - **iOS Simulator run destination** — Build, install, and launch your app on any booted iOS Simulator directly from a session card; cancel at any phase (Building / Installing / Launching) via a stop button; boot-readiness check times out after 90 seconds to prevent hangs
 - **Plan view** — Renders Claude-generated plan files with markdown and syntax highlighting; switch to Review mode to annotate individual lines and send batch feedback directly to Claude's interactive plan prompt
 - **Global search** — Search across all session files with ranked results
@@ -90,6 +91,27 @@ AgentHub includes a built-in file explorer and editor for supported text files. 
 File explorer, quick open, and built-in editor
 
 https://github.com/user-attachments/assets/6d263d11-6648-42e7-9335-04aa51a33296
+
+## Storybook
+
+When AgentHub detects a Storybook configuration in a project, the regular **Preview** button on each session card is replaced by a dedicated **Storybook** button. Clicking it spawns the Storybook dev server (via `npm run storybook`) and opens the web preview pane pinned to the Storybook URL — independently of any other dev server the agent has running.
+
+### Detection
+
+A project is treated as Storybook-enabled if **any** of these is true:
+
+- A `.storybook/` directory exists at the project root
+- `package.json` has a `"storybook"` or `"storybook:dev"` script entry
+- `package.json` devDependencies contains any `@storybook/*` package
+
+Detection lives in the standalone `Storybook` Swift module (`app/modules/Storybook/`), which has zero dependencies and can be reused outside `AgentHubCore`.
+
+### How it runs
+
+- The Storybook server is keyed by `"{sessionId}:storybook"` in `DevServerManager`, so it coexists with your primary dev server (Vite, Next, etc.) under the plain `sessionId` key.
+- If your `storybook` npm script already pins a port (e.g. `storybook dev -p 6006`), AgentHub honors that port instead of trying to override it — npm appends extra args after the script's, and Storybook only respects the first `-p`, so passing our own would desync the bind port from the tracked port.
+- If port 6006 is in use and Storybook prompts to use an alternate port, AgentHub auto-accepts; the actual port is captured from Storybook's `Local: http://localhost:N/` ready banner.
+- The web preview pane in Storybook mode resolves URLs from the storybook server slot only; it does not follow the agent's app-server URL changes, so the Storybook view stays pinned even if the agent restarts the primary dev server.
 
 ## Requirements
 

--- a/app/modules/AgentHubCore/Package.swift
+++ b/app/modules/AgentHubCore/Package.swift
@@ -19,6 +19,7 @@ let package = Package(
   ],
   dependencies: [
     .package(path: "../AgentHubGitHub"),
+    .package(path: "../Storybook"),
     .package(url: "https://github.com/jamesrochabrun/Canvas", from: "1.2.0"),
     .package(url: "https://github.com/jamesrochabrun/PierreDiffsSwift", exact: "1.1.7"),
     .package(url: "https://github.com/jamesrochabrun/SwiftTerm", exact: "1.13.0-agenthub.1"),
@@ -43,6 +44,7 @@ let package = Package(
       dependencies: [
         "ClaudeCodeClient",
         .product(name: "AgentHubGitHub", package: "AgentHubGitHub"),
+        .product(name: "Storybook", package: "Storybook"),
         .product(name: "Canvas", package: "Canvas"),
         .product(name: "PierreDiffsSwift", package: "PierreDiffsSwift"),
         .product(name: "SwiftTerm", package: "SwiftTerm"),

--- a/app/modules/AgentHubCore/Sources/AgentHub/Models/DevServerConfiguration.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Models/DevServerConfiguration.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import Storybook
 
 // MARK: - ProjectFramework
 
@@ -17,17 +18,25 @@ enum ProjectFramework: String, Sendable {
   case angular
   case vueCLI
   case astro
+  case storybook
   case staticHTML
   case unknown
 
   /// Whether this framework requires a dev server for transpilation/bundling
   var requiresDevServer: Bool {
     switch self {
-    case .vite, .nextjs, .createReactApp, .angular, .vueCLI, .astro:
+    case .vite, .nextjs, .createReactApp, .angular, .vueCLI, .astro, .storybook:
       return true
     case .staticHTML, .unknown:
       return false
     }
+  }
+
+  /// Whether the project at the given path has Storybook configured.
+  /// Detected in parallel with the primary framework — a project can have
+  /// both (e.g. Vite + Storybook).
+  static func hasStorybook(at projectPath: String) -> Bool {
+    StorybookDetector.hasStorybook(at: projectPath)
   }
 
   /// Fast synchronous detection of project framework from package.json
@@ -91,6 +100,11 @@ struct DetectedProject: Sendable {
   let defaultPort: Int
   /// Stdout/stderr patterns that indicate the server is ready
   let readinessPatterns: [String]
+  /// Pre-fed stdin used to auto-accept interactive prompts (e.g. Storybook
+  /// asking "Port 6006 is not available. Run on 6008 instead? [y/N]"). When
+  /// non-nil, a stdin pipe is attached and this string is written then closed
+  /// immediately after spawn. Tools that don't read stdin discard the bytes.
+  var stdinPrefill: String? = nil
 }
 
 // MARK: - DevServerState

--- a/app/modules/AgentHubCore/Sources/AgentHub/Models/WebPreviewMode.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Models/WebPreviewMode.swift
@@ -1,0 +1,33 @@
+//
+//  WebPreviewMode.swift
+//  AgentHub
+//
+//  Routing source-of-truth for the web preview pane: which dev server
+//  the pane is currently looking at.
+//
+
+import Foundation
+
+/// Which server the web preview pane is rendering.
+///
+/// Projects can run multiple dev servers concurrently (e.g. Vite at :5173
+/// and Storybook at :6006). The preview pane always shows exactly one;
+/// `WebPreviewMode` identifies which.
+public enum WebPreviewMode: String, Sendable, Equatable {
+  /// Primary application dev server (Vite, Next, CRA, Astro, etc.).
+  /// Auto-detected from `package.json`. Honors agent-advertised localhost URLs.
+  case app
+  /// Storybook component catalog. Compound key `"{sessionId}:storybook"` in
+  /// `DevServerManager`; ignores agent-advertised URLs (which target the app server).
+  case storybook
+
+  /// Returns the `DevServerManager` key for this mode.
+  /// `.app` keys by plain session ID so it matches the agent's primary server.
+  /// `.storybook` uses a compound key so it coexists with the app server.
+  public func serverKey(for sessionId: String) -> String {
+    switch self {
+    case .app: return sessionId
+    case .storybook: return "\(sessionId):storybook"
+    }
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/DevServerManager.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/DevServerManager.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import Storybook
 
 // MARK: - DevServerManager
 
@@ -69,6 +70,11 @@ public final class DevServerManager {
   /// Starts a dev server for the given key (typically session ID) at the specified project path.
   /// Idempotent: if already running or ready, returns immediately.
   public func startServer(for key: String, projectPath: String) async {
+    await startServer(for: key, projectPath: projectPath, forceFramework: nil)
+  }
+
+  /// Internal overload that allows bypassing framework auto-detection (used for Storybook).
+  func startServer(for key: String, projectPath: String, forceFramework: ProjectFramework?) async {
     // Guard: already in an active state
     switch servers[key] {
     case .ready, .starting, .waitingForReady, .detecting:
@@ -80,8 +86,11 @@ public final class DevServerManager {
     servers[key] = .detecting
 
     // 1. Detect project type (off main thread for file I/O)
-    let detected = await Task.detached { [projectPath] in
-      DevServerManager.detectProject(at: projectPath)
+    let detected = await Task.detached { [projectPath, forceFramework] in
+      if let framework = forceFramework {
+        return DevServerManager.detectProject(at: projectPath, framework: framework)
+      }
+      return DevServerManager.detectProject(at: projectPath)
     }.value
 
     // 2. Find executable
@@ -97,10 +106,19 @@ public final class DevServerManager {
       return
     }
 
-    // 3. Find available port
-    let port = await Task.detached {
-      DevServerManager.findAvailablePort(preferring: detected.defaultPort)
-    }.value
+    // 3. Find available port. We only scan when the args end with a `-p`/`--port`
+    // placeholder we can fill — otherwise the dev server's bind port is fixed
+    // by its own config (e.g. an npm script that pins `-p 6006`) and scanning
+    // would just desync our tracked port from the actual one.
+    let canOverridePort = detected.arguments.last == "-p" || detected.arguments.last == "--port"
+    let port: Int
+    if canOverridePort {
+      port = await Task.detached {
+        DevServerManager.findAvailablePort(preferring: detected.defaultPort)
+      }.value
+    } else {
+      port = detected.defaultPort
+    }
 
     assignedPorts[key] = port
 
@@ -160,6 +178,25 @@ public final class DevServerManager {
     disposeManagedServer(for: key, finalState: .failed(error: error), logAction: "Failing")
   }
 
+  // MARK: - Storybook
+
+  /// Starts a Storybook server alongside the main dev server.
+  /// Uses a compound key `"{sessionId}:storybook"` to coexist with the primary server.
+  public func startStorybookServer(for sessionId: String, projectPath: String) async {
+    let key = "\(sessionId):storybook"
+    await startServer(for: key, projectPath: projectPath, forceFramework: .storybook)
+  }
+
+  /// Stops the Storybook server for a given session.
+  public func stopStorybookServer(for sessionId: String) {
+    stopServer(for: "\(sessionId):storybook")
+  }
+
+  /// Current state of the Storybook server for a given session.
+  public func storybookState(for sessionId: String) -> DevServerState {
+    state(for: "\(sessionId):storybook")
+  }
+
   /// Stops all running servers. Called on app quit.
   public func stopAllServers() {
     for key in Array(servers.keys) {
@@ -214,12 +251,21 @@ public final class DevServerManager {
 
   // MARK: - Project Detection
 
+  /// Returns a `DetectedProject` for a specific framework, bypassing auto-detection.
+  /// Used when the caller already knows the framework (e.g. Storybook launched explicitly).
+  nonisolated static func detectProject(at projectPath: String, framework: ProjectFramework) -> DetectedProject {
+    mapFrameworkToProject(framework, projectPath: projectPath)
+  }
+
   /// Detects the project framework from package.json and returns the appropriate server config.
   /// Uses shared `ProjectFramework.detect(at:)` for framework identification, then maps to
   /// the full `DetectedProject` with command, args, port, and readiness patterns.
   nonisolated static func detectProject(at projectPath: String) -> DetectedProject {
     let framework = ProjectFramework.detect(at: projectPath)
+    return mapFrameworkToProject(framework, projectPath: projectPath)
+  }
 
+  private nonisolated static func mapFrameworkToProject(_ framework: ProjectFramework, projectPath: String) -> DetectedProject {
     switch framework {
     case .vite:
       return DetectedProject(
@@ -272,6 +318,30 @@ public final class DevServerManager {
         // Avoid matching npm's echoed command line (`astro dev --port ...`)
         // before Astro prints its real ready banner or localhost URL.
         readinessPatterns: ["ready in", "localhost:"]
+      )
+    case .storybook:
+      let scriptName = StorybookDetector.storybookScript(at: projectPath) ?? "storybook"
+      // If the npm script already pins a port (e.g. `storybook dev -p 6006`),
+      // honor it — npm appends our extra args AFTER the script's, and storybook
+      // only respects the first `-p`, so adding our own would leave the actual
+      // bind port out of sync with our tracked port.
+      if let scriptPort = StorybookDetector.storybookScriptPort(at: projectPath) {
+        return DetectedProject(
+          framework: .storybook,
+          command: "npm",
+          arguments: ["run", scriptName],
+          defaultPort: scriptPort,
+          readinessPatterns: StorybookDetector.readinessPatterns,
+          stdinPrefill: "y\n"
+        )
+      }
+      return DetectedProject(
+        framework: .storybook,
+        command: "npm",
+        arguments: ["run", scriptName, "--", "-p"],
+        defaultPort: StorybookDetector.defaultPort,
+        readinessPatterns: StorybookDetector.readinessPatterns,
+        stdinPrefill: "y\n"
       )
     case .unknown:
       // Has package.json with scripts but no recognized framework
@@ -423,6 +493,16 @@ public final class DevServerManager {
     process.standardOutput = stdoutPipe
     process.standardError = stderrPipe
 
+    // Pre-feed stdin for tools that gate on interactive prompts (e.g. Storybook
+    // asking to use an alternate port). The bytes sit in the pipe; tools that
+    // never call `read()` simply ignore them.
+    if let prefill = detected.stdinPrefill, let prefillData = prefill.data(using: .utf8) {
+      let stdinPipe = Pipe()
+      process.standardInput = stdinPipe
+      try? stdinPipe.fileHandleForWriting.write(contentsOf: prefillData)
+      try? stdinPipe.fileHandleForWriting.close()
+    }
+
     outputPipes[key] = (stdoutPipe, stderrPipe)
 
     // Set up readiness handlers BEFORE starting the process
@@ -525,6 +605,32 @@ public final class DevServerManager {
     if let pipes = outputPipes[key] {
       pipes.stdout.fileHandleForReading.readabilityHandler = nil
       pipes.stderr.fileHandleForReading.readabilityHandler = nil
+    }
+  }
+}
+
+// MARK: - StorybookService Conformance
+
+extension DevServerManager: StorybookService {
+  public func start(for sessionId: String, projectPath: String) async {
+    await startStorybookServer(for: sessionId, projectPath: projectPath)
+  }
+
+  public func stop(for sessionId: String) {
+    stopStorybookServer(for: sessionId)
+  }
+
+  public func state(for sessionId: String) -> StorybookServerState {
+    let key = "\(sessionId):storybook"
+    switch servers[key] {
+    case .idle, .detecting, .stopping, nil:
+      return .idle
+    case .starting, .waitingForReady:
+      return .starting
+    case .ready(let url):
+      return .ready(url: url)
+    case .failed(let error):
+      return .failed(error: error)
     }
   }
 }

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringCardView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringCardView.swift
@@ -35,7 +35,7 @@ public struct MonitoringCardView: View {
   let onInlineRequestSubmit: ((String, CLISession) -> Void)?
   let onShowDiff: ((CLISession, String) -> Void)?
   let onShowPlan: ((CLISession, PlanState) -> Void)?
-  let onShowWebPreview: ((CLISession, String) -> Void)?
+  let onShowWebPreview: ((CLISession, String, WebPreviewMode) -> Void)?
   let onShowMermaid: ((CLISession) -> Void)?
   let onShowGitHub: ((CLISession, String) -> Void)?
   let onShowPendingChanges: ((CLISession, PendingToolUse) -> Void)?
@@ -85,7 +85,7 @@ public struct MonitoringCardView: View {
     onInlineRequestSubmit: ((String, CLISession) -> Void)? = nil,
     onShowDiff: ((CLISession, String) -> Void)? = nil,
     onShowPlan: ((CLISession, PlanState) -> Void)? = nil,
-    onShowWebPreview: ((CLISession, String) -> Void)? = nil,
+    onShowWebPreview: ((CLISession, String, WebPreviewMode) -> Void)? = nil,
     onShowMermaid: ((CLISession) -> Void)? = nil,
     onShowGitHub: ((CLISession, String) -> Void)? = nil,
     onShowPendingChanges: ((CLISession, PendingToolUse) -> Void)? = nil,
@@ -417,8 +417,51 @@ public struct MonitoringCardView: View {
     }
   }
 
-  private func presentWebPreview() {
-    onShowWebPreview?(session, session.projectPath)
+  private func presentWebPreview(mode: WebPreviewMode = .app) {
+    onShowWebPreview?(session, session.projectPath, mode)
+  }
+
+  // MARK: - Web Preview Controls
+
+  /// Storybook takes precedence when present — it's the richer surface for
+  /// component-driven projects, and showing both buttons routes the same pane
+  /// to two different URLs in confusing ways.
+  @ViewBuilder
+  private var webPreviewControls: some View {
+    if ProjectFramework.hasStorybook(at: session.projectPath) {
+      Button(action: {
+        Task {
+          await DevServerManager.shared.startStorybookServer(
+            for: session.id,
+            projectPath: session.projectPath
+          )
+        }
+        presentWebPreview(mode: .storybook)
+      }) {
+        HStack(spacing: 4) {
+          Image(systemName: "book.pages")
+            .font(.caption2)
+          Text("Storybook")
+        }
+      }
+      .buttonStyle(.agentHubOutlined)
+      .help("Browse Storybook components")
+    } else if shouldShowWebPreviewButton {
+      Button(action: { presentWebPreview(mode: .app) }) {
+        HStack(spacing: 4) {
+          Image(systemName: "globe")
+            .font(.caption2)
+          Text("Preview")
+          if queuedPreviewContextCount > 0 {
+            previewContextBadge
+          }
+        }
+      }
+      .buttonStyle(.agentHubOutlined)
+      .help(queuedPreviewContextCount > 0
+        ? "Preview localhost web app (\(queuedPreviewContextCount) queued updates pending next send)"
+        : "Preview localhost web app")
+    }
   }
 
   @MainActor
@@ -522,24 +565,9 @@ public struct MonitoringCardView: View {
         .buttonStyle(.agentHubOutlined)
         .help("View git unstaged changes")
 
-        // Web preview button — visible when the project looks like a web project
-        // or the agent has already detected a running localhost server
-        if shouldShowWebPreviewButton {
-          Button(action: presentWebPreview) {
-            HStack(spacing: 4) {
-              Image(systemName: "globe")
-                .font(.caption2)
-              Text("Preview")
-              if queuedPreviewContextCount > 0 {
-                previewContextBadge
-              }
-            }
-          }
-          .buttonStyle(.agentHubOutlined)
-          .help(queuedPreviewContextCount > 0
-            ? "Preview localhost web app (\(queuedPreviewContextCount) queued updates pending next send)"
-            : "Preview localhost web app")
-        }
+        // Web preview controls — segmented App | Storybook when Storybook is
+        // detected, otherwise a single Preview button.
+        webPreviewControls
 
         // Mermaid diagram button (only visible when mermaid content is detected)
         if state?.hasMermaidContent == true {

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderMonitoringPanelView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderMonitoringPanelView.swift
@@ -15,7 +15,7 @@ import SwiftUI
 private enum SidePanelContent: Equatable {
   case diff(sessionId: String, session: CLISession, projectPath: String)
   case plan(sessionId: String, session: CLISession, planState: PlanState)
-  case webPreview(sessionId: String, session: CLISession, projectPath: String)
+  case webPreview(sessionId: String, session: CLISession, projectPath: String, mode: WebPreviewMode)
   case mermaid(sessionId: String, session: CLISession)
   case gitHub(sessionId: String, session: CLISession, projectPath: String)
   case edits(sessionId: String, session: CLISession)
@@ -26,8 +26,8 @@ private enum SidePanelContent: Equatable {
       return id1 == id2 && p1 == p2
     case (.plan(let id1, _, _), .plan(let id2, _, _)):
       return id1 == id2
-    case (.webPreview(let id1, _, let p1), .webPreview(let id2, _, let p2)):
-      return id1 == id2 && p1 == p2
+    case (.webPreview(let id1, _, let p1, let m1), .webPreview(let id2, _, let p2, let m2)):
+      return id1 == id2 && p1 == p2 && m1 == m2
     case (.mermaid(let id1, _), .mermaid(let id2, _)):
       return id1 == id2
     case (.gitHub(let id1, _, let p1), .gitHub(let id2, _, let p2)):
@@ -360,7 +360,7 @@ public struct MultiProviderMonitoringPanelView: View {
     }
     .onChange(of: effectivePrimarySessionId) { _, newId in
       guard let currentSidePanelContent = sidePanelContent else { return }
-      if case .webPreview(let sessionId, _, let projectPath) = currentSidePanelContent,
+      if case .webPreview(let sessionId, _, let projectPath, let mode) = currentSidePanelContent,
          sessionId.hasPrefix("pending-"),
          let newId,
          let item = allItems.first(where: { $0.id == newId }),
@@ -369,7 +369,8 @@ public struct MultiProviderMonitoringPanelView: View {
         sidePanelContent = .webPreview(
           sessionId: session.id,
           session: session,
-          projectPath: session.projectPath
+          projectPath: session.projectPath,
+          mode: mode
         )
       } else {
         sidePanelContent = nil
@@ -564,8 +565,8 @@ public struct MultiProviderMonitoringPanelView: View {
                 forItemID: item.id
               )
             },
-            onShowWebPreview: { session, projectPath in
-              presentWebPreviewInSidePanel(forItemID: item.id, session: session, projectPath: projectPath)
+            onShowWebPreview: { session, projectPath, mode in
+              presentWebPreviewInSidePanel(forItemID: item.id, session: session, projectPath: projectPath, mode: mode)
             },
             onShowMermaid: { session in
               toggleSidePanel(
@@ -649,8 +650,8 @@ public struct MultiProviderMonitoringPanelView: View {
                 forItemID: item.id
               )
             },
-            onShowWebPreview: { session, projectPath in
-              presentWebPreviewInSidePanel(forItemID: item.id, session: session, projectPath: projectPath)
+            onShowWebPreview: { session, projectPath, mode in
+              presentWebPreviewInSidePanel(forItemID: item.id, session: session, projectPath: projectPath, mode: mode)
             },
             onShowMermaid: { session in
               toggleSidePanel(
@@ -715,9 +716,9 @@ public struct MultiProviderMonitoringPanelView: View {
     .animation(.easeInOut(duration: 0.25), value: isEmbeddedSidePanelVisible)
   }
 
-  private func presentWebPreviewInSidePanel(forItemID itemID: String, session: CLISession, projectPath: String) {
+  private func presentWebPreviewInSidePanel(forItemID itemID: String, session: CLISession, projectPath: String, mode: WebPreviewMode) {
     toggleSidePanel(
-      .webPreview(sessionId: session.id, session: session, projectPath: projectPath),
+      .webPreview(sessionId: session.id, session: session, projectPath: projectPath, mode: mode),
       forItemID: itemID
     )
   }
@@ -779,7 +780,7 @@ public struct MultiProviderMonitoringPanelView: View {
           viewModel.showTerminalWithPrompt(for: sess, prompt: feedback)
         }
       )
-    case .webPreview(let sessionId, let session, let projectPath):
+    case .webPreview(let sessionId, let session, let projectPath, let mode):
       WebPreviewView(
         session: session,
         projectPath: projectPath,
@@ -794,6 +795,7 @@ public struct MultiProviderMonitoringPanelView: View {
           viewModel.sendPromptToActiveTerminal(forKey: sess.id, prompt: prompt)
         },
         viewModel: viewModel,
+        mode: mode,
         agentLocalhostURL: viewModel.monitorStates[sessionId]?.detectedLocalhostURL,
         monitorState: viewModel.monitorStates[sessionId]
       )
@@ -875,8 +877,8 @@ public struct MultiProviderMonitoringPanelView: View {
             forItemID: item.id
           )
         },
-        onShowWebPreview: { session, projectPath in
-          presentWebPreviewInSidePanel(forItemID: item.id, session: session, projectPath: projectPath)
+        onShowWebPreview: { session, projectPath, mode in
+          presentWebPreviewInSidePanel(forItemID: item.id, session: session, projectPath: projectPath, mode: mode)
         },
         onShowMermaid: { session in
           toggleSidePanel(
@@ -960,8 +962,8 @@ public struct MultiProviderMonitoringPanelView: View {
             forItemID: item.id
           )
         },
-        onShowWebPreview: { session, projectPath in
-          presentWebPreviewInSidePanel(forItemID: item.id, session: session, projectPath: projectPath)
+        onShowWebPreview: { session, projectPath, mode in
+          presentWebPreviewInSidePanel(forItemID: item.id, session: session, projectPath: projectPath, mode: mode)
         },
         onShowMermaid: { session in
           toggleSidePanel(
@@ -1094,8 +1096,8 @@ public struct MultiProviderMonitoringPanelView: View {
               forItemID: itemId
             )
           },
-          onShowWebPreview: { session, projectPath in
-            presentWebPreviewInSidePanel(forItemID: itemId, session: session, projectPath: projectPath)
+          onShowWebPreview: { session, projectPath, mode in
+            presentWebPreviewInSidePanel(forItemID: itemId, session: session, projectPath: projectPath, mode: mode)
           },
           onShowMermaid: { session in
             toggleSidePanel(
@@ -1180,8 +1182,8 @@ public struct MultiProviderMonitoringPanelView: View {
               forItemID: itemId
             )
           },
-          onShowWebPreview: { session, projectPath in
-            presentWebPreviewInSidePanel(forItemID: itemId, session: session, projectPath: projectPath)
+          onShowWebPreview: { session, projectPath, mode in
+            presentWebPreviewInSidePanel(forItemID: itemId, session: session, projectPath: projectPath, mode: mode)
           },
           onShowMermaid: { session in
             toggleSidePanel(

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/WebPreviewView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/WebPreviewView.swift
@@ -121,7 +121,12 @@ public struct WebPreviewView: View {
   var onInspectSubmit: ((String, CLISession) -> Void)?
   var onQueuedSubmit: ((String, CLISession) -> Bool)?
   let viewModel: CLISessionsViewModel?
+  /// Which server this preview is targeting. `.app` honors the agent-detected localhost URL
+  /// and the primary dev server. `.storybook` resolves only against the Storybook compound key.
+  let mode: WebPreviewMode
   /// Reactive localhost URL from the agent's session. When this changes, the preview updates.
+  /// Only consulted when `mode == .app` — Storybook ignores agent URLs because they target
+  /// the primary app server.
   var agentLocalhostURL: URL?
   var monitorState: SessionMonitorState?
   /// Reachability probe used before connecting to an agent-advertised URL.
@@ -164,8 +169,9 @@ public struct WebPreviewView: View {
     Color.adaptiveExpandedContentBackground(for: colorScheme, theme: runtimeTheme)
   }
 
-  /// Uses session ID as key for DevServerManager to support multiple sessions
-  private var serverKey: String { session.id }
+  /// Server key for `DevServerManager`. App mode uses the plain session ID;
+  /// Storybook uses the compound key so it can coexist with the app server.
+  private var serverKey: String { mode.serverKey(for: session.id) }
 
   private var serverState: DevServerState {
     DevServerManager.shared.state(for: serverKey)
@@ -183,6 +189,7 @@ public struct WebPreviewView: View {
     onInspectSubmit: ((String, CLISession) -> Void)? = nil,
     onQueuedSubmit: ((String, CLISession) -> Bool)? = nil,
     viewModel: CLISessionsViewModel? = nil,
+    mode: WebPreviewMode = .app,
     agentLocalhostURL: URL? = nil,
     monitorState: SessionMonitorState? = nil,
     reachabilityProbe: any LocalhostReachabilityProbing = LocalhostReachabilityProbe()
@@ -194,6 +201,7 @@ public struct WebPreviewView: View {
     self.onInspectSubmit = onInspectSubmit
     self.onQueuedSubmit = onQueuedSubmit
     self.viewModel = viewModel
+    self.mode = mode
     self.agentLocalhostURL = agentLocalhostURL
     self.monitorState = monitorState
     self.reachabilityProbe = reachabilityProbe
@@ -292,7 +300,9 @@ public struct WebPreviewView: View {
       await loadPreview()
     }
     .onChange(of: agentLocalhostURL) { _, newURL in
-      guard let newURL else { return }
+      // Storybook mode is pinned to its own server — don't follow the agent's
+      // app-server URL changes.
+      guard mode == .app, let newURL else { return }
       Task {
         await connectToAgentServer(newURL, logChange: true)
       }
@@ -886,6 +896,15 @@ public struct WebPreviewView: View {
 
   @MainActor
   private func loadPreview() async {
+    // Storybook mode bypasses agent URL recovery entirely — the agent's
+    // detected URL is for the primary app server, not Storybook.
+    if mode == .storybook {
+      await applyResolution(.devServer(projectPath: projectPath))
+      AppLogger.devServer.info("[WebPreview] Session \(session.id): starting Storybook server")
+      await DevServerManager.shared.startStorybookServer(for: session.id, projectPath: projectPath)
+      return
+    }
+
     if let agentURL = await WebPreviewAgentURLResolver.resolve(
       for: session,
       detectedLocalhostURL: agentLocalhostURL

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/DevServerManagerTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/DevServerManagerTests.swift
@@ -90,6 +90,26 @@ struct DevServerManagerTests {
     #expect(DevServerManager.shared.isExternalServer(for: key) == false)
   }
 
+  @Test("Storybook server uses compound key with :storybook suffix")
+  func storybookServerUsesCompoundKey() {
+    let sessionId = "test-\(UUID().uuidString)"
+    let storybookKey = "\(sessionId):storybook"
+
+    #expect(DevServerManager.shared.state(for: storybookKey) == .idle)
+
+    let url = URL(string: "http://localhost:6006")!
+    DevServerManager.shared.connectToExistingServer(for: storybookKey, url: url)
+    defer { DevServerManager.shared.stopServer(for: storybookKey) }
+
+    guard case .ready(let readyURL) = DevServerManager.shared.storybookState(for: sessionId) else {
+      Issue.record("Expected ready storybook server state")
+      return
+    }
+    #expect(readyURL.absoluteString == "http://localhost:6006")
+
+    #expect(DevServerManager.shared.state(for: sessionId) == .idle)
+  }
+
   private func makeProjectFixture(packageJSON: String) throws -> URL {
     let rootURL = FileManager.default.temporaryDirectory
       .appendingPathComponent("DevServerManagerTests-\(UUID().uuidString)", isDirectory: true)

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/StorybookDetectionTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/StorybookDetectionTests.swift
@@ -1,0 +1,64 @@
+import Foundation
+import Testing
+import Storybook
+
+@testable import AgentHubCore
+
+@Suite("Storybook Integration")
+struct StorybookIntegrationTests {
+
+  // MARK: - ProjectFramework delegates to StorybookDetector
+
+  @Test("ProjectFramework.hasStorybook delegates to StorybookDetector")
+  func delegatesToStorybookDetector() throws {
+    let tmpDir = FileManager.default.temporaryDirectory
+      .appendingPathComponent("storybook-test-\(UUID().uuidString)")
+    try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+    #expect(!ProjectFramework.hasStorybook(at: tmpDir.path))
+    #expect(!StorybookDetector.hasStorybook(at: tmpDir.path))
+
+    try FileManager.default.createDirectory(
+      at: tmpDir.appendingPathComponent(".storybook"),
+      withIntermediateDirectories: true
+    )
+
+    #expect(ProjectFramework.hasStorybook(at: tmpDir.path))
+    #expect(StorybookDetector.hasStorybook(at: tmpDir.path))
+  }
+
+  @Test("Storybook framework requires dev server")
+  func storybookRequiresDevServer() {
+    #expect(ProjectFramework.storybook.requiresDevServer)
+  }
+
+  // MARK: - DevServerManager conforms to StorybookService
+
+  @MainActor
+  @Test("DevServerManager conforms to StorybookService protocol")
+  func devServerManagerConformsToStorybookService() {
+    let service: any StorybookService = DevServerManager.shared
+    let sessionId = "conformance-test-\(UUID().uuidString)"
+
+    #expect(service.state(for: sessionId) == .idle)
+  }
+
+  @MainActor
+  @Test("StorybookService state maps DevServerState correctly")
+  func storybookServiceStateMapsCorrectly() {
+    let sessionId = "state-test-\(UUID().uuidString)"
+    let storybookKey = "\(sessionId):storybook"
+
+    let url = URL(string: "http://localhost:6006")!
+    DevServerManager.shared.connectToExistingServer(for: storybookKey, url: url)
+    defer { DevServerManager.shared.stopServer(for: storybookKey) }
+
+    let service: any StorybookService = DevServerManager.shared
+    guard case .ready(let readyURL) = service.state(for: sessionId) else {
+      Issue.record("Expected .ready state from StorybookService")
+      return
+    }
+    #expect(readyURL.absoluteString == "http://localhost:6006")
+  }
+}

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/WebPreviewModeTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/WebPreviewModeTests.swift
@@ -1,0 +1,57 @@
+import Foundation
+import Testing
+
+@testable import AgentHubCore
+
+@Suite("WebPreviewMode")
+struct WebPreviewModeTests {
+
+  // MARK: - serverKey
+
+  @Test("App mode uses the plain session ID")
+  func appModeUsesPlainSessionId() {
+    #expect(WebPreviewMode.app.serverKey(for: "abc-123") == "abc-123")
+  }
+
+  @Test("Storybook mode uses the compound :storybook key")
+  func storybookModeUsesCompoundKey() {
+    #expect(WebPreviewMode.storybook.serverKey(for: "abc-123") == "abc-123:storybook")
+  }
+
+  @Test("App and Storybook keys never collide for the same session")
+  func keysNeverCollide() {
+    let sessionId = "session-\(UUID().uuidString)"
+    let appKey = WebPreviewMode.app.serverKey(for: sessionId)
+    let storybookKey = WebPreviewMode.storybook.serverKey(for: sessionId)
+    #expect(appKey != storybookKey)
+  }
+
+  // MARK: - End-to-end mode → DevServerManager routing
+
+  @MainActor
+  @Test("Storybook mode reads from the same key DevServerManager.startStorybookServer writes to")
+  func storybookModeReadsFromCorrectKey() {
+    let sessionId = "routing-\(UUID().uuidString)"
+    let url = URL(string: "http://localhost:6006")!
+
+    // Simulate Storybook starting under the compound key (as startStorybookServer does)
+    DevServerManager.shared.connectToExistingServer(
+      for: WebPreviewMode.storybook.serverKey(for: sessionId),
+      url: url
+    )
+    defer {
+      DevServerManager.shared.stopServer(for: WebPreviewMode.storybook.serverKey(for: sessionId))
+    }
+
+    // The Storybook-mode key resolves to the running storybook server,
+    // and the App-mode key for the same session stays idle.
+    guard case .ready(let storybookURL) = DevServerManager.shared.state(
+      for: WebPreviewMode.storybook.serverKey(for: sessionId)
+    ) else {
+      Issue.record("Expected storybook key to be .ready")
+      return
+    }
+    #expect(storybookURL.absoluteString == "http://localhost:6006")
+    #expect(DevServerManager.shared.state(for: WebPreviewMode.app.serverKey(for: sessionId)) == .idle)
+  }
+}

--- a/app/modules/Storybook/Package.swift
+++ b/app/modules/Storybook/Package.swift
@@ -1,0 +1,33 @@
+// swift-tools-version: 6.0
+
+import PackageDescription
+
+let package = Package(
+  name: "Storybook",
+  platforms: [
+    .macOS(.v14)
+  ],
+  products: [
+    .library(
+      name: "Storybook",
+      targets: ["Storybook"]
+    ),
+  ],
+  targets: [
+    .target(
+      name: "Storybook",
+      path: "Sources/Storybook",
+      swiftSettings: [
+        .swiftLanguageMode(.v5)
+      ]
+    ),
+    .testTarget(
+      name: "StorybookTests",
+      dependencies: ["Storybook"],
+      path: "Tests/StorybookTests",
+      swiftSettings: [
+        .swiftLanguageMode(.v5)
+      ]
+    ),
+  ]
+)

--- a/app/modules/Storybook/Sources/Storybook/StorybookDetector.swift
+++ b/app/modules/Storybook/Sources/Storybook/StorybookDetector.swift
@@ -1,0 +1,116 @@
+//
+//  StorybookDetector.swift
+//  Storybook
+//
+//  Detects whether a project has Storybook configured by checking for
+//  .storybook/ directory, package.json scripts, or @storybook/ dependencies.
+//
+
+import Foundation
+
+/// Detects Storybook presence in a project directory.
+///
+/// Detection checks (in order):
+/// 1. `.storybook/` config directory at project root
+/// 2. `"storybook"` script key in `package.json` scripts
+/// 3. Any `@storybook/*` package in `devDependencies`
+///
+/// ```swift
+/// if StorybookDetector.hasStorybook(at: "/path/to/project") {
+///   // Show Storybook UI, start server, etc.
+/// }
+/// ```
+public enum StorybookDetector {
+
+  /// Whether the project at the given path has Storybook configured.
+  public static func hasStorybook(at projectPath: String) -> Bool {
+    let fm = FileManager.default
+
+    if fm.fileExists(atPath: "\(projectPath)/.storybook") {
+      return true
+    }
+
+    guard let packageJSON = readPackageJSON(at: projectPath) else {
+      return false
+    }
+
+    if let scripts = packageJSON["scripts"] as? [String: String],
+       scripts["storybook"] != nil {
+      return true
+    }
+
+    if let devDeps = packageJSON["devDependencies"] as? [String: Any],
+       devDeps.keys.contains(where: { $0.hasPrefix("@storybook/") }) {
+      return true
+    }
+
+    return false
+  }
+
+  /// Returns the Storybook start script name from package.json, if found.
+  /// Checks for `"storybook"` first, then `"storybook:dev"`.
+  public static func storybookScript(at projectPath: String) -> String? {
+    guard let packageJSON = readPackageJSON(at: projectPath),
+          let scripts = packageJSON["scripts"] as? [String: String] else {
+      return nil
+    }
+    if scripts["storybook"] != nil { return "storybook" }
+    if scripts["storybook:dev"] != nil { return "storybook:dev" }
+    return nil
+  }
+
+  /// Returns the port pinned by the storybook script's args, if present.
+  /// Recognizes `-p 6006`, `-p=6006`, `--port 6006`, `--port=6006`.
+  /// When non-nil, the caller must NOT append its own `-p` argument — npm
+  /// would just append it *after* the script's args, and storybook honors
+  /// the first occurrence, so the user-visible port and the manager-tracked
+  /// port would diverge.
+  public static func storybookScriptPort(at projectPath: String) -> Int? {
+    guard let packageJSON = readPackageJSON(at: projectPath),
+          let scripts = packageJSON["scripts"] as? [String: String] else {
+      return nil
+    }
+    guard let script = scripts["storybook"] ?? scripts["storybook:dev"] else { return nil }
+    return parsePort(from: script)
+  }
+
+  /// Default port for Storybook dev server.
+  public static let defaultPort: Int = 6006
+
+  /// Stdout patterns that indicate the Storybook server is ready.
+  /// Limited to URL-bearing lines so we don't match npm's pre-launch header
+  /// (e.g. `> storybook-demo@0.0.0 storybook`) before the port is bound.
+  public static let readinessPatterns: [String] = ["Local:", "localhost:"]
+
+  // MARK: - Private
+
+  private static func parsePort(from script: String) -> Int? {
+    // Try `-p 6006`, `-p=6006`, `--port 6006`, `--port=6006`
+    let patterns = [
+      #"(?<![\w-])-p[\s=](\d+)"#,
+      #"--port[\s=](\d+)"#,
+    ]
+    for pattern in patterns {
+      guard let regex = try? NSRegularExpression(pattern: pattern) else { continue }
+      let range = NSRange(script.startIndex..., in: script)
+      if let match = regex.firstMatch(in: script, range: range),
+         match.numberOfRanges > 1,
+         let portRange = Range(match.range(at: 1), in: script),
+         let port = Int(script[portRange]) {
+        return port
+      }
+    }
+    return nil
+  }
+
+  private static func readPackageJSON(at projectPath: String) -> [String: Any]? {
+    let fm = FileManager.default
+    let path = "\(projectPath)/package.json"
+    guard fm.fileExists(atPath: path),
+          let data = fm.contents(atPath: path),
+          let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+      return nil
+    }
+    return json
+  }
+}

--- a/app/modules/Storybook/Sources/Storybook/StorybookServiceProtocol.swift
+++ b/app/modules/Storybook/Sources/Storybook/StorybookServiceProtocol.swift
@@ -1,0 +1,46 @@
+//
+//  StorybookServiceProtocol.swift
+//  Storybook
+//
+//  Protocol for managing Storybook dev server lifecycle.
+//  AgentHubCore (or any consumer) provides the concrete implementation
+//  by conforming DevServerManager or a wrapper to this protocol.
+//
+
+import Foundation
+
+/// State of a Storybook server instance.
+public enum StorybookServerState: Equatable, Sendable {
+  case idle
+  case starting
+  case ready(url: URL)
+  case failed(error: String)
+}
+
+/// Manages Storybook dev server lifecycle for a session.
+///
+/// Consumers implement this protocol to wire Storybook server management
+/// into their existing dev server infrastructure.
+///
+/// ```swift
+/// import Storybook
+///
+/// let service: StorybookService = MyStorybookService()
+/// await service.start(for: sessionId, projectPath: path)
+///
+/// if case .ready(let url) = service.state(for: sessionId) {
+///   // Navigate web preview to url
+/// }
+/// ```
+@MainActor
+public protocol StorybookService: Sendable {
+  /// Starts a Storybook server for the given session at the specified project path.
+  /// Idempotent — if already running, returns immediately.
+  func start(for sessionId: String, projectPath: String) async
+
+  /// Stops the Storybook server for the given session.
+  func stop(for sessionId: String)
+
+  /// Returns the current state of the Storybook server for a session.
+  func state(for sessionId: String) -> StorybookServerState
+}

--- a/app/modules/Storybook/Tests/StorybookTests/StorybookDetectorTests.swift
+++ b/app/modules/Storybook/Tests/StorybookTests/StorybookDetectorTests.swift
@@ -1,0 +1,205 @@
+import Foundation
+import Testing
+
+@testable import Storybook
+
+@Suite("StorybookDetector")
+struct StorybookDetectorTests {
+
+  // MARK: - hasStorybook
+
+  @Test("Detects storybook via .storybook directory")
+  func detectsViaDirectory() throws {
+    let dir = makeTestDir()
+    defer { cleanup(dir) }
+    try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+
+    #expect(!StorybookDetector.hasStorybook(at: dir.path))
+
+    try FileManager.default.createDirectory(
+      at: dir.appendingPathComponent(".storybook"),
+      withIntermediateDirectories: true
+    )
+
+    #expect(StorybookDetector.hasStorybook(at: dir.path))
+  }
+
+  @Test("Detects storybook via package.json storybook script")
+  func detectsViaScript() throws {
+    let dir = makeTestDir()
+    defer { cleanup(dir) }
+
+    try writePackageJSON(to: dir, content: """
+    {
+      "scripts": { "dev": "vite", "storybook": "storybook dev -p 6006" }
+    }
+    """)
+
+    #expect(StorybookDetector.hasStorybook(at: dir.path))
+  }
+
+  @Test("Detects storybook via @storybook/ devDependency")
+  func detectsViaDevDependency() throws {
+    let dir = makeTestDir()
+    defer { cleanup(dir) }
+
+    try writePackageJSON(to: dir, content: """
+    {
+      "devDependencies": { "@storybook/react": "^7.0.0", "typescript": "^5.0.0" }
+    }
+    """)
+
+    #expect(StorybookDetector.hasStorybook(at: dir.path))
+  }
+
+  @Test("Returns false when no storybook indicators present")
+  func returnsFalseWithoutStorybook() throws {
+    let dir = makeTestDir()
+    defer { cleanup(dir) }
+
+    try writePackageJSON(to: dir, content: """
+    {
+      "scripts": { "dev": "vite" },
+      "devDependencies": { "vite": "^5.0.0" }
+    }
+    """)
+
+    #expect(!StorybookDetector.hasStorybook(at: dir.path))
+  }
+
+  @Test("Returns false for nonexistent path")
+  func returnsFalseForBadPath() {
+    #expect(!StorybookDetector.hasStorybook(at: "/nonexistent/\(UUID().uuidString)"))
+  }
+
+  // MARK: - storybookScript
+
+  @Test("Returns storybook script name from package.json")
+  func returnsScriptName() throws {
+    let dir = makeTestDir()
+    defer { cleanup(dir) }
+
+    try writePackageJSON(to: dir, content: """
+    {
+      "scripts": { "storybook": "storybook dev -p 6006" }
+    }
+    """)
+
+    #expect(StorybookDetector.storybookScript(at: dir.path) == "storybook")
+  }
+
+  @Test("Falls back to storybook:dev script")
+  func fallsBackToStorybookDev() throws {
+    let dir = makeTestDir()
+    defer { cleanup(dir) }
+
+    try writePackageJSON(to: dir, content: """
+    {
+      "scripts": { "storybook:dev": "start-storybook -p 6006" }
+    }
+    """)
+
+    #expect(StorybookDetector.storybookScript(at: dir.path) == "storybook:dev")
+  }
+
+  @Test("Returns nil when no storybook script")
+  func returnsNilWithoutScript() throws {
+    let dir = makeTestDir()
+    defer { cleanup(dir) }
+
+    try writePackageJSON(to: dir, content: """
+    { "scripts": { "dev": "vite" } }
+    """)
+
+    #expect(StorybookDetector.storybookScript(at: dir.path) == nil)
+  }
+
+  // MARK: - Constants
+
+  @Test("Default port is 6006")
+  func defaultPort() {
+    #expect(StorybookDetector.defaultPort == 6006)
+  }
+
+  // MARK: - storybookScriptPort
+
+  @Test("Parses port from `-p 6006` form")
+  func parsesShortFormPort() throws {
+    let dir = makeTestDir()
+    defer { cleanup(dir) }
+
+    try writePackageJSON(to: dir, content: """
+    { "scripts": { "storybook": "storybook dev -p 6006" } }
+    """)
+
+    #expect(StorybookDetector.storybookScriptPort(at: dir.path) == 6006)
+  }
+
+  @Test("Parses port from `--port 7007` form")
+  func parsesLongFormPort() throws {
+    let dir = makeTestDir()
+    defer { cleanup(dir) }
+
+    try writePackageJSON(to: dir, content: """
+    { "scripts": { "storybook": "storybook dev --port 7007" } }
+    """)
+
+    #expect(StorybookDetector.storybookScriptPort(at: dir.path) == 7007)
+  }
+
+  @Test("Parses port from `-p=8008` equals form")
+  func parsesEqualsFormPort() throws {
+    let dir = makeTestDir()
+    defer { cleanup(dir) }
+
+    try writePackageJSON(to: dir, content: """
+    { "scripts": { "storybook": "storybook dev -p=8008" } }
+    """)
+
+    #expect(StorybookDetector.storybookScriptPort(at: dir.path) == 8008)
+  }
+
+  @Test("Returns nil when script has no port flag")
+  func returnsNilWithoutPort() throws {
+    let dir = makeTestDir()
+    defer { cleanup(dir) }
+
+    try writePackageJSON(to: dir, content: """
+    { "scripts": { "storybook": "storybook dev" } }
+    """)
+
+    #expect(StorybookDetector.storybookScriptPort(at: dir.path) == nil)
+  }
+
+  @Test("Does not match `--no-port-flag` decoy strings")
+  func ignoresFalsePositives() throws {
+    let dir = makeTestDir()
+    defer { cleanup(dir) }
+
+    try writePackageJSON(to: dir, content: """
+    { "scripts": { "storybook": "storybook dev --no-disable-telemetry" } }
+    """)
+
+    #expect(StorybookDetector.storybookScriptPort(at: dir.path) == nil)
+  }
+
+  // MARK: - Helpers
+
+  private func makeTestDir() -> URL {
+    FileManager.default.temporaryDirectory
+      .appendingPathComponent("storybook-test-\(UUID().uuidString)")
+  }
+
+  private func cleanup(_ url: URL) {
+    try? FileManager.default.removeItem(at: url)
+  }
+
+  private func writePackageJSON(to dir: URL, content: String) throws {
+    try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    try content.write(
+      to: dir.appendingPathComponent("package.json"),
+      atomically: true,
+      encoding: .utf8
+    )
+  }
+}


### PR DESCRIPTION
## Summary

- Auto-detect Storybook-enabled projects (via `.storybook/`, `package.json` scripts, or `@storybook/*` devDeps) and replace the session card's Preview button with a dedicated Storybook button.
- Introduce `WebPreviewMode { .app, .storybook }` so the preview pane is explicitly routed — storybook mode pins the pane to the storybook server and ignores the agent's app-server URL changes.
- Run the storybook server under a compound `DevServerManager` key (`"{sessionId}:storybook"`) so it coexists with the primary app server.
- Detection lives in a new standalone `Storybook` Swift module (`app/modules/Storybook/`), pure Foundation, zero dependencies on `AgentHubCore`.

## Implementation notes

- **Script-pinned ports**: if the user's `storybook` script already includes `-p 6006`, we no longer append our own `-p` — npm appends extra args after the script's, and Storybook honors the first occurrence, which would desync our tracked port from the real bind port.
- **Interactive prompt auto-accept**: Storybook prompts on port collisions ("Port 6006 is not available. Run on 6008 instead? [y/N]"). `DetectedProject.stdinPrefill` lets us pre-feed `"y\n"` so the prompt resolves without hanging the spawn. Tools that don't read stdin discard the bytes.
- **Readiness patterns** tightened to URL-bearing lines only (`"Local:"`, `"localhost:"`) — the previous `"Storybook"` pattern matched npm's pre-launch header line and triggered ready before the port was bound.

## Tests

- `StorybookDetectorTests` (module-local) — detection rules + script-port parsing
- `StorybookDetectionTests` — integration with `ProjectFramework` + `StorybookService` conformance
- `WebPreviewModeTests` — `WebPreviewMode.serverKey(for:)` + end-to-end routing through `DevServerManager`
- `DevServerManagerTests` — compound-key regression test

## Test plan

- [ ] Open a Storybook-enabled project (e.g. a Vite + React + `npx storybook init` project) — Storybook button appears in the session card header in place of Preview
- [ ] Open a non-Storybook project — single Preview button only (unchanged behavior)
- [ ] Click Storybook with port 6006 free → server starts, preview pane loads `http://localhost:6006`
- [ ] Click Storybook with port 6006 busy → Storybook prompts, our prefill auto-accepts, preview pane loads the alternate port from the ready banner
- [ ] If the npm `storybook` script pins `-p 6006`, our spawn does not pass `-- -p` (verify in DevServerManager logs)
- [ ] `xcodebuild test -only-testing:AgentHubTests/StorybookIntegrationTests -only-testing:AgentHubTests/WebPreviewModeTests -only-testing:AgentHubTests/DevServerManagerTests` passes
- [ ] `swift test` inside `app/modules/Storybook/` passes (14 detector tests)