### PR TITLE
Hide Ghostty terminal backend toggle behind DEBUG, default to Regular

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/EmbeddedTerminalBackend.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/EmbeddedTerminalBackend.swift
@@ -18,7 +18,7 @@ public enum EmbeddedTerminalBackend: Int, CaseIterable, Sendable {
 
   public static var storedPreference: EmbeddedTerminalBackend {
     let rawValue = UserDefaults.standard.object(forKey: AgentHubDefaults.terminalBackend) as? Int
-      ?? EmbeddedTerminalBackend.ghostty.rawValue
-    return EmbeddedTerminalBackend(rawValue: rawValue) ?? .ghostty
+      ?? EmbeddedTerminalBackend.regular.rawValue
+    return EmbeddedTerminalBackend(rawValue: rawValue) ?? .regular
   }
 }

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/SettingsView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/SettingsView.swift
@@ -33,7 +33,7 @@ public struct SettingsView: View {
   private var terminalFontFamily: String = "SF Mono"
 
   @AppStorage(AgentHubDefaults.terminalBackend)
-  private var terminalBackendRawValue: Int = EmbeddedTerminalBackend.ghostty.rawValue
+  private var terminalBackendRawValue: Int = EmbeddedTerminalBackend.regular.rawValue
 
   @AppStorage(AgentHubDefaults.terminalGhosttyConfigPath)
   private var terminalGhosttyConfigPath: String = ""
@@ -263,6 +263,7 @@ public struct SettingsView: View {
       }
 
       Section("Terminal") {
+        #if DEBUG
         Picker("Terminal", selection: terminalBackendSelectionBinding) {
           ForEach(EmbeddedTerminalBackend.allCases, id: \.rawValue) { backend in
             Text(backend.label).tag(backend.rawValue)
@@ -270,6 +271,7 @@ public struct SettingsView: View {
         }
 
         ghosttyConfigFileSetting
+        #endif
 
         Picker("Font", selection: $terminalFontFamily) {
           ForEach(terminalFontFamilies, id: \.self) { family in


### PR DESCRIPTION
## Summary
- Default the embedded terminal backend to `Regular` (SwiftTerm) instead of `Ghostty` for fresh installs — the Ghostty package is currently unstable.
- Wrap the **Terminal** backend Picker and the **Ghostty config file** setting in `#if DEBUG` so they only appear in debug builds.
- Existing users keep their persisted selection (UserDefaults migration is not forced).

## Test plan
- [ ] Debug build: Settings → Appearance → Terminal still shows the backend Picker and "Ghostty config file" row.
- [ ] Release build (`xcodebuild -configuration Release`): Settings → Appearance → Terminal shows only Font / Font size / Newline shortcut / Open files with — no Ghostty rows.
- [ ] Fresh install (clear UserDefaults): app boots with the Regular SwiftTerm backend.
- [ ] Existing install with `terminal.backend = 0` (Ghostty) persisted: selection is preserved.