### PR TITLE
[codex] Add Ghostty-specific theme selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ https://github.com/user-attachments/assets/ee453a78-e417-488a-96c7-20732d1d1f60
 - **Usage stats** — Track token counts, costs, and daily activity per provider (menu bar or popover)
 - **Command palette** — Quick access to sessions, repositories, and actions via Cmd+K
 - **Pending changes preview** — Review Edit/Write/MultiEdit tool diffs before accepting
-- **Custom themes** — 7 bundled space-themed YAML themes (Singularity, Nebula, Helios, Rigel, Vela, Antares, Sentry) with full terminal ANSI palettes, custom backgrounds, and WCAG-compliant contrast; load custom YAML themes with hot-reload
+- **Custom themes** — bundled YAML themes (Singularity, Nebula, Helios, Rigel, Vela, Antares, Sentry, plus a Ghostty-only theme) with terminal ANSI palettes, custom backgrounds where applicable, and WCAG-compliant contrast; load custom YAML themes with hot-reload
 - **Terminal font picker** — Choose from 9 monospace fonts: SF Mono, JetBrains Mono, GeistMono, Fira Code, Cascadia Mono, Source Code Pro, Menlo, Monaco, Courier New
 - **Image & file attachments** — Drag-and-drop files into sessions
 - **Session naming** — Rename any session with custom names (SQLite-backed)

--- a/app/AgentHubTests/ThemeSelectionPolicyTests.swift
+++ b/app/AgentHubTests/ThemeSelectionPolicyTests.swift
@@ -1,0 +1,145 @@
+import AppKit
+import Foundation
+import SwiftUI
+import Testing
+
+@testable import AgentHubCore
+
+@Suite("Theme selection policy", .serialized)
+struct ThemeSelectionPolicyTests {
+
+  @Test("Ghostty backend only exposes the Ghostty bundled YAML theme")
+  func ghosttyBackendOnlyExposesGhosttyTheme() {
+    #expect(ThemeSelectionPolicy.bundledYAMLThemeFileIds(for: .ghostty) == ["ghostty.yaml"])
+  }
+
+  @Test("Regular backend exposes regular bundled YAML themes without Ghostty")
+  func regularBackendHidesGhosttyTheme() {
+    let fileIds = ThemeSelectionPolicy.bundledYAMLThemeFileIds(for: .regular)
+
+    #expect(fileIds.contains("singularity.yaml"))
+    #expect(fileIds.contains("nebula.yaml"))
+    #expect(!fileIds.contains("ghostty.yaml"))
+  }
+
+  @Test("Ghostty theme aliases normalize to ghostty.yaml")
+  func ghosttyThemeAliasesNormalize() {
+    #expect(ThemeSelectionPolicy.matchingBundledYAMLFileId(for: "ghostty") == "ghostty.yaml")
+    #expect(ThemeSelectionPolicy.matchingBundledYAMLFileId(for: "ghostty.yaml") == "ghostty.yaml")
+    #expect(ThemeSelectionPolicy.matchingBundledYAMLFileId(for: "ghostty.yml") == "ghostty.yaml")
+    #expect(ThemeSelectionPolicy.canonicalThemeId(for: "ghostty", backend: .ghostty) == "ghostty.yaml")
+    #expect(ThemeSelectionPolicy.canonicalThemeId(for: "ghostty", backend: .regular) == nil)
+  }
+
+  @Test("Switching to Ghostty preserves previous regular theme and selects Ghostty")
+  func switchingToGhosttyPreservesRegularTheme() throws {
+    let (defaults, suiteName) = try makeDefaults()
+    defer { defaults.removePersistentDomain(forName: suiteName) }
+    defaults.set("rigel.yml", forKey: AgentHubDefaults.selectedTheme)
+
+    let selectedThemeId = ThemeSelectionPolicy.coercePersistedThemeSelection(
+      defaults: defaults,
+      backend: .ghostty
+    )
+
+    #expect(selectedThemeId == "ghostty.yaml")
+    #expect(defaults.string(forKey: AgentHubDefaults.selectedTheme) == "ghostty.yaml")
+    #expect(defaults.string(forKey: AgentHubDefaults.previousNonGhosttyTheme) == "rigel.yaml")
+  }
+
+  @Test("Switching back to Regular restores previous regular theme")
+  func switchingBackToRegularRestoresPreviousTheme() throws {
+    let (defaults, suiteName) = try makeDefaults()
+    defer { defaults.removePersistentDomain(forName: suiteName) }
+    defaults.set("ghostty.yaml", forKey: AgentHubDefaults.selectedTheme)
+    defaults.set("vela.yaml", forKey: AgentHubDefaults.previousNonGhosttyTheme)
+
+    let selectedThemeId = ThemeSelectionPolicy.coercePersistedThemeSelection(
+      defaults: defaults,
+      backend: .regular
+    )
+
+    #expect(selectedThemeId == "vela.yaml")
+    #expect(defaults.string(forKey: AgentHubDefaults.selectedTheme) == "vela.yaml")
+    #expect(defaults.string(forKey: AgentHubDefaults.previousNonGhosttyTheme) == "vela.yaml")
+  }
+
+  @Test("Regular backend falls back to Singularity when previous regular theme is invalid")
+  func regularBackendFallsBackWhenPreviousThemeIsInvalid() throws {
+    let (defaults, suiteName) = try makeDefaults()
+    defer { defaults.removePersistentDomain(forName: suiteName) }
+    defaults.set("ghostty.yaml", forKey: AgentHubDefaults.selectedTheme)
+    defaults.set("not-a-theme", forKey: AgentHubDefaults.previousNonGhosttyTheme)
+
+    let selectedThemeId = ThemeSelectionPolicy.coercePersistedThemeSelection(
+      defaults: defaults,
+      backend: .regular
+    )
+
+    #expect(selectedThemeId == "singularity.yaml")
+    #expect(defaults.string(forKey: AgentHubDefaults.selectedTheme) == "singularity.yaml")
+    #expect(defaults.string(forKey: AgentHubDefaults.previousNonGhosttyTheme) == "singularity.yaml")
+  }
+
+  @Test("Regular backend preserves custom YAML theme selections")
+  func regularBackendPreservesCustomYAMLThemeSelections() throws {
+    let (defaults, suiteName) = try makeDefaults()
+    defer { defaults.removePersistentDomain(forName: suiteName) }
+    defaults.set("custom-theme.yml", forKey: AgentHubDefaults.selectedTheme)
+
+    let selectedThemeId = ThemeSelectionPolicy.coercePersistedThemeSelection(
+      defaults: defaults,
+      backend: .regular
+    )
+
+    #expect(selectedThemeId == "custom-theme.yml")
+    #expect(defaults.string(forKey: AgentHubDefaults.selectedTheme) == "custom-theme.yml")
+    #expect(defaults.string(forKey: AgentHubDefaults.previousNonGhosttyTheme) == "custom-theme.yml")
+  }
+
+  @Test("Ghostty YAML uses Singularity highlights with Ghostty backgrounds")
+  func ghosttyYAMLUsesSingularityHighlightsWithGhosttyBackgrounds() throws {
+    let parser = YAMLThemeParser()
+    let theme = try parser.parse(fileURL: ghosttyThemeURL())
+    let runtime = RuntimeTheme(from: theme, sourceFileName: "ghostty.yaml")
+    let primaryHex = try hexString(from: runtime.brandPrimary)
+    let secondaryHex = try hexString(from: runtime.brandSecondary)
+    let tertiaryHex = try hexString(from: runtime.brandTertiary)
+    let backgroundDarkHex = try hexString(from: #require(runtime.backgroundDark))
+    let backgroundLightHex = try hexString(from: #require(runtime.backgroundLight))
+    let terminalBackgroundHex = try Color.hexString(from: #require(runtime.terminalBackground))
+
+    #expect(primaryHex == "#A0AEC0")
+    #expect(secondaryHex == "#2D3748")
+    #expect(tertiaryHex == "#CBD5E0")
+    #expect(runtime.hasCustomBackgrounds == true)
+    #expect(backgroundDarkHex == "#040F16")
+    #expect(backgroundLightHex == "#FBFBFF")
+    #expect(runtime.expandedContentBackgroundDark == nil)
+    #expect(terminalBackgroundHex == "#040F16")
+    #expect(runtime.terminalAnsiColors?.count == 16)
+  }
+
+  private func makeDefaults() throws -> (UserDefaults, String) {
+    let suiteName = "ThemeSelectionPolicyTests.\(UUID().uuidString)"
+    let defaults = try #require(UserDefaults(suiteName: suiteName))
+    defaults.removePersistentDomain(forName: suiteName)
+    return (defaults, suiteName)
+  }
+
+  private func ghosttyThemeURL() -> URL {
+    appRootURL()
+      .appendingPathComponent("modules/AgentHubCore/Sources/AgentHub/Design/Theme/BundledThemes/ghostty.yaml")
+  }
+
+  private func appRootURL() -> URL {
+    URL(fileURLWithPath: #filePath)
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+  }
+
+  private func hexString(from color: Color) throws -> String {
+    let nsColor = try #require(NSColor(color).usingColorSpace(.sRGB))
+    return Color.hexString(from: nsColor)
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubDefaults.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubDefaults.swift
@@ -190,6 +190,10 @@ public enum AgentHubDefaults {
   /// Type: String (default: "neutral")
   public static let selectedTheme = "\(keyPrefix)theme.selected"
 
+  /// Last non-Ghostty color theme selected before switching to the Ghostty terminal backend
+  /// Type: String (default: unset)
+  public static let previousNonGhosttyTheme = "\(keyPrefix)theme.previousNonGhostty"
+
   /// Custom primary color hex value
   /// Type: String (default: "#7C3AED")
   public static let customPrimaryHex = "\(keyPrefix)theme.customPrimaryHex"

--- a/app/modules/AgentHubCore/Sources/AgentHub/Design/Theme/BundledThemes/ghostty.yaml
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Design/Theme/BundledThemes/ghostty.yaml
@@ -1,0 +1,36 @@
+name: "Ghostty"
+version: "1.2"
+author: "AgentHub"
+description: "Ghostty-only theme with Singularity highlights and soft app backgrounds"
+
+colors:
+  brand:
+    primary: "#A0AEC0"
+    secondary: "#2D3748"
+    tertiary: "#CBD5E0"
+
+  backgrounds:
+    dark: "#040F16"
+    light: "#FBFBFF"
+
+  terminal:
+    background: "#040F16"
+    foreground: "#E2E8F0"
+    cursor: "#A0AEC0"
+    ansi:
+      black: "#0D0D0D"
+      red: "#E06C75"
+      green: "#98C379"
+      yellow: "#ECC94B"
+      blue: "#61AFEF"
+      magenta: "#C678DD"
+      cyan: "#56B6C2"
+      white: "#E2E8F0"
+      brightBlack: "#718096"
+      brightRed: "#E88A91"
+      brightGreen: "#B5D4A1"
+      brightYellow: "#F6E05E"
+      brightBlue: "#8CC8F5"
+      brightMagenta: "#D8A0E8"
+      brightCyan: "#7DCBD5"
+      brightWhite: "#F7FAFC"

--- a/app/modules/AgentHubCore/Sources/AgentHub/Design/Theme/Management/ThemeManager.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Design/Theme/Management/ThemeManager.swift
@@ -89,6 +89,45 @@ public final class ThemeManager {
       expandedContentDark: "#080808"
   """
 
+  private static let bundledGhosttyYAML = """
+  name: "Ghostty"
+  version: "1.2"
+  author: "AgentHub"
+  description: "Ghostty-only theme with Singularity highlights and soft app backgrounds"
+
+  colors:
+    brand:
+      primary: "#A0AEC0"
+      secondary: "#2D3748"
+      tertiary: "#CBD5E0"
+
+    backgrounds:
+      dark: "#040F16"
+      light: "#FBFBFF"
+
+    terminal:
+      background: "#040F16"
+      foreground: "#E2E8F0"
+      cursor: "#A0AEC0"
+      ansi:
+        black: "#0D0D0D"
+        red: "#E06C75"
+        green: "#98C379"
+        yellow: "#ECC94B"
+        blue: "#61AFEF"
+        magenta: "#C678DD"
+        cyan: "#56B6C2"
+        white: "#E2E8F0"
+        brightBlack: "#718096"
+        brightRed: "#E88A91"
+        brightGreen: "#B5D4A1"
+        brightYellow: "#F6E05E"
+        brightBlue: "#8CC8F5"
+        brightMagenta: "#D8A0E8"
+        brightCyan: "#7DCBD5"
+        brightWhite: "#F7FAFC"
+  """
+
   private static let bundledAntaresYAML = """
   name: "Antares"
   version: "1.0"
@@ -150,7 +189,7 @@ public final class ThemeManager {
 
   public init() {
     // Load the correct built-in theme synchronously to avoid flash on launch
-    let saved = UserDefaults.standard.string(forKey: AgentHubDefaults.selectedTheme) ?? "singularity.yaml"
+    let saved = ThemeSelectionPolicy.coercePersistedThemeSelection()
     if let appTheme = AppTheme(rawValue: saved) {
       self.currentTheme = Self.loadBuiltInTheme(appTheme)
     } else {
@@ -312,11 +351,11 @@ public final class ThemeManager {
   // MARK: - Persistence
 
   private func saveCurrentThemeSelection(_ themeId: String) {
-    UserDefaults.standard.set(themeId, forKey: AgentHubDefaults.selectedTheme)
+    ThemeSelectionPolicy.persistThemeSelection(themeId)
   }
 
   public func loadSavedTheme() async {
-    let saved = UserDefaults.standard.string(forKey: AgentHubDefaults.selectedTheme) ?? "singularity.yaml"
+    let saved = ThemeSelectionPolicy.coercePersistedThemeSelection()
 
     // Check if it's a built-in theme
     if let appTheme = AppTheme(rawValue: saved) {
@@ -331,9 +370,10 @@ public final class ThemeManager {
     if FileManager.default.fileExists(atPath: fileURL.path) {
       try? await loadTheme(fileURL: fileURL)
     } else {
-      // Fallback: try singularity, then neutral
-      let fallbackURL = themesDir.appendingPathComponent("singularity.yaml")
-      if FileManager.default.fileExists(atPath: fallbackURL.path) {
+      // Fallback: try the backend default, then neutral
+      let fallbackThemeId = ThemeSelectionPolicy.defaultThemeId(for: .storedPreference)
+      let fallbackURL = themesDir.appendingPathComponent(fallbackThemeId)
+      if fallbackThemeId != saved, FileManager.default.fileExists(atPath: fallbackURL.path) {
         try? await loadTheme(fileURL: fallbackURL)
       } else {
         loadBuiltInTheme(.neutral)
@@ -370,6 +410,7 @@ public final class ThemeManager {
     ("vela", bundledVelaYAML),
     ("antares", bundledAntaresYAML),
     ("singularity", bundledSingularityYAML),
+    ("ghostty", bundledGhosttyYAML),
     ("nebula", bundledNebulaYAML),
     ("helios", bundledHeliosYAML),
   ]

--- a/app/modules/AgentHubCore/Sources/AgentHub/Design/Theme/Management/ThemeSelectionPolicy.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Design/Theme/Management/ThemeSelectionPolicy.swift
@@ -1,0 +1,159 @@
+//
+//  ThemeSelectionPolicy.swift
+//  AgentHub
+//
+//  Backend-aware theme availability and persistence rules.
+//
+
+import Foundation
+
+enum ThemeSelectionPolicy {
+  static let ghosttyThemeId = "ghostty.yaml"
+  static let defaultRegularThemeId = "singularity.yaml"
+
+  static let regularBundledYAMLThemeFileIds = [
+    "sentry.yaml",
+    "rigel.yaml",
+    "vela.yaml",
+    "antares.yaml",
+    "singularity.yaml",
+    "nebula.yaml",
+    "helios.yaml",
+  ]
+
+  static let allBundledYAMLThemeFileIds = regularBundledYAMLThemeFileIds + [ghosttyThemeId]
+
+  static func defaultThemeId(for backend: EmbeddedTerminalBackend) -> String {
+    switch backend {
+    case .ghostty:
+      return ghosttyThemeId
+    case .regular:
+      return defaultRegularThemeId
+    }
+  }
+
+  static func bundledYAMLThemeFileIds(for backend: EmbeddedTerminalBackend) -> [String] {
+    switch backend {
+    case .ghostty:
+      return [ghosttyThemeId]
+    case .regular:
+      return regularBundledYAMLThemeFileIds
+    }
+  }
+
+  static func matchingBundledYAMLFileId(
+    for value: String,
+    in fileIds: [String] = allBundledYAMLThemeFileIds
+  ) -> String? {
+    let normalized = normalizedThemeToken(value)
+    guard !normalized.isEmpty else { return nil }
+
+    return fileIds.first { fileId in
+      let baseName = baseName(for: fileId)
+      return normalized == baseName
+        || normalized == fileId
+        || normalized == "\(baseName).yml"
+    }
+  }
+
+  static func canonicalThemeId(
+    for value: String,
+    backend: EmbeddedTerminalBackend
+  ) -> String? {
+    if backend == .regular {
+      return canonicalRegularThemeId(for: value)
+    }
+
+    return matchingBundledYAMLFileId(
+      for: value,
+      in: bundledYAMLThemeFileIds(for: backend)
+    )
+  }
+
+  @discardableResult
+  static func coercePersistedThemeSelection(
+    defaults: UserDefaults = .standard,
+    backend: EmbeddedTerminalBackend = .storedPreference
+  ) -> String {
+    let savedThemeId = defaults.string(forKey: AgentHubDefaults.selectedTheme)
+
+    switch backend {
+    case .ghostty:
+      if let savedThemeId,
+         !isGhosttyTheme(savedThemeId),
+         let regularThemeId = canonicalRegularThemeId(for: savedThemeId) {
+        defaults.set(regularThemeId, forKey: AgentHubDefaults.previousNonGhosttyTheme)
+      }
+      defaults.set(ghosttyThemeId, forKey: AgentHubDefaults.selectedTheme)
+      return ghosttyThemeId
+
+    case .regular:
+      if let savedThemeId,
+         let regularThemeId = canonicalRegularThemeId(for: savedThemeId) {
+        defaults.set(regularThemeId, forKey: AgentHubDefaults.selectedTheme)
+        defaults.set(regularThemeId, forKey: AgentHubDefaults.previousNonGhosttyTheme)
+        return regularThemeId
+      }
+
+      let previousThemeId = defaults.string(forKey: AgentHubDefaults.previousNonGhosttyTheme)
+      let restoredThemeId = canonicalRegularThemeId(for: previousThemeId) ?? defaultRegularThemeId
+      defaults.set(restoredThemeId, forKey: AgentHubDefaults.selectedTheme)
+      defaults.set(restoredThemeId, forKey: AgentHubDefaults.previousNonGhosttyTheme)
+      return restoredThemeId
+    }
+  }
+
+  static func persistThemeSelection(
+    _ themeId: String,
+    defaults: UserDefaults = .standard,
+    backend: EmbeddedTerminalBackend = .storedPreference
+  ) {
+    switch backend {
+    case .ghostty:
+      defaults.set(ghosttyThemeId, forKey: AgentHubDefaults.selectedTheme)
+    case .regular:
+      let regularThemeId = canonicalRegularThemeId(for: themeId) ?? defaultRegularThemeId
+      defaults.set(regularThemeId, forKey: AgentHubDefaults.selectedTheme)
+      defaults.set(regularThemeId, forKey: AgentHubDefaults.previousNonGhosttyTheme)
+    }
+  }
+
+  static func isGhosttyTheme(_ value: String) -> Bool {
+    matchingBundledYAMLFileId(for: value, in: [ghosttyThemeId]) == ghosttyThemeId
+  }
+
+  private static func canonicalRegularThemeId(for value: String?) -> String? {
+    guard let value else { return nil }
+    let trimmedValue = value.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmedValue.isEmpty, !isGhosttyTheme(trimmedValue) else { return nil }
+
+    if AppTheme(rawValue: trimmedValue) != nil {
+      return trimmedValue
+    }
+
+    if let bundledThemeId = matchingBundledYAMLFileId(for: trimmedValue, in: regularBundledYAMLThemeFileIds) {
+      return bundledThemeId
+    }
+
+    if isYAMLFileName(trimmedValue) {
+      return (trimmedValue as NSString).lastPathComponent
+    }
+
+    return nil
+  }
+
+  private static func normalizedThemeToken(_ value: String) -> String {
+    value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+  }
+
+  private static func baseName(for fileId: String) -> String {
+    fileId
+      .replacingOccurrences(of: ".yaml", with: "")
+      .replacingOccurrences(of: ".yml", with: "")
+  }
+
+  private static func isYAMLFileName(_ value: String) -> Bool {
+    let lowercased = value.lowercased()
+    return lowercased.hasSuffix(".yaml") || lowercased.hasSuffix(".yml")
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/SettingsView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/SettingsView.swift
@@ -81,8 +81,6 @@ public struct SettingsView: View {
   @Environment(\.colorScheme) private var colorScheme
   @Environment(\.runtimeTheme) private var runtimeTheme
   @AppStorage(AgentHubDefaults.selectedTheme) private var selectedThemeId: String = "singularity.yaml"
-  private let defaultThemeId = "singularity.yaml"
-  private let bundledYAMLThemeFileIds = ["sentry.yaml", "rigel.yaml", "vela.yaml", "antares.yaml", "singularity.yaml", "nebula.yaml", "helios.yaml"]
   private let terminalFontFamilies = [
     "SF Mono",
     "JetBrains Mono",
@@ -98,6 +96,14 @@ public struct SettingsView: View {
 
   private var activeTerminalBackend: EmbeddedTerminalBackend {
     agentHub?.terminalBackend ?? .storedPreference
+  }
+
+  private var defaultThemeId: String {
+    ThemeSelectionPolicy.defaultThemeId(for: activeTerminalBackend)
+  }
+
+  private var bundledYAMLThemeFileIds: [String] {
+    ThemeSelectionPolicy.bundledYAMLThemeFileIds(for: activeTerminalBackend)
   }
 
   public init() {}
@@ -467,7 +473,7 @@ public struct SettingsView: View {
         if let matchedFileId = matchingBundledYAMLFileId(for: selectedThemeId) {
           return matchedFileId
         }
-        if let appTheme = AppTheme(rawValue: selectedThemeId) {
+        if activeTerminalBackend == .regular, let appTheme = AppTheme(rawValue: selectedThemeId) {
           return appTheme.rawValue
         }
         return defaultThemeId
@@ -541,22 +547,19 @@ public struct SettingsView: View {
   }
 
   private func ensureSupportedThemeSelection() async {
-    if matchingBundledYAMLFileId(for: selectedThemeId) != nil {
-      await applyThemeSelection(selectedThemeId)
-      return
-    }
-
-    if AppTheme(rawValue: selectedThemeId) != nil {
-      return
-    }
-
-    selectedThemeId = defaultThemeId
-    themeManager.loadBuiltInTheme(.neutral)
+    let themeId = ThemeSelectionPolicy.coercePersistedThemeSelection(backend: activeTerminalBackend)
+    selectedThemeId = themeId
+    await applyThemeSelection(themeId)
   }
 
   private func applyThemeSelection(_ selection: String) async {
+    let selection = ThemeSelectionPolicy.canonicalThemeId(
+      for: selection,
+      backend: activeTerminalBackend
+    ) ?? defaultThemeId
+
     // Handle built-in themes
-    if let appTheme = AppTheme(rawValue: selection) {
+    if activeTerminalBackend == .regular, let appTheme = AppTheme(rawValue: selection) {
       selectedThemeId = appTheme.rawValue
       themeManager.loadBuiltInTheme(appTheme)
       return
@@ -580,16 +583,13 @@ public struct SettingsView: View {
       return
     }
 
-    selectedThemeId = defaultThemeId
     themeManager.loadBuiltInTheme(.neutral)
+    ThemeSelectionPolicy.persistThemeSelection(defaultThemeId, backend: activeTerminalBackend)
+    selectedThemeId = defaultThemeId
   }
 
   private func matchingBundledYAMLFileId(for value: String) -> String? {
-    let normalized = value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-    return bundledYAMLThemeFileIds.first { fileId in
-      let baseName = fileId.replacingOccurrences(of: ".yaml", with: "").replacingOccurrences(of: ".yml", with: "")
-      return normalized == baseName || normalized == fileId || normalized == baseName + ".yml"
-    }
+    ThemeSelectionPolicy.matchingBundledYAMLFileId(for: value, in: bundledYAMLThemeFileIds)
   }
 
   private func yamlThemeDisplayName(_ fileId: String) -> String {


### PR DESCRIPTION
## Summary
- Adds a Ghostty-only bundled YAML theme and filters theme selection so Ghostty exposes only that theme.
- Preserves/restores the previous non-Ghostty theme when switching terminal backends.
- Sets Ghostty app and terminal dark backgrounds to `#040F16`, light background to `#FBFBFF`, and bumps the bundled theme version to reinstall stale local copies.

## Validation
- `git diff --check`
- `xcodebuild test -project app/AgentHub.xcodeproj -scheme AgentHub -destination 'platform=macOS' -only-testing:AgentHubTests/ThemeSelectionPolicyTests`