### PR TITLE
[codex] Fix project hierarchy grouping

### DIFF
--- a/app/AgentHub/AgentHubApp.swift
+++ b/app/AgentHub/AgentHubApp.swift
@@ -10,6 +10,7 @@ import AgentHubCore
 import Ghostty
 import UserNotifications
 import CoreText
+import os
 
 // MARK: - App Delegate
 
@@ -29,12 +30,22 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
   let updateController = UpdateController()
 
   func applicationDidFinishLaunching(_ notification: Notification) {
+    let startupStartedAt = Date()
+    AppLogger.startup.info("[Startup][AppDelegate] applicationDidFinishLaunching start")
+
     UNUserNotificationCenter.current().delegate = self
+
+    let fontsStartedAt = Date()
     registerBundledFonts()
+    AppLogger.startup.info("[Startup][AppDelegate] fonts registered elapsedMs=\(Self.elapsedMilliseconds(since: fontsStartedAt))")
+
     // Sweep any approval hooks left installed by a previous crash/force-quit
     // before sessions start restoring. Re-installs happen naturally as each
     // session begins monitoring.
+    let hookStartedAt = Date()
     provider.reconcileClaudeHooksOnLaunch()
+    AppLogger.startup.info("[Startup][AppDelegate] launch hook reconcile returned elapsedMs=\(Self.elapsedMilliseconds(since: hookStartedAt))")
+    AppLogger.startup.info("[Startup][AppDelegate] applicationDidFinishLaunching end elapsedMs=\(Self.elapsedMilliseconds(since: startupStartedAt))")
   }
 
   /// Register all bundled fonts (Geist, GeistMono, JetBrains Mono)
@@ -60,6 +71,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
         CTFontManagerRegisterFontsForURL(url as CFURL, .process, nil)
       }
     }
+  }
+
+  private static func elapsedMilliseconds(since start: Date) -> Int {
+    Int(Date().timeIntervalSince(start) * 1000)
   }
 
   func applicationWillTerminate(_ notification: Notification) {

--- a/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubProvider.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubProvider.swift
@@ -205,6 +205,9 @@ public final class AgentHubProvider {
     configuration: AgentHubConfiguration = .default,
     terminalSurfaceFactory: any EmbeddedTerminalSurfaceFactory = DefaultEmbeddedTerminalSurfaceFactory()
   ) {
+    AgentHubDefaults.migrateIfNeeded()
+    AppLogger.startup.info("[Startup][Provider] init start")
+
     self.configuration = configuration
     self.terminalBackend = .storedPreference
     self.terminalSurfaceFactory = terminalSurfaceFactory
@@ -228,6 +231,8 @@ public final class AgentHubProvider {
     } else if defaults.string(forKey: AgentHubDefaults.codexCommand) == nil {
       defaults.set("codex", forKey: AgentHubDefaults.codexCommand)
     }
+
+    AppLogger.startup.info("[Startup][Provider] init end")
   }
 
   /// Creates a provider with default configuration
@@ -345,6 +350,8 @@ public final class AgentHubProvider {
   /// those same paths back out as "stale", leaving approval hooks unregistered
   /// until the next repository change. Blocking here removes the race.
   public func reconcileClaudeHooksOnLaunch(timeout: TimeInterval = 3.0) {
+    let startedAt = Date()
+    AppLogger.startup.info("[Startup][ClaudeHook] reconcileOnLaunch start timeout=\(timeout)")
     let claimStore = approvalClaimStore
     let installer = claudeHookInstaller
     let sidecar = claudeHookSidecarWatcher
@@ -357,7 +364,10 @@ public final class AgentHubProvider {
       semaphore.signal()
     }
     if semaphore.wait(timeout: .now() + timeout) == .timedOut {
+      AppLogger.startup.error("[Startup][ClaudeHook] reconcileOnLaunch timed out elapsedMs=\(Self.elapsedMilliseconds(since: startedAt))")
       AppLogger.session.error("[ClaudeHook] reconcileClaudeHooksOnLaunch timed out after \(timeout)s — first session sync may race")
+    } else {
+      AppLogger.startup.info("[Startup][ClaudeHook] reconcileOnLaunch end elapsedMs=\(Self.elapsedMilliseconds(since: startedAt))")
     }
   }
 
@@ -373,6 +383,8 @@ public final class AgentHubProvider {
   /// fast (<100ms for a typical install set); a 3-second cap guards against
   /// deadlock without punishing normal quits.
   public func flushClaudeHooksOnTerminate(timeout: TimeInterval = 3.0) {
+    let startedAt = Date()
+    AppLogger.startup.info("[Startup][ClaudeHook] flushOnTerminate start timeout=\(timeout)")
     let claimStore = approvalClaimStore
     let installer = claudeHookInstaller
     let sidecar = claudeHookSidecarWatcher
@@ -386,8 +398,15 @@ public final class AgentHubProvider {
     }
     let deadline = DispatchTime.now() + timeout
     if semaphore.wait(timeout: deadline) == .timedOut {
+      AppLogger.startup.error("[Startup][ClaudeHook] flushOnTerminate timed out elapsedMs=\(Self.elapsedMilliseconds(since: startedAt))")
       AppLogger.session.error("[ClaudeHook] flushClaudeHooksOnTerminate timed out after \(timeout)s — shutdown may leave stale hook state behind")
+    } else {
+      AppLogger.startup.info("[Startup][ClaudeHook] flushOnTerminate end elapsedMs=\(Self.elapsedMilliseconds(since: startedAt))")
     }
+  }
+
+  private static func elapsedMilliseconds(since start: Date) -> Int {
+    Int(Date().timeIntervalSince(start) * 1000)
   }
 
   /// Terminates all active terminal processes.

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/CLISessionMonitorService.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/CLISessionMonitorService.swift
@@ -59,28 +59,29 @@ public actor CLISessionMonitorService {
   /// - Returns: The created SelectedRepository with detected worktrees
   @discardableResult
   public func addRepository(_ path: String) async -> SelectedRepository? {
-    guard !selectedRepositories.contains(where: { $0.path == path }) else {
-      return selectedRepositories.first { $0.path == path }
+    let result = await appendRepositoryShellIfNeeded(path)
+    guard let repository = result.repository else { return nil }
+
+    if result.didAddRepository {
+      // Scan for sessions in the new repository.
+      // Skip worktree re-detection since we just detected worktrees for this repo.
+      await refreshSessions(skipWorktreeRedetection: true)
     }
 
-    let detection = await RepositoryWorktreeResolver.detectRepository(at: path)
-    if let existing = selectedRepositories.first(where: { $0.path == detection.rootPath }) {
-      return existing
+    return repository
+  }
+
+  /// Adds a repository/worktree shell without scanning provider session files.
+  /// Used by fresh picker adds so the module row can appear before heavier session discovery.
+  @discardableResult
+  public func addRepositoryShell(_ path: String) async -> SelectedRepository? {
+    let startedAt = Date()
+    let result = await appendRepositoryShellIfNeeded(path)
+    guard let repository = result.repository else { return nil }
+    if result.didAddRepository {
+      repositoriesSubject.send(selectedRepositories)
+      AppLogger.startup.info("[Startup][ClaudeMonitor] addRepositoryShell emitted repo=\(repository.path, privacy: .public) worktrees=\(repository.worktrees.count) elapsedMs=\(Self.elapsedMilliseconds(since: startedAt))")
     }
-
-    let repository = SelectedRepository(
-      path: detection.rootPath,
-      worktrees: detection.worktrees,
-      isExpanded: true
-    )
-
-    selectedRepositories.append(repository)
-    invalidateHistoryCache()
-
-    // Scan for sessions in the new repository
-    // Skip worktree re-detection since we just detected worktrees for this repo
-    await refreshSessions(skipWorktreeRedetection: true)
-
     return repository
   }
 
@@ -115,6 +116,30 @@ public actor CLISessionMonitorService {
     // Single refreshSessions call for all repos
     await refreshSessions(skipWorktreeRedetection: true)
     AppLogger.startup.info("[Startup][ClaudeMonitor] addRepositories end repos=\(self.selectedRepositories.count) elapsedMs=\(Self.elapsedMilliseconds(since: startedAt))")
+  }
+
+  private func appendRepositoryShellIfNeeded(_ path: String) async -> (
+    repository: SelectedRepository?,
+    didAddRepository: Bool
+  ) {
+    guard !selectedRepositories.contains(where: { $0.path == path }) else {
+      return (selectedRepositories.first { $0.path == path }, false)
+    }
+
+    let detection = await RepositoryWorktreeResolver.detectRepository(at: path)
+    if let existing = selectedRepositories.first(where: { $0.path == detection.rootPath }) {
+      return (existing, false)
+    }
+
+    let repository = SelectedRepository(
+      path: detection.rootPath,
+      worktrees: detection.worktrees,
+      isExpanded: true
+    )
+
+    selectedRepositories.append(repository)
+    invalidateHistoryCache()
+    return (repository, true)
   }
 
   /// Removes a repository from monitoring

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/CLISessionMonitorService.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/CLISessionMonitorService.swift
@@ -59,17 +59,18 @@ public actor CLISessionMonitorService {
   /// - Returns: The created SelectedRepository with detected worktrees
   @discardableResult
   public func addRepository(_ path: String) async -> SelectedRepository? {
-    // Check if already added
     guard !selectedRepositories.contains(where: { $0.path == path }) else {
       return selectedRepositories.first { $0.path == path }
     }
 
-    // Detect worktrees for this repository
-    let worktrees = await detectWorktrees(at: path)
+    let detection = await RepositoryWorktreeResolver.detectRepository(at: path)
+    if let existing = selectedRepositories.first(where: { $0.path == detection.rootPath }) {
+      return existing
+    }
 
     let repository = SelectedRepository(
-      path: path,
-      worktrees: worktrees,
+      path: detection.rootPath,
+      worktrees: detection.worktrees,
       isExpanded: true
     )
 
@@ -93,13 +94,13 @@ public actor CLISessionMonitorService {
     guard !newPaths.isEmpty else { return }
 
     // Detect worktrees for all new repos in parallel
-    let allWorktrees = await detectWorktreesBatch(repoPaths: newPaths)
+    let detections = await detectRepositoriesBatch(paths: newPaths)
+    var selectedRootPaths = Set(selectedRepositories.map(\.path))
 
-    for path in newPaths {
-      let worktrees = allWorktrees[path] ?? []
+    for detection in detections where selectedRootPaths.insert(detection.rootPath).inserted {
       let repository = SelectedRepository(
-        path: path,
-        worktrees: worktrees,
+        path: detection.rootPath,
+        worktrees: detection.worktrees,
         isExpanded: true
       )
       selectedRepositories.append(repository)
@@ -282,7 +283,11 @@ public actor CLISessionMonitorService {
           // (e.g., session in /repo/subfolder should match worktree at /repo)
           // This must check the CURRENT worktree path, not all repo paths,
           // otherwise sessions from other worktrees would be incorrectly assigned
-          let pathIsSubdirectory = summary.project.hasPrefix(worktreePath + "/")
+          let pathMatchesCurrentWorktree = ProjectHierarchyResolver.isSameOrDescendant(
+            summary.project,
+            of: worktreePath
+          )
+          let pathIsSubdirectory = pathMatchesCurrentWorktree && summary.project != worktreePath
           guard pathIsSubdirectory else { continue }
 
           // Get session's metadata from session file
@@ -369,30 +374,26 @@ public actor CLISessionMonitorService {
   // MARK: - Worktree Detection
 
   private func detectWorktrees(at repoPath: String) async -> [WorktreeBranch] {
-    // Use GitWorktreeDetector to list all worktrees
-    let worktrees = await GitWorktreeDetector.listWorktrees(at: repoPath)
+    await RepositoryWorktreeResolver.detectWorktrees(at: repoPath)
+  }
 
-    if worktrees.isEmpty {
-      // If no worktrees detected, just use the main repo with current branch
-      let info = await GitWorktreeDetector.detectWorktreeInfo(for: repoPath)
+  private func detectRepositoriesBatch(paths: [String]) async -> [RepositoryWorktreeSnapshot] {
+    await withTaskGroup(of: (Int, RepositoryWorktreeSnapshot).self) { group in
+      for (index, path) in paths.enumerated() {
+        group.addTask {
+          let snapshot = await RepositoryWorktreeResolver.detectRepository(at: path)
+          return (index, snapshot)
+        }
+      }
 
-      return [
-        WorktreeBranch(
-          name: info?.branch ?? "main",
-          path: repoPath,
-          isWorktree: false,
-          sessions: []
-        )
-      ]
-    }
+      var results: [(Int, RepositoryWorktreeSnapshot)] = []
+      for await result in group {
+        results.append(result)
+      }
 
-    return worktrees.map { info in
-      WorktreeBranch(
-        name: info.branch ?? URL(fileURLWithPath: info.path).lastPathComponent,
-        path: info.path,
-        isWorktree: info.isWorktree,
-        sessions: []
-      )
+      return results
+        .sorted { $0.0 < $1.0 }
+        .map { $0.1 }
     }
   }
 
@@ -664,7 +665,7 @@ public actor CLISessionMonitorService {
 
   static func matchesMonitoredPath(_ project: String, monitoredPaths: Set<String>) -> Bool {
     monitoredPaths.contains { path in
-      project == path || project.hasPrefix(path + "/")
+      ProjectHierarchyResolver.isSameOrDescendant(project, of: path)
     }
   }
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/CLISessionMonitorService.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/CLISessionMonitorService.swift
@@ -87,14 +87,18 @@ public actor CLISessionMonitorService {
   /// Adds multiple repositories at once, detecting worktrees in parallel and
   /// calling refreshSessions only once at the end (instead of N times).
   public func addRepositories(_ paths: [String]) async {
+    let startedAt = Date()
     // Filter out already-added repos
     let newPaths = paths.filter { path in
       !selectedRepositories.contains(where: { $0.path == path })
     }
+    AppLogger.startup.info("[Startup][ClaudeMonitor] addRepositories requested=\(paths.count) new=\(newPaths.count) existing=\(self.selectedRepositories.count)")
     guard !newPaths.isEmpty else { return }
 
     // Detect worktrees for all new repos in parallel
+    let detectionStartedAt = Date()
     let detections = await detectRepositoriesBatch(paths: newPaths)
+    AppLogger.startup.info("[Startup][ClaudeMonitor] addRepositories detectRepositoryBatch count=\(detections.count) elapsedMs=\(Self.elapsedMilliseconds(since: detectionStartedAt))")
     var selectedRootPaths = Set(selectedRepositories.map(\.path))
 
     for detection in detections where selectedRootPaths.insert(detection.rootPath).inserted {
@@ -110,6 +114,7 @@ public actor CLISessionMonitorService {
 
     // Single refreshSessions call for all repos
     await refreshSessions(skipWorktreeRedetection: true)
+    AppLogger.startup.info("[Startup][ClaudeMonitor] addRepositories end repos=\(self.selectedRepositories.count) elapsedMs=\(Self.elapsedMilliseconds(since: startedAt))")
   }
 
   /// Removes a repository from monitoring
@@ -137,8 +142,11 @@ public actor CLISessionMonitorService {
   /// Refreshes sessions for all selected repositories
   /// - Parameter skipWorktreeRedetection: When true, skips worktree re-detection (used after adding a new repo)
   public func refreshSessions(skipWorktreeRedetection: Bool = false) async {
+    let refreshStartedAt = Date()
+    AppLogger.startup.info("[Startup][ClaudeMonitor] refreshSessions start repos=\(self.selectedRepositories.count) skipWorktreeRedetection=\(skipWorktreeRedetection)")
     guard !selectedRepositories.isEmpty else {
       repositoriesSubject.send([])
+      AppLogger.startup.info("[Startup][ClaudeMonitor] refreshSessions emitted empty repos elapsedMs=\(Self.elapsedMilliseconds(since: refreshStartedAt))")
       return
     }
 
@@ -148,10 +156,12 @@ public actor CLISessionMonitorService {
       AppLogger.git.info("[MonitorService] refreshSessions worktree re-detection start repos=\(repoCount)")
       // Detect worktrees for all repos in parallel (invalidate cache for full refresh)
       worktreeCache.removeAll()
+      let worktreeStartedAt = Date()
       let allWorktrees = await detectWorktreesBatch(
         repoPaths: selectedRepositories.map { $0.path }
       )
       AppLogger.git.info("[MonitorService] refreshSessions worktree re-detection end repos=\(repoCount)")
+      AppLogger.startup.info("[Startup][ClaudeMonitor] refreshSessions worktreeDetection repos=\(repoCount) elapsedMs=\(Self.elapsedMilliseconds(since: worktreeStartedAt))")
 
       // Merge detected worktrees with existing state
       for index in selectedRepositories.indices {
@@ -179,10 +189,14 @@ public actor CLISessionMonitorService {
     let allPaths = getAllMonitoredPaths()
 
     // Parse history for selected paths only
+    let historyStartedAt = Date()
     let sessionSummaries = await parseHistoryForPaths(allPaths)
+    AppLogger.startup.info("[Startup][ClaudeMonitor] refreshSessions parseHistory paths=\(allPaths.count) sessions=\(sessionSummaries.count) elapsedMs=\(Self.elapsedMilliseconds(since: historyStartedAt))")
 
     // Build a map of session ID -> (gitBranch, slug) (read from session files in parallel)
+    let metadataStartedAt = Date()
     let sessionMetadata = await readSessionMetadataBatch(sessionSummaries: sessionSummaries)
+    AppLogger.startup.info("[Startup][ClaudeMonitor] refreshSessions readMetadata requested=\(sessionSummaries.count) found=\(sessionMetadata.count) elapsedMs=\(Self.elapsedMilliseconds(since: metadataStartedAt))")
 
     // Build sessions and assign to worktrees
     var updatedRepositories = selectedRepositories
@@ -361,6 +375,11 @@ public actor CLISessionMonitorService {
 
     selectedRepositories = updatedRepositories
     repositoriesSubject.send(selectedRepositories)
+    let worktreeCount = updatedRepositories.reduce(0) { $0 + $1.worktrees.count }
+    let sessionCount = updatedRepositories.reduce(0) { total, repo in
+      total + repo.worktrees.reduce(0) { $0 + $1.sessions.count }
+    }
+    AppLogger.startup.info("[Startup][ClaudeMonitor] refreshSessions end repos=\(updatedRepositories.count) worktrees=\(worktreeCount) sessions=\(sessionCount) elapsedMs=\(Self.elapsedMilliseconds(since: refreshStartedAt))")
   }
 
   // MARK: - Message Utilities
@@ -705,6 +724,9 @@ public actor CLISessionMonitorService {
     sessionMetadataCache = sessionMetadataCache.filter { sessionIds.contains($0.key) }
   }
 
+  private static func elapsedMilliseconds(since start: Date) -> Int {
+    Int(Date().timeIntervalSince(start) * 1000)
+  }
 }
 
 // MARK: - Protocol Conformance

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/CodexSessionMonitorService.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/CodexSessionMonitorService.swift
@@ -41,16 +41,40 @@ public actor CodexSessionMonitorService {
       return selectedRepositories.first { $0.path == path }
     }
 
-    let worktrees = await detectWorktrees(at: path)
+    let detection = await RepositoryWorktreeResolver.detectRepository(at: path)
+    if let existing = selectedRepositories.first(where: { $0.path == detection.rootPath }) {
+      return existing
+    }
+
     let repository = SelectedRepository(
-      path: path,
-      worktrees: worktrees,
+      path: detection.rootPath,
+      worktrees: detection.worktrees,
       isExpanded: true
     )
 
     selectedRepositories.append(repository)
     await refreshSessions(skipWorktreeRedetection: true)
     return repository
+  }
+
+  public func addRepositories(_ paths: [String]) async {
+    let newPaths = paths.filter { path in
+      !selectedRepositories.contains(where: { $0.path == path })
+    }
+    guard !newPaths.isEmpty else { return }
+
+    let detections = await detectRepositoriesBatch(paths: newPaths)
+    var selectedRootPaths = Set(selectedRepositories.map(\.path))
+
+    for detection in detections where selectedRootPaths.insert(detection.rootPath).inserted {
+      selectedRepositories.append(SelectedRepository(
+        path: detection.rootPath,
+        worktrees: detection.worktrees,
+        isExpanded: true
+      ))
+    }
+
+    await refreshSessions(skipWorktreeRedetection: true)
   }
 
   public func removeRepository(_ path: String) async {
@@ -115,7 +139,7 @@ public actor CodexSessionMonitorService {
 
         for meta in sessionMetas {
           guard !assignedSessionIds.contains(meta.sessionId) else { continue }
-          let matchesPath = meta.projectPath == worktree.path || meta.projectPath.hasPrefix(worktree.path + "/")
+          let matchesPath = ProjectHierarchyResolver.isSameOrDescendant(meta.projectPath, of: worktree.path)
           guard matchesPath else { continue }
 
           let entries = historyBySession[meta.sessionId] ?? []
@@ -210,7 +234,7 @@ public actor CodexSessionMonitorService {
       guard let meta = CodexSessionFileScanner.readSessionMeta(from: path) else { continue }
 
       let matchesPath = paths.contains { p in
-        meta.projectPath == p || meta.projectPath.hasPrefix(p + "/")
+        ProjectHierarchyResolver.isSameOrDescendant(meta.projectPath, of: p)
       }
       guard matchesPath else { continue }
 
@@ -244,27 +268,26 @@ public actor CodexSessionMonitorService {
   // MARK: - Worktree Detection
 
   private func detectWorktrees(at repoPath: String) async -> [WorktreeBranch] {
-    let worktrees = await GitWorktreeDetector.listWorktrees(at: repoPath)
+    await RepositoryWorktreeResolver.detectWorktrees(at: repoPath)
+  }
 
-    if worktrees.isEmpty {
-      let info = await GitWorktreeDetector.detectWorktreeInfo(for: repoPath)
-      return [
-        WorktreeBranch(
-          name: info?.branch ?? "main",
-          path: repoPath,
-          isWorktree: false,
-          sessions: []
-        )
-      ]
-    }
+  private func detectRepositoriesBatch(paths: [String]) async -> [RepositoryWorktreeSnapshot] {
+    await withTaskGroup(of: (Int, RepositoryWorktreeSnapshot).self) { group in
+      for (index, path) in paths.enumerated() {
+        group.addTask {
+          let snapshot = await RepositoryWorktreeResolver.detectRepository(at: path)
+          return (index, snapshot)
+        }
+      }
 
-    return worktrees.map { info in
-      WorktreeBranch(
-        name: info.branch ?? URL(fileURLWithPath: info.path).lastPathComponent,
-        path: info.path,
-        isWorktree: info.isWorktree,
-        sessions: []
-      )
+      var results: [(Int, RepositoryWorktreeSnapshot)] = []
+      for await result in group {
+        results.append(result)
+      }
+
+      return results
+        .sorted { $0.0 < $1.0 }
+        .map { $0.1 }
     }
   }
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/CodexSessionMonitorService.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/CodexSessionMonitorService.swift
@@ -58,12 +58,16 @@ public actor CodexSessionMonitorService {
   }
 
   public func addRepositories(_ paths: [String]) async {
+    let startedAt = Date()
     let newPaths = paths.filter { path in
       !selectedRepositories.contains(where: { $0.path == path })
     }
+    AppLogger.startup.info("[Startup][CodexMonitor] addRepositories requested=\(paths.count) new=\(newPaths.count) existing=\(self.selectedRepositories.count)")
     guard !newPaths.isEmpty else { return }
 
+    let detectionStartedAt = Date()
     let detections = await detectRepositoriesBatch(paths: newPaths)
+    AppLogger.startup.info("[Startup][CodexMonitor] addRepositories detectRepositoryBatch count=\(detections.count) elapsedMs=\(Self.elapsedMilliseconds(since: detectionStartedAt))")
     var selectedRootPaths = Set(selectedRepositories.map(\.path))
 
     for detection in detections where selectedRootPaths.insert(detection.rootPath).inserted {
@@ -75,6 +79,7 @@ public actor CodexSessionMonitorService {
     }
 
     await refreshSessions(skipWorktreeRedetection: true)
+    AppLogger.startup.info("[Startup][CodexMonitor] addRepositories end repos=\(self.selectedRepositories.count) elapsedMs=\(Self.elapsedMilliseconds(since: startedAt))")
   }
 
   public func removeRepository(_ path: String) async {
@@ -94,15 +99,20 @@ public actor CodexSessionMonitorService {
   // MARK: - Session Scanning
 
   public func refreshSessions(skipWorktreeRedetection: Bool = false) async {
+    let refreshStartedAt = Date()
+    AppLogger.startup.info("[Startup][CodexMonitor] refreshSessions start repos=\(self.selectedRepositories.count) skipWorktreeRedetection=\(skipWorktreeRedetection)")
     guard !selectedRepositories.isEmpty else {
       repositoriesSubject.send([])
+      AppLogger.startup.info("[Startup][CodexMonitor] refreshSessions emitted empty repos elapsedMs=\(Self.elapsedMilliseconds(since: refreshStartedAt))")
       return
     }
 
     if !skipWorktreeRedetection {
+      let worktreeStartedAt = Date()
       let allWorktrees = await detectWorktreesBatch(
         repoPaths: selectedRepositories.map { $0.path }
       )
+      AppLogger.startup.info("[Startup][CodexMonitor] refreshSessions worktreeDetection repos=\(self.selectedRepositories.count) elapsedMs=\(Self.elapsedMilliseconds(since: worktreeStartedAt))")
 
       for index in selectedRepositories.indices {
         let repoPath = selectedRepositories[index].path
@@ -124,10 +134,14 @@ public actor CodexSessionMonitorService {
 
     let allPaths = getAllMonitoredPaths()
 
+    let historyStartedAt = Date()
     let historyEntries = parseHistory()
     let historyBySession = Dictionary(grouping: historyEntries) { $0.sessionId }
+    AppLogger.startup.info("[Startup][CodexMonitor] refreshSessions parseHistory entries=\(historyEntries.count) elapsedMs=\(Self.elapsedMilliseconds(since: historyStartedAt))")
 
+    let scanStartedAt = Date()
     let sessionMetas = scanSessions(for: allPaths)
+    AppLogger.startup.info("[Startup][CodexMonitor] refreshSessions scanSessions paths=\(allPaths.count) sessions=\(sessionMetas.count) elapsedMs=\(Self.elapsedMilliseconds(since: scanStartedAt))")
 
     var updatedRepositories = selectedRepositories
     var assignedSessionIds: Set<String> = []
@@ -176,6 +190,11 @@ public actor CodexSessionMonitorService {
 
     selectedRepositories = updatedRepositories
     repositoriesSubject.send(selectedRepositories)
+    let worktreeCount = updatedRepositories.reduce(0) { $0 + $1.worktrees.count }
+    let sessionCount = updatedRepositories.reduce(0) { total, repo in
+      total + repo.worktrees.reduce(0) { $0 + $1.sessions.count }
+    }
+    AppLogger.startup.info("[Startup][CodexMonitor] refreshSessions end repos=\(updatedRepositories.count) worktrees=\(worktreeCount) sessions=\(sessionCount) elapsedMs=\(Self.elapsedMilliseconds(since: refreshStartedAt))")
   }
 
   // MARK: - Helpers
@@ -317,6 +336,10 @@ public actor CodexSessionMonitorService {
       }
     }
     return paths
+  }
+
+  private static func elapsedMilliseconds(since start: Date) -> Int {
+    Int(Date().timeIntervalSince(start) * 1000)
   }
 }
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/CodexSessionMonitorService.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/CodexSessionMonitorService.swift
@@ -37,23 +37,27 @@ public actor CodexSessionMonitorService {
 
   @discardableResult
   public func addRepository(_ path: String) async -> SelectedRepository? {
-    guard !selectedRepositories.contains(where: { $0.path == path }) else {
-      return selectedRepositories.first { $0.path == path }
+    let result = await appendRepositoryShellIfNeeded(path)
+    guard let repository = result.repository else { return nil }
+
+    if result.didAddRepository {
+      await refreshSessions(skipWorktreeRedetection: true)
     }
 
-    let detection = await RepositoryWorktreeResolver.detectRepository(at: path)
-    if let existing = selectedRepositories.first(where: { $0.path == detection.rootPath }) {
-      return existing
+    return repository
+  }
+
+  /// Adds a repository/worktree shell without scanning provider session files.
+  /// Used by fresh picker adds so the module row can appear before heavier session discovery.
+  @discardableResult
+  public func addRepositoryShell(_ path: String) async -> SelectedRepository? {
+    let startedAt = Date()
+    let result = await appendRepositoryShellIfNeeded(path)
+    guard let repository = result.repository else { return nil }
+    if result.didAddRepository {
+      repositoriesSubject.send(selectedRepositories)
+      AppLogger.startup.info("[Startup][CodexMonitor] addRepositoryShell emitted repo=\(repository.path, privacy: .public) worktrees=\(repository.worktrees.count) elapsedMs=\(Self.elapsedMilliseconds(since: startedAt))")
     }
-
-    let repository = SelectedRepository(
-      path: detection.rootPath,
-      worktrees: detection.worktrees,
-      isExpanded: true
-    )
-
-    selectedRepositories.append(repository)
-    await refreshSessions(skipWorktreeRedetection: true)
     return repository
   }
 
@@ -80,6 +84,29 @@ public actor CodexSessionMonitorService {
 
     await refreshSessions(skipWorktreeRedetection: true)
     AppLogger.startup.info("[Startup][CodexMonitor] addRepositories end repos=\(self.selectedRepositories.count) elapsedMs=\(Self.elapsedMilliseconds(since: startedAt))")
+  }
+
+  private func appendRepositoryShellIfNeeded(_ path: String) async -> (
+    repository: SelectedRepository?,
+    didAddRepository: Bool
+  ) {
+    guard !selectedRepositories.contains(where: { $0.path == path }) else {
+      return (selectedRepositories.first { $0.path == path }, false)
+    }
+
+    let detection = await RepositoryWorktreeResolver.detectRepository(at: path)
+    if let existing = selectedRepositories.first(where: { $0.path == detection.rootPath }) {
+      return (existing, false)
+    }
+
+    let repository = SelectedRepository(
+      path: detection.rootPath,
+      worktrees: detection.worktrees,
+      isExpanded: true
+    )
+
+    selectedRepositories.append(repository)
+    return (repository, true)
   }
 
   public func removeRepository(_ path: String) async {

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/SessionProviderProtocols.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/SessionProviderProtocols.swift
@@ -22,6 +22,8 @@ public protocol SessionMonitorServiceProtocol: AnyObject, Sendable {
 
   @discardableResult
   func addRepository(_ path: String) async -> SelectedRepository?
+  @discardableResult
+  func addRepositoryShell(_ path: String) async -> SelectedRepository?
   func addRepositories(_ paths: [String]) async
   func removeRepository(_ path: String) async
   func getSelectedRepositories() async -> [SelectedRepository]
@@ -34,6 +36,12 @@ public protocol SessionMonitorServiceProtocol: AnyObject, Sendable {
 public extension SessionMonitorServiceProtocol {
   func refreshSessions() async {
     await refreshSessions(skipWorktreeRedetection: false)
+  }
+
+  /// Default implementation preserves existing behavior for simple mocks.
+  @discardableResult
+  func addRepositoryShell(_ path: String) async -> SelectedRepository? {
+    await addRepository(path)
   }
 
   /// Default implementation: loops addRepository one at a time

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringPanelView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringPanelView.swift
@@ -105,15 +105,10 @@ public struct MonitoringPanelView: View {
     case .monitored(let s, _): itemPath = s.projectPath
     }
 
-    // Find which SelectedRepository contains this path
-    for repo in viewModel.selectedRepositories {
-      for worktree in repo.worktrees {
-        if worktree.path == itemPath {
-          return repo.path  // Return main module path
-        }
-      }
-    }
-    return itemPath  // Fallback to original path
+    return ProjectHierarchyResolver.rootProjectPath(
+      for: itemPath,
+      repositories: viewModel.selectedRepositories
+    )
   }
 
   private var allItems: [MonitoringItem] {

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderMonitoringPanelView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderMonitoringPanelView.swift
@@ -1297,16 +1297,10 @@ public struct MultiProviderMonitoringPanelView: View {
   }
 
   private func findModulePath(for item: ProviderMonitoringItem) -> String {
-    let itemPath = item.projectPath
-
-    for repo in allSelectedRepositories {
-      for worktree in repo.worktrees {
-        if worktree.path == itemPath {
-          return repo.path
-        }
-      }
-    }
-    return itemPath
+    return ProjectHierarchyResolver.rootProjectPath(
+      for: item.projectPath,
+      repositories: allSelectedRepositories
+    )
   }
 
   private func openSessionFile(for session: CLISession, viewModel: CLISessionsViewModel) {

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderMonitoringPanelView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderMonitoringPanelView.swift
@@ -410,6 +410,22 @@ public struct MultiProviderMonitoringPanelView: View {
     accessibilityReduceMotion ? .easeInOut(duration: 0.12) : .spring(response: 0.28, dampingFraction: 0.9)
   }
 
+  private var projectLandingAnimation: Animation {
+    accessibilityReduceMotion
+      ? .easeInOut(duration: 0.15)
+      : .spring(response: 0.4, dampingFraction: 0.86)
+  }
+
+  private var projectLandingTransition: AnyTransition {
+    if accessibilityReduceMotion {
+      return .opacity
+    }
+    return .asymmetric(
+      insertion: .scale(scale: 0.97).combined(with: .opacity),
+      removal: .opacity
+    )
+  }
+
   private var auxiliaryShellDockTransition: AnyTransition {
     accessibilityReduceMotion ? .opacity : .move(edge: .bottom).combined(with: .opacity)
   }
@@ -423,6 +439,7 @@ public struct MultiProviderMonitoringPanelView: View {
     } else {
       mainContentBody
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+        .animation(projectLandingAnimation, value: projectLandingPath)
     }
   }
 
@@ -430,12 +447,17 @@ public struct MultiProviderMonitoringPanelView: View {
   private var mainContentBody: some View {
     if let projectLandingPath {
       projectLandingState(for: projectLandingPath)
+        .id("project-landing-\(projectLandingPath)")
+        .transition(projectLandingTransition)
     } else if isLoading {
       loadingState
+        .transition(.opacity)
     } else if allItems.isEmpty {
       emptyState
+        .transition(.opacity)
     } else {
       monitoredSessionsList
+        .transition(.opacity)
     }
   }
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderMonitoringPanelView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderMonitoringPanelView.swift
@@ -176,6 +176,7 @@ public struct MultiProviderMonitoringPanelView: View {
   @AppStorage(AgentHubDefaults.auxiliaryShellVisible) var isAuxiliaryShellVisible: Bool = false
   let onEmbeddedSidePanelVisibilityChange: (Bool) -> Void
   let onRequestStartSession: (String?) -> Void
+  let onRequestProjectStartSession: (String) -> Void
 
   @State private var sessionFileSheetItem: SessionFileSheetItem?
   @State private var maximizedSessionId: String?
@@ -183,6 +184,7 @@ public struct MultiProviderMonitoringPanelView: View {
   @State private var editorStates: [String: MonitoringEditorState] = [:]
   @State private var availableDetailWidth: CGFloat = 0
   @Binding var primarySessionId: String?
+  @Binding var projectLandingPath: String?
   @AppStorage(AgentHubDefaults.hubLayoutMode)
   private var layoutModeRawValue: Int = LayoutMode.single.rawValue
   @AppStorage(AgentHubDefaults.hubPreviousLayoutMode)
@@ -238,14 +240,18 @@ public struct MultiProviderMonitoringPanelView: View {
     claudeViewModel: CLISessionsViewModel,
     codexViewModel: CLISessionsViewModel,
     primarySessionId: Binding<String?>,
+    projectLandingPath: Binding<String?>,
     onEmbeddedSidePanelVisibilityChange: @escaping (Bool) -> Void = { _ in },
-    onRequestStartSession: @escaping (String?) -> Void
+    onRequestStartSession: @escaping (String?) -> Void,
+    onRequestProjectStartSession: @escaping (String) -> Void
   ) {
     self.claudeViewModel = claudeViewModel
     self.codexViewModel = codexViewModel
     self._primarySessionId = primarySessionId
+    self._projectLandingPath = projectLandingPath
     self.onEmbeddedSidePanelVisibilityChange = onEmbeddedSidePanelVisibilityChange
     self.onRequestStartSession = onRequestStartSession
+    self.onRequestProjectStartSession = onRequestProjectStartSession
   }
 
   public var body: some View {
@@ -422,7 +428,9 @@ public struct MultiProviderMonitoringPanelView: View {
 
   @ViewBuilder
   private var mainContentBody: some View {
-    if isLoading {
+    if let projectLandingPath {
+      projectLandingState(for: projectLandingPath)
+    } else if isLoading {
       loadingState
     } else if allItems.isEmpty {
       emptyState
@@ -454,6 +462,18 @@ public struct MultiProviderMonitoringPanelView: View {
     WelcomeView(
       viewModel: emptyStateViewModel,
       onStartSession: onRequestStartSession
+    )
+  }
+
+  private func projectLandingState(for projectPath: String) -> some View {
+    let repository = projectLandingRepository(for: projectPath)
+    let resolvedPath = repository?.path ?? projectPath
+    return ProjectLandingView(
+      projectName: repository?.name ?? URL(fileURLWithPath: resolvedPath).lastPathComponent,
+      projectPath: resolvedPath,
+      onStartSession: {
+        onRequestProjectStartSession(resolvedPath)
+      }
     )
   }
 
@@ -728,6 +748,7 @@ public struct MultiProviderMonitoringPanelView: View {
   private func toggleSidePanel(_ content: SidePanelContent, forItemID itemID: String) {
     withAnimation(.easeInOut(duration: 0.25)) {
       if primarySessionId != itemID {
+        projectLandingPath = nil
         primarySessionId = itemID
       }
       if layoutMode != .single {
@@ -1036,6 +1057,7 @@ public struct MultiProviderMonitoringPanelView: View {
   }
 
   private var effectivePrimarySessionId: String? {
+    if projectLandingPath != nil { return nil }
     if let current = primarySessionId, allItems.contains(where: { $0.id == current }) {
       return current
     }
@@ -1290,6 +1312,13 @@ public struct MultiProviderMonitoringPanelView: View {
     return map.values.sorted { $0.path < $1.path }
   }
 
+  private func projectLandingRepository(for projectPath: String) -> SelectedRepository? {
+    ProjectLandingResolver.resolvedRepository(
+      for: projectPath,
+      repositories: allSelectedRepositories
+    )
+  }
+
   private var emptyStateViewModel: CLISessionsViewModel {
     if !claudeViewModel.selectedRepositories.isEmpty { return claudeViewModel }
     if !codexViewModel.selectedRepositories.isEmpty { return codexViewModel }
@@ -1367,6 +1396,11 @@ public struct MultiProviderMonitoringPanelView: View {
   }
 
   private func ensurePrimarySelection() {
+    guard projectLandingPath == nil else {
+      primarySessionId = nil
+      return
+    }
+
     guard !allItems.isEmpty else {
       primarySessionId = nil
       return
@@ -1381,6 +1415,7 @@ public struct MultiProviderMonitoringPanelView: View {
 
   private func setPrimarySessionIfNeeded(_ sessionId: String) {
     guard primarySessionId != sessionId else { return }
+    projectLandingPath = nil
     primarySessionId = sessionId
   }
 
@@ -1537,6 +1572,7 @@ public struct MultiProviderMonitoringPanelView: View {
     )
     editorStates = result.states
     if let primaryItemID = result.primaryItemID {
+      projectLandingPath = nil
       primarySessionId = primaryItemID
     }
   }

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
@@ -1307,8 +1307,8 @@ public struct MultiProviderSessionsListView: View {
 
   private func addRepository(at path: String) {
     activateRecentlyAddedProjectLanding(for: path)
-    claudeViewModel.addRepository(at: path)
-    codexViewModel.addRepository(at: path)
+    claudeViewModel.addRepositoryShellFirst(at: path)
+    codexViewModel.addRepositoryShellFirst(at: path)
   }
 
   private func activateRecentlyAddedProjectLanding(for addedPath: String) {

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
@@ -532,6 +532,12 @@ public struct MultiProviderSessionsListView: View {
       : .spring(response: 0.35, dampingFraction: 0.88)
   }
 
+  private var projectLandingAnimation: Animation {
+    accessibilityReduceMotion
+      ? .easeInOut(duration: 0.15)
+      : .spring(response: 0.38, dampingFraction: 0.86)
+  }
+
   private var sidePanelView: some View {
     VStack(spacing: 0) {
       ScrollViewReader { proxy in
@@ -1306,35 +1312,27 @@ public struct MultiProviderSessionsListView: View {
   }
 
   private func activateRecentlyAddedProjectLanding(for addedPath: String) {
-    let resolvedPath = ProjectLandingResolver.landingPath(
+    guard let repository = ProjectLandingResolver.resolvedRepository(
       for: addedPath,
       repositories: allRepositories
-    )
-    recentlyAddedProjectLandingPath = resolvedPath
-    pendingProjectLandingPath = ProjectLandingResolver.resolvedRepository(
-      for: addedPath,
-      repositories: allRepositories
-    ) == nil ? addedPath : nil
-    primarySessionId = nil
-    setAuxiliaryShellVisible(false)
+    ) else {
+      pendingProjectLandingPath = addedPath
+      return
+    }
+
+    pendingProjectLandingPath = nil
+    showRecentlyAddedProjectLanding(repository.path)
   }
 
   private func reconcileRecentlyAddedProjectLanding() {
     if let pendingProjectLandingPath {
-      let resolvedPath = ProjectLandingResolver.landingPath(
+      guard let repository = ProjectLandingResolver.resolvedRepository(
         for: pendingProjectLandingPath,
         repositories: allRepositories
-      )
-      recentlyAddedProjectLandingPath = resolvedPath
-      primarySessionId = nil
-      setAuxiliaryShellVisible(false)
+      ) else { return }
 
-      if ProjectLandingResolver.resolvedRepository(
-        for: pendingProjectLandingPath,
-        repositories: allRepositories
-      ) != nil {
-        self.pendingProjectLandingPath = nil
-      }
+      self.pendingProjectLandingPath = nil
+      showRecentlyAddedProjectLanding(repository.path)
       return
     }
 
@@ -1348,9 +1346,19 @@ public struct MultiProviderSessionsListView: View {
     }
   }
 
+  private func showRecentlyAddedProjectLanding(_ path: String) {
+    withAnimation(projectLandingAnimation) {
+      recentlyAddedProjectLandingPath = path
+      primarySessionId = nil
+    }
+    setAuxiliaryShellVisible(false)
+  }
+
   private func clearRecentlyAddedProjectLanding() {
-    pendingProjectLandingPath = nil
-    recentlyAddedProjectLandingPath = nil
+    withAnimation(projectLandingAnimation) {
+      pendingProjectLandingPath = nil
+      recentlyAddedProjectLandingPath = nil
+    }
   }
 
   private func openSessionFile(for session: CLISession, viewModel: CLISessionsViewModel) {

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
@@ -839,13 +839,10 @@ public struct MultiProviderSessionsListView: View {
   /// "path is the repo root" and "path is a worktree under the repo". Falls back
   /// to the original path when no tracked repo matches (used for the orphan group).
   private func findParentRepoPath(for itemPath: String) -> String {
-    for repo in orderedTrackedRepos {
-      if repo.path == itemPath { return repo.path }
-      if repo.worktrees.contains(where: { $0.path == itemPath }) {
-        return repo.path
-      }
-    }
-    return itemPath
+    return ProjectHierarchyResolver.rootProjectPath(
+      for: itemPath,
+      repositories: orderedTrackedRepos
+    )
   }
 
   private var pinnedSessionSnapshot: ProviderScopedPinnedSessions {

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
@@ -1118,12 +1118,10 @@ public struct MultiProviderSessionsListView: View {
             primarySessionId = item.id
           }
         )
-        .transition(.opacity)
         .id(item.id)
       }
     }
     .padding(.top, 2)
-    .animation(.easeInOut(duration: 0.25), value: pinnedSessionSnapshot)
   }
 
   @ViewBuilder

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
@@ -152,6 +152,9 @@ public struct MultiProviderSessionsListView: View {
   @State private var isBrowseExpanded: Bool = false
   @State private var multiLaunchViewModel: MultiSessionLaunchViewModel?
   @State private var primarySessionId: String?
+  @State private var recentlyAddedProjectLandingPath: String?
+  @State private var pendingProjectLandingPath: String?
+  @State private var isStartSessionSheetPresented = false
   @State private var showDeleteWorktreeAlert = false
   @State private var sessionToDeleteWorktree: CLISession? = nil
   @State private var showCommandPalette = false
@@ -227,9 +230,13 @@ public struct MultiProviderSessionsListView: View {
           claudeViewModel: claudeViewModel,
           codexViewModel: codexViewModel,
           primarySessionId: $primarySessionId,
+          projectLandingPath: $recentlyAddedProjectLandingPath,
           onEmbeddedSidePanelVisibilityChange: handleEmbeddedSidePanelVisibilityChange,
           onRequestStartSession: { preferredRepositoryPath in
             triggerNewSessionFlow(preferredRepositoryPath: preferredRepositoryPath)
+          },
+          onRequestProjectStartSession: { repositoryPath in
+            presentStartSessionSheet(for: repositoryPath)
           }
         )
         .padding(12)
@@ -269,13 +276,18 @@ public struct MultiProviderSessionsListView: View {
     .onChange(of: codexViewModel.resolvedPendingSessions) { _, newResolutions in
       handleResolvedSessions(newResolutions, provider: .codex, viewModel: codexViewModel)
     }
+    .onChange(of: repositoryLandingSnapshot) { _, _ in
+      reconcileRecentlyAddedProjectLanding()
+    }
     .onChange(of: claudeViewModel.lastCreatedPendingId) { _, newId in
       guard let newId else { return }
+      clearRecentlyAddedProjectLanding()
       primarySessionId = "pending-claude-\(newId.uuidString)"
       claudeViewModel.lastCreatedPendingId = nil
     }
     .onChange(of: codexViewModel.lastCreatedPendingId) { _, newId in
       guard let newId else { return }
+      clearRecentlyAddedProjectLanding()
       primarySessionId = "pending-codex-\(newId.uuidString)"
       codexViewModel.lastCreatedPendingId = nil
     }
@@ -402,6 +414,15 @@ public struct MultiProviderSessionsListView: View {
           }
         }
       )
+    }
+    .sheet(isPresented: $isStartSessionSheetPresented) {
+      if let multiLaunchViewModel {
+        StartSessionSheet(
+          launchViewModel: multiLaunchViewModel,
+          intelligenceViewModel: intelligenceViewModel,
+          onDismiss: { isStartSessionSheetPresented = false }
+        )
+      }
     }
     .modifier(ArchiveConfirmationAlert(confirmation: $archiveConfirmation))
     .modifier(RemoveConfirmationAlert(confirmation: $removeConfirmation))
@@ -921,8 +942,9 @@ public struct MultiProviderSessionsListView: View {
       SessionsSectionHeader(
         groupMode: $sidebarGroupMode,
         repos: orderedTrackedRepos,
-        launchViewModel: multiLaunchViewModel,
-        intelligenceViewModel: intelligenceViewModel,
+        onStartSession: { repositoryPath in
+          presentStartSessionSheet(for: repositoryPath)
+        },
         onAddFolder: { showAddRepositoryPicker() }
       )
 
@@ -965,9 +987,9 @@ public struct MultiProviderSessionsListView: View {
                   }
                 }
               },
-              repoPath: group.id,
-              launchViewModel: multiLaunchViewModel,
-              intelligenceViewModel: intelligenceViewModel,
+              onStartSession: {
+                presentStartSessionSheet(for: group.id)
+              },
               onOpenInFinder: {
                 NSWorkspace.shared.selectFile(nil, inFileViewerRootedAtPath: group.id)
               },
@@ -1086,6 +1108,7 @@ public struct MultiProviderSessionsListView: View {
             }
           }(),
           onSelect: {
+            clearRecentlyAddedProjectLanding()
             primarySessionId = item.id
           }
         )
@@ -1277,8 +1300,57 @@ public struct MultiProviderSessionsListView: View {
   }
 
   private func addRepository(at path: String) {
+    activateRecentlyAddedProjectLanding(for: path)
     claudeViewModel.addRepository(at: path)
     codexViewModel.addRepository(at: path)
+  }
+
+  private func activateRecentlyAddedProjectLanding(for addedPath: String) {
+    let resolvedPath = ProjectLandingResolver.landingPath(
+      for: addedPath,
+      repositories: allRepositories
+    )
+    recentlyAddedProjectLandingPath = resolvedPath
+    pendingProjectLandingPath = ProjectLandingResolver.resolvedRepository(
+      for: addedPath,
+      repositories: allRepositories
+    ) == nil ? addedPath : nil
+    primarySessionId = nil
+    setAuxiliaryShellVisible(false)
+  }
+
+  private func reconcileRecentlyAddedProjectLanding() {
+    if let pendingProjectLandingPath {
+      let resolvedPath = ProjectLandingResolver.landingPath(
+        for: pendingProjectLandingPath,
+        repositories: allRepositories
+      )
+      recentlyAddedProjectLandingPath = resolvedPath
+      primarySessionId = nil
+      setAuxiliaryShellVisible(false)
+
+      if ProjectLandingResolver.resolvedRepository(
+        for: pendingProjectLandingPath,
+        repositories: allRepositories
+      ) != nil {
+        self.pendingProjectLandingPath = nil
+      }
+      return
+    }
+
+    guard let recentlyAddedProjectLandingPath else { return }
+    if ProjectLandingResolver.resolvedRepository(
+      for: recentlyAddedProjectLandingPath,
+      repositories: allRepositories
+    ) == nil {
+      clearRecentlyAddedProjectLanding()
+      ensurePrimarySelection()
+    }
+  }
+
+  private func clearRecentlyAddedProjectLanding() {
+    pendingProjectLandingPath = nil
+    recentlyAddedProjectLandingPath = nil
   }
 
   private func openSessionFile(for session: CLISession, viewModel: CLISessionsViewModel) {
@@ -1341,11 +1413,17 @@ public struct MultiProviderSessionsListView: View {
           let realSessionId = resolutions[pendingUUID] else { return }
     let newPrimaryId = "\(provider.rawValue.lowercased())-\(realSessionId)"
     AppLogger.session.info("[PrimarySelection] Resolved: \(currentPrimary.prefix(20), privacy: .public) -> \(newPrimaryId.prefix(20), privacy: .public)")
+    clearRecentlyAddedProjectLanding()
     primarySessionId = newPrimaryId
     viewModel.resolvedPendingSessions.removeValue(forKey: pendingUUID)
   }
 
   private func ensurePrimarySelection() {
+    guard recentlyAddedProjectLandingPath == nil else {
+      primarySessionId = nil
+      return
+    }
+
     let items = selectedSessionItems
     guard !items.isEmpty else {
       primarySessionId = nil
@@ -1382,6 +1460,13 @@ public struct MultiProviderSessionsListView: View {
     return map.values.sorted { $0.path < $1.path }
   }
 
+  private var repositoryLandingSnapshot: [String] {
+    allRepositories.flatMap { repository in
+      [repository.path] + repository.worktrees.map(\.path)
+    }
+    .sorted()
+  }
+
   private var totalSessionCount: Int {
     claudeViewModel.totalSessionCount + codexViewModel.totalSessionCount
   }
@@ -1415,6 +1500,7 @@ public struct MultiProviderSessionsListView: View {
 
     case .switchToSession(let id, _, _, _):
       if let item = selectedSessionItems.first(where: { $0.id == id }) {
+        clearRecentlyAddedProjectLanding()
         primarySessionId = item.id
         scrollToSessionId = item.id
       }
@@ -1486,6 +1572,26 @@ public struct MultiProviderSessionsListView: View {
     }
   }
 
+  private func presentStartSessionSheet(for repositoryPath: String) {
+    guard let multiLaunchViewModel else { return }
+    let resolvedPath = ProjectLandingResolver.landingPath(
+      for: repositoryPath,
+      repositories: allRepositories
+    )
+
+    isStartSessionSheetPresented = false
+    multiLaunchViewModel.reset()
+
+    Task { @MainActor in
+      let didPreselect = await multiLaunchViewModel.preselectRepository(path: resolvedPath)
+      if didPreselect {
+        isStartSessionSheetPresented = true
+      } else {
+        multiLaunchViewModel.selectRepository()
+      }
+    }
+  }
+
   private func toggleFocusMode() {
     let singleRaw = 0
     if layoutModeRawValue != singleRaw {
@@ -1503,6 +1609,7 @@ public struct MultiProviderSessionsListView: View {
   }
 
   private func toggleAuxiliaryShellDock() {
+    guard recentlyAddedProjectLandingPath == nil else { return }
     ensurePrimarySelection()
     guard !selectedSessionItems.isEmpty else { return }
     withAnimation(auxiliaryShellToggleAnimation) {
@@ -1526,6 +1633,7 @@ public struct MultiProviderSessionsListView: View {
   }
 
   private func navigateSessionHistory(direction: NavigationDirection) {
+    clearRecentlyAddedProjectLanding()
     let items = selectedSessionItems
     guard !items.isEmpty else { return }
 
@@ -1554,16 +1662,13 @@ private struct ProjectGroupHeader: View {
   let isExpanded: Bool
   let canToggle: Bool
   let onToggle: () -> Void
-  let repoPath: String
-  let launchViewModel: MultiSessionLaunchViewModel?
-  let intelligenceViewModel: IntelligenceViewModel?
+  let onStartSession: () -> Void
   let onOpenInFinder: () -> Void
   let onOpenGitHub: () -> Void
   let onArchiveSessions: (() -> Void)?
   let onRemove: () -> Void
 
   @State private var isHovered: Bool = false
-  @State private var showStartSheet: Bool = false
   @Environment(\.colorScheme) private var colorScheme
 
   var body: some View {
@@ -1608,29 +1713,14 @@ private struct ProjectGroupHeader: View {
           Label("Remove", systemImage: "xmark")
         }
       }
-      .opacity(isHovered || showStartSheet ? 1 : 0)
+      .opacity(isHovered ? 1 : 0)
 
       HeaderIconButton(
         systemName: "square.and.pencil",
         size: 14,
         help: "Start a new session"
-      ) {
-        guard let vm = launchViewModel else { return }
-        Task { @MainActor in
-          _ = await vm.preselectRepository(path: repoPath)
-          showStartSheet = true
-        }
-      }
-      .opacity(isHovered || showStartSheet ? 1 : 0)
-      .sheet(isPresented: $showStartSheet) {
-        if let vm = launchViewModel {
-          StartSessionSheet(
-            launchViewModel: vm,
-            intelligenceViewModel: intelligenceViewModel,
-            onDismiss: { showStartSheet = false }
-          )
-        }
-      }
+      ) { onStartSession() }
+      .opacity(isHovered ? 1 : 0)
     }
     .padding(.vertical, 6)
     .padding(.horizontal, 4)
@@ -1800,12 +1890,10 @@ private struct StartSessionSheet: View {
 private struct SessionsSectionHeader: View {
   @Binding var groupMode: SidebarGroupMode
   let repos: [SelectedRepository]
-  let launchViewModel: MultiSessionLaunchViewModel?
-  let intelligenceViewModel: IntelligenceViewModel?
+  let onStartSession: (String) -> Void
   let onAddFolder: () -> Void
 
   @State private var showGroupPopover = false
-  @State private var showStartSheet = false
 
   var body: some View {
     VStack(spacing: 0) {
@@ -1839,26 +1927,13 @@ private struct SessionsSectionHeader: View {
           ) {
             ForEach(repos, id: \.path) { repo in
               Button {
-                guard let vm = launchViewModel else { return }
-                Task { @MainActor in
-                  _ = await vm.preselectRepository(path: repo.path)
-                  showStartSheet = true
-                }
+                onStartSession(repo.path)
               } label: {
                 Label(
                   URL(fileURLWithPath: repo.path).lastPathComponent,
                   systemImage: "folder"
                 )
               }
-            }
-          }
-          .sheet(isPresented: $showStartSheet) {
-            if let vm = launchViewModel {
-              StartSessionSheet(
-                launchViewModel: vm,
-                intelligenceViewModel: intelligenceViewModel,
-                onDismiss: { showStartSheet = false }
-              )
             }
           }
         }

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
@@ -1261,23 +1261,18 @@ public struct MultiProviderSessionsListView: View {
 
   // MARK: - Actions
 
-  /// Uses asyncAfter to schedule NSOpenPanel creation on a future run loop iteration,
-  /// avoiding HIRunLoopSemaphore deadlock that occurs during GCD dispatch queue drain.
+  /// Schedules NSOpenPanel presentation on the run loop to avoid AppKit's
+  /// HIRunLoopSemaphore wait during main-dispatch-queue draining.
   private func showAddRepositoryPicker() {
-    DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
-      MainActor.assumeIsolated {
-        let panel = NSOpenPanel()
-        panel.title = "Select Repository"
-        panel.message = "Choose a git repository to monitor CLI sessions"
-        panel.canChooseFiles = false
-        panel.canChooseDirectories = true
-        panel.allowsMultipleSelection = false
-        panel.canCreateDirectories = false
-
-        if panel.runModal() == .OK, let url = panel.url {
-          self.addRepository(at: url.path)
-        }
-      }
+    NativeOpenPanelPresenter.present { panel in
+      panel.title = "Select Repository"
+      panel.message = "Choose a git repository to monitor CLI sessions"
+      panel.canChooseFiles = false
+      panel.canChooseDirectories = true
+      panel.allowsMultipleSelection = false
+      panel.canCreateDirectories = false
+    } onSelection: { url in
+      addRepository(at: url.path)
     }
   }
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/ProjectLandingView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/ProjectLandingView.swift
@@ -1,0 +1,74 @@
+//
+//  ProjectLandingView.swift
+//  AgentHub
+//
+
+import SwiftUI
+
+struct ProjectLandingView: View {
+  let projectName: String
+  let projectPath: String
+  let onStartSession: () -> Void
+
+  @Environment(\.colorScheme) private var colorScheme
+  @Environment(\.runtimeTheme) private var runtimeTheme
+
+  var body: some View {
+    VStack(spacing: 16) {
+      ZStack {
+        Circle()
+          .fill(Color.primary.opacity(0.1))
+          .frame(width: 86, height: 86)
+
+        Image(systemName: "folder.badge.plus")
+          .font(.system(size: 34, weight: .regular))
+          .foregroundColor(.primary.opacity(0.9))
+      }
+
+      VStack(spacing: 7) {
+        Text(projectName)
+          .font(.system(size: 24, weight: .semibold, design: .monospaced))
+          .foregroundColor(.primary)
+          .lineLimit(1)
+          .minimumScaleFactor(0.75)
+
+        Text(projectPath)
+          .font(.system(size: 12, weight: .regular, design: .monospaced))
+          .foregroundColor(.secondary)
+          .lineLimit(1)
+          .truncationMode(.middle)
+          .frame(maxWidth: 520)
+      }
+
+      Button(action: onStartSession) {
+        HStack(spacing: 8) {
+          Image(systemName: "plus.circle.fill")
+            .font(.system(size: 13))
+          Text("Start New Session")
+            .font(.system(size: 12, weight: .semibold, design: .monospaced))
+        }
+        .foregroundColor(colorScheme == .dark ? .black : .white)
+        .frame(height: 38)
+        .padding(.horizontal, 22)
+        .background(
+          RoundedRectangle(cornerRadius: 10)
+            .fill(Color.primary)
+        )
+        .shadow(color: Color.primary.opacity(0.28), radius: 7, y: 3)
+      }
+      .buttonStyle(.plain)
+      .padding(.top, 2)
+    }
+    .padding(28)
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+    .background(backgroundColor)
+  }
+
+  private var backgroundColor: some View {
+    if runtimeTheme?.hasCustomBackgrounds == true {
+      Color.adaptiveBackground(for: colorScheme, theme: runtimeTheme)
+    } else {
+      colorScheme == .dark ? Color(white: 0.06) : Color(white: 0.96)
+    }
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/ProjectLandingView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/ProjectLandingView.swift
@@ -12,6 +12,8 @@ struct ProjectLandingView: View {
 
   @Environment(\.colorScheme) private var colorScheme
   @Environment(\.runtimeTheme) private var runtimeTheme
+  @Environment(\.accessibilityReduceMotion) private var accessibilityReduceMotion
+  @State private var hasAppeared = false
 
   var body: some View {
     VStack(spacing: 16) {
@@ -60,8 +62,17 @@ struct ProjectLandingView: View {
       .padding(.top, 2)
     }
     .padding(28)
+    .opacity(hasAppeared ? 1 : 0)
+    .offset(y: accessibilityReduceMotion || hasAppeared ? 0 : 10)
+    .scaleEffect(accessibilityReduceMotion || hasAppeared ? 1 : 0.98)
     .frame(maxWidth: .infinity, maxHeight: .infinity)
     .background(backgroundColor)
+    .onAppear {
+      hasAppeared = false
+      withAnimation(appearanceAnimation) {
+        hasAppeared = true
+      }
+    }
   }
 
   private var backgroundColor: some View {
@@ -70,5 +81,11 @@ struct ProjectLandingView: View {
     } else {
       colorScheme == .dark ? Color(white: 0.06) : Color(white: 0.96)
     }
+  }
+
+  private var appearanceAnimation: Animation {
+    accessibilityReduceMotion
+      ? .easeInOut(duration: 0.12)
+      : .spring(response: 0.42, dampingFraction: 0.88)
   }
 }

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/SelectedSessionsPanelView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/SelectedSessionsPanelView.swift
@@ -141,12 +141,10 @@ public struct SelectedSessionsPanelView: View {
   }
 
   private func findModulePath(for itemPath: String) -> String {
-    for repo in viewModel.selectedRepositories {
-      for worktree in repo.worktrees where worktree.path == itemPath {
-        return repo.path
-      }
-    }
-    return itemPath
+    return ProjectHierarchyResolver.rootProjectPath(
+      for: itemPath,
+      repositories: viewModel.selectedRepositories
+    )
   }
 
   private func ensurePrimarySelection() {
@@ -336,12 +334,10 @@ public struct MultiProviderSelectedSessionsPanelView: View {
   }
 
   private func findModulePath(for itemPath: String) -> String {
-    for repo in allSelectedRepositories {
-      for worktree in repo.worktrees where worktree.path == itemPath {
-        return repo.path
-      }
-    }
-    return itemPath
+    return ProjectHierarchyResolver.rootProjectPath(
+      for: itemPath,
+      repositories: allSelectedRepositories
+    )
   }
 
   private func customName(for item: SelectedSessionItem) -> String? {

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/SessionsBrowserPanel.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/SessionsBrowserPanel.swift
@@ -195,16 +195,10 @@ public struct SessionsBrowserPanel: View {
   }
 
   private func findModulePath(for item: ProviderMonitoringItem) -> String {
-    let itemPath = item.projectPath
-
-    for repo in allSelectedRepositories {
-      for worktree in repo.worktrees {
-        if worktree.path == itemPath {
-          return repo.path
-        }
-      }
-    }
-    return itemPath
+    return ProjectHierarchyResolver.rootProjectPath(
+      for: item.projectPath,
+      repositories: allSelectedRepositories
+    )
   }
 
   // MARK: - Focus/Selection Logic

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/SettingsView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/SettingsView.swift
@@ -529,20 +529,19 @@ public struct SettingsView: View {
 
   private func chooseGhosttyConfigFile() {
     #if canImport(AppKit)
-    let panel = NSOpenPanel()
-    panel.title = "Choose Ghostty Config"
-    panel.message = "Choose a Ghostty configuration file for embedded Ghostty terminals."
-    panel.prompt = "Choose"
-    panel.canChooseFiles = true
-    panel.canChooseDirectories = false
-    panel.allowsMultipleSelection = false
+    NativeOpenPanelPresenter.present { panel in
+      panel.title = "Choose Ghostty Config"
+      panel.message = "Choose a Ghostty configuration file for embedded Ghostty terminals."
+      panel.prompt = "Choose"
+      panel.canChooseFiles = true
+      panel.canChooseDirectories = false
+      panel.allowsMultipleSelection = false
 
-    let expandedPath = (terminalGhosttyConfigPath as NSString).expandingTildeInPath
-    if !expandedPath.isEmpty {
-      panel.directoryURL = URL(fileURLWithPath: expandedPath).deletingLastPathComponent()
-    }
-
-    if panel.runModal() == .OK, let url = panel.url {
+      let expandedPath = (terminalGhosttyConfigPath as NSString).expandingTildeInPath
+      if !expandedPath.isEmpty {
+        panel.directoryURL = URL(fileURLWithPath: expandedPath).deletingLastPathComponent()
+      }
+    } onSelection: { url in
       terminalGhosttyConfigPath = url.path
     }
     #endif

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/WelcomeView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/WelcomeView.swift
@@ -283,7 +283,10 @@ public struct WelcomeView: View {
 
   private func hasActiveSessions(for repo: SelectedRepository) -> Bool {
     viewModel.monitoredSessions.contains { monitored in
-      repo.worktrees.contains { $0.path == monitored.session.projectPath }
+      ProjectHierarchyResolver.rootProjectPath(
+        for: monitored.session.projectPath,
+        repositories: [repo]
+      ) == repo.path
     }
   }
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/Utils/AppLogger.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Utils/AppLogger.swift
@@ -21,6 +21,9 @@ public enum AppLogger {
   /// Session-related logging (parsing, monitoring, lifecycle)
   public static let session = Logger(subsystem: subsystem, category: "Session")
 
+  /// Startup and persistence restoration logging
+  public static let startup = Logger(subsystem: subsystem, category: "Startup")
+
   /// Git operations (diff, worktree, commands)
   public static let git = Logger(subsystem: subsystem, category: "Git")
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/Utils/NativeOpenPanelPresenter.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Utils/NativeOpenPanelPresenter.swift
@@ -1,0 +1,33 @@
+//
+//  NativeOpenPanelPresenter.swift
+//  AgentHub
+//
+
+#if canImport(AppKit)
+import AppKit
+import Foundation
+
+@MainActor
+enum NativeOpenPanelPresenter {
+  static func present(
+    configure: @escaping @MainActor (NSOpenPanel) -> Void,
+    onSelection: @escaping @MainActor (URL) -> Void
+  ) {
+    let runLoop = CFRunLoopGetMain()
+    CFRunLoopPerformBlock(runLoop, CFRunLoopMode.commonModes.rawValue) {
+      MainActor.assumeIsolated {
+        let panel = NSOpenPanel()
+        configure(panel)
+
+        panel.begin { response in
+          guard response == .OK, let url = panel.url else { return }
+          MainActor.assumeIsolated {
+            onSelection(url)
+          }
+        }
+      }
+    }
+    CFRunLoopWakeUp(runLoop)
+  }
+}
+#endif

--- a/app/modules/AgentHubCore/Sources/AgentHub/Utils/ProjectHierarchyResolver.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Utils/ProjectHierarchyResolver.swift
@@ -1,0 +1,73 @@
+//
+//  ProjectHierarchyResolver.swift
+//  AgentHub
+//
+
+import Foundation
+
+/// Shared path rules for displaying sessions under the root repository that owns
+/// their worktree.
+public enum ProjectHierarchyResolver {
+  public static func rootProjectPath(
+    for projectPath: String,
+    repositories: [SelectedRepository]
+  ) -> String {
+    let normalizedProjectPath = normalize(projectPath)
+    var bestMatch: (rootPath: String, matchedLength: Int)?
+
+    for repository in repositories {
+      let normalizedRepositoryPath = normalize(repository.path)
+      if isSameOrDescendant(normalizedProjectPath, ofNormalizedRoot: normalizedRepositoryPath) {
+        bestMatch = chooseBetterMatch(
+          current: bestMatch,
+          candidate: (rootPath: repository.path, matchedLength: normalizedRepositoryPath.count)
+        )
+      }
+
+      for worktree in repository.worktrees {
+        let normalizedWorktreePath = normalize(worktree.path)
+        if isSameOrDescendant(normalizedProjectPath, ofNormalizedRoot: normalizedWorktreePath) {
+          bestMatch = chooseBetterMatch(
+            current: bestMatch,
+            candidate: (rootPath: repository.path, matchedLength: normalizedWorktreePath.count)
+          )
+        }
+      }
+    }
+
+    return bestMatch?.rootPath ?? projectPath
+  }
+
+  public static func rootRepositoryPath(
+    for requestedPath: String,
+    worktrees: [WorktreeBranch]
+  ) -> String {
+    worktrees.first(where: { !$0.isWorktree })?.path ?? requestedPath
+  }
+
+  public static func isSameOrDescendant(_ path: String, of root: String) -> Bool {
+    isSameOrDescendant(normalize(path), ofNormalizedRoot: normalize(root))
+  }
+
+  private static func chooseBetterMatch(
+    current: (rootPath: String, matchedLength: Int)?,
+    candidate: (rootPath: String, matchedLength: Int)
+  ) -> (rootPath: String, matchedLength: Int) {
+    guard let current else { return candidate }
+    return candidate.matchedLength > current.matchedLength ? candidate : current
+  }
+
+  private static func isSameOrDescendant(
+    _ normalizedPath: String,
+    ofNormalizedRoot normalizedRoot: String
+  ) -> Bool {
+    guard !normalizedRoot.isEmpty else { return false }
+    if normalizedPath == normalizedRoot { return true }
+    if normalizedRoot == "/" { return normalizedPath.hasPrefix("/") }
+    return normalizedPath.hasPrefix(normalizedRoot + "/")
+  }
+
+  private static func normalize(_ path: String) -> String {
+    URL(fileURLWithPath: path).standardizedFileURL.path
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/Utils/ProjectLandingResolver.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Utils/ProjectLandingResolver.swift
@@ -1,0 +1,27 @@
+//
+//  ProjectLandingResolver.swift
+//  AgentHub
+//
+
+import Foundation
+
+/// Resolves the repository that should own the recently-added project landing.
+public enum ProjectLandingResolver {
+  public static func landingPath(
+    for addedPath: String,
+    repositories: [SelectedRepository]
+  ) -> String {
+    resolvedRepository(for: addedPath, repositories: repositories)?.path ?? addedPath
+  }
+
+  public static func resolvedRepository(
+    for addedPath: String,
+    repositories: [SelectedRepository]
+  ) -> SelectedRepository? {
+    let rootPath = ProjectHierarchyResolver.rootProjectPath(
+      for: addedPath,
+      repositories: repositories
+    )
+    return repositories.first { $0.path == rootPath }
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/Utils/RepositoryWorktreeResolver.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Utils/RepositoryWorktreeResolver.swift
@@ -1,0 +1,69 @@
+//
+//  RepositoryWorktreeResolver.swift
+//  AgentHub
+//
+
+import Foundation
+
+struct RepositoryWorktreeSnapshot: Sendable {
+  let rootPath: String
+  let worktrees: [WorktreeBranch]
+}
+
+enum RepositoryWorktreeResolver {
+  static func detectRepository(at path: String) async -> RepositoryWorktreeSnapshot {
+    let worktrees = await detectWorktrees(at: path)
+    let rootPath = ProjectHierarchyResolver.rootRepositoryPath(
+      for: path,
+      worktrees: worktrees
+    )
+
+    return RepositoryWorktreeSnapshot(
+      rootPath: rootPath,
+      worktrees: worktrees
+    )
+  }
+
+  static func detectWorktrees(at path: String) async -> [WorktreeBranch] {
+    let worktrees = await GitWorktreeDetector.listWorktrees(at: path)
+    if !worktrees.isEmpty {
+      return worktrees.map(makeWorktreeBranch)
+    }
+
+    guard let info = await GitWorktreeDetector.detectWorktreeInfo(for: path) else {
+      return [
+        WorktreeBranch(
+          name: "main",
+          path: path,
+          isWorktree: false,
+          sessions: []
+        )
+      ]
+    }
+
+    if info.isWorktree, let mainRepoPath = info.mainRepoPath {
+      let mainWorktrees = await GitWorktreeDetector.listWorktrees(at: mainRepoPath)
+      if !mainWorktrees.isEmpty {
+        return mainWorktrees.map(makeWorktreeBranch)
+      }
+    }
+
+    return [
+      WorktreeBranch(
+        name: info.branch ?? "main",
+        path: path,
+        isWorktree: info.isWorktree,
+        sessions: []
+      )
+    ]
+  }
+
+  private static func makeWorktreeBranch(_ info: GitWorktreeInfo) -> WorktreeBranch {
+    WorktreeBranch(
+      name: info.branch ?? URL(fileURLWithPath: info.path).lastPathComponent,
+      path: info.path,
+      isWorktree: info.isWorktree,
+      sessions: []
+    )
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/CLISessionsViewModel.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/CLISessionsViewModel.swift
@@ -116,6 +116,13 @@ public final class CLISessionsViewModel {
   private var existingSessionIdsBeforeTerminal: Set<String> = []
   /// Session IDs awaiting progressive restoration on app launch
   private var pendingRestorationSessionIds: Set<String> = []
+  /// Repository paths captured synchronously from UserDefaults before subscribing
+  /// to the monitor service. This prevents the service's initial empty emission
+  /// from erasing saved repositories before restore reads them.
+  private var persistedRepositoryPathsOnLaunch: [String] = []
+  private var hasFinishedInitialRepositoryRestore = true
+  private var isRestoringPersistedRepositories = false
+  private var hasObservedNonEmptyRepositoryEmissionSinceLaunch = false
 
   /// Maps session IDs to prompts that should be sent to the terminal when it becomes ready.
   ///
@@ -795,6 +802,9 @@ public final class CLISessionsViewModel {
   private var monitoredSessionsKey: String {
     AgentHubDefaults.monitoredSessionIds + "." + providerDefaultsSuffix
   }
+  private var providerRepositoryMigrationKey: String {
+    AgentHubDefaults.keyPrefix + "sessions.selectedRepositories.providerMigration." + providerDefaultsSuffix
+  }
   // MARK: - Initialization
 
   public init(
@@ -832,10 +842,13 @@ public final class CLISessionsViewModel {
     let savedTimeout = UserDefaults.standard.integer(forKey: "CLISessionsApprovalTimeout")
     self.approvalTimeoutSeconds = savedTimeout > 0 ? savedTimeout : 5
 
+    persistedRepositoryPathsOnLaunch = loadPersistedRepositoryPathsForLaunch()
+    hasFinishedInitialRepositoryRestore = persistedRepositoryPathsOnLaunch.isEmpty
+    isRestoringPersistedRepositories = !persistedRepositoryPathsOnLaunch.isEmpty
+    AppLogger.startup.info("[Startup][\(providerKind.rawValue, privacy: .public)] ViewModel init persistedRepos=\(self.persistedRepositoryPathsOnLaunch.count) restorePending=\(!self.hasFinishedInitialRepositoryRestore)")
+
     // Set loading state synchronously so the UI never shows empty state during restoration
-    if let data = UserDefaults.standard.data(forKey: persistenceKey),
-       let paths = try? JSONDecoder().decode([String].self, from: data),
-       !paths.isEmpty {
+    if !persistedRepositoryPathsOnLaunch.isEmpty {
       loadingState = .restoringRepositories
     }
 
@@ -971,6 +984,10 @@ public final class CLISessionsViewModel {
 
         await MainActor.run { [weak self] in
           guard let self = self else { return }
+          let totalSessionCount = repositories.reduce(0) { total, repo in
+            total + repo.worktrees.reduce(0) { $0 + $1.sessions.count }
+          }
+          AppLogger.startup.info("[Startup][\(self.providerKind.rawValue, privacy: .public)] repository emission repos=\(repositories.count) sessions=\(totalSessionCount) restoring=\(self.isRestoringPersistedRepositories) restoreDone=\(self.hasFinishedInitialRepositoryRestore)")
 
           // Preserve expanded state from current repositories
           self.selectedRepositories = self.mergePreservingExpandedState(
@@ -978,8 +995,19 @@ public final class CLISessionsViewModel {
             updated: repositories
           )
 
-          // Persist after state is updated to ensure consistency
-          self.persistSelectedRepositories()
+          if Self.shouldPersistRepositoryEmission(
+            repositoryCount: repositories.count,
+            persistedRepositoryPathCountOnLaunch: self.persistedRepositoryPathsOnLaunch.count,
+            hasObservedNonEmptyRepositoryEmissionSinceLaunch: self.hasObservedNonEmptyRepositoryEmissionSinceLaunch
+          ) {
+            // Persist after state is updated to ensure consistency
+            self.persistSelectedRepositories()
+          } else {
+            AppLogger.startup.warning("[Startup][\(self.providerKind.rawValue, privacy: .public)] skipped persisting initial empty repository emission during restore")
+          }
+          if !repositories.isEmpty {
+            self.hasObservedNonEmptyRepositoryEmissionSinceLaunch = true
+          }
 
           // Sync backup with latest session data for monitored sessions
           self.syncMonitoredSessionBackup()
@@ -1052,29 +1080,82 @@ public final class CLISessionsViewModel {
 
   // MARK: - Persistence
 
+  nonisolated static func shouldPersistRepositoryEmission(
+    repositoryCount: Int,
+    persistedRepositoryPathCountOnLaunch: Int,
+    hasObservedNonEmptyRepositoryEmissionSinceLaunch: Bool
+  ) -> Bool {
+    !(repositoryCount == 0
+      && persistedRepositoryPathCountOnLaunch > 0
+      && !hasObservedNonEmptyRepositoryEmissionSinceLaunch)
+  }
+
+  private static func decodePersistedRepositoryPaths(forKey key: String) -> [String] {
+    guard let data = UserDefaults.standard.data(forKey: key),
+          let paths = try? JSONDecoder().decode([String].self, from: data) else {
+      return []
+    }
+    return paths
+  }
+
+  private static func elapsedMilliseconds(since start: Date) -> Int {
+    Int(Date().timeIntervalSince(start) * 1000)
+  }
+
+  private func loadPersistedRepositoryPathsForLaunch() -> [String] {
+    let providerPaths = Self.decodePersistedRepositoryPaths(forKey: persistenceKey)
+    if !providerPaths.isEmpty {
+      AppLogger.startup.info("[Startup][\(self.providerKind.rawValue, privacy: .public)] loaded provider-specific persisted repos count=\(providerPaths.count)")
+      return providerPaths
+    }
+
+    let legacyPaths = Self.decodePersistedRepositoryPaths(forKey: AgentHubDefaults.selectedRepositories)
+    let hasMigratedProviderRepositories = UserDefaults.standard.bool(forKey: providerRepositoryMigrationKey)
+    if !legacyPaths.isEmpty && !hasMigratedProviderRepositories {
+      AppLogger.startup.warning("[Startup][\(self.providerKind.rawValue, privacy: .public)] using legacy persisted repos fallback count=\(legacyPaths.count)")
+      return legacyPaths
+    }
+
+    let providerKeyExists = UserDefaults.standard.object(forKey: persistenceKey) != nil
+    AppLogger.startup.info("[Startup][\(self.providerKind.rawValue, privacy: .public)] no persisted repos providerKeyExists=\(providerKeyExists) legacyCount=\(legacyPaths.count) migrationComplete=\(hasMigratedProviderRepositories)")
+    return []
+  }
+
   private func restorePersistedRepositories() {
+    let paths = persistedRepositoryPathsOnLaunch
+    guard !paths.isEmpty else {
+      hasFinishedInitialRepositoryRestore = true
+      isRestoringPersistedRepositories = false
+      return
+    }
+
     Task {
-      // Load persisted repository paths
-      guard let data = UserDefaults.standard.data(forKey: persistenceKey),
-            let paths = try? JSONDecoder().decode([String].self, from: data),
-            !paths.isEmpty else {
-        return
-      }
+      let restoreStartedAt = Date()
+      AppLogger.startup.info("[Startup][\(self.providerKind.rawValue, privacy: .public)] restorePersistedRepositories start paths=\(paths.count)")
 
       // Store persisted session IDs for progressive restoration
       let persistedSessionIds = loadPersistedSessionIds()
+      AppLogger.startup.info("[Startup][\(self.providerKind.rawValue, privacy: .public)] persisted monitored sessions count=\(persistedSessionIds.count)")
       if !persistedSessionIds.isEmpty {
         pendingRestorationSessionIds = persistedSessionIds
       }
 
       // Add repositories (triggers refreshSessions → setupSubscriptions)
       loadingState = .restoringRepositories
+      let addStartedAt = Date()
       await monitorService.addRepositories(paths)
+      AppLogger.startup.info("[Startup][\(self.providerKind.rawValue, privacy: .public)] monitor addRepositories returned elapsedMs=\(Self.elapsedMilliseconds(since: addStartedAt))")
       restoreExpansionState()
       loadingState = .idle
+      isRestoringPersistedRepositories = false
+      hasFinishedInitialRepositoryRestore = true
+      AppLogger.startup.info("[Startup][\(self.providerKind.rawValue, privacy: .public)] restorePersistedRepositories end elapsedMs=\(Self.elapsedMilliseconds(since: restoreStartedAt)) repos=\(self.selectedRepositories.count) pendingSessionRestores=\(self.pendingRestorationSessionIds.count)")
 
       // Safety timeout: stop trying to restore after 10 seconds
       try? await Task.sleep(for: .seconds(10))
+      if !pendingRestorationSessionIds.isEmpty {
+        AppLogger.startup.warning("[Startup][\(self.providerKind.rawValue, privacy: .public)] clearing unrestored session ids after timeout count=\(self.pendingRestorationSessionIds.count)")
+      }
       pendingRestorationSessionIds.removeAll()
     }
   }
@@ -1095,6 +1176,7 @@ public final class CLISessionsViewModel {
   private func processPendingSessionRestorations() {
     guard !pendingRestorationSessionIds.isEmpty else { return }
 
+    let pendingBefore = pendingRestorationSessionIds.count
     var restoredIds: Set<String> = []
 
     for sessionId in pendingRestorationSessionIds {
@@ -1113,6 +1195,7 @@ public final class CLISessionsViewModel {
 
     if !restoredIds.isEmpty {
       pendingRestorationSessionIds.subtract(restoredIds)
+      AppLogger.startup.info("[Startup][\(self.providerKind.rawValue, privacy: .public)] restored monitored sessions restored=\(restoredIds.count) pendingBefore=\(pendingBefore) pendingAfter=\(self.pendingRestorationSessionIds.count)")
       expandItemsContainingMonitoredSessions()
       loadCustomNames()
       loadPinnedSessions()
@@ -1141,6 +1224,8 @@ public final class CLISessionsViewModel {
     let paths = selectedRepositories.map { $0.path }
     if let data = try? JSONEncoder().encode(paths) {
       UserDefaults.standard.set(data, forKey: persistenceKey)
+      UserDefaults.standard.set(true, forKey: providerRepositoryMigrationKey)
+      AppLogger.startup.debug("[Startup][\(self.providerKind.rawValue, privacy: .public)] persisted repository paths count=\(paths.count)")
     }
     persistExpansionState()
   }

--- a/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/CLISessionsViewModel.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/CLISessionsViewModel.swift
@@ -1265,24 +1265,19 @@ public final class CLISessionsViewModel {
   // MARK: - Repository Management
 
   /// Opens a directory picker and adds the selected repository.
-  /// Uses asyncAfter to schedule NSOpenPanel creation on a future run loop iteration,
-  /// avoiding HIRunLoopSemaphore deadlock that occurs during GCD dispatch queue drain.
+  /// Schedules NSOpenPanel presentation on the run loop to avoid AppKit's
+  /// HIRunLoopSemaphore wait during main-dispatch-queue draining.
   public func showAddRepositoryPicker() {
     #if canImport(AppKit)
-    DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
-      MainActor.assumeIsolated {
-        let panel = NSOpenPanel()
-        panel.title = "Select Repository"
-        panel.message = "Choose a git repository to monitor CLI sessions"
-        panel.canChooseFiles = false
-        panel.canChooseDirectories = true
-        panel.allowsMultipleSelection = false
-        panel.canCreateDirectories = false
-
-        if panel.runModal() == .OK, let url = panel.url {
-          self.addRepository(at: url.path)
-        }
-      }
+    NativeOpenPanelPresenter.present { panel in
+      panel.title = "Select Repository"
+      panel.message = "Choose a git repository to monitor CLI sessions"
+      panel.canChooseFiles = false
+      panel.canChooseDirectories = true
+      panel.allowsMultipleSelection = false
+      panel.canCreateDirectories = false
+    } onSelection: { [weak self] url in
+      self?.addRepository(at: url.path)
     }
     #endif
   }
@@ -2527,27 +2522,22 @@ public final class CLISessionsViewModel {
   // MARK: - Search Filter
 
   /// Opens a folder picker to select a repository for filtering search results.
-  /// Uses asyncAfter to schedule NSOpenPanel creation on a future run loop iteration,
-  /// avoiding HIRunLoopSemaphore deadlock that occurs during GCD dispatch queue drain.
+  /// Schedules NSOpenPanel presentation on the run loop to avoid AppKit's
+  /// HIRunLoopSemaphore wait during main-dispatch-queue draining.
   public func showSearchFilterPicker() {
     #if canImport(AppKit)
-    DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
-      MainActor.assumeIsolated {
-        let panel = NSOpenPanel()
-        panel.title = "Filter by Repository"
-        panel.message = "Select a repository to filter search results"
-        panel.canChooseFiles = false
-        panel.canChooseDirectories = true
-        panel.allowsMultipleSelection = false
-        panel.canCreateDirectories = false
-
-        if panel.runModal() == .OK, let url = panel.url {
-          self.searchFilterPath = url.path
-          // Re-run search with new filter if there's an active query
-          if !self.searchQuery.isEmpty {
-            self.performSearch()
-          }
-        }
+    NativeOpenPanelPresenter.present { panel in
+      panel.title = "Filter by Repository"
+      panel.message = "Select a repository to filter search results"
+      panel.canChooseFiles = false
+      panel.canChooseDirectories = true
+      panel.allowsMultipleSelection = false
+      panel.canCreateDirectories = false
+    } onSelection: { [weak self] url in
+      guard let self else { return }
+      self.searchFilterPath = url.path
+      if !self.searchQuery.isEmpty {
+        self.performSearch()
       }
     }
     #endif

--- a/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/CLISessionsViewModel.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/CLISessionsViewModel.swift
@@ -1098,7 +1098,7 @@ public final class CLISessionsViewModel {
     return paths
   }
 
-  private static func elapsedMilliseconds(since start: Date) -> Int {
+  nonisolated private static func elapsedMilliseconds(since start: Date) -> Int {
     Int(Date().timeIntervalSince(start) * 1000)
   }
 
@@ -1379,6 +1379,32 @@ public final class CLISessionsViewModel {
       // [CLISessionsVM] monitorService.addRepository completed")
       loadingState = .idle
       // [CLISessionsVM] loadingState = .idle")
+    }
+  }
+
+  /// Adds a repository shell first, then refreshes sessions after the UI can show the project row.
+  /// Intended for fresh picker adds where the landing page is the primary experience.
+  public func addRepositoryShellFirst(at path: String) {
+    let repoName = URL(fileURLWithPath: path).lastPathComponent
+    Task {
+      loadingState = .addingRepository(name: repoName)
+      let repository = await monitorService.addRepositoryShell(path)
+      loadingState = .idle
+
+      guard repository != nil else { return }
+      scheduleDeferredSessionRefresh(afterAdding: path)
+    }
+  }
+
+  private func scheduleDeferredSessionRefresh(afterAdding path: String) {
+    let providerKind = self.providerKind
+    let monitorService = self.monitorService
+    Task.detached(priority: .utility) {
+      try? await Task.sleep(for: .milliseconds(250))
+      let startedAt = Date()
+      AppLogger.startup.info("[Startup][\(providerKind.rawValue, privacy: .public)] deferred session refresh start path=\(path, privacy: .public)")
+      await monitorService.refreshSessions(skipWorktreeRedetection: true)
+      AppLogger.startup.info("[Startup][\(providerKind.rawValue, privacy: .public)] deferred session refresh end elapsedMs=\(Self.elapsedMilliseconds(since: startedAt))")
     }
   }
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/CLISessionsViewModel.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/CLISessionsViewModel.swift
@@ -1305,7 +1305,12 @@ public final class CLISessionsViewModel {
   /// Removes a repository from monitoring
   public func removeRepository(_ repository: SelectedRepository) {
     // Cancel any pending hub sessions in this repository
-    let pendingToCancel = pendingHubSessions.filter { $0.worktree.path.hasPrefix(repository.path) }
+    let pendingToCancel = pendingHubSessions.filter {
+      ProjectHierarchyResolver.rootProjectPath(
+        for: $0.worktree.path,
+        repositories: [repository]
+      ) == repository.path
+    }
     for pending in pendingToCancel {
       cancelPendingSession(pending)
     }
@@ -2251,7 +2256,7 @@ public final class CLISessionsViewModel {
   }
 
   private func codexSessionMatchesWorktree(_ meta: CodexSessionMeta, worktree: WorktreeBranch) -> Bool {
-    meta.projectPath == worktree.path || meta.projectPath.hasPrefix(worktree.path + "/")
+    ProjectHierarchyResolver.isSameOrDescendant(meta.projectPath, of: worktree.path)
   }
 
   private func fileModificationDate(_ path: String) -> Date? {
@@ -2462,7 +2467,10 @@ public final class CLISessionsViewModel {
 
       // Find the repository containing this project path
       guard let repoIndex = selectedRepositories.firstIndex(where: {
-        $0.path == projectPath || $0.worktrees.contains { $0.path == projectPath }
+        ProjectHierarchyResolver.rootProjectPath(
+          for: projectPath,
+          repositories: [$0]
+        ) == $0.path
       }) else {
         return
       }

--- a/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/MultiSessionLaunchViewModel.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/MultiSessionLaunchViewModel.swift
@@ -241,32 +241,28 @@ public final class MultiSessionLaunchViewModel {
   // MARK: - Actions
 
   /// Opens an NSOpenPanel to select a repository directory.
-  /// Uses asyncAfter to schedule NSOpenPanel creation on a future run loop iteration,
-  /// avoiding HIRunLoopSemaphore deadlock that occurs during GCD dispatch queue drain.
+  /// Schedules presentation on the run loop to avoid AppKit's HIRunLoopSemaphore
+  /// wait during main-dispatch-queue draining.
   public func selectRepository() {
-    DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
-      MainActor.assumeIsolated {
-        let panel = NSOpenPanel()
-        panel.title = "Select Repository"
-        panel.message = "Choose a git repository"
-        panel.canChooseFiles = false
-        panel.canChooseDirectories = true
-        panel.allowsMultipleSelection = false
-        panel.canCreateDirectories = false
-
-        if panel.runModal() == .OK, let url = panel.url {
-          let path = url.path
-          let name = url.lastPathComponent
-          self.selectedRepository = SelectedRepository(
-            path: path,
-            name: name,
-            worktrees: [],
-            isExpanded: true
-          )
-          Task {
-            await self.loadBranches()
-          }
-        }
+    NativeOpenPanelPresenter.present { panel in
+      panel.title = "Select Repository"
+      panel.message = "Choose a git repository"
+      panel.canChooseFiles = false
+      panel.canChooseDirectories = true
+      panel.allowsMultipleSelection = false
+      panel.canCreateDirectories = false
+    } onSelection: { [weak self] url in
+      guard let self else { return }
+      let path = url.path
+      let name = url.lastPathComponent
+      self.selectedRepository = SelectedRepository(
+        path: path,
+        name: name,
+        worktrees: [],
+        isExpanded: true
+      )
+      Task {
+        await self.loadBranches()
       }
     }
   }

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/ProjectHierarchyResolverTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/ProjectHierarchyResolverTests.swift
@@ -1,0 +1,70 @@
+import Testing
+
+@testable import AgentHubCore
+
+@Suite("ProjectHierarchyResolver")
+struct ProjectHierarchyResolverTests {
+  @Test("Maps worktree sessions to the root repository")
+  func mapsWorktreeSessionToRootRepository() {
+    let repository = makeRepository()
+
+    let rootPath = ProjectHierarchyResolver.rootProjectPath(
+      for: "/tmp/AgentHub/project-feature",
+      repositories: [repository]
+    )
+
+    #expect(rootPath == "/tmp/AgentHub/project")
+  }
+
+  @Test("Maps worktree subdirectory sessions to the root repository")
+  func mapsWorktreeSubdirectorySessionToRootRepository() {
+    let repository = makeRepository()
+
+    let rootPath = ProjectHierarchyResolver.rootProjectPath(
+      for: "/tmp/AgentHub/project-feature/app/Sources",
+      repositories: [repository]
+    )
+
+    #expect(rootPath == "/tmp/AgentHub/project")
+  }
+
+  @Test("Uses path boundaries instead of sibling prefixes")
+  func usesPathBoundariesInsteadOfSiblingPrefixes() {
+    let repository = makeRepository()
+
+    let rootPath = ProjectHierarchyResolver.rootProjectPath(
+      for: "/tmp/AgentHub/project-feature-copy",
+      repositories: [repository]
+    )
+
+    #expect(rootPath == "/tmp/AgentHub/project-feature-copy")
+  }
+
+  @Test("Returns the main worktree as the root repository path")
+  func returnsMainWorktreeAsRootRepositoryPath() {
+    let rootPath = ProjectHierarchyResolver.rootRepositoryPath(
+      for: "/tmp/AgentHub/project-feature",
+      worktrees: makeRepository().worktrees
+    )
+
+    #expect(rootPath == "/tmp/AgentHub/project")
+  }
+
+  private func makeRepository() -> SelectedRepository {
+    SelectedRepository(
+      path: "/tmp/AgentHub/project",
+      worktrees: [
+        WorktreeBranch(
+          name: "main",
+          path: "/tmp/AgentHub/project",
+          isWorktree: false
+        ),
+        WorktreeBranch(
+          name: "feature",
+          path: "/tmp/AgentHub/project-feature",
+          isWorktree: true
+        )
+      ]
+    )
+  }
+}

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/ProjectLandingResolverTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/ProjectLandingResolverTests.swift
@@ -1,0 +1,70 @@
+import Testing
+
+@testable import AgentHubCore
+
+@Suite("ProjectLandingResolver")
+struct ProjectLandingResolverTests {
+  @Test("Uses the tracked root repository for an added root path")
+  func usesTrackedRootRepositoryForRootPath() {
+    let repository = makeRepository()
+
+    let landingPath = ProjectLandingResolver.landingPath(
+      for: "/tmp/AgentHub/project",
+      repositories: [repository]
+    )
+
+    #expect(landingPath == "/tmp/AgentHub/project")
+  }
+
+  @Test("Maps an added worktree path to its root repository")
+  func mapsAddedWorktreePathToRootRepository() {
+    let repository = makeRepository()
+
+    let landingPath = ProjectLandingResolver.landingPath(
+      for: "/tmp/AgentHub/project-feature",
+      repositories: [repository]
+    )
+
+    #expect(landingPath == "/tmp/AgentHub/project")
+  }
+
+  @Test("Keeps the added path while the repository is not tracked yet")
+  func keepsAddedPathWhenRepositoryIsNotTrackedYet() {
+    let landingPath = ProjectLandingResolver.landingPath(
+      for: "/tmp/AgentHub/new-project",
+      repositories: []
+    )
+
+    #expect(landingPath == "/tmp/AgentHub/new-project")
+  }
+
+  @Test("Returns the resolved repository for worktree paths")
+  func returnsResolvedRepositoryForWorktreePaths() {
+    let repository = makeRepository()
+
+    let resolvedRepository = ProjectLandingResolver.resolvedRepository(
+      for: "/tmp/AgentHub/project-feature/app",
+      repositories: [repository]
+    )
+
+    #expect(resolvedRepository?.path == "/tmp/AgentHub/project")
+  }
+
+  private func makeRepository() -> SelectedRepository {
+    SelectedRepository(
+      path: "/tmp/AgentHub/project",
+      worktrees: [
+        WorktreeBranch(
+          name: "main",
+          path: "/tmp/AgentHub/project",
+          isWorktree: false
+        ),
+        WorktreeBranch(
+          name: "feature",
+          path: "/tmp/AgentHub/project-feature",
+          isWorktree: true
+        )
+      ]
+    )
+  }
+}

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/RepositoryRestorePersistenceGateTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/RepositoryRestorePersistenceGateTests.swift
@@ -1,0 +1,61 @@
+import Testing
+
+@testable import AgentHubCore
+
+@Suite("Repository restore persistence gate")
+struct RepositoryRestorePersistenceGateTests {
+  @Test("Skips initial empty emission while launch restore is pending")
+  func skipsInitialEmptyEmissionWhileRestoreIsPending() {
+    let shouldPersist = CLISessionsViewModel.shouldPersistRepositoryEmission(
+      repositoryCount: 0,
+      persistedRepositoryPathCountOnLaunch: 2,
+      hasObservedNonEmptyRepositoryEmissionSinceLaunch: false
+    )
+
+    #expect(!shouldPersist)
+  }
+
+  @Test("Skips empty emissions until restored repositories are observed")
+  func skipsEmptyEmissionsUntilRestoredRepositoriesAreObserved() {
+    let shouldPersist = CLISessionsViewModel.shouldPersistRepositoryEmission(
+      repositoryCount: 0,
+      persistedRepositoryPathCountOnLaunch: 2,
+      hasObservedNonEmptyRepositoryEmissionSinceLaunch: false
+    )
+
+    #expect(!shouldPersist)
+  }
+
+  @Test("Persists empty emission after repositories have been observed")
+  func persistsEmptyEmissionAfterRepositoriesHaveBeenObserved() {
+    let shouldPersist = CLISessionsViewModel.shouldPersistRepositoryEmission(
+      repositoryCount: 0,
+      persistedRepositoryPathCountOnLaunch: 2,
+      hasObservedNonEmptyRepositoryEmissionSinceLaunch: true
+    )
+
+    #expect(shouldPersist)
+  }
+
+  @Test("Persists populated emissions during launch restore")
+  func persistsPopulatedEmissionDuringRestore() {
+    let shouldPersist = CLISessionsViewModel.shouldPersistRepositoryEmission(
+      repositoryCount: 1,
+      persistedRepositoryPathCountOnLaunch: 2,
+      hasObservedNonEmptyRepositoryEmissionSinceLaunch: false
+    )
+
+    #expect(shouldPersist)
+  }
+
+  @Test("Persists empty emission when there was no persisted launch state")
+  func persistsEmptyEmissionWithoutPersistedLaunchState() {
+    let shouldPersist = CLISessionsViewModel.shouldPersistRepositoryEmission(
+      repositoryCount: 0,
+      persistedRepositoryPathCountOnLaunch: 0,
+      hasObservedNonEmptyRepositoryEmissionSinceLaunch: false
+    )
+
+    #expect(shouldPersist)
+  }
+}

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/SessionMonitorRepositoryRootTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/SessionMonitorRepositoryRootTests.swift
@@ -21,6 +21,23 @@ struct SessionMonitorRepositoryRootTests {
     #expect(repositories.first?.worktrees.contains { $0.path == worktreePath } == true)
   }
 
+  @Test("Claude monitor shell add stores the root repository when adding a linked worktree")
+  func claudeMonitorShellAddStoresRootRepositoryForLinkedWorktree() async throws {
+    let fixture = try GitRepositoryRootFixture.create()
+    defer { fixture.cleanUp() }
+    let worktreePath = try fixture.addWorktree(branch: "feature/root-header-shell")
+    let dataPath = try fixture.makeDataPath(named: "claude-shell")
+
+    let service = CLISessionMonitorService(claudeDataPath: dataPath.path)
+    let returnedRepository = await service.addRepositoryShell(worktreePath)
+    let repositories = await service.getSelectedRepositories()
+
+    #expect(returnedRepository?.path == fixture.repoPath)
+    #expect(repositories.map(\.path) == [fixture.repoPath])
+    #expect(repositories.first?.worktrees.contains { $0.path == worktreePath } == true)
+    #expect(repositories.first?.worktrees.flatMap(\.sessions).isEmpty == true)
+  }
+
   @Test("Codex monitor stores the root repository when adding a linked worktree")
   func codexMonitorStoresRootRepositoryForLinkedWorktree() async throws {
     let fixture = try GitRepositoryRootFixture.create()
@@ -35,6 +52,23 @@ struct SessionMonitorRepositoryRootTests {
     #expect(returnedRepository?.path == fixture.repoPath)
     #expect(repositories.map(\.path) == [fixture.repoPath])
     #expect(repositories.first?.worktrees.contains { $0.path == worktreePath } == true)
+  }
+
+  @Test("Codex monitor shell add stores the root repository when adding a linked worktree")
+  func codexMonitorShellAddStoresRootRepositoryForLinkedWorktree() async throws {
+    let fixture = try GitRepositoryRootFixture.create()
+    defer { fixture.cleanUp() }
+    let worktreePath = try fixture.addWorktree(branch: "feature/root-header-shell")
+    let dataPath = try fixture.makeDataPath(named: "codex-shell")
+
+    let service = CodexSessionMonitorService(codexDataPath: dataPath.path)
+    let returnedRepository = await service.addRepositoryShell(worktreePath)
+    let repositories = await service.getSelectedRepositories()
+
+    #expect(returnedRepository?.path == fixture.repoPath)
+    #expect(repositories.map(\.path) == [fixture.repoPath])
+    #expect(repositories.first?.worktrees.contains { $0.path == worktreePath } == true)
+    #expect(repositories.first?.worktrees.flatMap(\.sessions).isEmpty == true)
   }
 }
 

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/SessionMonitorRepositoryRootTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/SessionMonitorRepositoryRootTests.swift
@@ -1,0 +1,132 @@
+import Foundation
+import Testing
+
+@testable import AgentHubCore
+
+@Suite("Session monitor repository roots")
+struct SessionMonitorRepositoryRootTests {
+  @Test("Claude monitor stores the root repository when adding a linked worktree")
+  func claudeMonitorStoresRootRepositoryForLinkedWorktree() async throws {
+    let fixture = try GitRepositoryRootFixture.create()
+    defer { fixture.cleanUp() }
+    let worktreePath = try fixture.addWorktree(branch: "feature/root-header")
+    let dataPath = try fixture.makeDataPath(named: "claude")
+
+    let service = CLISessionMonitorService(claudeDataPath: dataPath.path)
+    let returnedRepository = await service.addRepository(worktreePath)
+    let repositories = await service.getSelectedRepositories()
+
+    #expect(returnedRepository?.path == fixture.repoPath)
+    #expect(repositories.map(\.path) == [fixture.repoPath])
+    #expect(repositories.first?.worktrees.contains { $0.path == worktreePath } == true)
+  }
+
+  @Test("Codex monitor stores the root repository when adding a linked worktree")
+  func codexMonitorStoresRootRepositoryForLinkedWorktree() async throws {
+    let fixture = try GitRepositoryRootFixture.create()
+    defer { fixture.cleanUp() }
+    let worktreePath = try fixture.addWorktree(branch: "feature/root-header")
+    let dataPath = try fixture.makeDataPath(named: "codex")
+
+    let service = CodexSessionMonitorService(codexDataPath: dataPath.path)
+    let returnedRepository = await service.addRepository(worktreePath)
+    let repositories = await service.getSelectedRepositories()
+
+    #expect(returnedRepository?.path == fixture.repoPath)
+    #expect(repositories.map(\.path) == [fixture.repoPath])
+    #expect(repositories.first?.worktrees.contains { $0.path == worktreePath } == true)
+  }
+}
+
+private struct GitRepositoryRootFixture {
+  let parentURL: URL
+  let repoURL: URL
+
+  var repoPath: String { repoURL.path }
+
+  static func create() throws -> GitRepositoryRootFixture {
+    let tempBase = URL(fileURLWithPath: NSTemporaryDirectory())
+      .resolvingSymlinksInPath()
+    let parentURL = tempBase
+      .appendingPathComponent("AgentHubRootTests-\(UUID().uuidString)", isDirectory: true)
+    let repoURL = parentURL.appendingPathComponent("repo", isDirectory: true)
+    try FileManager.default.createDirectory(at: repoURL, withIntermediateDirectories: true)
+
+    let fixture = GitRepositoryRootFixture(parentURL: parentURL, repoURL: repoURL)
+    try fixture.runGit("init", "-b", "main")
+    try fixture.runGit("config", "user.email", "test@example.com")
+    try fixture.runGit("config", "user.name", "Test User")
+    try "initial\n".write(
+      to: repoURL.appendingPathComponent("README.md"),
+      atomically: true,
+      encoding: .utf8
+    )
+    try fixture.runGit("add", ".")
+    try fixture.runGit("commit", "-m", "initial")
+    return fixture
+  }
+
+  func addWorktree(branch: String) throws -> String {
+    try runGit("branch", branch)
+    let safeDirectoryName = branch.replacingOccurrences(of: "/", with: "-")
+    let worktreeURL = parentURL.appendingPathComponent(safeDirectoryName, isDirectory: true)
+    try runGit("worktree", "add", worktreeURL.path, branch)
+    return worktreeURL.path
+  }
+
+  func makeDataPath(named name: String) throws -> URL {
+    let url = parentURL.appendingPathComponent(".\(name)", isDirectory: true)
+    try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+    return url
+  }
+
+  func cleanUp() {
+    try? FileManager.default.removeItem(at: parentURL)
+  }
+
+  @discardableResult
+  func runGit(_ arguments: String...) throws -> String {
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "/usr/bin/git")
+    process.arguments = arguments
+    process.currentDirectoryURL = repoURL
+
+    let stdout = Pipe()
+    let stderr = Pipe()
+    process.standardOutput = stdout
+    process.standardError = stderr
+
+    try process.run()
+    process.waitUntilExit()
+
+    let output = String(
+      data: stdout.fileHandleForReading.readDataToEndOfFile(),
+      encoding: .utf8
+    )?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+    let errorOutput = String(
+      data: stderr.fileHandleForReading.readDataToEndOfFile(),
+      encoding: .utf8
+    )?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+
+    if process.terminationStatus != 0 {
+      throw GitRepositoryRootFixtureError.commandFailed(
+        command: arguments.joined(separator: " "),
+        output: output,
+        error: errorOutput
+      )
+    }
+
+    return output
+  }
+}
+
+private enum GitRepositoryRootFixtureError: Error, CustomStringConvertible {
+  case commandFailed(command: String, output: String, error: String)
+
+  var description: String {
+    switch self {
+    case .commandFailed(let command, let output, let error):
+      return "git \(command) failed\nstdout: \(output)\nstderr: \(error)"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Fixes project/session grouping so sessions always display under the root repository that owns the worktree. This keeps root projects as the section headers and places sessions from linked worktrees, including worktree subdirectories, under that root project.

## Details

- Adds shared project hierarchy path resolution for root repo/worktree grouping.
- Canonicalizes added Claude and Codex repository paths so adding a linked worktree stores the owning root repo.
- Updates monitored and selected session grouping views to use the shared root-project resolver.
- Adds regression coverage for worktree paths, worktree subdirectory paths, sibling prefix boundaries, and monitor-service root canonicalization.

## Validation

- `xcodebuild test -project app/AgentHub.xcodeproj -scheme AgentHub -destination 'platform=macOS' -only-testing:AgentHubTests/ProjectHierarchyResolverTests -only-testing:AgentHubTests/SessionMonitorRepositoryRootTests -only-testing:AgentHubTests/CLISessionMonitorServiceHistoryTests`