### PR TITLE
Extract Ghostty terminal backend into a standalone Swift Package

### DIFF
--- a/app/AgentHub.xcodeproj/project.pbxproj
+++ b/app/AgentHub.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		7B03D9422F14D66700C36AA3 /* AgentHubCore in Frameworks */ = {isa = PBXBuildFile; productRef = 7B03D9412F14D66700C36AA3 /* AgentHubCore */; };
 		7B03D9502F18A00000C36AA3 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = 7B03D94F2F18A00000C36AA3 /* Sparkle */; };
+		7B03DA022F18A10000C36AA3 /* Ghostty in Frameworks */ = {isa = PBXBuildFile; productRef = 7B03DA012F18A10000C36AA3 /* Ghostty */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -58,6 +59,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				7B03D9422F14D66700C36AA3 /* AgentHubCore in Frameworks */,
+				7B03DA022F18A10000C36AA3 /* Ghostty in Frameworks */,
 				7B03D9502F18A00000C36AA3 /* Sparkle in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -120,6 +122,7 @@
 			name = AgentHub;
 			packageProductDependencies = (
 				7B03D9412F14D66700C36AA3 /* AgentHubCore */,
+				7B03DA012F18A10000C36AA3 /* Ghostty */,
 				7B03D94F2F18A00000C36AA3 /* Sparkle */,
 			);
 			productName = AgentHub;
@@ -206,6 +209,7 @@
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
 				7B03D9402F14D66700C36AA3 /* XCLocalSwiftPackageReference "modules/AgentHubCore" */,
+				7B03DA002F18A10000C36AA3 /* XCLocalSwiftPackageReference "modules/Ghostty" */,
 				7B03D94E2F18A00000C36AA3 /* XCRemoteSwiftPackageReference "Sparkle" */,
 			);
 			preferredProjectObjectVersion = 77;
@@ -592,6 +596,10 @@
 			isa = XCLocalSwiftPackageReference;
 			relativePath = modules/AgentHubCore;
 		};
+		7B03DA002F18A10000C36AA3 /* XCLocalSwiftPackageReference "modules/Ghostty" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = modules/Ghostty;
+		};
 /* End XCLocalSwiftPackageReference section */
 
 /* Begin XCRemoteSwiftPackageReference section */
@@ -614,6 +622,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 7B03D94E2F18A00000C36AA3 /* XCRemoteSwiftPackageReference "Sparkle" */;
 			productName = Sparkle;
+		};
+		7B03DA012F18A10000C36AA3 /* Ghostty */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 7B03DA002F18A10000C36AA3 /* XCLocalSwiftPackageReference "modules/Ghostty" */;
+			productName = Ghostty;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/app/AgentHub/AgentHubApp.swift
+++ b/app/AgentHub/AgentHubApp.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 import AgentHubCore
+import Ghostty
 import UserNotifications
 import CoreText
 
@@ -15,8 +16,14 @@ import CoreText
 /// Handles app lifecycle events for process cleanup
 @MainActor
 class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDelegate {
-  /// Shared provider instance - created here so it's available for lifecycle events
-  let provider = AgentHubProvider()
+  /// Shared provider instance - created here so it's available for lifecycle events.
+  /// Wires the Ghostty-aware terminal surface factory; `AgentHubCore` falls back
+  /// to the regular SwiftTerm surface when no provider is supplied.
+  let provider = AgentHubProvider(
+    terminalSurfaceFactory: DefaultEmbeddedTerminalSurfaceFactory(
+      ghosttyProvider: { AgentHubGhosttyTerminalSurface() }
+    )
+  )
 
   /// Update controller for Sparkle auto-updates
   let updateController = UpdateController()

--- a/app/modules/AgentHubCore/Package.resolved
+++ b/app/modules/AgentHubCore/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "048fdc7eabbe5ec84600004f7df71198287fc1f04fda1b094732ae52d9cf8ebb",
+  "originHash" : "2511505667b950e1859a2260088780e371095ebeab5f7c64eb621a2e3bc062d7",
   "pins" : [
     {
       "identity" : "beautiful-mermaid-swift",
@@ -62,15 +62,6 @@
       "state" : {
         "revision" : "92efb78b73a8b665ee74bacfb0f1f5b17bbe1b38",
         "version" : "0.1.0"
-      }
-    },
-    {
-      "identity" : "ghosttyswift",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/jamesrochabrun/GhosttySwift",
-      "state" : {
-        "revision" : "09013e66d2ee1854519367824bdf0197a81e4e2e",
-        "version" : "1.0.3"
       }
     },
     {

--- a/app/modules/AgentHubCore/Package.swift
+++ b/app/modules/AgentHubCore/Package.swift
@@ -20,7 +20,6 @@ let package = Package(
   dependencies: [
     .package(path: "../AgentHubGitHub"),
     .package(path: "../Storybook"),
-    .package(url: "https://github.com/jamesrochabrun/GhosttySwift", exact: "1.0.3"),
     .package(url: "https://github.com/jamesrochabrun/Canvas", from: "1.2.0"),
     .package(url: "https://github.com/jamesrochabrun/PierreDiffsSwift", exact: "1.1.7"),
     .package(url: "https://github.com/jamesrochabrun/SwiftTerm", exact: "1.13.0-agenthub.1"),
@@ -46,7 +45,6 @@ let package = Package(
         "ClaudeCodeClient",
         .product(name: "AgentHubGitHub", package: "AgentHubGitHub"),
         .product(name: "Storybook", package: "Storybook"),
-        .product(name: "GhosttySwift", package: "GhosttySwift"),
         .product(name: "Canvas", package: "Canvas"),
         .product(name: "PierreDiffsSwift", package: "PierreDiffsSwift"),
         .product(name: "SwiftTerm", package: "SwiftTerm"),
@@ -80,7 +78,6 @@ let package = Package(
       dependencies: [
         "AgentHubCore",
         "ClaudeCodeClient",
-        .product(name: "GhosttySwift", package: "GhosttySwift"),
       ],
       path: "Tests/AgentHubTests",
       swiftSettings: [

--- a/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubProvider.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubProvider.swift
@@ -40,6 +40,12 @@ public final class AgentHubProvider {
   public let configuration: AgentHubConfiguration
   public let terminalBackend: EmbeddedTerminalBackend
 
+  /// Factory used to construct embedded terminal surfaces for the chosen backend.
+  /// The app target injects a Ghostty-aware factory; tests and standalone uses
+  /// of `AgentHubCore` get the default factory which falls back to the regular
+  /// SwiftTerm surface when `.ghostty` is selected.
+  public let terminalSurfaceFactory: any EmbeddedTerminalSurfaceFactory
+
   // MARK: - Lazy Services
 
   /// Monitor service for tracking CLI sessions
@@ -189,10 +195,19 @@ public final class AgentHubProvider {
   // MARK: - Initialization
 
   /// Creates a provider with the specified configuration
-  /// - Parameter configuration: Configuration for services. Defaults to `.default`
-  public init(configuration: AgentHubConfiguration = .default) {
+  /// - Parameters:
+  ///   - configuration: Configuration for services. Defaults to `.default`
+  ///   - terminalSurfaceFactory: Optional factory override. Defaults to a
+  ///     parameterless `DefaultEmbeddedTerminalSurfaceFactory()` which falls
+  ///     back to the regular backend when `.ghostty` is selected. The app
+  ///     target should pass a Ghostty-aware factory.
+  public init(
+    configuration: AgentHubConfiguration = .default,
+    terminalSurfaceFactory: any EmbeddedTerminalSurfaceFactory = DefaultEmbeddedTerminalSurfaceFactory()
+  ) {
     self.configuration = configuration
     self.terminalBackend = .storedPreference
+    self.terminalSurfaceFactory = terminalSurfaceFactory
 
     // Persist developer-provided commands to UserDefaults
     let defaults = UserDefaults.standard
@@ -301,6 +316,7 @@ public final class AgentHubProvider {
       webPreviewCandidateService: webPreviewCandidateService,
       approvalClaimStore: claimStore,
       hookInstaller: installer,
+      terminalSurfaceFactory: terminalSurfaceFactory,
       terminalBackend: terminalBackend,
       terminalWorkspaceStore: metadataStore
     )

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/TerminalProcessRegistry.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/TerminalProcessRegistry.swift
@@ -8,8 +8,8 @@
 import Darwin
 import Foundation
 
-final class TerminalProcessRegistry {
-  static let shared = TerminalProcessRegistry()
+public final class TerminalProcessRegistry {
+  public static let shared = TerminalProcessRegistry()
 
   private let lock = NSLock()
   private let storageKey = "AgentHub.TerminalProcessRegistry"
@@ -19,7 +19,7 @@ final class TerminalProcessRegistry {
     load()
   }
 
-  func register(pid: pid_t) {
+  public func register(pid: pid_t) {
     guard pid > 0 else { return }
     lock.lock()
     entries[pid] = Date().timeIntervalSince1970
@@ -28,7 +28,7 @@ final class TerminalProcessRegistry {
     lock.unlock()
   }
 
-  func unregister(pid: pid_t) {
+  public func unregister(pid: pid_t) {
     guard pid > 0 else { return }
     lock.lock()
     entries.removeValue(forKey: pid)

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/EmbeddedTerminalLaunchBuilder.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/EmbeddedTerminalLaunchBuilder.swift
@@ -5,19 +5,24 @@
 
 import Foundation
 
-struct EmbeddedTerminalLaunch {
-  let shellCommand: String
-  let environment: [String: String]
+public struct EmbeddedTerminalLaunch {
+  public let shellCommand: String
+  public let environment: [String: String]
 
-  var swiftTermExecutable: String { "/bin/bash" }
-  var swiftTermArguments: [String] { ["-c", shellCommand] }
-  var swiftTermEnvironment: [String] {
+  public init(shellCommand: String, environment: [String: String]) {
+    self.shellCommand = shellCommand
+    self.environment = environment
+  }
+
+  public var swiftTermExecutable: String { "/bin/bash" }
+  public var swiftTermArguments: [String] { ["-c", shellCommand] }
+  public var swiftTermEnvironment: [String] {
     var swiftTermEnvironment = environment
     swiftTermEnvironment["TERM_PROGRAM"] = "SwiftTerm"
     return swiftTermEnvironment.map { "\($0.key)=\($0.value)" }
   }
 
-  var ghosttyCommand: String {
+  public var ghosttyCommand: String {
     "/bin/bash -c \(Self.shellEscapeSingleQuotedAllowingNewlines(shellCommand))"
   }
 
@@ -27,10 +32,10 @@ struct EmbeddedTerminalLaunch {
   }
 }
 
-enum EmbeddedTerminalLaunchError: LocalizedError, Equatable {
+public enum EmbeddedTerminalLaunchError: LocalizedError, Equatable {
   case executableNotFound(String)
 
-  var errorDescription: String? {
+  public var errorDescription: String? {
     switch self {
     case .executableNotFound(let command):
       return "Could not find '\(command)' command."
@@ -38,8 +43,8 @@ enum EmbeddedTerminalLaunchError: LocalizedError, Equatable {
   }
 }
 
-enum EmbeddedTerminalLaunchBuilder {
-  static func cliLaunch(
+public enum EmbeddedTerminalLaunchBuilder {
+  public static func cliLaunch(
     sessionId: String?,
     projectPath: String,
     cliConfiguration: CLICommandConfiguration,
@@ -97,7 +102,7 @@ enum EmbeddedTerminalLaunchBuilder {
     return .success(EmbeddedTerminalLaunch(shellCommand: shellCommand, environment: environment))
   }
 
-  static func shellLaunch(
+  public static func shellLaunch(
     projectPath: String,
     shellPath: String? = nil
   ) -> EmbeddedTerminalLaunch {

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/EmbeddedTerminalSurface.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/EmbeddedTerminalSurface.swift
@@ -61,12 +61,24 @@ public protocol EmbeddedTerminalSurfaceFactory {
 }
 
 public struct DefaultEmbeddedTerminalSurfaceFactory: EmbeddedTerminalSurfaceFactory {
-  public init() {}
+  private let ghosttyProvider: (@MainActor () -> any EmbeddedTerminalSurface)?
+
+  /// - Parameter ghosttyProvider: Closure that builds a Ghostty-backed surface.
+  ///   Wired by the app target after importing the `Ghostty` module. When
+  ///   omitted (e.g. unit tests, or builds where the Ghostty module is absent),
+  ///   selecting `.ghostty` silently falls back to the regular SwiftTerm
+  ///   surface so core code keeps functioning standalone.
+  public init(ghosttyProvider: (@MainActor () -> any EmbeddedTerminalSurface)? = nil) {
+    self.ghosttyProvider = ghosttyProvider
+  }
 
   public func makeSurface(for backend: EmbeddedTerminalBackend) -> any EmbeddedTerminalSurface {
     switch backend {
     case .ghostty:
-      return AgentHubGhosttyTerminalSurface()
+      if let ghosttyProvider {
+        return ghosttyProvider()
+      }
+      return TerminalContainerView()
     case .regular:
       return TerminalContainerView()
     }

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/EmbeddedTerminalView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/EmbeddedTerminalView.swift
@@ -187,7 +187,8 @@ public struct EmbeddedTerminalView: NSViewRepresentable {
       return existing
     }
 
-    let terminal = DefaultEmbeddedTerminalSurfaceFactory().makeSurface(for: .storedPreference)
+    let factory = agentHub?.terminalSurfaceFactory ?? DefaultEmbeddedTerminalSurfaceFactory()
+    let terminal = factory.makeSurface(for: .storedPreference)
     terminal.configure(
       sessionId: sessionId,
       projectPath: projectPath,

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/TerminalPromptSubmissionPayload.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/TerminalPromptSubmissionPayload.swift
@@ -7,12 +7,12 @@
 
 import Foundation
 
-enum TerminalPromptSubmissionPayload {
+public enum TerminalPromptSubmissionPayload {
   private static let carriageReturn: UInt8 = 0x0D
   private static let bracketedPasteStart: [UInt8] = [0x1B, 0x5B, 0x32, 0x30, 0x30, 0x7E]
   private static let bracketedPasteEnd: [UInt8] = [0x1B, 0x5B, 0x32, 0x30, 0x31, 0x7E]
 
-  static func bytes(prompt: String, bracketedPasteMode: Bool) -> [UInt8] {
+  public static func bytes(prompt: String, bracketedPasteMode: Bool) -> [UInt8] {
     var payload = textBytes(prompt: prompt, bracketedPasteMode: bracketedPasteMode)
     payload.append(carriageReturn)
     return payload
@@ -21,7 +21,7 @@ enum TerminalPromptSubmissionPayload {
   /// Returns the prompt wrapped in bracketed-paste markers (when active)
   /// but WITHOUT the trailing carriage return. Callers that need a delay
   /// between paste-end and submit can send CR separately.
-  static func textBytes(prompt: String, bracketedPasteMode: Bool) -> [UInt8] {
+  public static func textBytes(prompt: String, bracketedPasteMode: Bool) -> [UInt8] {
     var payload: [UInt8] = []
     if bracketedPasteMode {
       payload.append(contentsOf: bracketedPasteStart)
@@ -33,7 +33,7 @@ enum TerminalPromptSubmissionPayload {
     return payload
   }
 
-  static func bracketedPasteTextBytes(prompt: String) -> [UInt8] {
+  public static func bracketedPasteTextBytes(prompt: String) -> [UInt8] {
     textBytes(prompt: prompt, bracketedPasteMode: true)
   }
 }

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/TerminalSubmitInterception.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/TerminalSubmitInterception.swift
@@ -7,22 +7,22 @@
 
 import AppKit
 
-enum TerminalReturnKeyAction: Equatable {
+public enum TerminalReturnKeyAction: Equatable {
   case passthrough
   case newline
   case submit
   case systemSubmit
 }
 
-enum TerminalSubmitDispatch: Equatable {
+public enum TerminalSubmitDispatch: Equatable {
   case passthrough
   case newline
   case submit
   case appendContextAndSubmit(String)
 }
 
-enum TerminalSubmitInterception {
-  static func keyAction(
+public enum TerminalSubmitInterception {
+  public static func keyAction(
     shortcut: NewlineShortcut,
     isReturn: Bool,
     flags: NSEvent.ModifierFlags
@@ -43,7 +43,7 @@ enum TerminalSubmitInterception {
     }
   }
 
-  static func dispatch(
+  public static func dispatch(
     for action: TerminalReturnKeyAction,
     queuedContextPrompt: String?
   ) -> TerminalSubmitDispatch {

--- a/app/modules/AgentHubCore/Sources/AgentHub/Utils/AppLogger.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Utils/AppLogger.swift
@@ -15,39 +15,39 @@ import os
 /// AppLogger.git.info("Found \(count) changed files")
 /// AppLogger.watcher.warning("Stale watcher detected")
 /// ```
-enum AppLogger {
+public enum AppLogger {
   private static let subsystem = "com.agenthub"
 
   /// Session-related logging (parsing, monitoring, lifecycle)
-  static let session = Logger(subsystem: subsystem, category: "Session")
+  public static let session = Logger(subsystem: subsystem, category: "Session")
 
   /// Git operations (diff, worktree, commands)
-  static let git = Logger(subsystem: subsystem, category: "Git")
+  public static let git = Logger(subsystem: subsystem, category: "Git")
 
   /// Intelligence/AI stream processing
-  static let intelligence = Logger(subsystem: subsystem, category: "Intelligence")
+  public static let intelligence = Logger(subsystem: subsystem, category: "Intelligence")
 
   /// Orchestration and worktree execution
-  static let orchestration = Logger(subsystem: subsystem, category: "Orchestration")
+  public static let orchestration = Logger(subsystem: subsystem, category: "Orchestration")
 
   /// Stats and metrics collection
-  static let stats = Logger(subsystem: subsystem, category: "Stats")
+  public static let stats = Logger(subsystem: subsystem, category: "Stats")
 
   /// Search and indexing
-  static let search = Logger(subsystem: subsystem, category: "Search")
+  public static let search = Logger(subsystem: subsystem, category: "Search")
 
   /// File watching and monitoring
-  static let watcher = Logger(subsystem: subsystem, category: "Watcher")
+  public static let watcher = Logger(subsystem: subsystem, category: "Watcher")
 
   /// UI-related logging
-  static let ui = Logger(subsystem: subsystem, category: "UI")
+  public static let ui = Logger(subsystem: subsystem, category: "UI")
 
   /// Dev server lifecycle and output
-  static let devServer = Logger(subsystem: subsystem, category: "DevServer")
+  public static let devServer = Logger(subsystem: subsystem, category: "DevServer")
 
   /// iOS Simulator management
-  static let simulator = Logger(subsystem: subsystem, category: "Simulator")
+  public static let simulator = Logger(subsystem: subsystem, category: "Simulator")
 
   /// GitHub CLI operations (PRs, issues, reviews, checks)
-  static let github = Logger(subsystem: subsystem, category: "GitHub")
+  public static let github = Logger(subsystem: subsystem, category: "GitHub")
 }

--- a/app/modules/Ghostty/Package.swift
+++ b/app/modules/Ghostty/Package.swift
@@ -1,0 +1,41 @@
+// swift-tools-version: 6.0
+
+import PackageDescription
+
+let package = Package(
+  name: "Ghostty",
+  platforms: [
+    .macOS(.v14)
+  ],
+  products: [
+    .library(
+      name: "Ghostty",
+      targets: ["Ghostty"]
+    ),
+  ],
+  dependencies: [
+    .package(path: "../AgentHubCore"),
+    .package(url: "https://github.com/jamesrochabrun/GhosttySwift", exact: "1.0.3"),
+  ],
+  targets: [
+    .target(
+      name: "Ghostty",
+      dependencies: [
+        .product(name: "AgentHubCore", package: "AgentHubCore"),
+        .product(name: "GhosttySwift", package: "GhosttySwift"),
+      ],
+      path: "Sources/Ghostty",
+      swiftSettings: [
+        .swiftLanguageMode(.v5)
+      ]
+    ),
+    .testTarget(
+      name: "GhosttyTests",
+      dependencies: ["Ghostty"],
+      path: "Tests/GhosttyTests",
+      swiftSettings: [
+        .swiftLanguageMode(.v5)
+      ]
+    ),
+  ]
+)

--- a/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyRuntimeLogging.swift
+++ b/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyRuntimeLogging.swift
@@ -1,0 +1,22 @@
+//
+//  AgentHubGhosttyRuntimeLogging.swift
+//  AgentHub
+//
+
+import Darwin
+import Foundation
+
+enum AgentHubGhosttyRuntimeLogging {
+  static let environmentKey = "GHOSTTY_LOG"
+  private static let quietDefaultValue = "false"
+
+  static func applyQuietDefault(
+    environment: [String: String] = ProcessInfo.processInfo.environment,
+    setEnvironment: (String, String, Int32) -> Int32 = { key, value, overwrite in
+      setenv(key, value, overwrite)
+    }
+  ) {
+    guard environment[environmentKey] == nil else { return }
+    _ = setEnvironment(environmentKey, quietDefaultValue, 0)
+  }
+}

--- a/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalShortcut.swift
+++ b/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalShortcut.swift
@@ -6,7 +6,7 @@
 import AppKit
 import GhosttySwift
 
-enum AgentHubGhosttyTerminalShortcut: Equatable {
+public enum AgentHubGhosttyTerminalShortcut: Equatable {
   case startSearch
   case searchNext
   case searchPrevious
@@ -16,7 +16,7 @@ enum AgentHubGhosttyTerminalShortcut: Equatable {
   case focusPanel(TerminalPanelNavigationDirection)
   case selectTab(TerminalTabNavigationDirection)
 
-  static func action(for event: NSEvent) -> AgentHubGhosttyTerminalShortcut? {
+  public static func action(for event: NSEvent) -> AgentHubGhosttyTerminalShortcut? {
     action(
       keyCode: event.keyCode,
       charactersIgnoringModifiers: event.charactersIgnoringModifiers,
@@ -24,7 +24,7 @@ enum AgentHubGhosttyTerminalShortcut: Equatable {
     )
   }
 
-  static func action(
+  public static func action(
     keyCode: UInt16,
     charactersIgnoringModifiers: String?,
     modifierFlags: NSEvent.ModifierFlags

--- a/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalSurface.swift
+++ b/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalSurface.swift
@@ -373,6 +373,7 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
     protectsPrimaryTab: Bool
   ) {
     do {
+      AgentHubGhosttyRuntimeLogging.applyQuietDefault()
       let session = try TerminalSession(
         configPath: GhosttyConfigPathResolver.configuredPath(),
         primaryConfiguration: primaryConfiguration,

--- a/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalSurface.swift
+++ b/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalSurface.swift
@@ -3,12 +3,13 @@
 //  AgentHub
 //
 
+import AgentHubCore
 import AppKit
 import GhosttySwift
 import SwiftUI
 
 @MainActor
-final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurface {
+public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurface {
   private struct PendingMount {
     let command: String
     let environment: [String: String]
@@ -35,45 +36,45 @@ final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurface {
   private static let terminalPaneDividerSize: CGFloat = 1
   private static let terminalTabStripHeight: CGFloat = 24
 
-  var onUserInteraction: (() -> Void)?
-  var onRequestShowEditor: (() -> Void)?
-  var consumeQueuedWebPreviewContextOnSubmit: (() -> String?)?
-  var onWorkspaceChanged: ((TerminalWorkspaceSnapshot) -> Void)?
+  public var onUserInteraction: (() -> Void)?
+  public var onRequestShowEditor: (() -> Void)?
+  public var consumeQueuedWebPreviewContextOnSubmit: (() -> String?)?
+  public var onWorkspaceChanged: ((TerminalWorkspaceSnapshot) -> Void)?
   private var terminalSessionKey: String?
   private weak var sessionViewModel: CLISessionsViewModel?
   var terminateProcessCallCount = 0
 
-  var view: NSView { self }
+  public var view: NSView { self }
 
-  var currentProcessPID: Int32? {
+  public var currentProcessPID: Int32? {
     protectedAgentController?.foregroundProcessID ?? activeController?.foregroundProcessID
   }
 
-  override var isOpaque: Bool { false }
+  public override var isOpaque: Bool { false }
 
-  override init(frame frameRect: NSRect) {
+  public override init(frame frameRect: NSRect) {
     super.init(frame: frameRect)
     makeViewTransparent(self)
   }
 
-  required init?(coder: NSCoder) {
+  public required init?(coder: NSCoder) {
     super.init(coder: coder)
     makeViewTransparent(self)
   }
 
-  override func performKeyEquivalent(with event: NSEvent) -> Bool {
+  public override func performKeyEquivalent(with event: NSEvent) -> Bool {
     if handleKeyDown(event) {
       return true
     }
     return super.performKeyEquivalent(with: event)
   }
 
-  override func viewDidMoveToWindow() {
+  public override func viewDidMoveToWindow() {
     super.viewDidMoveToWindow()
     mountPendingGhosttySessionIfReady()
   }
 
-  override func layout() {
+  public override func layout() {
     super.layout()
     mountPendingGhosttySessionIfReady()
   }
@@ -89,12 +90,12 @@ final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurface {
     }
   }
 
-  func updateContext(terminalSessionKey: String?, sessionViewModel: CLISessionsViewModel?) {
+  public func updateContext(terminalSessionKey: String?, sessionViewModel: CLISessionsViewModel?) {
     self.terminalSessionKey = terminalSessionKey
     self.sessionViewModel = sessionViewModel
   }
 
-  func configure(
+  public func configure(
     sessionId: String?,
     projectPath: String,
     cliConfiguration: CLICommandConfiguration,
@@ -137,7 +138,7 @@ final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurface {
     }
   }
 
-  func configureShell(projectPath: String, isDark: Bool, shellPath: String?) {
+  public func configureShell(projectPath: String, isDark: Bool, shellPath: String?) {
     guard !isConfigured else { return }
     isConfigured = true
     self.projectPath = projectPath
@@ -157,7 +158,7 @@ final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurface {
     )
   }
 
-  func restart(sessionId: String?, projectPath: String, cliConfiguration: CLICommandConfiguration) {
+  public func restart(sessionId: String?, projectPath: String, cliConfiguration: CLICommandConfiguration) {
     terminateProcess()
     removeMountedContent()
     terminalSession = nil
@@ -182,18 +183,18 @@ final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurface {
     )
   }
 
-  func terminateProcess() {
+  public func terminateProcess() {
     terminateProcessCallCount += 1
     terminalSession?.requestCloseAll()
     cancelPIDRegistrationTasks()
     unregisterAllPIDs()
   }
 
-  func resetPromptDeliveryFlag() {
+  public func resetPromptDeliveryFlag() {
     hasDeliveredInitialPrompt = false
   }
 
-  func sendPromptIfNeeded(_ prompt: String) {
+  public func sendPromptIfNeeded(_ prompt: String) {
     guard !hasDeliveredInitialPrompt else { return }
     hasDeliveredInitialPrompt = true
     focusProtectedAgentTab()
@@ -226,7 +227,7 @@ final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurface {
     }
   }
 
-  func submitPromptImmediately(_ prompt: String) -> Bool {
+  public func submitPromptImmediately(_ prompt: String) -> Bool {
     guard protectedAgentController != nil else { return false }
     focusProtectedAgentTab()
     sendBracketedPasteText(prompt, to: protectedAgentController)
@@ -238,11 +239,11 @@ final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurface {
     return true
   }
 
-  func typeText(_ text: String) {
+  public func typeText(_ text: String) {
     activeController?.sendText(text)
   }
 
-  func typeInitialTextIfNeeded(_ text: String) {
+  public func typeInitialTextIfNeeded(_ text: String) {
     guard !text.isEmpty else { return }
     guard !hasPrefilledInitialInputText else { return }
     hasPrefilledInitialInputText = true
@@ -250,15 +251,15 @@ final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurface {
     protectedAgentController?.sendText(text)
   }
 
-  func syncAppearance(isDark: Bool, fontSize: CGFloat, fontFamily: String, theme: RuntimeTheme?) {
+  public func syncAppearance(isDark: Bool, fontSize: CGFloat, fontFamily: String, theme: RuntimeTheme?) {
     // Ghostty owns live appearance through its config. Font size is applied at surface creation.
   }
 
-  func focus() {
+  public func focus() {
     activeController?.focusTerminal()
   }
 
-  func captureWorkspaceSnapshot() -> TerminalWorkspaceSnapshot? {
+  public func captureWorkspaceSnapshot() -> TerminalWorkspaceSnapshot? {
     guard let terminalSession else { return nil }
 
     let panels = terminalSession.panels.map { panel in
@@ -288,7 +289,7 @@ final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurface {
     )
   }
 
-  func restoreWorkspaceSnapshot(_ snapshot: TerminalWorkspaceSnapshot) {
+  public func restoreWorkspaceSnapshot(_ snapshot: TerminalWorkspaceSnapshot) {
     guard let terminalSession else {
       pendingWorkspaceSnapshot = snapshot
       return

--- a/app/modules/Ghostty/Sources/Ghostty/GhosttyConfigPathResolver.swift
+++ b/app/modules/Ghostty/Sources/Ghostty/GhosttyConfigPathResolver.swift
@@ -3,10 +3,11 @@
 //  AgentHub
 //
 
+import AgentHubCore
 import Foundation
 
-enum GhosttyConfigPathResolver {
-  static func configuredPath(
+public enum GhosttyConfigPathResolver {
+  public static func configuredPath(
     defaults: UserDefaults = .standard,
     fileManager: FileManager = .default
   ) -> String? {

--- a/app/modules/Ghostty/Tests/GhosttyTests/AgentHubGhosttyRuntimeLoggingTests.swift
+++ b/app/modules/Ghostty/Tests/GhosttyTests/AgentHubGhosttyRuntimeLoggingTests.swift
@@ -1,0 +1,33 @@
+import Testing
+@testable import Ghostty
+
+@Suite("AgentHub Ghostty runtime logging")
+struct AgentHubGhosttyRuntimeLoggingTests {
+  @Test("Quiet default disables Ghostty runtime logging when unset")
+  func appliesQuietDefaultWhenUnset() {
+    var recorded: (key: String, value: String, overwrite: Int32)?
+
+    AgentHubGhosttyRuntimeLogging.applyQuietDefault(environment: [:]) { key, value, overwrite in
+      recorded = (key, value, overwrite)
+      return 0
+    }
+
+    #expect(recorded?.key == "GHOSTTY_LOG")
+    #expect(recorded?.value == "false")
+    #expect(recorded?.overwrite == 0)
+  }
+
+  @Test("Explicit Ghostty runtime logging configuration is preserved")
+  func preservesExplicitLoggingConfiguration() {
+    var didSetEnvironment = false
+
+    AgentHubGhosttyRuntimeLogging.applyQuietDefault(
+      environment: ["GHOSTTY_LOG": "stderr,macos"]
+    ) { _, _, _ in
+      didSetEnvironment = true
+      return 0
+    }
+
+    #expect(didSetEnvironment == false)
+  }
+}

--- a/app/modules/Ghostty/Tests/GhosttyTests/AgentHubGhosttyTerminalShortcutTests.swift
+++ b/app/modules/Ghostty/Tests/GhosttyTests/AgentHubGhosttyTerminalShortcutTests.swift
@@ -2,7 +2,7 @@ import AppKit
 import GhosttySwift
 import Testing
 
-@testable import AgentHubCore
+@testable import Ghostty
 
 @Suite("AgentHub Ghostty terminal shortcuts")
 struct AgentHubGhosttyTerminalShortcutTests {

--- a/app/modules/Ghostty/Tests/GhosttyTests/GhosttyConfigPathResolverTests.swift
+++ b/app/modules/Ghostty/Tests/GhosttyTests/GhosttyConfigPathResolverTests.swift
@@ -1,7 +1,8 @@
+import AgentHubCore
 import Foundation
 import Testing
 
-@testable import AgentHubCore
+@testable import Ghostty
 
 @Suite("Ghostty config path resolver")
 struct GhosttyConfigPathResolverTests {


### PR DESCRIPTION
## Summary
- Mirrors the `Storybook` pattern: new `app/modules/Ghostty/` package owns the GhosttySwift dependency and all Ghostty-specific code (surface, shortcut enum, config-path resolver). `AgentHubCore` no longer imports `GhosttySwift`.
- `DefaultEmbeddedTerminalSurfaceFactory` now takes an optional `ghosttyProvider` closure; missing providers (tests, standalone core) silently fall back to the regular SwiftTerm surface so core builds in isolation.
- App target injects the Ghostty provider once at startup via `AgentHubProvider(terminalSurfaceFactory:)`. Promoted the shared terminal submit helpers needed by the Ghostty module so both backends keep the same submit/interception behavior.
- Embedded Ghostty sessions now default `GHOSTTY_LOG=false` unless the developer explicitly sets `GHOSTTY_LOG`, which suppresses noisy Ghostty runtime logs during Claude/Codex streaming while preserving an override for debugging.

## Test plan
- [x] `xcodebuild -project app/AgentHub.xcodeproj -scheme AgentHub build -quiet`
- [x] `xcodebuild test -project app/AgentHub.xcodeproj -scheme AgentHub -only-testing:AgentHubTests/TerminalSubmitInterceptionTests -only-testing:AgentHubTests/TerminalPromptSubmissionPayloadTests -quiet`
- [x] Dependency hygiene: `rg "import GhosttySwift|AgentHubGhostty|GhosttyConfigPathResolver" app/modules/AgentHubCore/` returns no matches.
- [ ] Full suite: `xcodebuild -project app/AgentHub.xcodeproj -scheme AgentHub test`
- [ ] Smoke test in the running app:
  - [ ] Settings → Appearance → Terminal Backend offers `Ghostty` and `Regular`.
  - [ ] Pick `Ghostty`, relaunch, verify Cmd+T tabs / Cmd+D pane / Cmd+F search work.
  - [ ] Verify Claude/Codex streaming no longer floods the console with Ghostty focus/mailbox/runtime logs unless `GHOSTTY_LOG` is explicitly set.
  - [ ] Switch to `Regular`, relaunch, verify SwiftTerm sessions still launch.
  - [ ] Custom Ghostty config path under Settings is honored.

## Notes
- Direct `swift test --package-path app/modules/Ghostty --filter AgentHubGhosttyRuntimeLoggingTests` is still blocked before this package's tests run by the upstream `CodeEditSymbols` `Bundle.module` resource issue.