### PR TITLE
[codex] Add Ghostty terminal backend

### DIFF
--- a/app/AgentHub.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/app/AgentHub.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "899299d379ba92b27381e66d9ff9d16a920f9b8fb6ce0135529ff6f23da21164",
+  "originHash" : "62cbf0414f4ca61f2f3966fb9c15798279a026c4d7c36944699cc6dbd0321562",
   "pins" : [
     {
       "identity" : "beautiful-mermaid-swift",
@@ -62,6 +62,15 @@
       "state" : {
         "revision" : "92efb78b73a8b665ee74bacfb0f1f5b17bbe1b38",
         "version" : "0.1.0"
+      }
+    },
+    {
+      "identity" : "ghosttyswift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/jamesrochabrun/GhosttySwift",
+      "state" : {
+        "revision" : "09013e66d2ee1854519367824bdf0197a81e4e2e",
+        "version" : "1.0.3"
       }
     },
     {

--- a/app/modules/AgentHubCore/Package.resolved
+++ b/app/modules/AgentHubCore/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "13aed19909ebcecf9b53ec458c34bd9403660f196f661ce384495b288c73164c",
+  "originHash" : "048fdc7eabbe5ec84600004f7df71198287fc1f04fda1b094732ae52d9cf8ebb",
   "pins" : [
     {
       "identity" : "beautiful-mermaid-swift",
@@ -62,6 +62,15 @@
       "state" : {
         "revision" : "92efb78b73a8b665ee74bacfb0f1f5b17bbe1b38",
         "version" : "0.1.0"
+      }
+    },
+    {
+      "identity" : "ghosttyswift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/jamesrochabrun/GhosttySwift",
+      "state" : {
+        "revision" : "09013e66d2ee1854519367824bdf0197a81e4e2e",
+        "version" : "1.0.3"
       }
     },
     {

--- a/app/modules/AgentHubCore/Package.swift
+++ b/app/modules/AgentHubCore/Package.swift
@@ -20,6 +20,7 @@ let package = Package(
   dependencies: [
     .package(path: "../AgentHubGitHub"),
     .package(path: "../Storybook"),
+    .package(path: "../../../../GhosttySwift"),
     .package(url: "https://github.com/jamesrochabrun/Canvas", from: "1.2.0"),
     .package(url: "https://github.com/jamesrochabrun/PierreDiffsSwift", exact: "1.1.7"),
     .package(url: "https://github.com/jamesrochabrun/SwiftTerm", exact: "1.13.0-agenthub.1"),
@@ -45,6 +46,7 @@ let package = Package(
         "ClaudeCodeClient",
         .product(name: "AgentHubGitHub", package: "AgentHubGitHub"),
         .product(name: "Storybook", package: "Storybook"),
+        .product(name: "GhosttySwift", package: "GhosttySwift"),
         .product(name: "Canvas", package: "Canvas"),
         .product(name: "PierreDiffsSwift", package: "PierreDiffsSwift"),
         .product(name: "SwiftTerm", package: "SwiftTerm"),

--- a/app/modules/AgentHubCore/Package.swift
+++ b/app/modules/AgentHubCore/Package.swift
@@ -77,7 +77,11 @@ let package = Package(
     ),
     .testTarget(
       name: "AgentHubTests",
-      dependencies: ["AgentHubCore", "ClaudeCodeClient"],
+      dependencies: [
+        "AgentHubCore",
+        "ClaudeCodeClient",
+        .product(name: "GhosttySwift", package: "GhosttySwift"),
+      ],
       path: "Tests/AgentHubTests",
       swiftSettings: [
         .swiftLanguageMode(.v5)

--- a/app/modules/AgentHubCore/Package.swift
+++ b/app/modules/AgentHubCore/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
   dependencies: [
     .package(path: "../AgentHubGitHub"),
     .package(path: "../Storybook"),
-    .package(path: "../../../../GhosttySwift"),
+    .package(url: "https://github.com/jamesrochabrun/GhosttySwift", exact: "1.0.3"),
     .package(url: "https://github.com/jamesrochabrun/Canvas", from: "1.2.0"),
     .package(url: "https://github.com/jamesrochabrun/PierreDiffsSwift", exact: "1.1.7"),
     .package(url: "https://github.com/jamesrochabrun/SwiftTerm", exact: "1.13.0-agenthub.1"),

--- a/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubDefaults.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubDefaults.swift
@@ -98,6 +98,10 @@ public enum AgentHubDefaults {
   /// Type: String (default: "SF Mono")
   public static let terminalFontFamily = "\(keyPrefix)terminal.fontFamily"
 
+  /// Embedded terminal backend
+  /// Type: Int (default: 0 = Ghostty)
+  public static let terminalBackend = "\(keyPrefix)terminal.backend"
+
   /// Whether source editors show the CodeEdit minimap
   /// Type: Bool (default: false)
   public static let sourceEditorMinimapEnabled = "\(keyPrefix)editor.minimapEnabled"

--- a/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubDefaults.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubDefaults.swift
@@ -102,6 +102,10 @@ public enum AgentHubDefaults {
   /// Type: Int (default: 0 = Ghostty)
   public static let terminalBackend = "\(keyPrefix)terminal.backend"
 
+  /// Custom Ghostty config file path for embedded Ghostty terminals
+  /// Type: String (default: "")
+  public static let terminalGhosttyConfigPath = "\(keyPrefix)terminal.ghosttyConfigPath"
+
   /// Whether source editors show the CodeEdit minimap
   /// Type: Bool (default: false)
   public static let sourceEditorMinimapEnabled = "\(keyPrefix)editor.minimapEnabled"

--- a/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubProvider.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubProvider.swift
@@ -334,9 +334,10 @@ public final class AgentHubProvider {
     let sidecar = claudeHookSidecarWatcher
     let semaphore = DispatchSemaphore(value: 0)
     Task.detached(priority: .userInitiated) {
-      await claimStore.resetAll()
-      await sidecar.wipeAll()
-      await installer.reconcileOnLaunch(expectedPaths: [])
+      async let resetClaims: Void = claimStore.resetAll()
+      async let wipeSidecars: Void = sidecar.wipeAll()
+      async let reconcileHooks: Void = installer.reconcileOnLaunch(expectedPaths: [])
+      _ = await (resetClaims, wipeSidecars, reconcileHooks)
       semaphore.signal()
     }
     if semaphore.wait(timeout: .now() + timeout) == .timedOut {
@@ -361,9 +362,10 @@ public final class AgentHubProvider {
     let sidecar = claudeHookSidecarWatcher
     let semaphore = DispatchSemaphore(value: 0)
     Task.detached(priority: .userInitiated) {
-      await installer.flushAll()
-      await claimStore.resetAll()
-      await sidecar.wipeAll()
+      async let flushHooks: Void = installer.flushAll()
+      async let resetClaims: Void = claimStore.resetAll()
+      async let wipeSidecars: Void = sidecar.wipeAll()
+      _ = await (flushHooks, resetClaims, wipeSidecars)
       semaphore.signal()
     }
     let deadline = DispatchTime.now() + timeout

--- a/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubProvider.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubProvider.swift
@@ -301,7 +301,8 @@ public final class AgentHubProvider {
       webPreviewCandidateService: webPreviewCandidateService,
       approvalClaimStore: claimStore,
       hookInstaller: installer,
-      terminalBackend: terminalBackend
+      terminalBackend: terminalBackend,
+      terminalWorkspaceStore: metadataStore
     )
     vm.agentHubProvider = self
     return vm

--- a/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubProvider.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubProvider.swift
@@ -10,6 +10,10 @@ import Foundation
 import os
 import ClaudeCodeClient
 
+#if canImport(AppKit)
+import AppKit
+#endif
+
 /// Central service provider that manages all AgentHub services
 ///
 /// `AgentHubProvider` provides lazy initialization of services and a single
@@ -34,6 +38,7 @@ public final class AgentHubProvider {
 
   /// The configuration used by this provider
   public let configuration: AgentHubConfiguration
+  public let terminalBackend: EmbeddedTerminalBackend
 
   // MARK: - Lazy Services
 
@@ -187,6 +192,7 @@ public final class AgentHubProvider {
   /// - Parameter configuration: Configuration for services. Defaults to `.default`
   public init(configuration: AgentHubConfiguration = .default) {
     self.configuration = configuration
+    self.terminalBackend = .storedPreference
 
     // Persist developer-provided commands to UserDefaults
     let defaults = UserDefaults.standard
@@ -294,7 +300,8 @@ public final class AgentHubProvider {
       metadataStore: metadataStore,
       webPreviewCandidateService: webPreviewCandidateService,
       approvalClaimStore: claimStore,
-      hookInstaller: installer
+      hookInstaller: installer,
+      terminalBackend: terminalBackend
     )
     vm.agentHubProvider = self
     return vm
@@ -374,5 +381,33 @@ public final class AgentHubProvider {
       AppLogger.session.info("Terminating terminal for key: \(key)")
       terminal.terminateProcess()
     }
+  }
+
+  public func recreateEmbeddedTerminalsForSelectedBackend() {
+    AppLogger.session.info("Terminal backend changes require app restart; keeping existing terminals alive")
+  }
+
+  public func relaunchApplication() {
+    #if canImport(AppKit)
+    let bundlePath = Bundle.main.bundlePath
+    let escapedBundlePath = shellEscapedPath(bundlePath)
+    let script = "sleep 1; /usr/bin/open -n \(escapedBundlePath)"
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "/bin/sh")
+    process.arguments = ["-c", script]
+
+    do {
+      try process.run()
+      NSApplication.shared.terminate(nil)
+    } catch {
+      AppLogger.session.error("Failed to relaunch AgentHub: \(error.localizedDescription)")
+    }
+    #else
+    AppLogger.session.error("Relaunch is unavailable outside AppKit")
+    #endif
+  }
+
+  private func shellEscapedPath(_ path: String) -> String {
+    "'\(path.replacingOccurrences(of: "'", with: "'\\''"))'"
   }
 }

--- a/app/modules/AgentHubCore/Sources/AgentHub/Models/TerminalWorkspaceRecord.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Models/TerminalWorkspaceRecord.swift
@@ -1,0 +1,33 @@
+//
+//  TerminalWorkspaceRecord.swift
+//  AgentHub
+//
+//  SQLite record for persisted embedded terminal workspaces.
+//
+
+import Foundation
+import GRDB
+
+public struct TerminalWorkspaceRecord: Codable, Sendable, FetchableRecord, PersistableRecord {
+  public var provider: String
+  public var sessionId: String
+  public var backend: Int
+  public var snapshotData: Data
+  public var updatedAt: Date
+
+  public static var databaseTableName: String { "terminal_workspaces" }
+
+  public init(
+    provider: String,
+    sessionId: String,
+    backend: Int,
+    snapshotData: Data,
+    updatedAt: Date = Date()
+  ) {
+    self.provider = provider
+    self.sessionId = sessionId
+    self.backend = backend
+    self.snapshotData = snapshotData
+    self.updatedAt = updatedAt
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/Models/TerminalWorkspaceSnapshot.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Models/TerminalWorkspaceSnapshot.swift
@@ -1,0 +1,69 @@
+//
+//  TerminalWorkspaceSnapshot.swift
+//  AgentHub
+//
+//  Persisted structure for restoring embedded terminal workspaces.
+//
+
+import Foundation
+
+public struct TerminalWorkspaceSnapshot: Codable, Equatable, Sendable {
+  public var schemaVersion: Int
+  public var panels: [TerminalWorkspacePanelSnapshot]
+  public var activePanelIndex: Int
+
+  public init(
+    schemaVersion: Int = 1,
+    panels: [TerminalWorkspacePanelSnapshot],
+    activePanelIndex: Int = 0
+  ) {
+    self.schemaVersion = schemaVersion
+    self.panels = panels
+    self.activePanelIndex = activePanelIndex
+  }
+}
+
+public struct TerminalWorkspacePanelSnapshot: Codable, Equatable, Sendable {
+  public var role: TerminalWorkspacePanelRole
+  public var tabs: [TerminalWorkspaceTabSnapshot]
+  public var activeTabIndex: Int
+
+  public init(
+    role: TerminalWorkspacePanelRole,
+    tabs: [TerminalWorkspaceTabSnapshot],
+    activeTabIndex: Int = 0
+  ) {
+    self.role = role
+    self.tabs = tabs
+    self.activeTabIndex = activeTabIndex
+  }
+}
+
+public enum TerminalWorkspacePanelRole: String, Codable, Equatable, Sendable {
+  case primary
+  case auxiliary
+}
+
+public struct TerminalWorkspaceTabSnapshot: Codable, Equatable, Sendable {
+  public var role: TerminalWorkspaceTabRole
+  public var name: String?
+  public var title: String?
+  public var workingDirectory: String?
+
+  public init(
+    role: TerminalWorkspaceTabRole,
+    name: String? = nil,
+    title: String? = nil,
+    workingDirectory: String? = nil
+  ) {
+    self.role = role
+    self.name = name
+    self.title = title
+    self.workingDirectory = workingDirectory
+  }
+}
+
+public enum TerminalWorkspaceTabRole: String, Codable, Equatable, Sendable {
+  case agent
+  case shell
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/ClaudeHookInstaller.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/ClaudeHookInstaller.swift
@@ -112,8 +112,9 @@ public actor ClaudeHookInstaller: ClaudeHookInstallerProtocol {
     let previouslyInstalled = Set(loadInstalledPaths())
     let stale = previouslyInstalled.subtracting(expected)
     for path in stale {
-      uninstall(atProjectPath: path)
+      uninstall(atProjectPath: path, updatesInstalledPaths: false)
     }
+    saveInstalledPaths(Array(previouslyInstalled.subtracting(stale)))
   }
 
   // MARK: - Install / uninstall mechanics
@@ -129,14 +130,16 @@ public actor ClaudeHookInstaller: ClaudeHookInstallerProtocol {
     }
   }
 
-  private func uninstall(atProjectPath path: String) {
+  private func uninstall(atProjectPath path: String, updatesInstalledPaths: Bool = true) {
     let settingsURL = ClaudeHookPaths.settingsLocalURL(inProjectAt: path)
     do {
       migrateLegacyPerProjectScript(atProjectPath: path, settingsURL: settingsURL)
       if fileManager.fileExists(atPath: settingsURL.path) {
         try unmergeSettingsLocal(at: settingsURL, scriptPath: sharedScriptURL.path)
       }
-      forgetInstalled(path: path)
+      if updatesInstalledPaths {
+        forgetInstalled(path: path)
+      }
     } catch {
       AppLogger.watcher.error("[ClaudeHookInstaller] uninstall failed for \(path): \(error.localizedDescription)")
     }

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/SessionMetadataStore.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/SessionMetadataStore.swift
@@ -10,7 +10,7 @@ import GRDB
 
 /// Actor-based service for persisting session metadata to SQLite
 /// Uses GRDB for database operations with async/await support
-public actor SessionMetadataStore {
+public actor SessionMetadataStore: TerminalWorkspaceStoreProtocol {
 
   // MARK: - Properties
 
@@ -82,6 +82,17 @@ public actor SessionMetadataStore {
     migrator.registerMigration("v4_add_pinned") { db in
       try db.alter(table: "session_metadata") { t in
         t.add(column: "isPinned", .boolean).notNull().defaults(to: false)
+      }
+    }
+
+    migrator.registerMigration("v5_create_terminal_workspaces") { db in
+      try db.create(table: "terminal_workspaces") { t in
+        t.column("provider", .text).notNull()
+        t.column("sessionId", .text).notNull()
+        t.column("backend", .integer).notNull()
+        t.column("snapshotData", .blob).notNull()
+        t.column("updatedAt", .datetime).notNull()
+        t.primaryKey(["provider", "sessionId", "backend"], onConflict: .replace)
       }
     }
 
@@ -170,6 +181,9 @@ public actor SessionMetadataStore {
   /// Deletes metadata for a session
   public func deleteMetadata(for sessionId: String) throws {
     try dbQueue.write { db in
+      _ = try TerminalWorkspaceRecord
+        .filter(Column("sessionId") == sessionId)
+        .deleteAll(db)
       _ = try SessionMetadata.deleteOne(db, key: sessionId)
     }
   }
@@ -177,6 +191,7 @@ public actor SessionMetadataStore {
   /// Clears all metadata (for testing/reset)
   public func clearAll() throws {
     try dbQueue.write { db in
+      _ = try TerminalWorkspaceRecord.deleteAll(db)
       _ = try AIConfigRecord.deleteAll(db)
       _ = try SessionRepoMapping.deleteAll(db)
       _ = try SessionMetadata.deleteAll(db)
@@ -247,6 +262,60 @@ public actor SessionMetadataStore {
       var record = record
       record.updatedAt = Date()
       try record.save(db)
+    }
+  }
+
+  // MARK: - Terminal Workspaces
+
+  public nonisolated func loadTerminalWorkspace(
+    provider: SessionProviderKind,
+    sessionId: String,
+    backend: EmbeddedTerminalBackend
+  ) -> TerminalWorkspaceSnapshot? {
+    try? dbQueue.read { db in
+      guard let record = try TerminalWorkspaceRecord
+        .filter(Column("provider") == provider.rawValue)
+        .filter(Column("sessionId") == sessionId)
+        .filter(Column("backend") == backend.rawValue)
+        .fetchOne(db)
+      else {
+        return nil
+      }
+
+      return try JSONDecoder().decode(TerminalWorkspaceSnapshot.self, from: record.snapshotData)
+    }
+  }
+
+  public func saveTerminalWorkspace(
+    _ snapshot: TerminalWorkspaceSnapshot,
+    provider: SessionProviderKind,
+    sessionId: String,
+    backend: EmbeddedTerminalBackend
+  ) async throws {
+    let data = try JSONEncoder().encode(snapshot)
+    let record = TerminalWorkspaceRecord(
+      provider: provider.rawValue,
+      sessionId: sessionId,
+      backend: backend.rawValue,
+      snapshotData: data
+    )
+
+    try await dbQueue.write { db in
+      try record.save(db)
+    }
+  }
+
+  public func deleteTerminalWorkspace(
+    provider: SessionProviderKind,
+    sessionId: String,
+    backend: EmbeddedTerminalBackend
+  ) async throws {
+    try await dbQueue.write { db in
+      _ = try TerminalWorkspaceRecord
+        .filter(Column("provider") == provider.rawValue)
+        .filter(Column("sessionId") == sessionId)
+        .filter(Column("backend") == backend.rawValue)
+        .deleteAll(db)
     }
   }
 }

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/TerminalWorkspaceStoreProtocol.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/TerminalWorkspaceStoreProtocol.swift
@@ -1,0 +1,29 @@
+//
+//  TerminalWorkspaceStoreProtocol.swift
+//  AgentHub
+//
+//  Persistence abstraction for embedded terminal workspace layouts.
+//
+
+import Foundation
+
+public protocol TerminalWorkspaceStoreProtocol: Sendable {
+  func loadTerminalWorkspace(
+    provider: SessionProviderKind,
+    sessionId: String,
+    backend: EmbeddedTerminalBackend
+  ) -> TerminalWorkspaceSnapshot?
+
+  func saveTerminalWorkspace(
+    _ snapshot: TerminalWorkspaceSnapshot,
+    provider: SessionProviderKind,
+    sessionId: String,
+    backend: EmbeddedTerminalBackend
+  ) async throws
+
+  func deleteTerminalWorkspace(
+    provider: SessionProviderKind,
+    sessionId: String,
+    backend: EmbeddedTerminalBackend
+  ) async throws
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/AgentHubGhosttyTerminalShortcut.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/AgentHubGhosttyTerminalShortcut.swift
@@ -1,0 +1,79 @@
+//
+//  AgentHubGhosttyTerminalShortcut.swift
+//  AgentHub
+//
+
+import AppKit
+import GhosttySwift
+
+enum AgentHubGhosttyTerminalShortcut: Equatable {
+  case startSearch
+  case searchNext
+  case searchPrevious
+  case openTab
+  case openPane
+  case closePanel
+  case focusPanel(TerminalPanelNavigationDirection)
+  case selectTab(TerminalTabNavigationDirection)
+
+  static func action(for event: NSEvent) -> AgentHubGhosttyTerminalShortcut? {
+    action(
+      keyCode: event.keyCode,
+      charactersIgnoringModifiers: event.charactersIgnoringModifiers,
+      modifierFlags: event.modifierFlags
+    )
+  }
+
+  static func action(
+    keyCode: UInt16,
+    charactersIgnoringModifiers: String?,
+    modifierFlags: NSEvent.ModifierFlags
+  ) -> AgentHubGhosttyTerminalShortcut? {
+    let flags = normalizedModifierFlags(modifierFlags)
+    let key = charactersIgnoringModifiers?.lowercased()
+
+    if flags == [.command] {
+      switch keyCode {
+      case 123: return .focusPanel(.left)
+      case 124: return .focusPanel(.right)
+      case 125: return .focusPanel(.down)
+      case 126: return .focusPanel(.up)
+      default:
+        break
+      }
+
+      switch key {
+      case "f": return .startSearch
+      case "g": return .searchNext
+      case "t": return .openTab
+      case "d": return .openPane
+      default: return nil
+      }
+    }
+
+    if flags == [.command, .shift] {
+      switch keyCode {
+      case 123: return .selectTab(.previous)
+      case 124: return .selectTab(.next)
+      default:
+        break
+      }
+
+      switch key {
+      case "g": return .searchPrevious
+      case "w": return .closePanel
+      default: return nil
+      }
+    }
+
+    return nil
+  }
+
+  private static func normalizedModifierFlags(
+    _ flags: NSEvent.ModifierFlags
+  ) -> NSEvent.ModifierFlags {
+    flags
+      .intersection(.deviceIndependentFlagsMask)
+      .subtracting([.numericPad, .function, .capsLock])
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/AgentHubGhosttyTerminalSurface.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/AgentHubGhosttyTerminalSurface.swift
@@ -388,6 +388,9 @@ final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurface {
         },
         onCloseTab: { [weak self] panel, tab in
           self?.closeGhosttyTab(tab, in: panel)
+        },
+        onOpenTab: { [weak self] panel in
+          self?.openShellTab(in: panel.id)
         }
       )
     )
@@ -452,9 +455,12 @@ final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurface {
     )
   }
 
-  private func shellConfigurationForNewTerminal() -> GhosttySurfaceConfiguration {
-    let workingDirectory = activeController?.workingDirectory
-      ?? activeController?.configuration.workingDirectory
+  private func shellConfigurationForNewTerminal(in panelID: TerminalPanelID? = nil) -> GhosttySurfaceConfiguration {
+    let sourceController = panelID
+      .flatMap { terminalSession?.panel(for: $0)?.activeTab?.controller }
+      ?? activeController
+    let workingDirectory = sourceController?.workingDirectory
+      ?? sourceController?.configuration.workingDirectory
       ?? resolvedProjectPath
     let launch = EmbeddedTerminalLaunchBuilder.shellLaunch(projectPath: workingDirectory)
     return makeGhosttyConfiguration(
@@ -710,12 +716,13 @@ final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurface {
     }
   }
 
-  private func openShellTab() {
+  private func openShellTab(in panelID: TerminalPanelID? = nil) {
     guard let terminalSession else { return }
     do {
       let tab = try terminalSession.openTab(
+        in: panelID,
         named: "Shell",
-        configuration: shellConfigurationForNewTerminal()
+        configuration: shellConfigurationForNewTerminal(in: panelID)
       )
       configureControllerHooks(for: tab.controller)
       notifyWorkspaceChanged()

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/AgentHubGhosttyTerminalSurface.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/AgentHubGhosttyTerminalSurface.swift
@@ -37,6 +37,18 @@ final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurface {
     protectedAgentController?.foregroundProcessID ?? activeController?.foregroundProcessID
   }
 
+  override var isOpaque: Bool { false }
+
+  override init(frame frameRect: NSRect) {
+    super.init(frame: frameRect)
+    makeViewTransparent(self)
+  }
+
+  required init?(coder: NSCoder) {
+    super.init(coder: coder)
+    makeViewTransparent(self)
+  }
+
   override func performKeyEquivalent(with event: NSEvent) -> Bool {
     if handleKeyDown(event) {
       return true
@@ -334,6 +346,7 @@ final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurface {
   ) {
     do {
       let session = try TerminalSession(
+        configPath: GhosttyConfigPathResolver.configuredPath(),
         primaryConfiguration: primaryConfiguration,
         primaryName: protectsPrimaryTab ? "Agent" : "Shell"
       )
@@ -378,11 +391,13 @@ final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurface {
         }
       )
     )
+    makeViewTransparent(host)
     mount(host)
     hostingView = host
   }
 
   private func mount(_ child: NSView) {
+    makeViewTransparent(child)
     child.translatesAutoresizingMaskIntoConstraints = false
     addSubview(child)
     NSLayoutConstraint.activate([
@@ -391,6 +406,12 @@ final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurface {
       child.topAnchor.constraint(equalTo: topAnchor),
       child.bottomAnchor.constraint(equalTo: bottomAnchor)
     ])
+  }
+
+  private func makeViewTransparent(_ view: NSView) {
+    view.wantsLayer = true
+    view.layer?.backgroundColor = NSColor.clear.cgColor
+    view.layer?.isOpaque = false
   }
 
   private func removeMountedContent() {

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/AgentHubGhosttyTerminalSurface.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/AgentHubGhosttyTerminalSurface.swift
@@ -9,10 +9,20 @@ import SwiftUI
 
 @MainActor
 final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurface {
+  private struct PendingMount {
+    let command: String
+    let environment: [String: String]
+    let initialInput: String?
+    let workingDirectory: String
+    let protectsPrimaryTab: Bool
+  }
+
   private var terminalSession: TerminalSession?
   private var hostingView: NSHostingView<TerminalSurfaceView>?
   private var protectedAgentPanelID: TerminalPanelID?
   private var protectedAgentTabID: TerminalTabID?
+  private var pendingMount: PendingMount?
+  private var pendingWorkspaceSnapshot: TerminalWorkspaceSnapshot?
   private var isConfigured = false
   private var hasDeliveredInitialPrompt = false
   private var hasPrefilledInitialInputText = false
@@ -22,6 +32,8 @@ final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurface {
   private var projectPath: String = ""
   private var isRestoringWorkspace = false
   private var lastWorkspaceSnapshot: TerminalWorkspaceSnapshot?
+  private static let terminalPaneDividerSize: CGFloat = 1
+  private static let terminalTabStripHeight: CGFloat = 24
 
   var onUserInteraction: (() -> Void)?
   var onRequestShowEditor: (() -> Void)?
@@ -54,6 +66,16 @@ final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurface {
       return true
     }
     return super.performKeyEquivalent(with: event)
+  }
+
+  override func viewDidMoveToWindow() {
+    super.viewDidMoveToWindow()
+    mountPendingGhosttySessionIfReady()
+  }
+
+  override func layout() {
+    super.layout()
+    mountPendingGhosttySessionIfReady()
   }
 
   deinit {
@@ -101,14 +123,14 @@ final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurface {
 
     switch launch {
     case .success(let launch):
-      mountGhosttySession(
-        primaryConfiguration: makeGhosttyConfiguration(
+      queueOrMountGhosttySession(
+        PendingMount(
           command: launch.ghosttyCommand,
           environment: launch.environment,
           initialInput: initialInputText,
-          workingDirectory: resolvedProjectPath
-        ),
-        protectsPrimaryTab: true
+          workingDirectory: resolvedProjectPath,
+          protectsPrimaryTab: true
+        )
       )
     case .failure(let error):
       mountError(error.localizedDescription)
@@ -124,14 +146,14 @@ final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurface {
       projectPath: projectPath,
       shellPath: shellPath
     )
-    mountGhosttySession(
-      primaryConfiguration: makeGhosttyConfiguration(
+    queueOrMountGhosttySession(
+      PendingMount(
         command: launch.ghosttyCommand,
         environment: launch.environment,
         initialInput: nil,
-        workingDirectory: resolvedProjectPath
-      ),
-      protectsPrimaryTab: false
+        workingDirectory: resolvedProjectPath,
+        protectsPrimaryTab: false
+      )
     )
   }
 
@@ -139,6 +161,8 @@ final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurface {
     terminateProcess()
     removeMountedContent()
     terminalSession = nil
+    pendingMount = nil
+    pendingWorkspaceSnapshot = nil
     protectedAgentPanelID = nil
     protectedAgentTabID = nil
     isConfigured = false
@@ -265,7 +289,10 @@ final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurface {
   }
 
   func restoreWorkspaceSnapshot(_ snapshot: TerminalWorkspaceSnapshot) {
-    guard let terminalSession else { return }
+    guard let terminalSession else {
+      pendingWorkspaceSnapshot = snapshot
+      return
+    }
     guard !snapshot.panels.isEmpty else { return }
 
     isRestoringWorkspace = true
@@ -357,10 +384,50 @@ final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurface {
       configureControllerHooks(for: session.primaryPanel.activeTab?.controller)
       mount(session)
       terminalSession = session
+      restorePendingWorkspaceSnapshotIfNeeded()
       installInteractionMonitorIfNeeded()
     } catch {
       mountError(error.localizedDescription)
     }
+  }
+
+  private func queueOrMountGhosttySession(_ pendingMount: PendingMount) {
+    guard canMountGhosttySession else {
+      self.pendingMount = pendingMount
+      needsLayout = true
+      return
+    }
+
+    mountGhosttySession(pendingMount)
+  }
+
+  private func mountPendingGhosttySessionIfReady() {
+    guard let pendingMount, canMountGhosttySession else { return }
+    self.pendingMount = nil
+    mountGhosttySession(pendingMount)
+  }
+
+  private var canMountGhosttySession: Bool {
+    window != nil && bounds.width > 0 && bounds.height > 0
+  }
+
+  private func mountGhosttySession(_ pendingMount: PendingMount) {
+    mountGhosttySession(
+      primaryConfiguration: makeGhosttyConfiguration(
+        command: pendingMount.command,
+        environment: pendingMount.environment,
+        initialInput: pendingMount.initialInput,
+        workingDirectory: pendingMount.workingDirectory,
+        initialSize: currentInitialSurfaceSize()
+      ),
+      protectsPrimaryTab: pendingMount.protectsPrimaryTab
+    )
+  }
+
+  private func restorePendingWorkspaceSnapshotIfNeeded() {
+    guard let snapshot = pendingWorkspaceSnapshot else { return }
+    pendingWorkspaceSnapshot = nil
+    restoreWorkspaceSnapshot(snapshot)
   }
 
   private func mount(_ session: TerminalSession) {
@@ -444,14 +511,16 @@ final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurface {
     command: String,
     environment: [String: String],
     initialInput: String?,
-    workingDirectory: String
+    workingDirectory: String,
+    initialSize: GhosttySurfaceInitialSize? = nil
   ) -> GhosttySurfaceConfiguration {
     GhosttySurfaceConfiguration(
       workingDirectory: workingDirectory,
       command: command,
       environment: environment,
       initialInput: initialInput,
-      fontSize: resolvedFontSize()
+      fontSize: resolvedFontSize(),
+      initialSize: initialSize
     )
   }
 
@@ -467,19 +536,64 @@ final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurface {
       command: launch.ghosttyCommand,
       environment: launch.environment,
       initialInput: nil,
-      workingDirectory: workingDirectory
+      workingDirectory: workingDirectory,
+      initialSize: predictedInitialSizeForNewTerminal(in: panelID)
     )
   }
 
-  private func shellConfiguration(forRestoredWorkingDirectory workingDirectory: String?) -> GhosttySurfaceConfiguration {
+  private func shellConfiguration(
+    forRestoredWorkingDirectory workingDirectory: String?,
+    in panelID: TerminalPanelID? = nil
+  ) -> GhosttySurfaceConfiguration {
     let restoredPath = resolvedExistingDirectory(workingDirectory)
     let launch = EmbeddedTerminalLaunchBuilder.shellLaunch(projectPath: restoredPath)
     return makeGhosttyConfiguration(
       command: launch.ghosttyCommand,
       environment: launch.environment,
       initialInput: nil,
-      workingDirectory: restoredPath
+      workingDirectory: restoredPath,
+      initialSize: predictedInitialSizeForNewTerminal(in: panelID)
     )
+  }
+
+  private func currentInitialSurfaceSize() -> GhosttySurfaceInitialSize? {
+    initialSurfaceSize(from: bounds.size)
+  }
+
+  private func predictedInitialSizeForNewTerminal(in panelID: TerminalPanelID? = nil) -> GhosttySurfaceInitialSize? {
+    guard let terminalSession else {
+      return currentInitialSurfaceSize()
+    }
+
+    if let panelID {
+      if let size = terminalSession.panel(for: panelID)?.activeTab?.containerView.bounds.size,
+         size.width > 0,
+         size.height > 0 {
+        return initialSurfaceSize(from: size)
+      }
+      return currentInitialSurfaceSize()
+    }
+
+    let newPanelID = TerminalPanelID()
+    let projectedPanelIDs = terminalSession.visiblePanels.map(\.id) + [newPanelID]
+    let projectedLayout = TerminalSplitLayout(axis: .horizontal, panelIDs: projectedPanelIDs)
+    let frames = Self.panelFrames(
+      for: projectedLayout.root,
+      in: CGRect(origin: .zero, size: bounds.size)
+    )
+
+    guard let paneSize = frames[newPanelID]?.size else {
+      return currentInitialSurfaceSize()
+    }
+
+    return initialSurfaceSize(
+      from: Self.terminalContentSize(forPaneSize: paneSize, showsTabStrip: true)
+    )
+  }
+
+  private func initialSurfaceSize(from size: CGSize) -> GhosttySurfaceInitialSize? {
+    guard size.width > 0, size.height > 0 else { return nil }
+    return GhosttySurfaceInitialSize(width: size.width, height: size.height)
   }
 
   private func resolvedExistingDirectory(_ path: String?) -> String {
@@ -535,7 +649,10 @@ final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurface {
         let tab = try terminalSession.openTab(
           in: panelID,
           named: restoredTabName(for: tabSnapshot),
-          configuration: shellConfiguration(forRestoredWorkingDirectory: tabSnapshot.workingDirectory)
+          configuration: shellConfiguration(
+            forRestoredWorkingDirectory: tabSnapshot.workingDirectory,
+            in: panelID
+          )
         )
         configureControllerHooks(for: tab.controller)
         restoredTabIDs.append(tab.id)
@@ -734,6 +851,9 @@ final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurface {
   private func openShellPane() {
     guard let terminalSession, terminalSession.canOpenPanel else { return }
     do {
+      prepareVisiblePanelsForPaneTransition(
+        projectedPanelIDs: terminalSession.visiblePanels.map(\.id) + [TerminalPanelID()]
+      )
       let panel = try terminalSession.openPanel(
         named: "Shell",
         configuration: shellConfigurationForNewTerminal()
@@ -780,6 +900,9 @@ final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurface {
 
   private func closeGhosttyPanel(_ panel: TerminalPanel) {
     guard let terminalSession, canCloseGhosttyPanel(panel) else { return }
+    prepareVisiblePanelsForPaneTransition(
+      projectedPanelIDs: terminalSession.visiblePanels.map(\.id).filter { $0 != panel.id }
+    )
     requestClose(panel)
     if terminalSession.closePanel(panel.id) {
       notifyWorkspaceChanged()
@@ -798,6 +921,102 @@ final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurface {
     for tab in panel.tabs {
       requestClose(tab)
     }
+  }
+
+  private func prepareVisiblePanelsForPaneTransition(projectedPanelIDs: [TerminalPanelID]) {
+    guard let terminalSession, bounds.width > 0, bounds.height > 0 else { return }
+    guard !projectedPanelIDs.isEmpty else { return }
+
+    let layout = TerminalSplitLayout(axis: .horizontal, panelIDs: projectedPanelIDs)
+    let frames = Self.panelFrames(
+      for: layout.root,
+      in: CGRect(origin: .zero, size: bounds.size)
+    )
+
+    for panel in terminalSession.visiblePanels {
+      guard let paneSize = frames[panel.id]?.size else { continue }
+      let contentSize = terminalContentSize(for: panel, paneSize: paneSize)
+      panel.activeTab?.containerView.prepareForHostResize(to: contentSize)
+    }
+  }
+
+  private func terminalContentSize(for panel: TerminalPanel, paneSize: CGSize) -> CGSize {
+    Self.terminalContentSize(
+      forPaneSize: paneSize,
+      showsTabStrip: shouldShowTabStrip(for: panel)
+    )
+  }
+
+  private func shouldShowTabStrip(for panel: TerminalPanel) -> Bool {
+    panel.tabs.count > 1 || canCloseGhosttyPanel(panel)
+  }
+
+  private static func terminalContentSize(forPaneSize paneSize: CGSize, showsTabStrip: Bool) -> CGSize {
+    CGSize(
+      width: max(1, paneSize.width),
+      height: max(1, paneSize.height - (showsTabStrip ? terminalTabStripHeight : 0))
+    )
+  }
+
+  private static func panelFrames(
+    for node: TerminalSplitLayout.Node,
+    in rect: CGRect
+  ) -> [TerminalPanelID: CGRect] {
+    switch node {
+    case .panel(let panelID):
+      return [panelID: rect]
+    case .split(let axis, let children):
+      return splitPanelFrames(axis: axis, children: children, in: rect)
+    }
+  }
+
+  private static func splitPanelFrames(
+    axis: TerminalSplitAxis,
+    children: [TerminalSplitLayout.Node],
+    in rect: CGRect
+  ) -> [TerminalPanelID: CGRect] {
+    guard !children.isEmpty else { return [:] }
+
+    var result: [TerminalPanelID: CGRect] = [:]
+    let childCount = CGFloat(children.count)
+
+    switch axis {
+    case .horizontal:
+      let totalDividerWidth = terminalPaneDividerSize * CGFloat(max(children.count - 1, 0))
+      let childWidth = max(0, rect.width - totalDividerWidth) / childCount
+      var nextX = rect.minX
+
+      for (index, child) in children.enumerated() {
+        if index > 0 {
+          nextX += terminalPaneDividerSize
+        }
+        let childRect = CGRect(x: nextX, y: rect.minY, width: childWidth, height: rect.height)
+        result.merge(
+          panelFrames(for: child, in: childRect),
+          uniquingKeysWith: { current, _ in current }
+        )
+        nextX += childWidth
+      }
+
+    case .vertical:
+      let totalDividerHeight = terminalPaneDividerSize * CGFloat(max(children.count - 1, 0))
+      let childHeight = max(0, rect.height - totalDividerHeight) / childCount
+      var nextY = rect.minY
+
+      for (index, child) in children.enumerated() {
+        if index > 0 {
+          nextY += terminalPaneDividerSize
+        }
+        let childRect = CGRect(x: rect.minX, y: nextY, width: rect.width, height: childHeight)
+        result.merge(
+          panelFrames(for: child, in: childRect),
+          uniquingKeysWith: { current, _ in current }
+        )
+        nextY += childHeight
+      }
+    }
+
+    return result
   }
 
   private func requestClose(_ tab: TerminalTab) {

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/AgentHubGhosttyTerminalSurface.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/AgentHubGhosttyTerminalSurface.swift
@@ -183,7 +183,7 @@ final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurface {
       return
     }
 
-    protectedAgentController?.sendText(prompt)
+    sendBracketedPasteText(prompt, to: protectedAgentController)
     Task { @MainActor [weak self] in
       try? await Task.sleep(for: .milliseconds(100))
       self?.protectedAgentController?.sendReturnKey()
@@ -193,7 +193,7 @@ final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurface {
   func submitPromptImmediately(_ prompt: String) -> Bool {
     guard protectedAgentController != nil else { return false }
     focusProtectedAgentTab()
-    protectedAgentController?.sendText(prompt)
+    sendBracketedPasteText(prompt, to: protectedAgentController)
     let delay = Self.submitDelay(forByteCount: prompt.utf8.count)
     Task { @MainActor [weak self] in
       try? await Task.sleep(for: delay)
@@ -564,6 +564,13 @@ final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurface {
     }
   }
 
+  private func sendBracketedPasteText(
+    _ text: String,
+    to controller: GhosttyTerminalController?
+  ) {
+    controller?.sendBytes(TerminalPromptSubmissionPayload.bracketedPasteTextBytes(prompt: text))
+  }
+
   private func installInteractionMonitorIfNeeded() {
     guard localEventMonitor == nil else { return }
     localEventMonitor = NSEvent.addLocalMonitorForEvents(matching: [.keyDown, .leftMouseUp]) { [weak self] event in
@@ -637,7 +644,7 @@ final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurface {
       return true
     case .appendContextAndSubmit(let queuedContextPrompt):
       let fullText = "\n\n\(queuedContextPrompt)"
-      protectedAgentController?.sendText(fullText)
+      sendBracketedPasteText(fullText, to: protectedAgentController)
       let delay = Self.submitDelay(forByteCount: fullText.utf8.count)
       Task { @MainActor [weak self] in
         try? await Task.sleep(for: delay)

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/AgentHubGhosttyTerminalSurface.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/AgentHubGhosttyTerminalSurface.swift
@@ -9,12 +9,15 @@ import SwiftUI
 
 @MainActor
 final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurface {
-  private var controller: GhosttyTerminalController?
-  private var containerView: GhosttySwift.GhosttyTerminalContainerView?
+  private var terminalSession: TerminalSession?
+  private var hostingView: NSHostingView<TerminalSurfaceView>?
+  private var protectedAgentPanelID: TerminalPanelID?
+  private var protectedAgentTabID: TerminalTabID?
   private var isConfigured = false
   private var hasDeliveredInitialPrompt = false
   private var hasPrefilledInitialInputText = false
-  private var registeredPID: pid_t?
+  private var registeredPIDs: [ObjectIdentifier: pid_t] = [:]
+  private var pidRegistrationTasks: [ObjectIdentifier: Task<Void, Never>] = [:]
   private var localEventMonitor: Any?
   private var projectPath: String = ""
 
@@ -28,7 +31,14 @@ final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurface {
   var view: NSView { self }
 
   var currentProcessPID: Int32? {
-    controller?.foregroundProcessID
+    protectedAgentController?.foregroundProcessID ?? activeController?.foregroundProcessID
+  }
+
+  override func performKeyEquivalent(with event: NSEvent) -> Bool {
+    if handleKeyDown(event) {
+      return true
+    }
+    return super.performKeyEquivalent(with: event)
   }
 
   deinit {
@@ -36,8 +46,9 @@ final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurface {
       NSEvent.removeMonitor(localEventMonitor)
     }
     MainActor.assumeIsolated {
-      controller?.requestClose()
-      unregisterPID()
+      terminalSession?.requestCloseAll()
+      cancelPIDRegistrationTasks()
+      unregisterAllPIDs()
     }
   }
 
@@ -75,7 +86,15 @@ final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurface {
 
     switch launch {
     case .success(let launch):
-      mountGhostty(command: launch.ghosttyCommand, environment: launch.environment, initialInputText: initialInputText)
+      mountGhosttySession(
+        primaryConfiguration: makeGhosttyConfiguration(
+          command: launch.ghosttyCommand,
+          environment: launch.environment,
+          initialInput: initialInputText,
+          workingDirectory: resolvedProjectPath
+        ),
+        protectsPrimaryTab: true
+      )
     case .failure(let error):
       mountError(error.localizedDescription)
     }
@@ -90,14 +109,23 @@ final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurface {
       projectPath: projectPath,
       shellPath: shellPath
     )
-    mountGhostty(command: launch.ghosttyCommand, environment: launch.environment, initialInputText: nil)
+    mountGhosttySession(
+      primaryConfiguration: makeGhosttyConfiguration(
+        command: launch.ghosttyCommand,
+        environment: launch.environment,
+        initialInput: nil,
+        workingDirectory: resolvedProjectPath
+      ),
+      protectsPrimaryTab: false
+    )
   }
 
   func restart(sessionId: String?, projectPath: String, cliConfiguration: CLICommandConfiguration) {
     terminateProcess()
-    containerView?.removeFromSuperview()
-    containerView = nil
-    controller = nil
+    removeMountedContent()
+    terminalSession = nil
+    protectedAgentPanelID = nil
+    protectedAgentTabID = nil
     isConfigured = false
     hasDeliveredInitialPrompt = false
     hasPrefilledInitialInputText = false
@@ -117,8 +145,9 @@ final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurface {
 
   func terminateProcess() {
     terminateProcessCallCount += 1
-    controller?.requestClose()
-    unregisterPID()
+    terminalSession?.requestCloseAll()
+    cancelPIDRegistrationTasks()
+    unregisterAllPIDs()
   }
 
   func resetPromptDeliveryFlag() {
@@ -128,55 +157,58 @@ final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurface {
   func sendPromptIfNeeded(_ prompt: String) {
     guard !hasDeliveredInitialPrompt else { return }
     hasDeliveredInitialPrompt = true
+    focusProtectedAgentTab()
 
     let planFeedbackPrefix = "\u{1B}[B\u{1B}[B\u{1B}[B\r"
     if prompt.hasPrefix(planFeedbackPrefix) {
       let feedback = String(prompt.dropFirst(planFeedbackPrefix.count))
       Task { @MainActor [weak self] in
-        self?.controller?.sendArrowDownKey()
+        self?.protectedAgentController?.sendArrowDownKey()
         try? await Task.sleep(for: .milliseconds(80))
-        self?.controller?.sendArrowDownKey()
+        self?.protectedAgentController?.sendArrowDownKey()
         try? await Task.sleep(for: .milliseconds(80))
-        self?.controller?.sendArrowDownKey()
+        self?.protectedAgentController?.sendArrowDownKey()
         try? await Task.sleep(for: .milliseconds(80))
-        self?.controller?.sendReturnKey()
+        self?.protectedAgentController?.sendReturnKey()
         try? await Task.sleep(for: .milliseconds(150))
         if !feedback.isEmpty {
-          self?.controller?.sendText(feedback)
+          self?.protectedAgentController?.sendText(feedback)
           try? await Task.sleep(for: .milliseconds(100))
         }
-        self?.controller?.sendReturnKey()
+        self?.protectedAgentController?.sendReturnKey()
       }
       return
     }
 
-    controller?.sendText(prompt)
+    protectedAgentController?.sendText(prompt)
     Task { @MainActor [weak self] in
       try? await Task.sleep(for: .milliseconds(100))
-      self?.controller?.sendReturnKey()
+      self?.protectedAgentController?.sendReturnKey()
     }
   }
 
   func submitPromptImmediately(_ prompt: String) -> Bool {
-    guard controller != nil else { return false }
-    controller?.sendText(prompt)
+    guard protectedAgentController != nil else { return false }
+    focusProtectedAgentTab()
+    protectedAgentController?.sendText(prompt)
     let delay = Self.submitDelay(forByteCount: prompt.utf8.count)
     Task { @MainActor [weak self] in
       try? await Task.sleep(for: delay)
-      self?.controller?.sendReturnKey()
+      self?.protectedAgentController?.sendReturnKey()
     }
     return true
   }
 
   func typeText(_ text: String) {
-    controller?.sendText(text)
+    activeController?.sendText(text)
   }
 
   func typeInitialTextIfNeeded(_ text: String) {
     guard !text.isEmpty else { return }
     guard !hasPrefilledInitialInputText else { return }
     hasPrefilledInitialInputText = true
-    typeText(text)
+    focusProtectedAgentTab()
+    protectedAgentController?.sendText(text)
   }
 
   func syncAppearance(isDark: Bool, fontSize: CGFloat, fontFamily: String, theme: RuntimeTheme?) {
@@ -184,37 +216,74 @@ final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurface {
   }
 
   func focus() {
-    controller?.focusTerminal()
+    activeController?.focusTerminal()
   }
 
-  private func mountGhostty(command: String, environment: [String: String], initialInputText: String?) {
+  private var resolvedProjectPath: String {
+    projectPath.isEmpty ? NSHomeDirectory() : projectPath
+  }
+
+  private var activeController: GhosttyTerminalController? {
+    terminalSession?.activeTab?.controller
+  }
+
+  private var protectedAgentController: GhosttyTerminalController? {
+    guard
+      let terminalSession,
+      let protectedAgentPanelID,
+      let protectedAgentTabID
+    else {
+      return nil
+    }
+    return terminalSession.controller(for: protectedAgentTabID, in: protectedAgentPanelID)
+  }
+
+  private func mountGhosttySession(
+    primaryConfiguration: GhosttySurfaceConfiguration,
+    protectsPrimaryTab: Bool
+  ) {
     do {
-      let fontSize = Float(UserDefaults.standard.double(forKey: AgentHubDefaults.terminalFontSize))
-      let resolvedFontSize = fontSize > 0 ? fontSize : 12
-      let controller = try GhosttyTerminalController(
-        configuration: GhosttySurfaceConfiguration(
-          workingDirectory: projectPath.isEmpty ? NSHomeDirectory() : projectPath,
-          command: command,
-          environment: environment,
-          initialInput: initialInputText,
-          fontSize: resolvedFontSize
-        )
+      let session = try TerminalSession(
+        primaryConfiguration: primaryConfiguration,
+        primaryName: protectsPrimaryTab ? "Agent" : "Shell"
       )
-      controller.onClose = { [weak self] _ in
-        self?.unregisterPID()
+      if protectsPrimaryTab, let primaryTab = session.primaryPanel.activeTab {
+        protectedAgentPanelID = session.primaryPanelID
+        protectedAgentTabID = primaryTab.id
       }
-      controller.onOpenURL = { [weak self] url in
-        self?.handleOpenURL(url) ?? false
-      }
-      let container = try GhosttySwift.GhosttyTerminalContainerView(controller: controller)
-      mount(container)
-      self.controller = controller
-      self.containerView = container
+      configureControllerHooks(for: session.primaryPanel.activeTab?.controller)
+      mount(session)
+      terminalSession = session
       installInteractionMonitorIfNeeded()
-      registerPIDWhenAvailable()
     } catch {
       mountError(error.localizedDescription)
     }
+  }
+
+  private func mount(_ session: TerminalSession) {
+    let host = NSHostingView(
+      rootView: TerminalSurfaceView(
+        session: session,
+        showsPaneLabels: false,
+        showsTabBar: true,
+        allowsClosingPanels: true,
+        allowsClosingTabs: true,
+        panelClosePolicy: { [weak self] panel in
+          self?.canCloseGhosttyPanel(panel) ?? false
+        },
+        tabClosePolicy: { [weak self] panel, tab in
+          self?.canCloseGhosttyTab(tab, in: panel) ?? false
+        },
+        onClosePanel: { [weak self] panel in
+          self?.closeGhosttyPanel(panel)
+        },
+        onCloseTab: { [weak self] panel, tab in
+          self?.closeGhosttyTab(tab, in: panel)
+        }
+      )
+    )
+    mount(host)
+    hostingView = host
   }
 
   private func mount(_ child: NSView) {
@@ -228,7 +297,16 @@ final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurface {
     ])
   }
 
+  private func removeMountedContent() {
+    hostingView?.removeFromSuperview()
+    hostingView = nil
+    for subview in subviews {
+      subview.removeFromSuperview()
+    }
+  }
+
   private func mountError(_ message: String) {
+    removeMountedContent()
     let label = NSTextField(wrappingLabelWithString: "\nError: \(message)\nPlease ensure the CLI is installed.")
     label.translatesAutoresizingMaskIntoConstraints = false
     label.alignment = .center
@@ -242,6 +320,39 @@ final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurface {
     ])
   }
 
+  private func makeGhosttyConfiguration(
+    command: String,
+    environment: [String: String],
+    initialInput: String?,
+    workingDirectory: String
+  ) -> GhosttySurfaceConfiguration {
+    GhosttySurfaceConfiguration(
+      workingDirectory: workingDirectory,
+      command: command,
+      environment: environment,
+      initialInput: initialInput,
+      fontSize: resolvedFontSize()
+    )
+  }
+
+  private func shellConfigurationForNewTerminal() -> GhosttySurfaceConfiguration {
+    let workingDirectory = activeController?.workingDirectory
+      ?? activeController?.configuration.workingDirectory
+      ?? resolvedProjectPath
+    let launch = EmbeddedTerminalLaunchBuilder.shellLaunch(projectPath: workingDirectory)
+    return makeGhosttyConfiguration(
+      command: launch.ghosttyCommand,
+      environment: launch.environment,
+      initialInput: nil,
+      workingDirectory: workingDirectory
+    )
+  }
+
+  private func resolvedFontSize() -> Float {
+    let fontSize = Float(UserDefaults.standard.double(forKey: AgentHubDefaults.terminalFontSize))
+    return fontSize > 0 ? fontSize : 12
+  }
+
   private static func submitDelay(forByteCount count: Int) -> Duration {
     switch count {
     case ..<500:   return .milliseconds(100)
@@ -253,81 +364,13 @@ final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurface {
   private func installInteractionMonitorIfNeeded() {
     guard localEventMonitor == nil else { return }
     localEventMonitor = NSEvent.addLocalMonitorForEvents(matching: [.keyDown, .leftMouseUp]) { [weak self] event in
-      guard let self, let surfaceView = self.containerView?.surfaceView else { return event }
+      guard let self else { return event }
 
       switch event.type {
       case .keyDown:
-        guard let window = surfaceView.window, event.window === window else { break }
-        let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
-        let isTerminalVisible = surfaceView.superview != nil && !surfaceView.isHidden && surfaceView.alphaValue > 0
-
-        if isTerminalVisible,
-           self.isTerminalResponderActive(window: window, terminal: surfaceView),
-           flags == .control,
-           event.keyCode == 50,
-           self.onRequestShowEditor != nil {
-          self.onRequestShowEditor?()
-          self.onUserInteraction?()
-          return nil
-        }
-
-        if isTerminalVisible,
-           self.isTerminalResponderActive(window: window, terminal: surfaceView),
-           flags == .command,
-           event.charactersIgnoringModifiers == "f" {
-          _ = self.controller?.performBindingAction("search:")
-          self.onUserInteraction?()
-          return nil
-        }
-
-        guard isTerminalResponderActive(window: window, terminal: surfaceView) else { break }
-
-        let shortcut = NewlineShortcut(
-          rawValue: UserDefaults.standard.integer(forKey: AgentHubDefaults.terminalNewlineShortcut)
-        ) ?? .system
-        let action = TerminalSubmitInterception.keyAction(
-          shortcut: shortcut,
-          isReturn: event.keyCode == 36,
-          flags: flags
-        )
-        let queuedContextPrompt: String?
-        switch action {
-        case .submit, .systemSubmit:
-          queuedContextPrompt = self.consumeQueuedWebPreviewContextOnSubmit?()
-        case .passthrough, .newline:
-          queuedContextPrompt = nil
-        }
-
-        switch TerminalSubmitInterception.dispatch(for: action, queuedContextPrompt: queuedContextPrompt) {
-        case .passthrough:
-          self.onUserInteraction?()
-        case .newline:
-          self.controller?.sendText("\n")
-          self.onUserInteraction?()
-          return nil
-        case .submit:
-          self.controller?.sendReturnKey()
-          self.onUserInteraction?()
-          return nil
-        case .appendContextAndSubmit(let queuedContextPrompt):
-          let fullText = "\n\n\(queuedContextPrompt)"
-          self.controller?.sendText(fullText)
-          let delay = Self.submitDelay(forByteCount: fullText.utf8.count)
-          Task { @MainActor [weak self] in
-            try? await Task.sleep(for: delay)
-            self?.controller?.sendReturnKey()
-          }
-          self.onUserInteraction?()
-          return nil
-        }
+        return handleKeyDown(event) ? nil : event
       case .leftMouseUp:
-        guard let window = surfaceView.window, event.window === window else { return event }
-        let locationInTerminal = surfaceView.convert(event.locationInWindow, from: nil)
-        if surfaceView.bounds.contains(locationInTerminal) {
-          DispatchQueue.main.async { [weak self] in
-            self?.onUserInteraction?()
-          }
-        }
+        handleMouseUp(event)
       default:
         break
       }
@@ -336,34 +379,326 @@ final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurface {
     }
   }
 
-  private func isTerminalResponderActive(window: NSWindow, terminal: NSView) -> Bool {
-    guard let responder = window.firstResponder else { return false }
-    if responder === terminal { return true }
-    if let responderView = responder as? NSView {
-      return responderView.isDescendant(of: terminal)
+  private func handleKeyDown(_ event: NSEvent) -> Bool {
+    guard let window = event.window ?? self.window, window === self.window else { return false }
+    guard let focusedTab = focusedTab(in: window) else { return false }
+    syncSessionSelection(to: focusedTab)
+
+    if let shortcut = AgentHubGhosttyTerminalShortcut.action(for: event) {
+      handleShortcut(shortcut)
+      onUserInteraction?()
+      return true
     }
-    return false
+
+    let flags = normalizedModifierFlags(event.modifierFlags)
+    if flags == .control,
+       event.keyCode == 50,
+       onRequestShowEditor != nil {
+      onRequestShowEditor?()
+      onUserInteraction?()
+      return true
+    }
+
+    guard isProtectedAgentTab(focusedTab) else {
+      onUserInteraction?()
+      return false
+    }
+
+    let shortcut = NewlineShortcut(
+      rawValue: UserDefaults.standard.integer(forKey: AgentHubDefaults.terminalNewlineShortcut)
+    ) ?? .system
+    let action = TerminalSubmitInterception.keyAction(
+      shortcut: shortcut,
+      isReturn: event.keyCode == 36,
+      flags: flags
+    )
+    let queuedContextPrompt: String?
+    switch action {
+    case .submit, .systemSubmit:
+      queuedContextPrompt = consumeQueuedWebPreviewContextOnSubmit?()
+    case .passthrough, .newline:
+      queuedContextPrompt = nil
+    }
+
+    switch TerminalSubmitInterception.dispatch(for: action, queuedContextPrompt: queuedContextPrompt) {
+    case .passthrough:
+      onUserInteraction?()
+      return false
+    case .newline:
+      protectedAgentController?.sendText("\n")
+      onUserInteraction?()
+      return true
+    case .submit:
+      protectedAgentController?.sendReturnKey()
+      onUserInteraction?()
+      return true
+    case .appendContextAndSubmit(let queuedContextPrompt):
+      let fullText = "\n\n\(queuedContextPrompt)"
+      protectedAgentController?.sendText(fullText)
+      let delay = Self.submitDelay(forByteCount: fullText.utf8.count)
+      Task { @MainActor [weak self] in
+        try? await Task.sleep(for: delay)
+        self?.protectedAgentController?.sendReturnKey()
+      }
+      onUserInteraction?()
+      return true
+    }
   }
 
-  private func registerPIDWhenAvailable() {
-    Task { @MainActor [weak self] in
+  private func handleMouseUp(_ event: NSEvent) {
+    guard let window = event.window, window === self.window else { return }
+    guard let tab = tab(containingMouseEvent: event) else { return }
+    syncSessionSelection(to: tab)
+    DispatchQueue.main.async { [weak self] in
+      self?.onUserInteraction?()
+    }
+  }
+
+  private func handleShortcut(_ shortcut: AgentHubGhosttyTerminalShortcut) {
+    switch shortcut {
+    case .startSearch:
+      _ = activeController?.startSearch()
+    case .searchNext:
+      _ = activeController?.navigateSearchNext()
+    case .searchPrevious:
+      _ = activeController?.navigateSearchPrevious()
+    case .openTab:
+      openShellTab()
+    case .openPane:
+      openShellPane()
+    case .closePanel:
+      closeActiveOrLastAuxiliaryPanel()
+    case .focusPanel(let direction):
+      _ = terminalSession?.focusPanel(direction: direction)
+    case .selectTab(let direction):
+      _ = terminalSession?.selectTab(direction: direction)
+    }
+  }
+
+  private func openShellTab() {
+    guard let terminalSession else { return }
+    do {
+      let tab = try terminalSession.openTab(
+        named: "Shell",
+        configuration: shellConfigurationForNewTerminal()
+      )
+      configureControllerHooks(for: tab.controller)
+    } catch {
+      AppLogger.session.error("Failed to open Ghostty shell tab: \(error.localizedDescription)")
+    }
+  }
+
+  private func openShellPane() {
+    guard let terminalSession, terminalSession.canOpenPanel else { return }
+    do {
+      let panel = try terminalSession.openPanel(
+        named: "Shell",
+        configuration: shellConfigurationForNewTerminal()
+      )
+      configureControllerHooks(for: panel.activeTab?.controller)
+    } catch {
+      AppLogger.session.error("Failed to open Ghostty shell pane: \(error.localizedDescription)")
+    }
+  }
+
+  private func closeActiveOrLastAuxiliaryPanel() {
+    guard let terminalSession else { return }
+    let targetPanel = terminalSession.activePanelID == terminalSession.primaryPanelID
+      ? terminalSession.visiblePanels.reversed().first { $0.id != terminalSession.primaryPanelID }
+      : terminalSession.panel(for: terminalSession.activePanelID)
+
+    guard let targetPanel, targetPanel.id != terminalSession.primaryPanelID else { return }
+    closeGhosttyPanel(targetPanel)
+  }
+
+  private func canCloseGhosttyPanel(_ panel: TerminalPanel) -> Bool {
+    guard let terminalSession else { return false }
+    return panel.id != terminalSession.primaryPanelID
+  }
+
+  private func canCloseGhosttyTab(_ tab: TerminalTab, in panel: TerminalPanel) -> Bool {
+    !isProtectedAgentTab(tab, in: panel.id)
+  }
+
+  private func closeGhosttyPanel(_ panel: TerminalPanel) {
+    guard let terminalSession, canCloseGhosttyPanel(panel) else { return }
+    requestClose(panel)
+    _ = terminalSession.closePanel(panel.id)
+  }
+
+  private func closeGhosttyTab(_ tab: TerminalTab, in panel: TerminalPanel) {
+    guard let terminalSession, canCloseGhosttyTab(tab, in: panel) else { return }
+    requestClose(tab)
+    _ = terminalSession.closeTab(tab.id, in: panel.id)
+  }
+
+  private func requestClose(_ panel: TerminalPanel) {
+    for tab in panel.tabs {
+      requestClose(tab)
+    }
+  }
+
+  private func requestClose(_ tab: TerminalTab) {
+    tab.controller.requestClose()
+    unregisterPID(for: tab.controller)
+  }
+
+  private func focusProtectedAgentTab() {
+    guard
+      let terminalSession,
+      let protectedAgentPanelID,
+      let protectedAgentTabID
+    else {
+      return
+    }
+    _ = terminalSession.selectTab(protectedAgentTabID, in: protectedAgentPanelID)
+  }
+
+  private func configureControllerHooks(for controller: GhosttyTerminalController?) {
+    guard let controller else { return }
+    controller.closesHostWindowOnClose = false
+    controller.onClose = { [weak self, weak controller] _ in
+      guard let self, let controller else { return }
+      self.unregisterPID(for: controller)
+    }
+    controller.onCloseWindow = { [weak self, weak controller] in
+      guard let self, let controller else { return }
+      self.closeControllerIfAllowed(controller)
+    }
+    controller.onOpenURL = { [weak self] url in
+      self?.handleOpenURL(url) ?? false
+    }
+    registerPIDWhenAvailable(for: controller)
+  }
+
+  private func closeControllerIfAllowed(_ controller: GhosttyTerminalController) {
+    guard
+      let terminalSession,
+      let located = locateController(controller)
+    else {
+      return
+    }
+    guard !isProtectedAgentTab(located.tab, in: located.panel.id) else { return }
+    requestClose(located.tab)
+    _ = terminalSession.closeTab(located.tab.id, in: located.panel.id)
+  }
+
+  private func focusedTab(in window: NSWindow) -> TerminalTab? {
+    guard let responder = window.firstResponder else { return nil }
+    if let focusedTab = allTabs().first(where: { tab in
+      guard let responderView = responder as? NSView else {
+        return responder === tab.containerView.surfaceView
+      }
+
+      return responderView === tab.containerView
+        || responderView === tab.containerView.surfaceView
+        || responderView.isDescendant(of: tab.containerView)
+    }) {
+      return focusedTab
+    }
+
+    guard let responderView = responder as? NSView else { return nil }
+    if responderView === self || responderView.isDescendant(of: self) {
+      return terminalSession?.activeTab
+    }
+
+    return nil
+  }
+
+  private func tab(containingMouseEvent event: NSEvent) -> TerminalTab? {
+    allTabs().first { tab in
+      guard event.window === tab.containerView.window else { return false }
+      let location = tab.containerView.convert(event.locationInWindow, from: nil)
+      return tab.containerView.bounds.contains(location)
+    }
+  }
+
+  private func syncSessionSelection(to tab: TerminalTab) {
+    guard let terminalSession, let located = locateTab(tab) else { return }
+    if terminalSession.activePanelID != located.panel.id || located.panel.activeTabID != tab.id {
+      _ = terminalSession.selectTab(tab.id, in: located.panel.id)
+    }
+  }
+
+  private func isProtectedAgentTab(_ tab: TerminalTab) -> Bool {
+    guard let located = locateTab(tab) else { return false }
+    return isProtectedAgentTab(tab, in: located.panel.id)
+  }
+
+  private func isProtectedAgentTab(_ tab: TerminalTab, in panelID: TerminalPanelID) -> Bool {
+    panelID == protectedAgentPanelID && tab.id == protectedAgentTabID
+  }
+
+  private func locateTab(_ tab: TerminalTab) -> (panel: TerminalPanel, tab: TerminalTab)? {
+    for panel in terminalSession?.panels ?? [] {
+      if let matchedTab = panel.tabs.first(where: { $0.id == tab.id }) {
+        return (panel, matchedTab)
+      }
+    }
+    return nil
+  }
+
+  private func locateController(
+    _ controller: GhosttyTerminalController
+  ) -> (panel: TerminalPanel, tab: TerminalTab)? {
+    for panel in terminalSession?.panels ?? [] {
+      if let tab = panel.tabs.first(where: { $0.controller === controller }) {
+        return (panel, tab)
+      }
+    }
+    return nil
+  }
+
+  private func allTabs() -> [TerminalTab] {
+    terminalSession?.panels.flatMap(\.tabs) ?? []
+  }
+
+  private func normalizedModifierFlags(_ flags: NSEvent.ModifierFlags) -> NSEvent.ModifierFlags {
+    flags
+      .intersection(.deviceIndependentFlagsMask)
+      .subtracting([.numericPad, .function, .capsLock])
+  }
+
+  private func registerPIDWhenAvailable(for controller: GhosttyTerminalController) {
+    let id = ObjectIdentifier(controller)
+    pidRegistrationTasks[id]?.cancel()
+    pidRegistrationTasks[id] = Task { @MainActor [weak self, weak controller] in
       for _ in 0..<10 {
-        guard let self else { return }
-        if let pid = self.currentProcessPID, pid > 0 {
-          self.registeredPID = pid
+        guard let self, let controller else { return }
+        guard self.locateController(controller) != nil else { return }
+        if let pid = controller.foregroundProcessID, pid > 0 {
+          self.registeredPIDs[id] = pid
           TerminalProcessRegistry.shared.register(pid: pid)
+          self.pidRegistrationTasks[id] = nil
           return
         }
         try? await Task.sleep(for: .milliseconds(100))
       }
+      self?.pidRegistrationTasks[id] = nil
     }
   }
 
-  private func unregisterPID() {
-    if let registeredPID {
+  private func unregisterPID(for controller: GhosttyTerminalController) {
+    let id = ObjectIdentifier(controller)
+    pidRegistrationTasks[id]?.cancel()
+    pidRegistrationTasks[id] = nil
+    if let registeredPID = registeredPIDs.removeValue(forKey: id) {
       TerminalProcessRegistry.shared.unregister(pid: registeredPID)
-      self.registeredPID = nil
     }
+  }
+
+  private func cancelPIDRegistrationTasks() {
+    for task in pidRegistrationTasks.values {
+      task.cancel()
+    }
+    pidRegistrationTasks.removeAll()
+  }
+
+  private func unregisterAllPIDs() {
+    for pid in registeredPIDs.values {
+      TerminalProcessRegistry.shared.unregister(pid: pid)
+    }
+    registeredPIDs.removeAll()
   }
 
   private func handleOpenURL(_ value: String) -> Bool {

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/AgentHubGhosttyTerminalSurface.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/AgentHubGhosttyTerminalSurface.swift
@@ -1,0 +1,464 @@
+//
+//  AgentHubGhosttyTerminalSurface.swift
+//  AgentHub
+//
+
+import AppKit
+import GhosttySwift
+import SwiftUI
+
+@MainActor
+final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurface {
+  private var controller: GhosttyTerminalController?
+  private var containerView: GhosttySwift.GhosttyTerminalContainerView?
+  private var isConfigured = false
+  private var hasDeliveredInitialPrompt = false
+  private var hasPrefilledInitialInputText = false
+  private var registeredPID: pid_t?
+  private var localEventMonitor: Any?
+  private var projectPath: String = ""
+
+  var onUserInteraction: (() -> Void)?
+  var onRequestShowEditor: (() -> Void)?
+  var consumeQueuedWebPreviewContextOnSubmit: (() -> String?)?
+  private var terminalSessionKey: String?
+  private weak var sessionViewModel: CLISessionsViewModel?
+  var terminateProcessCallCount = 0
+
+  var view: NSView { self }
+
+  var currentProcessPID: Int32? {
+    controller?.foregroundProcessID
+  }
+
+  deinit {
+    if let localEventMonitor {
+      NSEvent.removeMonitor(localEventMonitor)
+    }
+    MainActor.assumeIsolated {
+      controller?.requestClose()
+      unregisterPID()
+    }
+  }
+
+  func updateContext(terminalSessionKey: String?, sessionViewModel: CLISessionsViewModel?) {
+    self.terminalSessionKey = terminalSessionKey
+    self.sessionViewModel = sessionViewModel
+  }
+
+  func configure(
+    sessionId: String?,
+    projectPath: String,
+    cliConfiguration: CLICommandConfiguration,
+    initialPrompt: String?,
+    initialInputText: String?,
+    isDark: Bool,
+    dangerouslySkipPermissions: Bool,
+    permissionModePlan: Bool,
+    worktreeName: String?,
+    metadataStore: SessionMetadataStore?
+  ) {
+    guard !isConfigured else { return }
+    isConfigured = true
+    self.projectPath = projectPath
+
+    let launch = EmbeddedTerminalLaunchBuilder.cliLaunch(
+      sessionId: sessionId,
+      projectPath: projectPath,
+      cliConfiguration: cliConfiguration,
+      initialPrompt: initialPrompt,
+      dangerouslySkipPermissions: dangerouslySkipPermissions,
+      permissionModePlan: permissionModePlan,
+      worktreeName: worktreeName,
+      metadataStore: metadataStore
+    )
+
+    switch launch {
+    case .success(let launch):
+      mountGhostty(command: launch.ghosttyCommand, environment: launch.environment, initialInputText: initialInputText)
+    case .failure(let error):
+      mountError(error.localizedDescription)
+    }
+  }
+
+  func configureShell(projectPath: String, isDark: Bool, shellPath: String?) {
+    guard !isConfigured else { return }
+    isConfigured = true
+    self.projectPath = projectPath
+
+    let launch = EmbeddedTerminalLaunchBuilder.shellLaunch(
+      projectPath: projectPath,
+      shellPath: shellPath
+    )
+    mountGhostty(command: launch.ghosttyCommand, environment: launch.environment, initialInputText: nil)
+  }
+
+  func restart(sessionId: String?, projectPath: String, cliConfiguration: CLICommandConfiguration) {
+    terminateProcess()
+    containerView?.removeFromSuperview()
+    containerView = nil
+    controller = nil
+    isConfigured = false
+    hasDeliveredInitialPrompt = false
+    hasPrefilledInitialInputText = false
+    configure(
+      sessionId: sessionId,
+      projectPath: projectPath,
+      cliConfiguration: cliConfiguration,
+      initialPrompt: nil,
+      initialInputText: nil,
+      isDark: true,
+      dangerouslySkipPermissions: false,
+      permissionModePlan: false,
+      worktreeName: nil,
+      metadataStore: nil
+    )
+  }
+
+  func terminateProcess() {
+    terminateProcessCallCount += 1
+    controller?.requestClose()
+    unregisterPID()
+  }
+
+  func resetPromptDeliveryFlag() {
+    hasDeliveredInitialPrompt = false
+  }
+
+  func sendPromptIfNeeded(_ prompt: String) {
+    guard !hasDeliveredInitialPrompt else { return }
+    hasDeliveredInitialPrompt = true
+
+    let planFeedbackPrefix = "\u{1B}[B\u{1B}[B\u{1B}[B\r"
+    if prompt.hasPrefix(planFeedbackPrefix) {
+      let feedback = String(prompt.dropFirst(planFeedbackPrefix.count))
+      Task { @MainActor [weak self] in
+        self?.controller?.sendArrowDownKey()
+        try? await Task.sleep(for: .milliseconds(80))
+        self?.controller?.sendArrowDownKey()
+        try? await Task.sleep(for: .milliseconds(80))
+        self?.controller?.sendArrowDownKey()
+        try? await Task.sleep(for: .milliseconds(80))
+        self?.controller?.sendReturnKey()
+        try? await Task.sleep(for: .milliseconds(150))
+        if !feedback.isEmpty {
+          self?.controller?.sendText(feedback)
+          try? await Task.sleep(for: .milliseconds(100))
+        }
+        self?.controller?.sendReturnKey()
+      }
+      return
+    }
+
+    controller?.sendText(prompt)
+    Task { @MainActor [weak self] in
+      try? await Task.sleep(for: .milliseconds(100))
+      self?.controller?.sendReturnKey()
+    }
+  }
+
+  func submitPromptImmediately(_ prompt: String) -> Bool {
+    guard controller != nil else { return false }
+    controller?.sendText(prompt)
+    let delay = Self.submitDelay(forByteCount: prompt.utf8.count)
+    Task { @MainActor [weak self] in
+      try? await Task.sleep(for: delay)
+      self?.controller?.sendReturnKey()
+    }
+    return true
+  }
+
+  func typeText(_ text: String) {
+    controller?.sendText(text)
+  }
+
+  func typeInitialTextIfNeeded(_ text: String) {
+    guard !text.isEmpty else { return }
+    guard !hasPrefilledInitialInputText else { return }
+    hasPrefilledInitialInputText = true
+    typeText(text)
+  }
+
+  func syncAppearance(isDark: Bool, fontSize: CGFloat, fontFamily: String, theme: RuntimeTheme?) {
+    // Ghostty owns live appearance through its config. Font size is applied at surface creation.
+  }
+
+  func focus() {
+    controller?.focusTerminal()
+  }
+
+  private func mountGhostty(command: String, environment: [String: String], initialInputText: String?) {
+    do {
+      let fontSize = Float(UserDefaults.standard.double(forKey: AgentHubDefaults.terminalFontSize))
+      let resolvedFontSize = fontSize > 0 ? fontSize : 12
+      let controller = try GhosttyTerminalController(
+        configuration: GhosttySurfaceConfiguration(
+          workingDirectory: projectPath.isEmpty ? NSHomeDirectory() : projectPath,
+          command: command,
+          environment: environment,
+          initialInput: initialInputText,
+          fontSize: resolvedFontSize
+        )
+      )
+      controller.onClose = { [weak self] _ in
+        self?.unregisterPID()
+      }
+      controller.onOpenURL = { [weak self] url in
+        self?.handleOpenURL(url) ?? false
+      }
+      let container = try GhosttySwift.GhosttyTerminalContainerView(controller: controller)
+      mount(container)
+      self.controller = controller
+      self.containerView = container
+      installInteractionMonitorIfNeeded()
+      registerPIDWhenAvailable()
+    } catch {
+      mountError(error.localizedDescription)
+    }
+  }
+
+  private func mount(_ child: NSView) {
+    child.translatesAutoresizingMaskIntoConstraints = false
+    addSubview(child)
+    NSLayoutConstraint.activate([
+      child.leadingAnchor.constraint(equalTo: leadingAnchor),
+      child.trailingAnchor.constraint(equalTo: trailingAnchor),
+      child.topAnchor.constraint(equalTo: topAnchor),
+      child.bottomAnchor.constraint(equalTo: bottomAnchor)
+    ])
+  }
+
+  private func mountError(_ message: String) {
+    let label = NSTextField(wrappingLabelWithString: "\nError: \(message)\nPlease ensure the CLI is installed.")
+    label.translatesAutoresizingMaskIntoConstraints = false
+    label.alignment = .center
+    label.textColor = .secondaryLabelColor
+    addSubview(label)
+    NSLayoutConstraint.activate([
+      label.centerXAnchor.constraint(equalTo: centerXAnchor),
+      label.centerYAnchor.constraint(equalTo: centerYAnchor),
+      label.leadingAnchor.constraint(greaterThanOrEqualTo: leadingAnchor, constant: 24),
+      trailingAnchor.constraint(greaterThanOrEqualTo: label.trailingAnchor, constant: 24)
+    ])
+  }
+
+  private static func submitDelay(forByteCount count: Int) -> Duration {
+    switch count {
+    case ..<500:   return .milliseconds(100)
+    case ..<2000:  return .milliseconds(250)
+    default:       return .milliseconds(500)
+    }
+  }
+
+  private func installInteractionMonitorIfNeeded() {
+    guard localEventMonitor == nil else { return }
+    localEventMonitor = NSEvent.addLocalMonitorForEvents(matching: [.keyDown, .leftMouseUp]) { [weak self] event in
+      guard let self, let surfaceView = self.containerView?.surfaceView else { return event }
+
+      switch event.type {
+      case .keyDown:
+        guard let window = surfaceView.window, event.window === window else { break }
+        let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+        let isTerminalVisible = surfaceView.superview != nil && !surfaceView.isHidden && surfaceView.alphaValue > 0
+
+        if isTerminalVisible,
+           self.isTerminalResponderActive(window: window, terminal: surfaceView),
+           flags == .control,
+           event.keyCode == 50,
+           self.onRequestShowEditor != nil {
+          self.onRequestShowEditor?()
+          self.onUserInteraction?()
+          return nil
+        }
+
+        if isTerminalVisible,
+           self.isTerminalResponderActive(window: window, terminal: surfaceView),
+           flags == .command,
+           event.charactersIgnoringModifiers == "f" {
+          _ = self.controller?.performBindingAction("search:")
+          self.onUserInteraction?()
+          return nil
+        }
+
+        guard isTerminalResponderActive(window: window, terminal: surfaceView) else { break }
+
+        let shortcut = NewlineShortcut(
+          rawValue: UserDefaults.standard.integer(forKey: AgentHubDefaults.terminalNewlineShortcut)
+        ) ?? .system
+        let action = TerminalSubmitInterception.keyAction(
+          shortcut: shortcut,
+          isReturn: event.keyCode == 36,
+          flags: flags
+        )
+        let queuedContextPrompt: String?
+        switch action {
+        case .submit, .systemSubmit:
+          queuedContextPrompt = self.consumeQueuedWebPreviewContextOnSubmit?()
+        case .passthrough, .newline:
+          queuedContextPrompt = nil
+        }
+
+        switch TerminalSubmitInterception.dispatch(for: action, queuedContextPrompt: queuedContextPrompt) {
+        case .passthrough:
+          self.onUserInteraction?()
+        case .newline:
+          self.controller?.sendText("\n")
+          self.onUserInteraction?()
+          return nil
+        case .submit:
+          self.controller?.sendReturnKey()
+          self.onUserInteraction?()
+          return nil
+        case .appendContextAndSubmit(let queuedContextPrompt):
+          let fullText = "\n\n\(queuedContextPrompt)"
+          self.controller?.sendText(fullText)
+          let delay = Self.submitDelay(forByteCount: fullText.utf8.count)
+          Task { @MainActor [weak self] in
+            try? await Task.sleep(for: delay)
+            self?.controller?.sendReturnKey()
+          }
+          self.onUserInteraction?()
+          return nil
+        }
+      case .leftMouseUp:
+        guard let window = surfaceView.window, event.window === window else { return event }
+        let locationInTerminal = surfaceView.convert(event.locationInWindow, from: nil)
+        if surfaceView.bounds.contains(locationInTerminal) {
+          DispatchQueue.main.async { [weak self] in
+            self?.onUserInteraction?()
+          }
+        }
+      default:
+        break
+      }
+
+      return event
+    }
+  }
+
+  private func isTerminalResponderActive(window: NSWindow, terminal: NSView) -> Bool {
+    guard let responder = window.firstResponder else { return false }
+    if responder === terminal { return true }
+    if let responderView = responder as? NSView {
+      return responderView.isDescendant(of: terminal)
+    }
+    return false
+  }
+
+  private func registerPIDWhenAvailable() {
+    Task { @MainActor [weak self] in
+      for _ in 0..<10 {
+        guard let self else { return }
+        if let pid = self.currentProcessPID, pid > 0 {
+          self.registeredPID = pid
+          TerminalProcessRegistry.shared.register(pid: pid)
+          return
+        }
+        try? await Task.sleep(for: .milliseconds(100))
+      }
+    }
+  }
+
+  private func unregisterPID() {
+    if let registeredPID {
+      TerminalProcessRegistry.shared.unregister(pid: registeredPID)
+      self.registeredPID = nil
+    }
+  }
+
+  private func handleOpenURL(_ value: String) -> Bool {
+    if let fileLink = filePathFromImplicitLink(value) {
+      requestOpenFile(path: fileLink.path, lineNumber: fileLink.lineNumber)
+      return true
+    }
+
+    guard let url = URL(string: value), url.scheme != nil else {
+      return false
+    }
+    NSWorkspace.shared.open(url)
+    return true
+  }
+
+  private func requestOpenFile(path: String, lineNumber: Int?) {
+    let resolvedPath: String
+    if path.hasPrefix("/") || path.hasPrefix("~") {
+      resolvedPath = (path as NSString).expandingTildeInPath
+    } else if !projectPath.isEmpty {
+      resolvedPath = (projectPath as NSString).appendingPathComponent(path)
+    } else {
+      resolvedPath = (NSHomeDirectory() as NSString).appendingPathComponent(path)
+    }
+
+    var isDirectory: ObjCBool = false
+    guard FileManager.default.fileExists(atPath: resolvedPath, isDirectory: &isDirectory) else {
+      return
+    }
+
+    let editor = FileOpenEditor(
+      rawValue: UserDefaults.standard.integer(forKey: AgentHubDefaults.terminalFileOpenEditor)
+    ) ?? .agentHub
+    switch editor {
+    case .agentHub:
+      if let vm = sessionViewModel, let key = terminalSessionKey {
+        vm.pendingFileOpen = (sessionId: key, filePath: resolvedPath, lineNumber: lineNumber)
+      }
+    case .vscode:
+      openInVSCode(path: resolvedPath, line: lineNumber)
+    case .xcode:
+      openInXcode(path: resolvedPath, line: lineNumber)
+    }
+  }
+
+  private func openInVSCode(path: String, line: Int?) {
+    let codePaths = [
+      "/usr/local/bin/code",
+      "/opt/homebrew/bin/code",
+      "/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code"
+    ]
+    guard let codePath = codePaths.first(where: { FileManager.default.isExecutableFile(atPath: $0) }) else {
+      NSWorkspace.shared.open(URL(fileURLWithPath: path))
+      return
+    }
+    let task = Process()
+    task.executableURL = URL(fileURLWithPath: codePath)
+    task.arguments = ["--goto", line != nil ? "\(path):\(line!)" : path]
+    try? task.run()
+  }
+
+  private func openInXcode(path: String, line: Int?) {
+    let task = Process()
+    task.executableURL = URL(fileURLWithPath: "/usr/bin/xed")
+    task.arguments = line != nil ? ["--line", "\(line!)", path] : [path]
+    try? task.run()
+  }
+
+  private func filePathFromImplicitLink(_ link: String) -> (path: String, lineNumber: Int?)? {
+    let trimmed = link.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else { return nil }
+
+    if let url = URL(string: trimmed), url.isFileURL {
+      return (url.path, nil)
+    }
+
+    guard !trimmed.contains("://"),
+          URLComponents(string: trimmed)?.scheme == nil,
+          trimmed.contains("/")
+            || trimmed.hasPrefix("~")
+            || trimmed.hasPrefix(".")
+            || trimmed.hasPrefix("/")
+    else {
+      return nil
+    }
+
+    var path = trimmed
+    var lineNumber: Int?
+    if let suffixRange = path.range(of: #":\d+(?::\d+)?$"#, options: .regularExpression) {
+      let suffix = String(path[suffixRange])
+      let parts = suffix.dropFirst().split(separator: ":")
+      lineNumber = parts.first.flatMap { Int($0) }
+      path = String(path[..<suffixRange.lowerBound])
+    }
+
+    return path.isEmpty ? nil : (path, lineNumber)
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/AgentHubGhosttyTerminalSurface.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/AgentHubGhosttyTerminalSurface.swift
@@ -20,10 +20,13 @@ final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurface {
   private var pidRegistrationTasks: [ObjectIdentifier: Task<Void, Never>] = [:]
   private var localEventMonitor: Any?
   private var projectPath: String = ""
+  private var isRestoringWorkspace = false
+  private var lastWorkspaceSnapshot: TerminalWorkspaceSnapshot?
 
   var onUserInteraction: (() -> Void)?
   var onRequestShowEditor: (() -> Void)?
   var consumeQueuedWebPreviewContextOnSubmit: (() -> String?)?
+  var onWorkspaceChanged: ((TerminalWorkspaceSnapshot) -> Void)?
   private var terminalSessionKey: String?
   private weak var sessionViewModel: CLISessionsViewModel?
   var terminateProcessCallCount = 0
@@ -219,6 +222,93 @@ final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurface {
     activeController?.focusTerminal()
   }
 
+  func captureWorkspaceSnapshot() -> TerminalWorkspaceSnapshot? {
+    guard let terminalSession else { return nil }
+
+    let panels = terminalSession.panels.map { panel in
+      let tabs = panel.tabs.map { tab in
+        TerminalWorkspaceTabSnapshot(
+          role: isProtectedAgentTab(tab, in: panel.id) ? .agent : .shell,
+          name: Self.nonEmpty(tab.name),
+          title: Self.nonEmpty(tab.title),
+          workingDirectory: Self.nonEmpty(
+            tab.controller.workingDirectory
+              ?? tab.controller.configuration.workingDirectory
+              ?? resolvedProjectPath
+          )
+        )
+      }
+      let activeTabIndex = panel.tabs.firstIndex { $0.id == panel.activeTabID } ?? 0
+      return TerminalWorkspacePanelSnapshot(
+        role: panel.id == terminalSession.primaryPanelID ? .primary : .auxiliary,
+        tabs: tabs,
+        activeTabIndex: activeTabIndex
+      )
+    }
+
+    return TerminalWorkspaceSnapshot(
+      panels: panels,
+      activePanelIndex: terminalSession.panels.firstIndex { $0.id == terminalSession.activePanelID } ?? 0
+    )
+  }
+
+  func restoreWorkspaceSnapshot(_ snapshot: TerminalWorkspaceSnapshot) {
+    guard let terminalSession else { return }
+    guard !snapshot.panels.isEmpty else { return }
+
+    isRestoringWorkspace = true
+    defer {
+      isRestoringWorkspace = false
+      lastWorkspaceSnapshot = captureWorkspaceSnapshot()
+    }
+
+    resetToPrimaryAgentTab(in: terminalSession)
+
+    let panelSnapshots = normalizedPanelSnapshots(snapshot.panels)
+    var restoredPanelIDs: [TerminalPanelID] = [terminalSession.primaryPanelID]
+    var restoredTabIDs: [[TerminalTabID]] = [[protectedAgentTabID ?? terminalSession.primaryPanel.activeTabID]]
+
+    if let primarySnapshot = panelSnapshots.first {
+      restoredTabIDs[0] = restoreShellTabs(
+        from: primarySnapshot,
+        in: terminalSession.primaryPanelID,
+        existingTabIDs: restoredTabIDs[0]
+      )
+    }
+
+    for panelSnapshot in panelSnapshots.dropFirst() {
+      guard terminalSession.canOpenPanel else { break }
+      guard let firstShellTab = panelSnapshot.tabs.first(where: { $0.role == .shell }) else { continue }
+
+      do {
+        let panel = try terminalSession.openPanel(
+          named: restoredTabName(for: firstShellTab),
+          configuration: shellConfiguration(forRestoredWorkingDirectory: firstShellTab.workingDirectory)
+        )
+        configureControllerHooks(for: panel.activeTab?.controller)
+        restoredPanelIDs.append(panel.id)
+
+        var tabIDs = panel.activeTab.map { [$0.id] } ?? []
+        tabIDs = restoreShellTabs(
+          from: panelSnapshot,
+          in: panel.id,
+          existingTabIDs: tabIDs,
+          skippingFirstShellTab: true
+        )
+        restoredTabIDs.append(tabIDs)
+      } catch {
+        AppLogger.session.error("Failed to restore Ghostty shell pane: \(error.localizedDescription)")
+      }
+    }
+
+    terminalSession.showPrimaryAndAuxiliaries()
+    restoreActiveSelection(
+      from: snapshot,
+      panelIDs: restoredPanelIDs,
+      tabIDs: restoredTabIDs
+    )
+  }
+
   private var resolvedProjectPath: String {
     projectPath.isEmpty ? NSHomeDirectory() : projectPath
   }
@@ -273,6 +363,12 @@ final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurface {
         },
         tabClosePolicy: { [weak self] panel, tab in
           self?.canCloseGhosttyTab(tab, in: panel) ?? false
+        },
+        onActivatePanel: { [weak self] panel in
+          self?.activateGhosttyPanel(panel)
+        },
+        onSelectTab: { [weak self] panel, tab in
+          self?.selectGhosttyTab(tab, in: panel)
         },
         onClosePanel: { [weak self] panel in
           self?.closeGhosttyPanel(panel)
@@ -348,9 +444,116 @@ final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurface {
     )
   }
 
+  private func shellConfiguration(forRestoredWorkingDirectory workingDirectory: String?) -> GhosttySurfaceConfiguration {
+    let restoredPath = resolvedExistingDirectory(workingDirectory)
+    let launch = EmbeddedTerminalLaunchBuilder.shellLaunch(projectPath: restoredPath)
+    return makeGhosttyConfiguration(
+      command: launch.ghosttyCommand,
+      environment: launch.environment,
+      initialInput: nil,
+      workingDirectory: restoredPath
+    )
+  }
+
+  private func resolvedExistingDirectory(_ path: String?) -> String {
+    guard let path = Self.nonEmpty(path) else { return resolvedProjectPath }
+    let expandedPath = (path as NSString).expandingTildeInPath
+    var isDirectory: ObjCBool = false
+    guard FileManager.default.fileExists(atPath: expandedPath, isDirectory: &isDirectory),
+          isDirectory.boolValue else {
+      return resolvedProjectPath
+    }
+    return expandedPath
+  }
+
+  private func normalizedPanelSnapshots(
+    _ panels: [TerminalWorkspacePanelSnapshot]
+  ) -> [TerminalWorkspacePanelSnapshot] {
+    let primary = panels.first { $0.role == .primary } ?? panels.first
+    let auxiliaries = panels.filter { $0.role == .auxiliary }
+    return ([primary].compactMap { $0 } + auxiliaries).prefix(4).map { $0 }
+  }
+
+  private func resetToPrimaryAgentTab(in terminalSession: TerminalSession) {
+    for panel in terminalSession.auxiliaryPanels {
+      requestClose(panel)
+      _ = terminalSession.closePanel(panel.id)
+    }
+
+    for tab in terminalSession.primaryPanel.tabs where !isProtectedAgentTab(tab, in: terminalSession.primaryPanelID) {
+      requestClose(tab)
+      _ = terminalSession.closeTab(tab.id, in: terminalSession.primaryPanelID)
+    }
+
+    focusProtectedAgentTab()
+  }
+
+  private func restoreShellTabs(
+    from panelSnapshot: TerminalWorkspacePanelSnapshot,
+    in panelID: TerminalPanelID,
+    existingTabIDs: [TerminalTabID],
+    skippingFirstShellTab: Bool = false
+  ) -> [TerminalTabID] {
+    guard let terminalSession else { return existingTabIDs }
+    var restoredTabIDs = existingTabIDs
+    var hasSkippedFirstShellTab = false
+
+    for tabSnapshot in panelSnapshot.tabs where tabSnapshot.role == .shell {
+      if skippingFirstShellTab && !hasSkippedFirstShellTab {
+        hasSkippedFirstShellTab = true
+        continue
+      }
+
+      do {
+        let tab = try terminalSession.openTab(
+          in: panelID,
+          named: restoredTabName(for: tabSnapshot),
+          configuration: shellConfiguration(forRestoredWorkingDirectory: tabSnapshot.workingDirectory)
+        )
+        configureControllerHooks(for: tab.controller)
+        restoredTabIDs.append(tab.id)
+      } catch {
+        AppLogger.session.error("Failed to restore Ghostty shell tab: \(error.localizedDescription)")
+      }
+    }
+
+    return restoredTabIDs
+  }
+
+  private func restoreActiveSelection(
+    from snapshot: TerminalWorkspaceSnapshot,
+    panelIDs: [TerminalPanelID],
+    tabIDs: [[TerminalTabID]]
+  ) {
+    guard let terminalSession else { return }
+    guard !panelIDs.isEmpty else { return }
+
+    let panelIndex = min(max(snapshot.activePanelIndex, 0), panelIDs.count - 1)
+    let panelID = panelIDs[panelIndex]
+    let savedPanel = snapshot.panels.indices.contains(panelIndex) ? snapshot.panels[panelIndex] : nil
+    let savedActiveTabIndex = savedPanel?.activeTabIndex ?? 0
+    let panelTabIDs = tabIDs.indices.contains(panelIndex) ? tabIDs[panelIndex] : []
+    guard !panelTabIDs.isEmpty else {
+      _ = terminalSession.focusPanel(panelID)
+      return
+    }
+
+    let tabIndex = min(max(savedActiveTabIndex, 0), panelTabIDs.count - 1)
+    _ = terminalSession.selectTab(panelTabIDs[tabIndex], in: panelID)
+  }
+
+  private func restoredTabName(for tab: TerminalWorkspaceTabSnapshot) -> String? {
+    Self.nonEmpty(tab.name) ?? Self.nonEmpty(tab.title) ?? "Shell"
+  }
+
   private func resolvedFontSize() -> Float {
     let fontSize = Float(UserDefaults.standard.double(forKey: AgentHubDefaults.terminalFontSize))
     return fontSize > 0 ? fontSize : 12
+  }
+
+  private static func nonEmpty(_ value: String?) -> String? {
+    let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines)
+    return trimmed?.isEmpty == false ? trimmed : nil
   }
 
   private static func submitDelay(forByteCount count: Int) -> Duration {
@@ -469,9 +672,13 @@ final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurface {
     case .closePanel:
       closeActiveOrLastAuxiliaryPanel()
     case .focusPanel(let direction):
-      _ = terminalSession?.focusPanel(direction: direction)
+      if terminalSession?.focusPanel(direction: direction) == true {
+        notifyWorkspaceChanged()
+      }
     case .selectTab(let direction):
-      _ = terminalSession?.selectTab(direction: direction)
+      if terminalSession?.selectTab(direction: direction) == true {
+        notifyWorkspaceChanged()
+      }
     }
   }
 
@@ -483,6 +690,7 @@ final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurface {
         configuration: shellConfigurationForNewTerminal()
       )
       configureControllerHooks(for: tab.controller)
+      notifyWorkspaceChanged()
     } catch {
       AppLogger.session.error("Failed to open Ghostty shell tab: \(error.localizedDescription)")
     }
@@ -496,6 +704,7 @@ final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurface {
         configuration: shellConfigurationForNewTerminal()
       )
       configureControllerHooks(for: panel.activeTab?.controller)
+      notifyWorkspaceChanged()
     } catch {
       AppLogger.session.error("Failed to open Ghostty shell pane: \(error.localizedDescription)")
     }
@@ -520,16 +729,34 @@ final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurface {
     !isProtectedAgentTab(tab, in: panel.id)
   }
 
+  private func activateGhosttyPanel(_ panel: TerminalPanel) {
+    guard let terminalSession else { return }
+    if terminalSession.focusPanel(panel.id) {
+      notifyWorkspaceChanged()
+    }
+  }
+
+  private func selectGhosttyTab(_ tab: TerminalTab, in panel: TerminalPanel) {
+    guard let terminalSession else { return }
+    if terminalSession.selectTab(tab.id, in: panel.id) {
+      notifyWorkspaceChanged()
+    }
+  }
+
   private func closeGhosttyPanel(_ panel: TerminalPanel) {
     guard let terminalSession, canCloseGhosttyPanel(panel) else { return }
     requestClose(panel)
-    _ = terminalSession.closePanel(panel.id)
+    if terminalSession.closePanel(panel.id) {
+      notifyWorkspaceChanged()
+    }
   }
 
   private func closeGhosttyTab(_ tab: TerminalTab, in panel: TerminalPanel) {
     guard let terminalSession, canCloseGhosttyTab(tab, in: panel) else { return }
     requestClose(tab)
-    _ = terminalSession.closeTab(tab.id, in: panel.id)
+    if terminalSession.closeTab(tab.id, in: panel.id) {
+      notifyWorkspaceChanged()
+    }
   }
 
   private func requestClose(_ panel: TerminalPanel) {
@@ -560,10 +787,14 @@ final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurface {
     controller.onClose = { [weak self, weak controller] _ in
       guard let self, let controller else { return }
       self.unregisterPID(for: controller)
+      self.notifyWorkspaceChanged()
     }
     controller.onCloseWindow = { [weak self, weak controller] in
       guard let self, let controller else { return }
       self.closeControllerIfAllowed(controller)
+    }
+    controller.onStateChange = { [weak self] _ in
+      self?.notifyWorkspaceChanged()
     }
     controller.onOpenURL = { [weak self] url in
       self?.handleOpenURL(url) ?? false
@@ -580,7 +811,9 @@ final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurface {
     }
     guard !isProtectedAgentTab(located.tab, in: located.panel.id) else { return }
     requestClose(located.tab)
-    _ = terminalSession.closeTab(located.tab.id, in: located.panel.id)
+    if terminalSession.closeTab(located.tab.id, in: located.panel.id) {
+      notifyWorkspaceChanged()
+    }
   }
 
   private func focusedTab(in window: NSWindow) -> TerminalTab? {
@@ -617,6 +850,7 @@ final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurface {
     guard let terminalSession, let located = locateTab(tab) else { return }
     if terminalSession.activePanelID != located.panel.id || located.panel.activeTabID != tab.id {
       _ = terminalSession.selectTab(tab.id, in: located.panel.id)
+      notifyWorkspaceChanged()
     }
   }
 
@@ -657,6 +891,14 @@ final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurface {
     flags
       .intersection(.deviceIndependentFlagsMask)
       .subtracting([.numericPad, .function, .capsLock])
+  }
+
+  private func notifyWorkspaceChanged() {
+    guard !isRestoringWorkspace else { return }
+    guard let snapshot = captureWorkspaceSnapshot() else { return }
+    guard snapshot != lastWorkspaceSnapshot else { return }
+    lastWorkspaceSnapshot = snapshot
+    onWorkspaceChanged?(snapshot)
   }
 
   private func registerPIDWhenAvailable(for controller: GhosttyTerminalController) {

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/AuxiliaryShellTerminalHostView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/AuxiliaryShellTerminalHostView.swift
@@ -5,37 +5,43 @@
 
 import AppKit
 
-public final class AuxiliaryShellTerminalHostView: NSView {
+public final class EmbeddedTerminalHostView: NSView {
   public private(set) var mountedTerminalKey: String?
-  private weak var mountedTerminal: TerminalContainerView?
+  private weak var mountedTerminalView: NSView?
 
-  public func mount(_ terminal: TerminalContainerView, key: String) {
-    guard mountedTerminal !== terminal else {
+  public func mount(_ terminal: any EmbeddedTerminalSurface, key: String) {
+    mountView(terminal.view, key: key)
+  }
+
+  private func mountView(_ terminalView: NSView, key: String) {
+    guard mountedTerminalView !== terminalView else {
       mountedTerminalKey = key
       return
     }
 
-    mountedTerminal?.removeFromSuperview()
+    mountedTerminalView?.removeFromSuperview()
 
-    if terminal.superview !== self {
-      terminal.removeFromSuperview()
-      terminal.translatesAutoresizingMaskIntoConstraints = false
-      addSubview(terminal)
+    if terminalView.superview !== self {
+      terminalView.removeFromSuperview()
+      terminalView.translatesAutoresizingMaskIntoConstraints = false
+      addSubview(terminalView)
       NSLayoutConstraint.activate([
-        terminal.leadingAnchor.constraint(equalTo: leadingAnchor),
-        terminal.trailingAnchor.constraint(equalTo: trailingAnchor),
-        terminal.topAnchor.constraint(equalTo: topAnchor),
-        terminal.bottomAnchor.constraint(equalTo: bottomAnchor)
+        terminalView.leadingAnchor.constraint(equalTo: leadingAnchor),
+        terminalView.trailingAnchor.constraint(equalTo: trailingAnchor),
+        terminalView.topAnchor.constraint(equalTo: topAnchor),
+        terminalView.bottomAnchor.constraint(equalTo: bottomAnchor)
       ])
     }
 
-    mountedTerminal = terminal
+    mountedTerminalView = terminalView
     mountedTerminalKey = key
   }
 
   public func unmountTerminal() {
-    mountedTerminal?.removeFromSuperview()
-    mountedTerminal = nil
+    mountedTerminalView?.removeFromSuperview()
+    mountedTerminalView = nil
     mountedTerminalKey = nil
   }
 }
+
+public typealias AuxiliaryShellTerminalHostView = EmbeddedTerminalHostView

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/AuxiliaryShellTerminalView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/AuxiliaryShellTerminalView.swift
@@ -7,7 +7,9 @@ import SwiftUI
 
 public struct AuxiliaryShellTerminalView: NSViewRepresentable {
   @Environment(\.colorScheme) private var colorScheme
+  @Environment(\.runtimeTheme) private var runtimeTheme
   @AppStorage(AgentHubDefaults.terminalFontSize) private var terminalFontSize: Double = 12
+  @AppStorage(AgentHubDefaults.terminalFontFamily) private var terminalFontFamily: String = "SF Mono"
 
   let terminalKey: String
   let projectPath: String
@@ -35,14 +37,14 @@ public struct AuxiliaryShellTerminalView: NSViewRepresentable {
   public func updateNSView(_ nsView: AuxiliaryShellTerminalHostView, context: Context) {
     let terminal = resolveTerminal()
     nsView.mount(terminal, key: terminalKey)
-    terminal.syncAppearance(isDark: colorScheme == .dark, fontSize: CGFloat(terminalFontSize))
+    terminal.syncAppearance(isDark: colorScheme == .dark, fontSize: CGFloat(terminalFontSize), fontFamily: terminalFontFamily, theme: runtimeTheme)
   }
 
   public static func dismantleNSView(_ nsView: AuxiliaryShellTerminalHostView, coordinator: ()) {
     nsView.unmountTerminal()
   }
 
-  private func resolveTerminal() -> TerminalContainerView {
+  private func resolveTerminal() -> any EmbeddedTerminalSurface {
     viewModel.getOrCreateAuxiliaryShellTerminal(
       forKey: terminalKey,
       projectPath: projectPath,

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/EmbeddedTerminalBackend.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/EmbeddedTerminalBackend.swift
@@ -1,0 +1,24 @@
+//
+//  EmbeddedTerminalBackend.swift
+//  AgentHub
+//
+
+import Foundation
+
+public enum EmbeddedTerminalBackend: Int, CaseIterable, Sendable {
+  case ghostty = 0
+  case regular = 1
+
+  public var label: String {
+    switch self {
+    case .ghostty: return "Ghostty"
+    case .regular: return "Regular"
+    }
+  }
+
+  public static var storedPreference: EmbeddedTerminalBackend {
+    let rawValue = UserDefaults.standard.object(forKey: AgentHubDefaults.terminalBackend) as? Int
+      ?? EmbeddedTerminalBackend.ghostty.rawValue
+    return EmbeddedTerminalBackend(rawValue: rawValue) ?? .ghostty
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/EmbeddedTerminalLaunchBuilder.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/EmbeddedTerminalLaunchBuilder.swift
@@ -1,0 +1,140 @@
+//
+//  EmbeddedTerminalLaunchBuilder.swift
+//  AgentHub
+//
+
+import Foundation
+
+struct EmbeddedTerminalLaunch {
+  let shellCommand: String
+  let environment: [String: String]
+
+  var swiftTermExecutable: String { "/bin/bash" }
+  var swiftTermArguments: [String] { ["-c", shellCommand] }
+  var swiftTermEnvironment: [String] {
+    var swiftTermEnvironment = environment
+    swiftTermEnvironment["TERM_PROGRAM"] = "SwiftTerm"
+    return swiftTermEnvironment.map { "\($0.key)=\($0.value)" }
+  }
+
+  var ghosttyCommand: String {
+    "/bin/bash -c \(Self.shellEscapeSingleQuotedAllowingNewlines(shellCommand))"
+  }
+
+  private static func shellEscapeSingleQuotedAllowingNewlines(_ value: String) -> String {
+    let escaped = value.replacingOccurrences(of: "'", with: "'\\''")
+    return "'\(escaped)'"
+  }
+}
+
+enum EmbeddedTerminalLaunchError: LocalizedError, Equatable {
+  case executableNotFound(String)
+
+  var errorDescription: String? {
+    switch self {
+    case .executableNotFound(let command):
+      return "Could not find '\(command)' command."
+    }
+  }
+}
+
+enum EmbeddedTerminalLaunchBuilder {
+  static func cliLaunch(
+    sessionId: String?,
+    projectPath: String,
+    cliConfiguration: CLICommandConfiguration,
+    initialPrompt: String?,
+    dangerouslySkipPermissions: Bool,
+    permissionModePlan: Bool,
+    worktreeName: String?,
+    metadataStore: SessionMetadataStore?
+  ) -> Result<EmbeddedTerminalLaunch, EmbeddedTerminalLaunchError> {
+    let executablePath: String?
+    switch cliConfiguration.mode {
+    case .codex:
+      executablePath = TerminalLauncher.findCodexExecutable(
+        command: cliConfiguration.executableName,
+        additionalPaths: cliConfiguration.additionalPaths
+      )
+    case .claude:
+      executablePath = TerminalLauncher.findExecutable(
+        command: cliConfiguration.executableName,
+        additionalPaths: cliConfiguration.additionalPaths
+      )
+    }
+
+    guard let executablePath else {
+      return .failure(.executableNotFound(cliConfiguration.command))
+    }
+
+    let environment = makeProcessEnvironment(additionalPaths: cliConfiguration.additionalPaths)
+    let workingDirectory = projectPath.isEmpty ? NSHomeDirectory() : projectPath
+    let escapedPath = shellEscape(workingDirectory)
+    let escapedCLIPath = shellEscape(executablePath)
+
+    let aiConfig = metadataStore?.getAIConfigSync(for: cliConfiguration.mode.rawValue)
+    let allowedTools = AIConfigRecord.parseToolPatterns(aiConfig?.allowedTools)
+    let disallowedTools = AIConfigRecord.parseToolPatterns(aiConfig?.disallowedTools)
+    let args = cliConfiguration.argumentsForSession(
+      sessionId: sessionId,
+      prompt: initialPrompt,
+      dangerouslySkipPermissions: dangerouslySkipPermissions,
+      worktreeName: worktreeName,
+      permissionModePlan: permissionModePlan,
+      model: aiConfig?.defaultModel,
+      effortLevel: aiConfig?.effortLevel,
+      allowedTools: allowedTools.isEmpty ? nil : allowedTools,
+      disallowedTools: disallowedTools.isEmpty ? nil : disallowedTools,
+      codexApprovalPolicy: aiConfig?.approvalPolicy
+    )
+    let joinedArgs = args
+      .map { "'\(shellEscape($0))'" }
+      .joined(separator: " ")
+    let shellCommand = joinedArgs.isEmpty
+      ? "cd '\(escapedPath)' && exec '\(escapedCLIPath)'"
+      : "cd '\(escapedPath)' && exec '\(escapedCLIPath)' \(joinedArgs)"
+
+    return .success(EmbeddedTerminalLaunch(shellCommand: shellCommand, environment: environment))
+  }
+
+  static func shellLaunch(
+    projectPath: String,
+    shellPath: String? = nil
+  ) -> EmbeddedTerminalLaunch {
+    let environment = makeProcessEnvironment(additionalPaths: [])
+    let shellExecutable = resolveShellExecutablePath(shellPath)
+    let escapedPath = shellEscape(projectPath.isEmpty ? NSHomeDirectory() : projectPath)
+    let escapedShellPath = shellEscape(shellExecutable)
+    let shellCommand = "cd '\(escapedPath)' && exec '\(escapedShellPath)' -l"
+    return EmbeddedTerminalLaunch(shellCommand: shellCommand, environment: environment)
+  }
+
+  static func makeProcessEnvironment(additionalPaths: [String]) -> [String: String] {
+    var environment = ProcessInfo.processInfo.environment
+    environment["TERM"] = "xterm-256color"
+    environment["COLORTERM"] = "truecolor"
+    environment["LANG"] = "en_US.UTF-8"
+    environment.removeValue(forKey: "TERM_PROGRAM")
+
+    let paths = CLIPathResolver.executableSearchPaths(additionalPaths: additionalPaths)
+    let pathString = paths.joined(separator: ":")
+    if let existingPath = environment["PATH"] {
+      environment["PATH"] = "\(pathString):\(existingPath)"
+    } else {
+      environment["PATH"] = pathString
+    }
+    return environment
+  }
+
+  static func shellEscape(_ value: String) -> String {
+    value.replacingOccurrences(of: "'", with: "'\\''")
+  }
+
+  private static func resolveShellExecutablePath(_ shellPath: String?) -> String {
+    let candidate = shellPath ?? ProcessInfo.processInfo.environment["SHELL"] ?? "/bin/zsh"
+    if FileManager.default.isExecutableFile(atPath: candidate) {
+      return candidate
+    }
+    return "/bin/zsh"
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/EmbeddedTerminalSurface.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/EmbeddedTerminalSurface.swift
@@ -13,6 +13,7 @@ public protocol EmbeddedTerminalSurface: AnyObject {
   var onUserInteraction: (() -> Void)? { get set }
   var onRequestShowEditor: (() -> Void)? { get set }
   var consumeQueuedWebPreviewContextOnSubmit: (() -> String?)? { get set }
+  var onWorkspaceChanged: ((TerminalWorkspaceSnapshot) -> Void)? { get set }
 
   func updateContext(terminalSessionKey: String?, sessionViewModel: CLISessionsViewModel?)
   func configure(
@@ -37,6 +38,21 @@ public protocol EmbeddedTerminalSurface: AnyObject {
   func typeInitialTextIfNeeded(_ text: String)
   func syncAppearance(isDark: Bool, fontSize: CGFloat, fontFamily: String, theme: RuntimeTheme?)
   func focus()
+  func captureWorkspaceSnapshot() -> TerminalWorkspaceSnapshot?
+  func restoreWorkspaceSnapshot(_ snapshot: TerminalWorkspaceSnapshot)
+}
+
+public extension EmbeddedTerminalSurface {
+  var onWorkspaceChanged: ((TerminalWorkspaceSnapshot) -> Void)? {
+    get { nil }
+    set {}
+  }
+
+  func captureWorkspaceSnapshot() -> TerminalWorkspaceSnapshot? {
+    nil
+  }
+
+  func restoreWorkspaceSnapshot(_ snapshot: TerminalWorkspaceSnapshot) {}
 }
 
 public protocol EmbeddedTerminalSurfaceFactory {

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/EmbeddedTerminalSurface.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/EmbeddedTerminalSurface.swift
@@ -1,0 +1,72 @@
+//
+//  EmbeddedTerminalSurface.swift
+//  AgentHub
+//
+
+import AppKit
+import SwiftUI
+
+@MainActor
+public protocol EmbeddedTerminalSurface: AnyObject {
+  var view: NSView { get }
+  var currentProcessPID: Int32? { get }
+  var onUserInteraction: (() -> Void)? { get set }
+  var onRequestShowEditor: (() -> Void)? { get set }
+  var consumeQueuedWebPreviewContextOnSubmit: (() -> String?)? { get set }
+
+  func updateContext(terminalSessionKey: String?, sessionViewModel: CLISessionsViewModel?)
+  func configure(
+    sessionId: String?,
+    projectPath: String,
+    cliConfiguration: CLICommandConfiguration,
+    initialPrompt: String?,
+    initialInputText: String?,
+    isDark: Bool,
+    dangerouslySkipPermissions: Bool,
+    permissionModePlan: Bool,
+    worktreeName: String?,
+    metadataStore: SessionMetadataStore?
+  )
+  func configureShell(projectPath: String, isDark: Bool, shellPath: String?)
+  func restart(sessionId: String?, projectPath: String, cliConfiguration: CLICommandConfiguration)
+  func terminateProcess()
+  func resetPromptDeliveryFlag()
+  func sendPromptIfNeeded(_ prompt: String)
+  func submitPromptImmediately(_ prompt: String) -> Bool
+  func typeText(_ text: String)
+  func typeInitialTextIfNeeded(_ text: String)
+  func syncAppearance(isDark: Bool, fontSize: CGFloat, fontFamily: String, theme: RuntimeTheme?)
+  func focus()
+}
+
+public protocol EmbeddedTerminalSurfaceFactory {
+  @MainActor
+  func makeSurface(for backend: EmbeddedTerminalBackend) -> any EmbeddedTerminalSurface
+}
+
+public struct DefaultEmbeddedTerminalSurfaceFactory: EmbeddedTerminalSurfaceFactory {
+  public init() {}
+
+  public func makeSurface(for backend: EmbeddedTerminalBackend) -> any EmbeddedTerminalSurface {
+    switch backend {
+    case .ghostty:
+      return AgentHubGhosttyTerminalSurface()
+    case .regular:
+      return TerminalContainerView()
+    }
+  }
+}
+
+extension TerminalContainerView: EmbeddedTerminalSurface {
+  public var view: NSView { self }
+
+  public func updateContext(terminalSessionKey: String?, sessionViewModel: CLISessionsViewModel?) {
+    self.terminalSessionKey = terminalSessionKey
+    self.sessionViewModel = sessionViewModel
+  }
+
+  public func focus() {
+    guard let terminalView, let window = terminalView.window else { return }
+    window.makeFirstResponder(terminalView)
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/EmbeddedTerminalView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/EmbeddedTerminalView.swift
@@ -133,12 +133,41 @@ public struct EmbeddedTerminalView: NSViewRepresentable {
     self.consumeQueuedWebPreviewContextOnSubmit = consumeQueuedWebPreviewContextOnSubmit
   }
 
-  public func makeNSView(context: Context) -> TerminalContainerView {
-    let isDark = colorScheme == .dark
+  public final class Coordinator {
+    var standaloneTerminal: (any EmbeddedTerminalSurface)?
+  }
 
-    // Use shared terminal storage if viewModel is provided
-    if let viewModel = viewModel {
-      let terminalContainer = viewModel.getOrCreateTerminal(
+  public func makeCoordinator() -> Coordinator {
+    Coordinator()
+  }
+
+  public func makeNSView(context: Context) -> EmbeddedTerminalHostView {
+    let hostView = EmbeddedTerminalHostView()
+    let isDark = colorScheme == .dark
+    let terminal = resolveTerminal(context: context, isDark: isDark)
+    applyCallbacks(to: terminal)
+    hostView.mount(terminal, key: terminalKey)
+    return hostView
+  }
+
+  public func updateNSView(_ nsView: EmbeddedTerminalHostView, context: Context) {
+    let terminal = resolveTerminal(context: context, isDark: colorScheme == .dark)
+    applyCallbacks(to: terminal)
+    nsView.mount(terminal, key: terminalKey)
+    terminal.syncAppearance(isDark: colorScheme == .dark, fontSize: CGFloat(terminalFontSize), fontFamily: terminalFontFamily, theme: runtimeTheme)
+
+    // If there's a pending prompt in the viewModel, send it (and clear it)
+    // Use terminalKey (not sessionId) since it works for both pending and real sessions
+    if let prompt = viewModel?.pendingPrompt(for: terminalKey) {
+      terminal.resetPromptDeliveryFlag()
+      terminal.sendPromptIfNeeded(prompt)
+      viewModel?.clearPendingPrompt(for: terminalKey)
+    }
+  }
+
+  private func resolveTerminal(context: Context, isDark: Bool) -> any EmbeddedTerminalSurface {
+    if let viewModel {
+      let terminal = viewModel.getOrCreateTerminal(
         forKey: terminalKey,
         sessionId: sessionId,
         projectPath: projectPath,
@@ -150,17 +179,16 @@ public struct EmbeddedTerminalView: NSViewRepresentable {
         permissionModePlan: permissionModePlan,
         worktreeName: worktreeName
       )
-      terminalContainer.onUserInteraction = onUserInteraction
-      terminalContainer.onRequestShowEditor = onRequestShowEditor
-      terminalContainer.consumeQueuedWebPreviewContextOnSubmit = consumeQueuedWebPreviewContextOnSubmit
-      terminalContainer.terminalSessionKey = terminalKey
-      terminalContainer.sessionViewModel = viewModel
-      return terminalContainer
+      terminal.updateContext(terminalSessionKey: terminalKey, sessionViewModel: viewModel)
+      return terminal
     }
 
-    // Fallback: create standalone terminal (for previews)
-    let containerView = TerminalContainerView()
-    containerView.configure(
+    if let existing = context.coordinator.standaloneTerminal {
+      return existing
+    }
+
+    let terminal = DefaultEmbeddedTerminalSurfaceFactory().makeSurface(for: .storedPreference)
+    terminal.configure(
       sessionId: sessionId,
       projectPath: projectPath,
       cliConfiguration: cliConfiguration,
@@ -172,25 +200,14 @@ public struct EmbeddedTerminalView: NSViewRepresentable {
       worktreeName: worktreeName,
       metadataStore: agentHub?.metadataStore
     )
-    containerView.onUserInteraction = onUserInteraction
-    containerView.onRequestShowEditor = onRequestShowEditor
-    containerView.consumeQueuedWebPreviewContextOnSubmit = consumeQueuedWebPreviewContextOnSubmit
-    return containerView
+    context.coordinator.standaloneTerminal = terminal
+    return terminal
   }
 
-  public func updateNSView(_ nsView: TerminalContainerView, context: Context) {
-    nsView.onUserInteraction = onUserInteraction
-    nsView.onRequestShowEditor = onRequestShowEditor
-    nsView.consumeQueuedWebPreviewContextOnSubmit = consumeQueuedWebPreviewContextOnSubmit
-    nsView.syncAppearance(isDark: colorScheme == .dark, fontSize: CGFloat(terminalFontSize), fontFamily: terminalFontFamily, theme: runtimeTheme)
-
-    // If there's a pending prompt in the viewModel, send it (and clear it)
-    // Use terminalKey (not sessionId) since it works for both pending and real sessions
-    if let prompt = viewModel?.pendingPrompt(for: terminalKey) {
-      nsView.resetPromptDeliveryFlag()
-      nsView.sendPromptIfNeeded(prompt)
-      viewModel?.clearPendingPrompt(for: terminalKey)
-    }
+  private func applyCallbacks(to terminal: any EmbeddedTerminalSurface) {
+    terminal.onUserInteraction = onUserInteraction
+    terminal.onRequestShowEditor = onRequestShowEditor
+    terminal.consumeQueuedWebPreviewContextOnSubmit = consumeQueuedWebPreviewContextOnSubmit
   }
 }
 
@@ -244,7 +261,7 @@ public class TerminalContainerView: NSView, ManagedLocalProcessTerminalViewDeleg
 
   /// Restarts the terminal by terminating the current process and starting a new one.
   /// Use this to reload session history after external changes.
-  func restart(
+  public func restart(
     sessionId: String?,
     projectPath: String,
     cliConfiguration: CLICommandConfiguration
@@ -258,7 +275,7 @@ public class TerminalContainerView: NSView, ManagedLocalProcessTerminalViewDeleg
     configure(sessionId: sessionId, projectPath: projectPath, cliConfiguration: cliConfiguration)
   }
 
-  func configure(
+  public func configure(
     sessionId: String?,
     projectPath: String,
     cliConfiguration: CLICommandConfiguration,
@@ -305,7 +322,7 @@ public class TerminalContainerView: NSView, ManagedLocalProcessTerminalViewDeleg
     }
   }
 
-  func configureShell(
+  public func configureShell(
     projectPath: String,
     isDark: Bool = true,
     shellPath: String? = nil
@@ -326,12 +343,12 @@ public class TerminalContainerView: NSView, ManagedLocalProcessTerminalViewDeleg
 
   /// Resets the prompt delivery flag so a new prompt can be sent.
   /// Call this before sendPromptIfNeeded when sending a follow-up prompt (e.g., from inline editor).
-  func resetPromptDeliveryFlag() {
+  public func resetPromptDeliveryFlag() {
     hasDeliveredInitialPrompt = false
   }
 
   /// Sends a prompt to the terminal (only once per terminal instance unless reset)
-  func sendPromptIfNeeded(_ prompt: String) {
+  public func sendPromptIfNeeded(_ prompt: String) {
     guard let terminal = terminalView else { return }
     guard !hasDeliveredInitialPrompt else { return }
     hasDeliveredInitialPrompt = true
@@ -370,7 +387,7 @@ public class TerminalContainerView: NSView, ManagedLocalProcessTerminalViewDeleg
   /// Sends a follow-up prompt directly to the running CLI and submits it.
   /// This path is for explicit user actions and must not be gated by initial
   /// prompt delivery state.
-  func submitPromptImmediately(_ prompt: String) -> Bool {
+  public func submitPromptImmediately(_ prompt: String) -> Bool {
     guard let terminal = terminalView else { return false }
     terminal.send(TerminalPromptSubmissionPayload.textBytes(
       prompt: prompt,
@@ -638,75 +655,37 @@ public class TerminalContainerView: NSView, ManagedLocalProcessTerminalViewDeleg
     permissionModePlan: Bool = false,
     worktreeName: String? = nil
   ) {
-    // Find the CLI executable using just the executable name (first word of command)
-    let command = cliConfiguration.command
-    let additionalPaths = cliConfiguration.additionalPaths
+    let launch = EmbeddedTerminalLaunchBuilder.cliLaunch(
+      sessionId: sessionId,
+      projectPath: projectPath,
+      cliConfiguration: cliConfiguration,
+      initialPrompt: initialPrompt,
+      dangerouslySkipPermissions: dangerouslySkipPermissions,
+      permissionModePlan: permissionModePlan,
+      worktreeName: worktreeName,
+      metadataStore: metadataStore
+    )
 
-    let executablePath: String?
-    switch cliConfiguration.mode {
-    case .codex:
-      executablePath = TerminalLauncher.findCodexExecutable(
-        command: cliConfiguration.executableName,
-        additionalPaths: additionalPaths
-      )
-    case .claude:
-      executablePath = TerminalLauncher.findExecutable(
-        command: cliConfiguration.executableName,
-        additionalPaths: additionalPaths
-      )
-    }
-
-    guard let executablePath else {
+    guard case .success(let launch) = launch else {
       // Show error in terminal
-      terminal.feed(text: "\r\n\u{001B}[31mError: Could not find '\(command)' command.\u{001B}[0m\r\n")
+      let message = "Could not find '\(cliConfiguration.command)' command."
+      terminal.feed(text: "\r\n\u{001B}[31mError: \(message)\u{001B}[0m\r\n")
       terminal.feed(text: "Please ensure the CLI is installed.\r\n")
       return
     }
 
-    let environment = makeProcessEnvironment(additionalPaths: additionalPaths)
-
-    // Build the shell command with working directory
-    // Since SwiftTerm's Mac API doesn't support currentDirectory directly,
-    // we use bash -c to cd first then run claude
-    let workingDirectory = projectPath.isEmpty ? NSHomeDirectory() : projectPath
-    let escapedPath = workingDirectory.replacingOccurrences(of: "'", with: "'\\''")
-    let escapedCLIPath = executablePath.replacingOccurrences(of: "'", with: "'\\''")
 #if DEBUG
-    let homeEnv = environment["HOME"] ?? "<nil>"
+    let workingDirectory = projectPath.isEmpty ? NSHomeDirectory() : projectPath
+    let homeEnv = launch.environment["HOME"] ?? "<nil>"
     AppLogger.session.debug(
-      "[ClaudeProcess] workingDirectory=\(workingDirectory, privacy: .public) homeEnv=\(homeEnv, privacy: .public) command=\(command, privacy: .public)"
+      "[ClaudeProcess] workingDirectory=\(workingDirectory, privacy: .public) homeEnv=\(homeEnv, privacy: .public) command=\(cliConfiguration.command, privacy: .public)"
     )
 #endif
 
-    // Read AI configuration defaults for this provider from SQLite
-    let aiConfig = metadataStore?.getAIConfigSync(for: cliConfiguration.mode.rawValue)
-    let allowedTools = AIConfigRecord.parseToolPatterns(aiConfig?.allowedTools)
-    let disallowedTools = AIConfigRecord.parseToolPatterns(aiConfig?.disallowedTools)
-
-    // Build command: resume existing session or start new session
-    let args = cliConfiguration.argumentsForSession(
-      sessionId: sessionId,
-      prompt: initialPrompt,
-      dangerouslySkipPermissions: dangerouslySkipPermissions,
-      worktreeName: worktreeName,
-      permissionModePlan: permissionModePlan,
-      model: aiConfig?.defaultModel,
-      effortLevel: aiConfig?.effortLevel,
-      allowedTools: allowedTools.isEmpty ? nil : allowedTools,
-      disallowedTools: disallowedTools.isEmpty ? nil : disallowedTools,
-      codexApprovalPolicy: aiConfig?.approvalPolicy
-    )
-    let escapedArgs = args.map { $0.replacingOccurrences(of: "'", with: "'\\''") }
-    let joinedArgs = escapedArgs.map { "'\($0)'" }.joined(separator: " ")
-    let shellCommand = joinedArgs.isEmpty
-      ? "cd '\(escapedPath)' && exec '\(escapedCLIPath)'"
-      : "cd '\(escapedPath)' && exec '\(escapedCLIPath)' \(joinedArgs)"
-
-    // Start bash with the command
     terminal.startProcess(
-      executable: "/bin/bash",
-      args: ["-c", shellCommand],
-      environment: environment.map { "\($0.key)=\($0.value)" }
+      executable: launch.swiftTermExecutable,
+      args: launch.swiftTermArguments,
+      environment: launch.swiftTermEnvironment
     )
   }
 
@@ -715,46 +694,16 @@ public class TerminalContainerView: NSView, ManagedLocalProcessTerminalViewDeleg
     projectPath: String,
     shellPath: String? = nil
   ) {
-    let environment = makeProcessEnvironment(additionalPaths: [])
-    let shellExecutable = resolveShellExecutablePath(shellPath)
-    let escapedPath = shellEscape(projectPath.isEmpty ? NSHomeDirectory() : projectPath)
-    let escapedShellPath = shellEscape(shellExecutable)
-    let shellCommand = "cd '\(escapedPath)' && exec '\(escapedShellPath)' -l"
+    let launch = EmbeddedTerminalLaunchBuilder.shellLaunch(
+      projectPath: projectPath,
+      shellPath: shellPath
+    )
 
     terminal.startProcess(
-      executable: "/bin/bash",
-      args: ["-c", shellCommand],
-      environment: environment.map { "\($0.key)=\($0.value)" }
+      executable: launch.swiftTermExecutable,
+      args: launch.swiftTermArguments,
+      environment: launch.swiftTermEnvironment
     )
-  }
-
-  private func makeProcessEnvironment(additionalPaths: [String]) -> [String: String] {
-    var environment = ProcessInfo.processInfo.environment
-    environment["TERM"] = "xterm-256color"
-    environment["COLORTERM"] = "truecolor"
-    environment["LANG"] = "en_US.UTF-8"
-    environment["TERM_PROGRAM"] = "SwiftTerm"
-
-    let paths = CLIPathResolver.executableSearchPaths(additionalPaths: additionalPaths)
-    let pathString = paths.joined(separator: ":")
-    if let existingPath = environment["PATH"] {
-      environment["PATH"] = "\(pathString):\(existingPath)"
-    } else {
-      environment["PATH"] = pathString
-    }
-    return environment
-  }
-
-  private func resolveShellExecutablePath(_ shellPath: String?) -> String {
-    let candidate = shellPath ?? ProcessInfo.processInfo.environment["SHELL"] ?? "/bin/zsh"
-    if FileManager.default.isExecutableFile(atPath: candidate) {
-      return candidate
-    }
-    return "/bin/zsh"
-  }
-
-  private func shellEscape(_ value: String) -> String {
-    value.replacingOccurrences(of: "'", with: "'\\''")
   }
 
   private func registerProcessIfNeeded(for terminal: SafeLocalProcessTerminalView) {

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/GhosttyConfigPathResolver.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/GhosttyConfigPathResolver.swift
@@ -1,0 +1,29 @@
+//
+//  GhosttyConfigPathResolver.swift
+//  AgentHub
+//
+
+import Foundation
+
+enum GhosttyConfigPathResolver {
+  static func configuredPath(
+    defaults: UserDefaults = .standard,
+    fileManager: FileManager = .default
+  ) -> String? {
+    guard let rawPath = defaults.string(forKey: AgentHubDefaults.terminalGhosttyConfigPath) else {
+      return nil
+    }
+
+    let path = rawPath.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !path.isEmpty else { return nil }
+
+    let expandedPath = (path as NSString).expandingTildeInPath
+    var isDirectory: ObjCBool = false
+    guard fileManager.fileExists(atPath: expandedPath, isDirectory: &isDirectory),
+          !isDirectory.boolValue else {
+      return nil
+    }
+
+    return expandedPath
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringCardView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringCardView.swift
@@ -230,6 +230,8 @@ public struct MonitoringCardView: View {
       await loadWebPreviewCandidateIfNeeded()
     }
     .task(id: SessionGitHubQuickAccessViewModel.repositoryKey(projectPath: session.projectPath, branchName: session.branchName)) {
+      try? await Task.sleep(for: .seconds(2))
+      guard !Task.isCancelled else { return }
       await sessionGitHubQuickAccessViewModel.load(
         projectPath: session.projectPath,
         branchName: session.branchName,

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/SettingsView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/SettingsView.swift
@@ -13,6 +13,8 @@ public struct SettingsView: View {
   @State private var aiConfigViewModel = AIConfigSettingsViewModel()
   @State private var isClaudeConfigurationExpanded = true
   @State private var isCodexConfigurationExpanded = true
+  @State private var pendingTerminalBackend: EmbeddedTerminalBackend?
+  @State private var showTerminalBackendRelaunchAlert = false
 
   @AppStorage(AgentHubDefaults.smartModeEnabled)
   private var smartModeEnabled: Bool = false
@@ -25,6 +27,9 @@ public struct SettingsView: View {
 
   @AppStorage(AgentHubDefaults.terminalFontFamily)
   private var terminalFontFamily: String = "SF Mono"
+
+  @AppStorage(AgentHubDefaults.terminalBackend)
+  private var terminalBackendRawValue: Int = EmbeddedTerminalBackend.ghostty.rawValue
 
   @AppStorage(AgentHubDefaults.sourceEditorMinimapEnabled)
   private var sourceEditorMinimapEnabled: Bool = false
@@ -84,6 +89,10 @@ public struct SettingsView: View {
   ]
   private let webPreviewInspectorDataLevels: [ElementInspectorDataLevel] = [.regular, .full]
 
+  private var activeTerminalBackend: EmbeddedTerminalBackend {
+    agentHub?.terminalBackend ?? .storedPreference
+  }
+
   public init() {}
 
   public var body: some View {
@@ -119,6 +128,24 @@ public struct SettingsView: View {
     .task {
       await ensureSupportedThemeSelection()
       await aiConfigViewModel.load(service: agentHub?.aiConfigService)
+    }
+    .alert(
+      "Relaunch AgentHub?",
+      isPresented: $showTerminalBackendRelaunchAlert,
+      presenting: pendingTerminalBackend
+    ) { backend in
+      Button("Cancel", role: .cancel) {
+        pendingTerminalBackend = nil
+      }
+      Button("Relaunch") {
+        terminalBackendRawValue = backend.rawValue
+        pendingTerminalBackend = nil
+        agentHub?.relaunchApplication()
+      }
+    } message: { backend in
+      Text(
+        "Switching to \(backend.label) requires relaunching AgentHub. Running terminals will be closed during relaunch."
+      )
     }
   }
 
@@ -223,6 +250,12 @@ public struct SettingsView: View {
       }
 
       Section("Terminal") {
+        Picker("Terminal", selection: terminalBackendSelectionBinding) {
+          ForEach(EmbeddedTerminalBackend.allCases, id: \.rawValue) { backend in
+            Text(backend.label).tag(backend.rawValue)
+          }
+        }
+
         Picker("Font", selection: $terminalFontFamily) {
           ForEach(terminalFontFamilies, id: \.self) { family in
             Text(family)
@@ -434,6 +467,23 @@ public struct SettingsView: View {
         Task {
           await applyThemeSelection(newValue)
         }
+      }
+    )
+  }
+
+  private var terminalBackendSelectionBinding: Binding<Int> {
+    Binding(
+      get: { terminalBackendRawValue },
+      set: { newValue in
+        let requestedBackend = EmbeddedTerminalBackend(rawValue: newValue) ?? .ghostty
+        guard requestedBackend != activeTerminalBackend else {
+          terminalBackendRawValue = requestedBackend.rawValue
+          pendingTerminalBackend = nil
+          return
+        }
+
+        pendingTerminalBackend = requestedBackend
+        showTerminalBackendRelaunchAlert = true
       }
     )
   }

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/SettingsView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/SettingsView.swift
@@ -8,6 +8,10 @@
 import SwiftUI
 import Canvas
 
+#if canImport(AppKit)
+import AppKit
+#endif
+
 public struct SettingsView: View {
   @Environment(\.agentHub) private var agentHub
   @State private var aiConfigViewModel = AIConfigSettingsViewModel()
@@ -30,6 +34,9 @@ public struct SettingsView: View {
 
   @AppStorage(AgentHubDefaults.terminalBackend)
   private var terminalBackendRawValue: Int = EmbeddedTerminalBackend.ghostty.rawValue
+
+  @AppStorage(AgentHubDefaults.terminalGhosttyConfigPath)
+  private var terminalGhosttyConfigPath: String = ""
 
   @AppStorage(AgentHubDefaults.sourceEditorMinimapEnabled)
   private var sourceEditorMinimapEnabled: Bool = false
@@ -255,6 +262,8 @@ public struct SettingsView: View {
             Text(backend.label).tag(backend.rawValue)
           }
         }
+
+        ghosttyConfigFileSetting
 
         Picker("Font", selection: $terminalFontFamily) {
           ForEach(terminalFontFamilies, id: \.self) { family in
@@ -486,6 +495,49 @@ public struct SettingsView: View {
         showTerminalBackendRelaunchAlert = true
       }
     )
+  }
+
+  private var ghosttyConfigFileSetting: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      Text("Ghostty config file")
+
+      HStack(spacing: 8) {
+        TextField("Optional config file path", text: $terminalGhosttyConfigPath)
+          .textFieldStyle(.roundedBorder)
+
+        Button("Choose…", action: chooseGhosttyConfigFile)
+
+        Button("Clear") {
+          terminalGhosttyConfigPath = ""
+        }
+        .disabled(terminalGhosttyConfigPath.isEmpty)
+      }
+
+      Text("Applied when creating new Ghostty terminal sessions.")
+        .font(.caption)
+        .foregroundColor(.secondary)
+    }
+  }
+
+  private func chooseGhosttyConfigFile() {
+    #if canImport(AppKit)
+    let panel = NSOpenPanel()
+    panel.title = "Choose Ghostty Config"
+    panel.message = "Choose a Ghostty configuration file for embedded Ghostty terminals."
+    panel.prompt = "Choose"
+    panel.canChooseFiles = true
+    panel.canChooseDirectories = false
+    panel.allowsMultipleSelection = false
+
+    let expandedPath = (terminalGhosttyConfigPath as NSString).expandingTildeInPath
+    if !expandedPath.isEmpty {
+      panel.directoryURL = URL(fileURLWithPath: expandedPath).deletingLastPathComponent()
+    }
+
+    if panel.runModal() == .OK, let url = panel.url {
+      terminalGhosttyConfigPath = url.path
+    }
+    #endif
   }
 
   private func ensureSupportedThemeSelection() async {

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/TerminalPromptSubmissionPayload.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/TerminalPromptSubmissionPayload.swift
@@ -32,4 +32,8 @@ enum TerminalPromptSubmissionPayload {
     }
     return payload
   }
+
+  static func bracketedPasteTextBytes(prompt: String) -> [UInt8] {
+    textBytes(prompt: prompt, bracketedPasteMode: true)
+  }
 }

--- a/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/CLISessionsViewModel.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/CLISessionsViewModel.swift
@@ -34,6 +34,8 @@ public final class CLISessionsViewModel {
   private let approvalNotificationService: any ApprovalNotificationServiceProtocol
   private let approvalClaimStore: (any ApprovalClaimStoreProtocol)?
   private let hookInstaller: (any ClaudeHookInstallerProtocol)?
+  private let terminalSurfaceFactory: any EmbeddedTerminalSurfaceFactory
+  private let terminalBackend: EmbeddedTerminalBackend
   weak var agentHubProvider: AgentHubProvider?
 
   // MARK: - State
@@ -321,6 +323,100 @@ public final class CLISessionsViewModel {
     )
   }
 
+  private enum TerminalSurfaceDescriptor {
+    case cli(
+      sessionId: String?,
+      projectPath: String,
+      cliConfiguration: CLICommandConfiguration,
+      initialPrompt: String?,
+      initialInputText: String?,
+      isDark: Bool,
+      dangerouslySkipPermissions: Bool,
+      permissionModePlan: Bool,
+      worktreeName: String?
+    )
+    case shell(projectPath: String, isDark: Bool, shellPath: String?)
+
+    @MainActor
+    func configure(_ surface: any EmbeddedTerminalSurface, metadataStore: SessionMetadataStore?) {
+      switch self {
+      case let .cli(
+        sessionId,
+        projectPath,
+        cliConfiguration,
+        initialPrompt,
+        initialInputText,
+        isDark,
+        dangerouslySkipPermissions,
+        permissionModePlan,
+        worktreeName
+      ):
+        surface.configure(
+          sessionId: sessionId,
+          projectPath: projectPath,
+          cliConfiguration: cliConfiguration,
+          initialPrompt: initialPrompt,
+          initialInputText: initialInputText,
+          isDark: isDark,
+          dangerouslySkipPermissions: dangerouslySkipPermissions,
+          permissionModePlan: permissionModePlan,
+          worktreeName: worktreeName,
+          metadataStore: metadataStore
+        )
+      case let .shell(projectPath, isDark, shellPath):
+        surface.configureShell(projectPath: projectPath, isDark: isDark, shellPath: shellPath)
+      }
+    }
+
+    func transferred(toSessionId sessionId: String) -> TerminalSurfaceDescriptor {
+      switch self {
+      case let .cli(
+        _,
+        projectPath,
+        cliConfiguration,
+        _,
+        _,
+        isDark,
+        dangerouslySkipPermissions,
+        permissionModePlan,
+        worktreeName
+      ):
+        return .cli(
+          sessionId: sessionId,
+          projectPath: projectPath,
+          cliConfiguration: cliConfiguration,
+          initialPrompt: nil,
+          initialInputText: nil,
+          isDark: isDark,
+          dangerouslySkipPermissions: dangerouslySkipPermissions,
+          permissionModePlan: permissionModePlan,
+          worktreeName: worktreeName
+        )
+      case .shell:
+        return self
+      }
+    }
+  }
+
+  private func makeTerminalSurface(
+    forKey key: String,
+    descriptor: TerminalSurfaceDescriptor
+  ) -> any EmbeddedTerminalSurface {
+    let terminal = terminalSurfaceFactory.makeSurface(for: terminalBackend)
+    terminal.updateContext(terminalSessionKey: key, sessionViewModel: self)
+    descriptor.configure(terminal, metadataStore: metadataStore)
+    return terminal
+  }
+
+  private func copyTerminalCallbacks(
+    from oldTerminal: (any EmbeddedTerminalSurface)?,
+    to newTerminal: any EmbeddedTerminalSurface
+  ) {
+    newTerminal.onUserInteraction = oldTerminal?.onUserInteraction
+    newTerminal.onRequestShowEditor = oldTerminal?.onRequestShowEditor
+    newTerminal.consumeQueuedWebPreviewContextOnSubmit = oldTerminal?.consumeQueuedWebPreviewContextOnSubmit
+  }
+
   /// Gets an existing terminal or creates a new one for the given key.
   /// Key should be session ID for real sessions, or "pending-{pendingId}" for pending sessions.
   /// This preserves the terminal PTY across pending → real session transitions.
@@ -335,11 +431,24 @@ public final class CLISessionsViewModel {
     dangerouslySkipPermissions: Bool = false,
     permissionModePlan: Bool = false,
     worktreeName: String? = nil
-  ) -> TerminalContainerView {
+  ) -> any EmbeddedTerminalSurface {
+    let config = cliConfiguration ?? self.currentCLIConfiguration
+    let descriptor = TerminalSurfaceDescriptor.cli(
+      sessionId: sessionId,
+      projectPath: projectPath,
+      cliConfiguration: config,
+      initialPrompt: key.hasPrefix("pending-") ? initialPrompt : nil,
+      initialInputText: key.hasPrefix("pending-") ? initialInputText : nil,
+      isDark: isDark,
+      dangerouslySkipPermissions: dangerouslySkipPermissions,
+      permissionModePlan: permissionModePlan,
+      worktreeName: worktreeName
+    )
+
     if let existing = activeTerminals[key] {
-      #if DEBUG
-      AppLogger.session.debug("[Terminal] REUSING existing terminal for key: \(key, privacy: .public)")
-      #endif
+      if activeTerminalDescriptors[key] == nil {
+        activeTerminalDescriptors[key] = descriptor
+      }
       // Send prompt to existing terminal if provided
       if let prompt = initialPrompt {
         if !key.hasPrefix("pending-") {
@@ -353,15 +462,14 @@ public final class CLISessionsViewModel {
       if let inputText = initialInputText, !inputText.isEmpty {
         existing.typeInitialTextIfNeeded(inputText)
       }
+      existing.updateContext(terminalSessionKey: key, sessionViewModel: self)
       return existing
     }
 
     #if DEBUG
     AppLogger.session.debug("[Terminal] CREATING new terminal for key: \(key, privacy: .public)")
     #endif
-    let terminal = TerminalContainerView()
-    let config = cliConfiguration ?? self.currentCLIConfiguration
-    terminal.configure(
+    let createDescriptor = TerminalSurfaceDescriptor.cli(
       sessionId: sessionId,
       projectPath: projectPath,
       cliConfiguration: config,
@@ -370,9 +478,10 @@ public final class CLISessionsViewModel {
       isDark: isDark,
       dangerouslySkipPermissions: dangerouslySkipPermissions,
       permissionModePlan: permissionModePlan,
-      worktreeName: worktreeName,
-      metadataStore: metadataStore
+      worktreeName: worktreeName
     )
+    activeTerminalDescriptors[key] = createDescriptor
+    let terminal = makeTerminalSurface(forKey: key, descriptor: createDescriptor)
     activeTerminals[key] = terminal
     return terminal
   }
@@ -384,22 +493,22 @@ public final class CLISessionsViewModel {
     forKey key: String,
     projectPath: String,
     isDark: Bool = true
-  ) -> TerminalContainerView {
+  ) -> any EmbeddedTerminalSurface {
+    let descriptor = TerminalSurfaceDescriptor.shell(projectPath: projectPath, isDark: isDark, shellPath: nil)
+
     if let existing = auxiliaryShellTerminals[key] {
-      #if DEBUG
-      AppLogger.session.debug("[AuxShell] REUSING auxiliary shell for key: \(key, privacy: .public)")
-      #endif
+      if auxiliaryShellTerminalDescriptors[key] == nil {
+        auxiliaryShellTerminalDescriptors[key] = descriptor
+      }
+      existing.updateContext(terminalSessionKey: key, sessionViewModel: self)
       return existing
     }
 
     #if DEBUG
     AppLogger.session.debug("[AuxShell] CREATING auxiliary shell for key: \(key, privacy: .public)")
     #endif
-    let terminal = TerminalContainerView()
-    terminal.configureShell(
-      projectPath: projectPath,
-      isDark: isDark
-    )
+    auxiliaryShellTerminalDescriptors[key] = descriptor
+    let terminal = makeTerminalSurface(forKey: key, descriptor: descriptor)
     auxiliaryShellTerminals[key] = terminal
     return terminal
   }
@@ -410,6 +519,7 @@ public final class CLISessionsViewModel {
       terminal.terminateProcess()
     }
     activeTerminals.removeValue(forKey: key)
+    activeTerminalDescriptors.removeValue(forKey: key)
   }
 
   /// Transfers terminal from pending key to real session ID (for pending → real transition)
@@ -417,6 +527,10 @@ public final class CLISessionsViewModel {
     let pendingKey = "pending-\(pendingId.uuidString)"
     if let terminal = activeTerminals.removeValue(forKey: pendingKey) {
       activeTerminals[sessionId] = terminal
+      terminal.updateContext(terminalSessionKey: sessionId, sessionViewModel: self)
+    }
+    if let descriptor = activeTerminalDescriptors.removeValue(forKey: pendingKey) {
+      activeTerminalDescriptors[sessionId] = descriptor.transferred(toSessionId: sessionId)
     }
     transferQueuedWebPreviewContext(from: pendingKey, to: sessionId)
   }
@@ -427,6 +541,7 @@ public final class CLISessionsViewModel {
       terminal.terminateProcess()
     }
     auxiliaryShellTerminals.removeValue(forKey: key)
+    auxiliaryShellTerminalDescriptors.removeValue(forKey: key)
   }
 
   /// Transfers the auxiliary shell terminal from pending key to real session ID.
@@ -434,14 +549,33 @@ public final class CLISessionsViewModel {
     let pendingKey = "pending-\(pendingId.uuidString)"
     if let terminal = auxiliaryShellTerminals.removeValue(forKey: pendingKey) {
       auxiliaryShellTerminals[sessionId] = terminal
+      terminal.updateContext(terminalSessionKey: sessionId, sessionViewModel: self)
+    }
+    if let descriptor = auxiliaryShellTerminalDescriptors.removeValue(forKey: pendingKey) {
+      auxiliaryShellTerminalDescriptors[sessionId] = descriptor
     }
   }
 
   /// Refreshes the terminal for a session by restarting it.
   /// This reloads the session history from the JSONL file (useful when session was updated externally).
   public func refreshTerminal(forKey key: String, sessionId: String?, projectPath: String) {
-    guard let terminal = activeTerminals[key] else { return }
-    terminal.restart(sessionId: sessionId, projectPath: projectPath, cliConfiguration: currentCLIConfiguration)
+    guard let oldTerminal = activeTerminals[key] else { return }
+    let descriptor = TerminalSurfaceDescriptor.cli(
+      sessionId: sessionId,
+      projectPath: projectPath,
+      cliConfiguration: currentCLIConfiguration,
+      initialPrompt: nil,
+      initialInputText: nil,
+      isDark: true,
+      dangerouslySkipPermissions: false,
+      permissionModePlan: false,
+      worktreeName: nil
+    )
+    activeTerminalDescriptors[key] = descriptor
+    oldTerminal.terminateProcess()
+    let newTerminal = makeTerminalSurface(forKey: key, descriptor: descriptor)
+    copyTerminalCallbacks(from: oldTerminal, to: newTerminal)
+    activeTerminals[key] = newTerminal
   }
 
   /// Types text into the terminal for a given key without pressing Enter.
@@ -456,10 +590,7 @@ public final class CLISessionsViewModel {
   public func focusTerminal(forKey key: String) {
     Task { @MainActor in
       try? await Task.sleep(for: .milliseconds(100))
-      guard let terminal = activeTerminals[key],
-            let terminalView = terminal.terminalView,
-            let window = terminalView.window else { return }
-      window.makeFirstResponder(terminalView)
+      activeTerminals[key]?.focus()
     }
   }
 
@@ -467,11 +598,12 @@ public final class CLISessionsViewModel {
   public func focusAuxiliaryShellTerminal(forKey key: String) {
     Task { @MainActor in
       try? await Task.sleep(for: .milliseconds(100))
-      guard let terminal = auxiliaryShellTerminals[key],
-            let terminalView = terminal.terminalView,
-            let window = terminalView.window else { return }
-      window.makeFirstResponder(terminalView)
+      auxiliaryShellTerminals[key]?.focus()
     }
+  }
+
+  public func recreateTerminalsForSelectedBackend() {
+    AppLogger.session.info("Terminal backend changes require app restart; keeping existing terminals alive")
   }
 
   /// Sessions being started in Hub's embedded terminal (no session ID yet)
@@ -487,13 +619,15 @@ public final class CLISessionsViewModel {
 
   /// Active agent terminal views keyed by session key.
   /// Preserves terminal PTY across pending → real session transition.
-  public var activeTerminals: [String: TerminalContainerView] = [:]
+  public var activeTerminals: [String: any EmbeddedTerminalSurface] = [:]
+  @ObservationIgnored private var activeTerminalDescriptors: [String: TerminalSurfaceDescriptor] = [:]
 
   /// Active auxiliary shell terminals keyed by session key.
   /// Preserves shell PTY across session selection changes and pending → real transitions.
-  public var auxiliaryShellTerminals: [String: TerminalContainerView] = [:]
+  public var auxiliaryShellTerminals: [String: any EmbeddedTerminalSurface] = [:]
+  @ObservationIgnored private var auxiliaryShellTerminalDescriptors: [String: TerminalSurfaceDescriptor] = [:]
 
-  public var managedTerminalEntries: [(key: String, terminal: TerminalContainerView)] {
+  public var managedTerminalEntries: [(key: String, terminal: any EmbeddedTerminalSurface)] {
     activeTerminals.map { ($0.key, $0.value) }
       + auxiliaryShellTerminals.map { ("shell:\($0.key)", $0.value) }
   }
@@ -561,7 +695,9 @@ public final class CLISessionsViewModel {
     webPreviewCandidateService: any WebPreviewCandidateServiceProtocol = WebPreviewCandidateService.shared,
     approvalNotificationService: any ApprovalNotificationServiceProtocol = ApprovalNotificationService.shared,
     approvalClaimStore: (any ApprovalClaimStoreProtocol)? = nil,
-    hookInstaller: (any ClaudeHookInstallerProtocol)? = nil
+    hookInstaller: (any ClaudeHookInstallerProtocol)? = nil,
+    terminalSurfaceFactory: any EmbeddedTerminalSurfaceFactory = DefaultEmbeddedTerminalSurfaceFactory(),
+    terminalBackend: EmbeddedTerminalBackend = .storedPreference
   ) {
     // [CLISessionsVM] init called")
     self.monitorService = monitorService
@@ -572,6 +708,8 @@ public final class CLISessionsViewModel {
     self.approvalNotificationService = approvalNotificationService
     self.approvalClaimStore = approvalClaimStore
     self.hookInstaller = hookInstaller
+    self.terminalSurfaceFactory = terminalSurfaceFactory
+    self.terminalBackend = terminalBackend
     self.cliConfiguration = cliConfiguration
     self.providerKind = providerKind
     self.showLastMessage = UserDefaults.standard.bool(forKey: "CLISessionsShowLastMessage")

--- a/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/CLISessionsViewModel.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/CLISessionsViewModel.swift
@@ -29,6 +29,7 @@ public final class CLISessionsViewModel {
   public let providerKind: SessionProviderKind
   private let worktreeService = GitWorktreeService()
   private let metadataStore: SessionMetadataStore?
+  private let terminalWorkspaceStore: (any TerminalWorkspaceStoreProtocol)?
   private let fileWatcher: any SessionFileWatcherProtocol
   private let webPreviewCandidateService: any WebPreviewCandidateServiceProtocol
   private let approvalNotificationService: any ApprovalNotificationServiceProtocol
@@ -36,6 +37,7 @@ public final class CLISessionsViewModel {
   private let hookInstaller: (any ClaudeHookInstallerProtocol)?
   private let terminalSurfaceFactory: any EmbeddedTerminalSurfaceFactory
   private let terminalBackend: EmbeddedTerminalBackend
+  @ObservationIgnored private var terminalWorkspaceSaveTasks: [String: Task<Void, Never>] = [:]
   weak var agentHubProvider: AgentHubProvider?
 
   // MARK: - State
@@ -417,6 +419,102 @@ public final class CLISessionsViewModel {
     newTerminal.consumeQueuedWebPreviewContextOnSubmit = oldTerminal?.consumeQueuedWebPreviewContextOnSubmit
   }
 
+  private func persistableWorkspaceSessionId(key: String, sessionId: String?) -> String? {
+    let candidate = sessionId ?? key
+    guard !candidate.isEmpty, !candidate.hasPrefix("pending-") else { return nil }
+    return candidate
+  }
+
+  private func loadTerminalWorkspaceSnapshot(sessionId: String?) -> TerminalWorkspaceSnapshot? {
+    guard let sessionId, !sessionId.hasPrefix("pending-") else { return nil }
+    return terminalWorkspaceStore?.loadTerminalWorkspace(
+      provider: providerKind,
+      sessionId: sessionId,
+      backend: terminalBackend
+    )
+  }
+
+  private func configureTerminalWorkspacePersistence(
+    for terminal: any EmbeddedTerminalSurface,
+    key: String,
+    sessionId: String?
+  ) {
+    guard let sessionId = persistableWorkspaceSessionId(key: key, sessionId: sessionId) else {
+      terminal.onWorkspaceChanged = nil
+      return
+    }
+
+    terminal.onWorkspaceChanged = { [weak self] snapshot in
+      self?.scheduleTerminalWorkspaceSave(snapshot, sessionId: sessionId)
+    }
+  }
+
+  private func persistCurrentWorkspaceIfNeeded(
+    for terminal: any EmbeddedTerminalSurface,
+    key: String,
+    sessionId: String?,
+    debounce: Bool = true
+  ) {
+    guard
+      let sessionId = persistableWorkspaceSessionId(key: key, sessionId: sessionId),
+      let snapshot = terminal.captureWorkspaceSnapshot()
+    else {
+      return
+    }
+
+    scheduleTerminalWorkspaceSave(snapshot, sessionId: sessionId, debounce: debounce)
+  }
+
+  private func scheduleTerminalWorkspaceSave(
+    _ snapshot: TerminalWorkspaceSnapshot,
+    sessionId: String,
+    debounce: Bool = true
+  ) {
+    guard let store = terminalWorkspaceStore else { return }
+
+    terminalWorkspaceSaveTasks[sessionId]?.cancel()
+    if !debounce {
+      terminalWorkspaceSaveTasks.removeValue(forKey: sessionId)
+      let providerKind = providerKind
+      let terminalBackend = terminalBackend
+      Task { [store, snapshot, sessionId, providerKind, terminalBackend] in
+        do {
+          try await store.saveTerminalWorkspace(
+            snapshot,
+            provider: providerKind,
+            sessionId: sessionId,
+            backend: terminalBackend
+          )
+        } catch {
+          AppLogger.session.error("Failed to save terminal workspace: \(error.localizedDescription)")
+        }
+      }
+      return
+    }
+
+    let providerKind = providerKind
+    let terminalBackend = terminalBackend
+    terminalWorkspaceSaveTasks[sessionId] = Task { [weak self, store, snapshot, sessionId, providerKind, terminalBackend] in
+      try? await Task.sleep(for: .milliseconds(250))
+      guard !Task.isCancelled else { return }
+
+      do {
+        try await store.saveTerminalWorkspace(
+          snapshot,
+          provider: providerKind,
+          sessionId: sessionId,
+          backend: terminalBackend
+        )
+      } catch {
+        AppLogger.session.error("Failed to save terminal workspace: \(error.localizedDescription)")
+      }
+
+      await MainActor.run {
+        self?.terminalWorkspaceSaveTasks[sessionId] = nil
+      }
+    }
+  }
+
   /// Gets an existing terminal or creates a new one for the given key.
   /// Key should be session ID for real sessions, or "pending-{pendingId}" for pending sessions.
   /// This preserves the terminal PTY across pending → real session transitions.
@@ -463,6 +561,7 @@ public final class CLISessionsViewModel {
         existing.typeInitialTextIfNeeded(inputText)
       }
       existing.updateContext(terminalSessionKey: key, sessionViewModel: self)
+      configureTerminalWorkspacePersistence(for: existing, key: key, sessionId: sessionId)
       return existing
     }
 
@@ -482,6 +581,10 @@ public final class CLISessionsViewModel {
     )
     activeTerminalDescriptors[key] = createDescriptor
     let terminal = makeTerminalSurface(forKey: key, descriptor: createDescriptor)
+    configureTerminalWorkspacePersistence(for: terminal, key: key, sessionId: sessionId)
+    if let workspaceSnapshot = loadTerminalWorkspaceSnapshot(sessionId: persistableWorkspaceSessionId(key: key, sessionId: sessionId)) {
+      terminal.restoreWorkspaceSnapshot(workspaceSnapshot)
+    }
     activeTerminals[key] = terminal
     return terminal
   }
@@ -516,10 +619,13 @@ public final class CLISessionsViewModel {
   /// Removes the terminal for a given key and terminates its process
   public func removeTerminal(forKey key: String) {
     if let terminal = activeTerminals[key] {
+      persistCurrentWorkspaceIfNeeded(for: terminal, key: key, sessionId: key, debounce: false)
       terminal.terminateProcess()
     }
     activeTerminals.removeValue(forKey: key)
     activeTerminalDescriptors.removeValue(forKey: key)
+    terminalWorkspaceSaveTasks[key]?.cancel()
+    terminalWorkspaceSaveTasks.removeValue(forKey: key)
   }
 
   /// Transfers terminal from pending key to real session ID (for pending → real transition)
@@ -528,6 +634,8 @@ public final class CLISessionsViewModel {
     if let terminal = activeTerminals.removeValue(forKey: pendingKey) {
       activeTerminals[sessionId] = terminal
       terminal.updateContext(terminalSessionKey: sessionId, sessionViewModel: self)
+      configureTerminalWorkspacePersistence(for: terminal, key: sessionId, sessionId: sessionId)
+      persistCurrentWorkspaceIfNeeded(for: terminal, key: sessionId, sessionId: sessionId, debounce: false)
     }
     if let descriptor = activeTerminalDescriptors.removeValue(forKey: pendingKey) {
       activeTerminalDescriptors[sessionId] = descriptor.transferred(toSessionId: sessionId)
@@ -575,6 +683,10 @@ public final class CLISessionsViewModel {
     oldTerminal.terminateProcess()
     let newTerminal = makeTerminalSurface(forKey: key, descriptor: descriptor)
     copyTerminalCallbacks(from: oldTerminal, to: newTerminal)
+    configureTerminalWorkspacePersistence(for: newTerminal, key: key, sessionId: sessionId)
+    if let workspaceSnapshot = loadTerminalWorkspaceSnapshot(sessionId: persistableWorkspaceSessionId(key: key, sessionId: sessionId)) {
+      newTerminal.restoreWorkspaceSnapshot(workspaceSnapshot)
+    }
     activeTerminals[key] = newTerminal
   }
 
@@ -697,12 +809,14 @@ public final class CLISessionsViewModel {
     approvalClaimStore: (any ApprovalClaimStoreProtocol)? = nil,
     hookInstaller: (any ClaudeHookInstallerProtocol)? = nil,
     terminalSurfaceFactory: any EmbeddedTerminalSurfaceFactory = DefaultEmbeddedTerminalSurfaceFactory(),
-    terminalBackend: EmbeddedTerminalBackend = .storedPreference
+    terminalBackend: EmbeddedTerminalBackend = .storedPreference,
+    terminalWorkspaceStore: (any TerminalWorkspaceStoreProtocol)? = nil
   ) {
     // [CLISessionsVM] init called")
     self.monitorService = monitorService
     self.searchService = searchService
     self.metadataStore = metadataStore
+    self.terminalWorkspaceStore = terminalWorkspaceStore ?? metadataStore
     self.fileWatcher = fileWatcher
     self.webPreviewCandidateService = webPreviewCandidateService
     self.approvalNotificationService = approvalNotificationService

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/AIConfigSettingsTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/AIConfigSettingsTests.swift
@@ -254,12 +254,26 @@ struct AIConfigServicePersistenceTests {
     try await store.saveAIConfig(
       AIConfigRecord(provider: "claude", defaultModel: "opus")
     )
+    try await store.saveTerminalWorkspace(
+      TerminalWorkspaceSnapshot(
+        panels: [
+          TerminalWorkspacePanelSnapshot(
+            role: .primary,
+            tabs: [TerminalWorkspaceTabSnapshot(role: .agent)]
+          )
+        ]
+      ),
+      provider: .claude,
+      sessionId: "session-1",
+      backend: .ghostty
+    )
 
     try await store.clearAll()
 
     #expect(try await store.getCustomName(for: "session-1") == nil)
     #expect(try await store.getRepoMapping(for: "session-1") == nil)
     #expect(try await store.getAIConfig(for: "claude") == nil)
+    #expect(store.loadTerminalWorkspace(provider: .claude, sessionId: "session-1", backend: .ghostty) == nil)
   }
 
   @Test("Pinned session IDs round-trip through async and sync reads")
@@ -276,6 +290,49 @@ struct AIConfigServicePersistenceTests {
 
     #expect(try await store.getPinnedSessionIds().isEmpty)
     #expect(store.getPinnedSessionIdsSync().isEmpty)
+  }
+
+  @Test("Terminal workspace snapshots are scoped by provider session and backend")
+  func terminalWorkspaceRoundTrip() async throws {
+    let dbPath = temporaryDatabasePath()
+    let store = try SessionMetadataStore(path: dbPath)
+    let snapshot = TerminalWorkspaceSnapshot(
+      panels: [
+        TerminalWorkspacePanelSnapshot(
+          role: .primary,
+          tabs: [
+            TerminalWorkspaceTabSnapshot(
+              role: .agent,
+              name: "Agent",
+              title: "Claude",
+              workingDirectory: "/tmp/project"
+            ),
+            TerminalWorkspaceTabSnapshot(
+              role: .shell,
+              name: "Shell",
+              title: "zsh",
+              workingDirectory: "/tmp/project"
+            )
+          ],
+          activeTabIndex: 1
+        )
+      ]
+    )
+
+    try await store.saveTerminalWorkspace(
+      snapshot,
+      provider: .claude,
+      sessionId: "session-1",
+      backend: .ghostty
+    )
+
+    #expect(store.loadTerminalWorkspace(provider: .claude, sessionId: "session-1", backend: .ghostty) == snapshot)
+    #expect(store.loadTerminalWorkspace(provider: .codex, sessionId: "session-1", backend: .ghostty) == nil)
+    #expect(store.loadTerminalWorkspace(provider: .claude, sessionId: "session-1", backend: .regular) == nil)
+
+    try await store.deleteTerminalWorkspace(provider: .claude, sessionId: "session-1", backend: .ghostty)
+
+    #expect(store.loadTerminalWorkspace(provider: .claude, sessionId: "session-1", backend: .ghostty) == nil)
   }
 }
 

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/AgentHubGhosttyTerminalShortcutTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/AgentHubGhosttyTerminalShortcutTests.swift
@@ -1,0 +1,105 @@
+import AppKit
+import GhosttySwift
+import Testing
+
+@testable import AgentHubCore
+
+@Suite("AgentHub Ghostty terminal shortcuts")
+struct AgentHubGhosttyTerminalShortcutTests {
+
+  @Test("Command shortcuts match Ghostty terminal actions")
+  func commandShortcuts() {
+    expectAction(.openTab, key: "t", flags: .command)
+    expectAction(.openPane, key: "d", flags: .command)
+    expectAction(.startSearch, key: "f", flags: .command)
+    expectAction(.searchNext, key: "g", flags: .command)
+    expectNoAction(key: "w", flags: .command)
+  }
+
+  @Test("Shift-command shortcuts match Ghostty terminal actions")
+  func shiftedCommandShortcuts() {
+    expectAction(.searchPrevious, key: "g", flags: [.command, .shift])
+    expectAction(.closePanel, key: "w", flags: [.command, .shift])
+  }
+
+  @Test("Command arrow shortcuts focus panes")
+  func paneFocusShortcuts() {
+    expectFocusPanel(.left, keyCode: 123, flags: [.command, .numericPad])
+    expectFocusPanel(.right, keyCode: 124, flags: [.command, .numericPad])
+    expectFocusPanel(.down, keyCode: 125, flags: [.command, .numericPad])
+    expectFocusPanel(.up, keyCode: 126, flags: [.command, .numericPad])
+  }
+
+  @Test("Shift-command arrow shortcuts select tabs")
+  func tabSelectionShortcuts() {
+    expectSelectTab(.previous, keyCode: 123, flags: [.command, .shift, .numericPad])
+    expectSelectTab(.next, keyCode: 124, flags: [.command, .shift, .numericPad])
+  }
+}
+
+private func expectAction(
+  _ expected: AgentHubGhosttyTerminalShortcut,
+  key: String,
+  flags: NSEvent.ModifierFlags,
+  sourceLocation: SourceLocation = #_sourceLocation
+) {
+  let action = AgentHubGhosttyTerminalShortcut.action(
+    keyCode: 0,
+    charactersIgnoringModifiers: key,
+    modifierFlags: flags
+  )
+  #expect(action == expected, sourceLocation: sourceLocation)
+}
+
+private func expectNoAction(
+  key: String,
+  flags: NSEvent.ModifierFlags,
+  sourceLocation: SourceLocation = #_sourceLocation
+) {
+  let action = AgentHubGhosttyTerminalShortcut.action(
+    keyCode: 0,
+    charactersIgnoringModifiers: key,
+    modifierFlags: flags
+  )
+  #expect(action == nil, sourceLocation: sourceLocation)
+}
+
+private func expectFocusPanel(
+  _ expected: TerminalPanelNavigationDirection,
+  keyCode: UInt16,
+  flags: NSEvent.ModifierFlags,
+  sourceLocation: SourceLocation = #_sourceLocation
+) {
+  let action = AgentHubGhosttyTerminalShortcut.action(
+    keyCode: keyCode,
+    charactersIgnoringModifiers: nil,
+    modifierFlags: flags
+  )
+
+  switch action {
+  case .focusPanel(let actual):
+    #expect(actual == expected, sourceLocation: sourceLocation)
+  default:
+    Issue.record("Expected focus panel \(expected), got \(String(describing: action))", sourceLocation: sourceLocation)
+  }
+}
+
+private func expectSelectTab(
+  _ expected: TerminalTabNavigationDirection,
+  keyCode: UInt16,
+  flags: NSEvent.ModifierFlags,
+  sourceLocation: SourceLocation = #_sourceLocation
+) {
+  let action = AgentHubGhosttyTerminalShortcut.action(
+    keyCode: keyCode,
+    charactersIgnoringModifiers: nil,
+    modifierFlags: flags
+  )
+
+  switch action {
+  case .selectTab(let actual):
+    #expect(actual == expected, sourceLocation: sourceLocation)
+  default:
+    Issue.record("Expected select tab \(expected), got \(String(describing: action))", sourceLocation: sourceLocation)
+  }
+}

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/AuxiliaryShellTerminalManagementTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/AuxiliaryShellTerminalManagementTests.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Canvas
 import Combine
 import Foundation
@@ -32,18 +33,92 @@ private actor AuxiliaryShellStubFileWatcher: SessionFileWatcherProtocol {
 }
 
 @MainActor
-private func makeAuxiliaryShellViewModel() -> CLISessionsViewModel {
+private func makeAuxiliaryShellViewModel(
+  terminalSurfaceFactory: any EmbeddedTerminalSurfaceFactory = DefaultEmbeddedTerminalSurfaceFactory(),
+  terminalBackend: EmbeddedTerminalBackend = .storedPreference
+) -> CLISessionsViewModel {
   CLISessionsViewModel(
     monitorService: AuxiliaryShellStubMonitorService(),
     fileWatcher: AuxiliaryShellStubFileWatcher(),
     searchService: nil,
     cliConfiguration: CLICommandConfiguration(command: "claude", mode: .claude),
     providerKind: .claude,
-    approvalNotificationService: NoOpApprovalNotificationService()
+    approvalNotificationService: NoOpApprovalNotificationService(),
+    terminalSurfaceFactory: terminalSurfaceFactory,
+    terminalBackend: terminalBackend
   )
 }
 
-@Suite("Auxiliary shell terminal management")
+@MainActor
+private final class TestTerminalSurface: NSView, EmbeddedTerminalSurface {
+  var view: NSView { self }
+  var currentProcessPID: Int32?
+  var onUserInteraction: (() -> Void)?
+  var onRequestShowEditor: (() -> Void)?
+  var consumeQueuedWebPreviewContextOnSubmit: (() -> String?)?
+  private(set) var configuredProjectPath: String?
+  private(set) var configuredShellPath: String?
+  private(set) var configureCallCount = 0
+  private(set) var terminateCallCount = 0
+
+  func updateContext(terminalSessionKey: String?, sessionViewModel: CLISessionsViewModel?) {}
+
+  func configure(
+    sessionId: String?,
+    projectPath: String,
+    cliConfiguration: CLICommandConfiguration,
+    initialPrompt: String?,
+    initialInputText: String?,
+    isDark: Bool,
+    dangerouslySkipPermissions: Bool,
+    permissionModePlan: Bool,
+    worktreeName: String?,
+    metadataStore: SessionMetadataStore?
+  ) {
+    configuredProjectPath = projectPath
+    configureCallCount += 1
+  }
+
+  func configureShell(projectPath: String, isDark: Bool, shellPath: String?) {
+    configuredProjectPath = projectPath
+    configuredShellPath = shellPath
+    configureCallCount += 1
+  }
+
+  func restart(sessionId: String?, projectPath: String, cliConfiguration: CLICommandConfiguration) {}
+
+  func terminateProcess() {
+    terminateCallCount += 1
+  }
+
+  func resetPromptDeliveryFlag() {}
+  func sendPromptIfNeeded(_ prompt: String) {}
+  func submitPromptImmediately(_ prompt: String) -> Bool { true }
+  func typeText(_ text: String) {}
+  func typeInitialTextIfNeeded(_ text: String) {}
+  func syncAppearance(isDark: Bool, fontSize: CGFloat, fontFamily: String, theme: RuntimeTheme?) {}
+  func focus() {}
+}
+
+@MainActor
+private final class RecordingTerminalSurfaceFactory: EmbeddedTerminalSurfaceFactory {
+  private let surfaces: [TestTerminalSurface]
+  private var nextSurfaceIndex = 0
+  private(set) var requestedBackends: [EmbeddedTerminalBackend] = []
+
+  init(surfaces: [TestTerminalSurface]) {
+    self.surfaces = surfaces
+  }
+
+  func makeSurface(for backend: EmbeddedTerminalBackend) -> any EmbeddedTerminalSurface {
+    requestedBackends.append(backend)
+    let surface = surfaces[nextSurfaceIndex]
+    nextSurfaceIndex += 1
+    return surface
+  }
+}
+
+@Suite("Auxiliary shell terminal management", .serialized)
 struct AuxiliaryShellTerminalManagementTests {
 
   @Test("Transfers auxiliary shell terminal from pending key to resolved session ID")
@@ -58,7 +133,7 @@ struct AuxiliaryShellTerminalManagementTests {
     viewModel.transferAuxiliaryShellTerminal(fromPendingId: pendingID, toSessionId: "session-123")
 
     #expect(viewModel.auxiliaryShellTerminals[pendingKey] == nil)
-    #expect(viewModel.auxiliaryShellTerminals["session-123"] === terminal)
+    #expect(viewModel.auxiliaryShellTerminals["session-123"]?.view === terminal)
   }
 
   @Test("Resolving pending session transfers queued web preview context")
@@ -136,6 +211,71 @@ struct AuxiliaryShellTerminalManagementTests {
     #expect(viewModel.auxiliaryShellTerminals[session.id] == nil)
     #expect(agentTerminal.terminateProcessCallCount == 1)
     #expect(shellTerminal.terminateProcessCallCount == 1)
+  }
+
+  @Test("View model creates terminals through injected surface factory")
+  @MainActor
+  func createsTerminalThroughInjectedFactory() {
+    let surface = TestTerminalSurface()
+    let factory = RecordingTerminalSurfaceFactory(surfaces: [surface])
+    let viewModel = makeAuxiliaryShellViewModel(
+      terminalSurfaceFactory: factory,
+      terminalBackend: .regular
+    )
+
+    let terminal = viewModel.getOrCreateTerminal(
+      forKey: "session-123",
+      sessionId: "session-123",
+      projectPath: "/tmp/project",
+      initialPrompt: nil
+    )
+
+    #expect(terminal.view === surface)
+    #expect(surface.configuredProjectPath == "/tmp/project")
+    #expect(factory.requestedBackends == [.regular])
+  }
+
+  @Test("Changing terminal backend preference does not recreate cached terminal surfaces")
+  @MainActor
+  func changingTerminalBackendPreferenceRequiresRestart() {
+    let oldBackend = UserDefaults.standard.object(forKey: AgentHubDefaults.terminalBackend)
+    defer {
+      if let oldBackend {
+        UserDefaults.standard.set(oldBackend, forKey: AgentHubDefaults.terminalBackend)
+      } else {
+        UserDefaults.standard.removeObject(forKey: AgentHubDefaults.terminalBackend)
+      }
+    }
+
+    UserDefaults.standard.set(EmbeddedTerminalBackend.ghostty.rawValue, forKey: AgentHubDefaults.terminalBackend)
+    let firstSurface = TestTerminalSurface()
+    let secondSurface = TestTerminalSurface()
+    let factory = RecordingTerminalSurfaceFactory(surfaces: [firstSurface, secondSurface])
+    let viewModel = makeAuxiliaryShellViewModel(
+      terminalSurfaceFactory: factory,
+      terminalBackend: .ghostty
+    )
+
+    _ = viewModel.getOrCreateTerminal(
+      forKey: "session-123",
+      sessionId: "session-123",
+      projectPath: "/tmp/project",
+      initialPrompt: nil
+    )
+
+    UserDefaults.standard.set(EmbeddedTerminalBackend.regular.rawValue, forKey: AgentHubDefaults.terminalBackend)
+    _ = viewModel.getOrCreateTerminal(
+      forKey: "session-456",
+      sessionId: "session-456",
+      projectPath: "/tmp/another-project",
+      initialPrompt: nil
+    )
+
+    #expect(firstSurface.terminateCallCount == 0)
+    #expect(secondSurface.configuredProjectPath == "/tmp/another-project")
+    #expect(viewModel.activeTerminals["session-123"]?.view === firstSurface)
+    #expect(viewModel.activeTerminals["session-456"]?.view === secondSurface)
+    #expect(factory.requestedBackends == [.ghostty, .ghostty])
   }
 }
 

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/AuxiliaryShellTerminalManagementTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/AuxiliaryShellTerminalManagementTests.swift
@@ -35,7 +35,8 @@ private actor AuxiliaryShellStubFileWatcher: SessionFileWatcherProtocol {
 @MainActor
 private func makeAuxiliaryShellViewModel(
   terminalSurfaceFactory: any EmbeddedTerminalSurfaceFactory = DefaultEmbeddedTerminalSurfaceFactory(),
-  terminalBackend: EmbeddedTerminalBackend = .storedPreference
+  terminalBackend: EmbeddedTerminalBackend = .storedPreference,
+  terminalWorkspaceStore: (any TerminalWorkspaceStoreProtocol)? = nil
 ) -> CLISessionsViewModel {
   CLISessionsViewModel(
     monitorService: AuxiliaryShellStubMonitorService(),
@@ -45,7 +46,8 @@ private func makeAuxiliaryShellViewModel(
     providerKind: .claude,
     approvalNotificationService: NoOpApprovalNotificationService(),
     terminalSurfaceFactory: terminalSurfaceFactory,
-    terminalBackend: terminalBackend
+    terminalBackend: terminalBackend,
+    terminalWorkspaceStore: terminalWorkspaceStore
   )
 }
 
@@ -56,8 +58,11 @@ private final class TestTerminalSurface: NSView, EmbeddedTerminalSurface {
   var onUserInteraction: (() -> Void)?
   var onRequestShowEditor: (() -> Void)?
   var consumeQueuedWebPreviewContextOnSubmit: (() -> String?)?
+  var onWorkspaceChanged: ((TerminalWorkspaceSnapshot) -> Void)?
   private(set) var configuredProjectPath: String?
   private(set) var configuredShellPath: String?
+  private(set) var restoredWorkspaceSnapshot: TerminalWorkspaceSnapshot?
+  var workspaceSnapshotToCapture: TerminalWorkspaceSnapshot?
   private(set) var configureCallCount = 0
   private(set) var terminateCallCount = 0
 
@@ -98,6 +103,73 @@ private final class TestTerminalSurface: NSView, EmbeddedTerminalSurface {
   func typeInitialTextIfNeeded(_ text: String) {}
   func syncAppearance(isDark: Bool, fontSize: CGFloat, fontFamily: String, theme: RuntimeTheme?) {}
   func focus() {}
+  func captureWorkspaceSnapshot() -> TerminalWorkspaceSnapshot? {
+    workspaceSnapshotToCapture
+  }
+  func restoreWorkspaceSnapshot(_ snapshot: TerminalWorkspaceSnapshot) {
+    restoredWorkspaceSnapshot = snapshot
+  }
+}
+
+private final class RecordingTerminalWorkspaceStore: TerminalWorkspaceStoreProtocol, @unchecked Sendable {
+  private let lock = NSLock()
+  private var snapshots: [String: TerminalWorkspaceSnapshot]
+  private var savedSnapshotsByKey: [String: TerminalWorkspaceSnapshot] = [:]
+
+  init(snapshots: [String: TerminalWorkspaceSnapshot] = [:]) {
+    self.snapshots = snapshots
+  }
+
+  func loadTerminalWorkspace(
+    provider: SessionProviderKind,
+    sessionId: String,
+    backend: EmbeddedTerminalBackend
+  ) -> TerminalWorkspaceSnapshot? {
+    lock.lock()
+    defer { lock.unlock() }
+    return snapshots[key(provider: provider, sessionId: sessionId, backend: backend)]
+  }
+
+  func saveTerminalWorkspace(
+    _ snapshot: TerminalWorkspaceSnapshot,
+    provider: SessionProviderKind,
+    sessionId: String,
+    backend: EmbeddedTerminalBackend
+  ) async throws {
+    lock.lock()
+    defer { lock.unlock() }
+    let key = key(provider: provider, sessionId: sessionId, backend: backend)
+    snapshots[key] = snapshot
+    savedSnapshotsByKey[key] = snapshot
+  }
+
+  func deleteTerminalWorkspace(
+    provider: SessionProviderKind,
+    sessionId: String,
+    backend: EmbeddedTerminalBackend
+  ) async throws {
+    lock.lock()
+    defer { lock.unlock() }
+    snapshots.removeValue(forKey: key(provider: provider, sessionId: sessionId, backend: backend))
+  }
+
+  func savedSnapshot(
+    provider: SessionProviderKind,
+    sessionId: String,
+    backend: EmbeddedTerminalBackend
+  ) -> TerminalWorkspaceSnapshot? {
+    lock.lock()
+    defer { lock.unlock() }
+    return savedSnapshotsByKey[key(provider: provider, sessionId: sessionId, backend: backend)]
+  }
+
+  private func key(
+    provider: SessionProviderKind,
+    sessionId: String,
+    backend: EmbeddedTerminalBackend
+  ) -> String {
+    "\(provider.rawValue)|\(sessionId)|\(backend.rawValue)"
+  }
 }
 
 @MainActor
@@ -277,6 +349,79 @@ struct AuxiliaryShellTerminalManagementTests {
     #expect(viewModel.activeTerminals["session-456"]?.view === secondSurface)
     #expect(factory.requestedBackends == [.ghostty, .ghostty])
   }
+
+  @Test("Restores persisted workspace when creating a real session terminal")
+  @MainActor
+  func restoresPersistedWorkspaceForRealSessionTerminal() {
+    let snapshot = makeWorkspaceSnapshot()
+    let store = RecordingTerminalWorkspaceStore(snapshots: [
+      "Claude|session-123|\(EmbeddedTerminalBackend.ghostty.rawValue)": snapshot
+    ])
+    let surface = TestTerminalSurface()
+    let factory = RecordingTerminalSurfaceFactory(surfaces: [surface])
+    let viewModel = makeAuxiliaryShellViewModel(
+      terminalSurfaceFactory: factory,
+      terminalBackend: .ghostty,
+      terminalWorkspaceStore: store
+    )
+
+    _ = viewModel.getOrCreateTerminal(
+      forKey: "session-123",
+      sessionId: "session-123",
+      projectPath: "/tmp/project",
+      initialPrompt: nil
+    )
+
+    #expect(surface.restoredWorkspaceSnapshot == snapshot)
+  }
+
+  @Test("Saves terminal workspace changes through injected store")
+  @MainActor
+  func savesTerminalWorkspaceChanges() async throws {
+    let snapshot = makeWorkspaceSnapshot(activePanelIndex: 1)
+    let store = RecordingTerminalWorkspaceStore()
+    let surface = TestTerminalSurface()
+    let factory = RecordingTerminalSurfaceFactory(surfaces: [surface])
+    let viewModel = makeAuxiliaryShellViewModel(
+      terminalSurfaceFactory: factory,
+      terminalBackend: .ghostty,
+      terminalWorkspaceStore: store
+    )
+
+    _ = viewModel.getOrCreateTerminal(
+      forKey: "session-123",
+      sessionId: "session-123",
+      projectPath: "/tmp/project",
+      initialPrompt: nil
+    )
+    surface.onWorkspaceChanged?(snapshot)
+
+    try await Task.sleep(for: .milliseconds(350))
+
+    #expect(store.savedSnapshot(provider: .claude, sessionId: "session-123", backend: .ghostty) == snapshot)
+  }
+
+  @Test("Pending terminal workspace is saved when session resolves")
+  @MainActor
+  func pendingTerminalWorkspaceSavesAfterTransfer() async throws {
+    let snapshot = makeWorkspaceSnapshot(activePanelIndex: 1)
+    let store = RecordingTerminalWorkspaceStore()
+    let surface = TestTerminalSurface()
+    surface.workspaceSnapshotToCapture = snapshot
+    let pendingID = UUID()
+    let pendingKey = "pending-\(pendingID.uuidString)"
+    let viewModel = makeAuxiliaryShellViewModel(
+      terminalBackend: .ghostty,
+      terminalWorkspaceStore: store
+    )
+    viewModel.activeTerminals[pendingKey] = surface
+
+    viewModel.transferTerminal(fromPendingId: pendingID, toSessionId: "session-123")
+
+    try await Task.sleep(for: .milliseconds(350))
+
+    #expect(store.savedSnapshot(provider: .claude, sessionId: "session-123", backend: .ghostty) == snapshot)
+  }
 }
 
 private func makeQueuedElement() -> ElementInspectorData {
@@ -289,5 +434,42 @@ private func makeQueuedElement() -> ElementInspectorData {
     cssSelector: ".hero button",
     computedStyles: [:],
     boundingRect: .zero
+  )
+}
+
+private func makeWorkspaceSnapshot(activePanelIndex: Int = 0) -> TerminalWorkspaceSnapshot {
+  TerminalWorkspaceSnapshot(
+    panels: [
+      TerminalWorkspacePanelSnapshot(
+        role: .primary,
+        tabs: [
+          TerminalWorkspaceTabSnapshot(
+            role: .agent,
+            name: "Agent",
+            title: "Claude",
+            workingDirectory: "/tmp/project"
+          ),
+          TerminalWorkspaceTabSnapshot(
+            role: .shell,
+            name: "Shell",
+            title: "zsh",
+            workingDirectory: "/tmp/project"
+          )
+        ],
+        activeTabIndex: 1
+      ),
+      TerminalWorkspacePanelSnapshot(
+        role: .auxiliary,
+        tabs: [
+          TerminalWorkspaceTabSnapshot(
+            role: .shell,
+            name: "Shell",
+            title: "zsh",
+            workingDirectory: "/tmp/project"
+          )
+        ]
+      )
+    ],
+    activePanelIndex: activePanelIndex
   )
 }

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/GhosttyConfigPathResolverTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/GhosttyConfigPathResolverTests.swift
@@ -1,0 +1,50 @@
+import Foundation
+import Testing
+
+@testable import AgentHubCore
+
+@Suite("Ghostty config path resolver")
+struct GhosttyConfigPathResolverTests {
+
+  @Test("Returns nil when no config path is saved")
+  func emptyConfigPath() {
+    let defaults = makeDefaults()
+
+    #expect(GhosttyConfigPathResolver.configuredPath(defaults: defaults) == nil)
+  }
+
+  @Test("Returns saved file path when it exists")
+  func existingConfigPath() throws {
+    let defaults = makeDefaults()
+    let configURL = FileManager.default.temporaryDirectory
+      .appendingPathComponent("ghostty-\(UUID().uuidString).conf")
+    try "font-size = 14\n".write(to: configURL, atomically: true, encoding: .utf8)
+    defer { try? FileManager.default.removeItem(at: configURL) }
+
+    defaults.set(configURL.path, forKey: AgentHubDefaults.terminalGhosttyConfigPath)
+
+    #expect(GhosttyConfigPathResolver.configuredPath(defaults: defaults) == configURL.path)
+  }
+
+  @Test("Ignores missing files and directories")
+  func ignoresInvalidPaths() throws {
+    let defaults = makeDefaults()
+    let directoryURL = FileManager.default.temporaryDirectory
+      .appendingPathComponent("ghostty-config-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: directoryURL) }
+
+    defaults.set(directoryURL.path, forKey: AgentHubDefaults.terminalGhosttyConfigPath)
+    #expect(GhosttyConfigPathResolver.configuredPath(defaults: defaults) == nil)
+
+    defaults.set(directoryURL.appendingPathComponent("missing").path, forKey: AgentHubDefaults.terminalGhosttyConfigPath)
+    #expect(GhosttyConfigPathResolver.configuredPath(defaults: defaults) == nil)
+  }
+}
+
+private func makeDefaults() -> UserDefaults {
+  let suiteName = "com.agenthub.tests.ghostty-config.\(UUID().uuidString)"
+  let defaults = UserDefaults(suiteName: suiteName)!
+  defaults.removePersistentDomain(forName: suiteName)
+  return defaults
+}

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/TerminalPromptSubmissionPayloadTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/TerminalPromptSubmissionPayloadTests.swift
@@ -76,4 +76,16 @@ struct TerminalPromptSubmissionPayloadTests {
     #expect(payload == expected)
     #expect(!payload.contains(0x0D))
   }
+
+  @Test("bracketedPasteTextBytes always wraps and omits carriage return")
+  func bracketedPasteTextBytesAlwaysWraps() {
+    let prompt = "Queued update\nwith multiple lines"
+    let start: [UInt8] = [0x1B, 0x5B, 0x32, 0x30, 0x30, 0x7E]
+    let end: [UInt8] = [0x1B, 0x5B, 0x32, 0x30, 0x31, 0x7E]
+
+    let payload = TerminalPromptSubmissionPayload.bracketedPasteTextBytes(prompt: prompt)
+
+    #expect(payload == start + Array(prompt.utf8) + end)
+    #expect(!payload.contains(0x0D))
+  }
 }


### PR DESCRIPTION
## Summary

- Add the Ghostty-backed embedded terminal path, including pane creation, shortcut handling, prompt submission behavior, and workspace persistence.
- Add the Ghostty configuration path setting and tests around config resolution, terminal shortcuts, prompt submission, and auxiliary terminal management.
- Pin AgentHubCore to `GhosttySwift` `1.0.3` from GitHub instead of a local package path so clean checkouts and app builds do not depend on `/Users/.../GhosttySwift`.

## Packaging Note

`GhosttySwift` `1.0.3` publishes `GhosttyKit.xcframework.zip` as a release binary artifact and its package manifest references that artifact by URL/checksum. That keeps the binary out of the source git tree while still allowing SwiftPM to resolve the dependency remotely.

## Validation

- `swift package resolve` in `app/modules/AgentHubCore`
- `xcodebuild -scheme AgentHub -configuration Debug -destination 'platform=macOS' build`

The Xcode build exited successfully with `** BUILD SUCCEEDED **`; the existing SwiftLint plugin footer still prints two SwiftLint command lines after success.