### PR TITLE
Add GitHub context drag and SQLite session state

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,11 @@ Concrete types: `CLISessionMonitorService` / `CodexSessionMonitorService`, `Sess
 
 - AI override flags are applied only when starting a new CLI session, never when resuming an existing one
 - Empty or unsupported saved provider settings must fall back to the CLI's own defaults instead of emitting override flags
-- Session metadata is stored in SQLite via GRDB; schema changes must be added as new `DatabaseMigrator` migrations rather than rewriting existing migrations
+- UserDefaults is only for app/UI preferences. Session/workspace management state must live in SQLite via `SessionMetadataStore`.
+- Never add `AgentHubDefaults` keys for selected repositories, monitored session IDs, session restore state, repo mappings, or terminal workspace state.
+- Schema changes must append a new `DatabaseMigrator` migration. Never edit, rename, reorder, or delete existing migration identifiers or bodies.
+- Production migrations must be additive or explicit data transforms. Do not use broad `delete`, `drop table`, `clearAll()`, or `eraseDatabaseOnSchemaChange` in app migrations.
+- Every `SessionMetadataStore` schema change must include a migration-preservation test that seeds the current baseline DB and proves existing rows survive migration.
 
 ```swift
 protocol SessionSearchServiceProtocol {
@@ -99,7 +103,7 @@ AgentHub installs a `PreToolUse` hook to surface pending approvals in real time 
 - `@Observable` macro — never `ObservableObject`
 - `async/await` and actors — never completion handlers
 - `@MainActor` on ViewModels and UI-bound classes
-- UserDefaults keys namespaced under `com.agenthub.`
+- UserDefaults preference keys namespaced under `com.agenthub.`
 
 ## Git Commits
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ Native macOS app for monitoring and managing Claude Code and Codex CLI sessions 
 - **Language:** Swift (Swift 6.0 tools version, `.v5` language mode)
 - **State management:** `@Observable` macro — never use `ObservableObject`
 - **Concurrency:** Swift actors, `async/await`, `Task`, `withTaskGroup`
-- **Persistence:** UserDefaults (settings), SQLite via GRDB (session metadata)
+- **Persistence:** UserDefaults (app/UI preferences only), SQLite via GRDB (`SessionMetadataStore` for session/workspace state)
 - **File watching:** kqueue-based `DispatchSource` — no polling
 
 ## Project Structure
@@ -111,6 +111,14 @@ final class MockSessionMonitorService: SessionMonitorServiceProtocol { ... }
 - Use `async` test methods for testing actor-based services
 - Prefer deterministic tests — inject controlled data rather than relying on file system state
 
+### Database Migration Rules
+
+- Session/workspace management state belongs in `SessionMetadataStore` / SQLite, not UserDefaults.
+- Do not add `AgentHubDefaults` keys for selected repositories, monitored session IDs, session restore state, repo mappings, or terminal workspace state.
+- Never edit, rename, reorder, or delete existing `DatabaseMigrator` migrations. Add a new `vN_*` migration for every schema change.
+- Production migrations must preserve existing rows. Do not use broad `delete`, `drop table`, `clearAll()`, or `eraseDatabaseOnSchemaChange` in migrations.
+- Any `SessionMetadataStore` schema change must add or update migration-preservation tests that seed the current baseline database and verify all existing metadata still reads back after migration.
+
 ## SwiftUI View Guidelines
 
 ### Composability
@@ -151,7 +159,7 @@ struct MonitoringCardView: View {
 - Use `async/await` and actors — never completion handlers
 - Services that do I/O are Swift actors (e.g., `CLISessionMonitorService`, `SessionFileWatcher`)
 - Use `@MainActor` on ViewModels and UI-bound classes
-- UserDefaults keys are namespaced under `com.agenthub.` (see `AgentHubDefaults`)
+- UserDefaults preference keys are namespaced under `com.agenthub.` (see `AgentHubDefaults`)
 
 ## UI/UX Patterns
 
@@ -256,7 +264,7 @@ xcodebuild -workspace app/AgentHub.xcodeproj/project.xcworkspace -scheme AgentHu
 - Approval hook script: `~/Library/Application Support/AgentHub/hooks/agenthub-approval.sh`
 - Approval sidecars: `~/Library/Application Support/AgentHub/approvals/{sessionId}.jsonl`
 - Session claims: `~/Library/Application Support/AgentHub/claims/{sessionId}`
-- Session metadata DB: managed by `SessionMetadataStore` via GRDB
+- Session metadata/workspace DB: managed by `SessionMetadataStore` via GRDB
 
 ## Approval Detection (Claude only)
 

--- a/app/AgentHub/Info.plist
+++ b/app/AgentHub/Info.plist
@@ -4,6 +4,20 @@
 <dict>
   <key>ATSApplicationFontsPath</key>
   <string>Fonts</string>
+  <key>UTExportedTypeDeclarations</key>
+  <array>
+    <dict>
+      <key>UTTypeConformsTo</key>
+      <array>
+        <string>public.json</string>
+        <string>public.data</string>
+      </array>
+      <key>UTTypeDescription</key>
+      <string>AgentHub GitHub Context Item</string>
+      <key>UTTypeIdentifier</key>
+      <string>com.agenthub.github.context-item</string>
+    </dict>
+  </array>
   <key>NSUserNotificationsUsageDescription</key>
   <string>AgentHub sends notifications when a Claude or Codex session requires tool approval.</string>
   <key>NSScreenCaptureUsageDescription</key>

--- a/app/AgentHubTests/RemixProviderPickerTests.swift
+++ b/app/AgentHubTests/RemixProviderPickerTests.swift
@@ -250,10 +250,11 @@ struct RemixSessionProviderRoutingTests {
     let fixture = try RemixTestGitFixture.create()
     defer { fixture.cleanup() }
 
+    let metadataStore = try SessionMetadataStore(path: fixture.parentDir + "/session-metadata.sqlite")
     let hub = AgentHubProvider(configuration: AgentHubConfiguration(
       claudeDataPath: fixture.parentDir + "/claude",
       codexDataPath: fixture.parentDir + "/codex"
-    ))
+    ), metadataStore: metadataStore)
     let claudeVM = hub.claudeSessionsViewModel
     let codexVM = hub.codexSessionsViewModel
 

--- a/app/AgentHubTests/SessionMetadataMigrationSafetyTests.swift
+++ b/app/AgentHubTests/SessionMetadataMigrationSafetyTests.swift
@@ -1,0 +1,198 @@
+import Foundation
+import GRDB
+import Testing
+
+@testable import AgentHubCore
+
+@Suite("Session metadata migration safety")
+struct SessionMetadataMigrationSafetyTests {
+
+  @Test("Existing migration identifiers remain append-only")
+  func existingMigrationIdentifiersRemainAppendOnly() {
+    let baseline = [
+      "v1_create_session_metadata",
+      "v2_create_session_repo_mapping",
+      "v3_create_ai_config",
+      "v4_add_pinned",
+      "v5_create_terminal_workspaces",
+      "v6_create_session_workspace_state"
+    ]
+
+    #expect(Array(SessionMetadataStore.migrationIdentifiers.prefix(baseline.count)) == baseline)
+    #expect(SessionMetadataStore.migrationIdentifiers.count >= baseline.count)
+    #expect(Set(SessionMetadataStore.migrationIdentifiers).count == SessionMetadataStore.migrationIdentifiers.count)
+  }
+
+  @Test("Migrating current baseline preserves all session metadata tables")
+  func migratingCurrentBaselinePreservesAllSessionMetadataTables() async throws {
+    let dbPath = temporaryMigrationSafetyDatabasePath()
+    let seed = try seedCurrentBaselineDatabase(at: dbPath)
+
+    let store = try SessionMetadataStore(path: dbPath)
+
+    #expect(try await store.getCustomName(for: seed.sessionId) == "Important session")
+    #expect(try await store.getPinnedSessionIds() == Set([seed.sessionId]))
+
+    let repoMapping = try await store.getRepoMapping(for: seed.sessionId)
+    #expect(repoMapping?.parentRepoPath == seed.parentRepoPath)
+    #expect(repoMapping?.worktreePath == seed.worktreePath)
+
+    let aiConfig = try await store.getAIConfig(for: "claude")
+    #expect(aiConfig?.defaultModel == "opus")
+    #expect(aiConfig?.effortLevel == "high")
+    #expect(aiConfig?.allowedTools == "Read, Edit")
+    #expect(aiConfig?.disallowedTools == "Bash(rm *)")
+    #expect(aiConfig?.approvalPolicy == "on-request")
+
+    #expect(
+      store.loadTerminalWorkspace(
+        provider: .claude,
+        sessionId: seed.sessionId,
+        backend: .ghostty
+      ) == seed.terminalWorkspace
+    )
+    #expect(store.getWorkspaceStateSync(for: .claude) == seed.workspaceState)
+  }
+}
+
+private struct MigrationSafetySeed {
+  let sessionId: String
+  let parentRepoPath: String
+  let worktreePath: String
+  let terminalWorkspace: TerminalWorkspaceSnapshot
+  let workspaceState: SessionWorkspaceState
+}
+
+private func seedCurrentBaselineDatabase(at dbPath: String) throws -> MigrationSafetySeed {
+  let sessionId = "session-1"
+  let parentRepoPath = "/tmp/project"
+  let worktreePath = "/tmp/project/.worktrees/feature"
+  let terminalWorkspace = TerminalWorkspaceSnapshot(
+    panels: [
+      TerminalWorkspacePanelSnapshot(
+        role: .primary,
+        tabs: [
+          TerminalWorkspaceTabSnapshot(
+            role: .agent,
+            name: "Agent",
+            title: "Claude",
+            workingDirectory: worktreePath
+          )
+        ]
+      )
+    ]
+  )
+  let workspaceState = SessionWorkspaceState(
+    selectedRepositoryPaths: [parentRepoPath],
+    monitoredSessionIds: [sessionId],
+    expansionState: [
+      "repo:\(parentRepoPath)": true,
+      "wt:\(worktreePath)": true
+    ]
+  )
+
+  let queue = try DatabaseQueue(path: dbPath)
+  try queue.write { db in
+    try createCurrentBaselineSchema(in: db)
+
+    try SessionMetadata(
+      sessionId: sessionId,
+      customName: "Important session",
+      isPinned: true
+    ).insert(db)
+
+    try SessionRepoMapping(
+      sessionId: sessionId,
+      parentRepoPath: parentRepoPath,
+      worktreePath: worktreePath
+    ).insert(db)
+
+    try AIConfigRecord(
+      provider: "claude",
+      defaultModel: "opus",
+      effortLevel: "high",
+      allowedTools: "Read, Edit",
+      disallowedTools: "Bash(rm *)",
+      approvalPolicy: "on-request"
+    ).insert(db)
+
+    try TerminalWorkspaceRecord(
+      provider: SessionProviderKind.claude.rawValue,
+      sessionId: sessionId,
+      backend: EmbeddedTerminalBackend.ghostty.rawValue,
+      snapshotData: JSONEncoder().encode(terminalWorkspace)
+    ).insert(db)
+
+    try SessionWorkspaceStateRecord(
+      provider: SessionProviderKind.claude.rawValue,
+      state: workspaceState
+    ).insert(db)
+
+    for migrationIdentifier in SessionMetadataStore.migrationIdentifiers {
+      try db.execute(
+        sql: "INSERT INTO grdb_migrations (identifier) VALUES (?)",
+        arguments: [migrationIdentifier]
+      )
+    }
+  }
+
+  return MigrationSafetySeed(
+    sessionId: sessionId,
+    parentRepoPath: parentRepoPath,
+    worktreePath: worktreePath,
+    terminalWorkspace: terminalWorkspace,
+    workspaceState: workspaceState
+  )
+}
+
+private func createCurrentBaselineSchema(in db: Database) throws {
+  try db.create(table: "session_metadata") { t in
+    t.column("sessionId", .text).primaryKey()
+    t.column("customName", .text)
+    t.column("createdAt", .datetime).notNull()
+    t.column("updatedAt", .datetime).notNull()
+    t.column("isPinned", .boolean).notNull().defaults(to: false)
+  }
+
+  try db.create(table: "session_repo_mapping") { t in
+    t.column("sessionId", .text).primaryKey()
+    t.column("parentRepoPath", .text).notNull().indexed()
+    t.column("worktreePath", .text).notNull()
+    t.column("assignedAt", .datetime).notNull()
+  }
+
+  try db.create(table: "ai_config") { t in
+    t.column("provider", .text).primaryKey()
+    t.column("defaultModel", .text).notNull().defaults(to: "")
+    t.column("effortLevel", .text).notNull().defaults(to: "")
+    t.column("allowedTools", .text).notNull().defaults(to: "")
+    t.column("disallowedTools", .text).notNull().defaults(to: "")
+    t.column("approvalPolicy", .text).notNull().defaults(to: "")
+    t.column("updatedAt", .datetime).notNull()
+  }
+
+  try db.create(table: "terminal_workspaces") { t in
+    t.column("provider", .text).notNull()
+    t.column("sessionId", .text).notNull()
+    t.column("backend", .integer).notNull()
+    t.column("snapshotData", .blob).notNull()
+    t.column("updatedAt", .datetime).notNull()
+    t.primaryKey(["provider", "sessionId", "backend"], onConflict: .replace)
+  }
+
+  try db.create(table: "session_workspace_state") { t in
+    t.column("provider", .text).primaryKey()
+    t.column("selectedRepositoryPathsData", .blob).notNull()
+    t.column("monitoredSessionIdsData", .blob).notNull()
+    t.column("expansionStateData", .blob).notNull()
+    t.column("updatedAt", .datetime).notNull()
+  }
+
+  try db.execute(sql: "CREATE TABLE grdb_migrations (identifier TEXT NOT NULL PRIMARY KEY)")
+}
+
+private func temporaryMigrationSafetyDatabasePath() -> String {
+  FileManager.default.temporaryDirectory
+    .appending(path: "test_migration_safety_\(UUID().uuidString).sqlite")
+    .path
+}

--- a/app/AgentHubTests/SessionWorkspaceStatePersistenceTests.swift
+++ b/app/AgentHubTests/SessionWorkspaceStatePersistenceTests.swift
@@ -1,0 +1,49 @@
+import Foundation
+import Testing
+
+@testable import AgentHubCore
+
+@Suite("Session workspace state persistence")
+struct SessionWorkspaceStatePersistenceTests {
+
+  @Test("Workspace state round-trips and is provider scoped")
+  func workspaceStateRoundTrip() async throws {
+    let store = try SessionMetadataStore(path: temporaryWorkspaceStateDatabasePath())
+    let state = SessionWorkspaceState(
+      selectedRepositoryPaths: ["/tmp/project-a", "/tmp/project-b"],
+      monitoredSessionIds: ["session-1", "session-2"],
+      expansionState: [
+        "repo:/tmp/project-a": true,
+        "wt:/tmp/project-a/worktrees/feature": false
+      ]
+    )
+
+    try await store.saveWorkspaceState(state, for: .claude)
+
+    #expect(store.getWorkspaceStateSync(for: .claude) == state)
+    #expect(store.getWorkspaceStateSync(for: .codex) == SessionWorkspaceState())
+  }
+
+  @Test("Clear all removes workspace state")
+  func clearAllRemovesWorkspaceState() async throws {
+    let store = try SessionMetadataStore(path: temporaryWorkspaceStateDatabasePath())
+    try await store.saveWorkspaceState(
+      SessionWorkspaceState(
+        selectedRepositoryPaths: ["/tmp/project"],
+        monitoredSessionIds: ["session-1"],
+        expansionState: ["repo:/tmp/project": true]
+      ),
+      for: .claude
+    )
+
+    try await store.clearAll()
+
+    #expect(store.getWorkspaceStateSync(for: .claude) == SessionWorkspaceState())
+  }
+}
+
+private func temporaryWorkspaceStateDatabasePath() -> String {
+  FileManager.default.temporaryDirectory
+    .appending(path: "test_workspace_state_\(UUID().uuidString).sqlite")
+    .path
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubDefaults.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubDefaults.swift
@@ -44,15 +44,6 @@ public enum AgentHubDefaults {
   /// Type: Bool (default: true)
   public static let pushNotificationsEnabled = "\(keyPrefix)notifications.pushEnabled"
 
-  /// Persisted selected repositories (JSON-encoded array of paths)
-  /// Type: Data (JSON-encoded [String])
-  /// Note: Used with provider suffix (e.g., `.claude` or `.codex`) for provider-specific storage
-  public static let selectedRepositories = "\(keyPrefix)sessions.selectedRepositories"
-
-  /// Persisted monitored session IDs (JSON-encoded array of session IDs)
-  /// Type: Data (JSON-encoded [String])
-  public static let monitoredSessionIds = "\(keyPrefix)sessions.monitoredSessionIds"
-
   // MARK: - Provider Settings
 
   /// Base key for enabled providers
@@ -231,7 +222,6 @@ public enum AgentHubDefaults {
   private static let legacyKeyMappings: [String: String] = [
     "CLISessionsShowLastMessage": showLastMessage,
     "CLISessionsApprovalTimeout": approvalTimeout,
-    "CLISessionsSelectedRepositories": selectedRepositories,
     "selectedTheme": selectedTheme,
     "customPrimaryHex": customPrimaryHex,
     "customSecondaryHex": customSecondaryHex,

--- a/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubProvider.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubProvider.swift
@@ -45,6 +45,7 @@ public final class AgentHubProvider {
   /// of `AgentHubCore` get the default factory which falls back to the regular
   /// SwiftTerm surface when `.ghostty` is selected.
   public let terminalSurfaceFactory: any EmbeddedTerminalSurfaceFactory
+  private let metadataStoreOverride: SessionMetadataStore?
 
   // MARK: - Lazy Services
 
@@ -125,6 +126,9 @@ public final class AgentHubProvider {
 
   /// Session metadata store for user-provided session names
   public private(set) lazy var metadataStore: SessionMetadataStore? = {
+    if let metadataStoreOverride {
+      return metadataStoreOverride
+    }
     do {
       return try SessionMetadataStore()
     } catch {
@@ -203,11 +207,13 @@ public final class AgentHubProvider {
   ///     target should pass a Ghostty-aware factory.
   public init(
     configuration: AgentHubConfiguration = .default,
-    terminalSurfaceFactory: any EmbeddedTerminalSurfaceFactory = DefaultEmbeddedTerminalSurfaceFactory()
+    terminalSurfaceFactory: any EmbeddedTerminalSurfaceFactory = DefaultEmbeddedTerminalSurfaceFactory(),
+    metadataStore: SessionMetadataStore? = nil
   ) {
     self.configuration = configuration
     self.terminalBackend = .storedPreference
     self.terminalSurfaceFactory = terminalSurfaceFactory
+    self.metadataStoreOverride = metadataStore
 
     // Persist developer-provided commands to UserDefaults
     let defaults = UserDefaults.standard

--- a/app/modules/AgentHubCore/Sources/AgentHub/Models/SessionWorkspaceState.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Models/SessionWorkspaceState.swift
@@ -1,0 +1,23 @@
+//
+//  SessionWorkspaceState.swift
+//  AgentHub
+//
+
+import Foundation
+
+/// Persisted workspace/session selection state for one CLI provider.
+public struct SessionWorkspaceState: Codable, Equatable, Sendable {
+  public var selectedRepositoryPaths: [String]
+  public var monitoredSessionIds: [String]
+  public var expansionState: [String: Bool]
+
+  public init(
+    selectedRepositoryPaths: [String] = [],
+    monitoredSessionIds: [String] = [],
+    expansionState: [String: Bool] = [:]
+  ) {
+    self.selectedRepositoryPaths = selectedRepositoryPaths
+    self.monitoredSessionIds = monitoredSessionIds
+    self.expansionState = expansionState
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/Models/SessionWorkspaceStateRecord.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Models/SessionWorkspaceStateRecord.swift
@@ -1,0 +1,38 @@
+//
+//  SessionWorkspaceStateRecord.swift
+//  AgentHub
+//
+
+import Foundation
+import GRDB
+
+/// SQLite representation of workspace/session selection state for one provider.
+public struct SessionWorkspaceStateRecord: Codable, Sendable, FetchableRecord, PersistableRecord {
+  public static var databaseTableName: String { "session_workspace_state" }
+
+  public var provider: String
+  public var selectedRepositoryPathsData: Data
+  public var monitoredSessionIdsData: Data
+  public var expansionStateData: Data
+  public var updatedAt: Date
+
+  public init(
+    provider: String,
+    state: SessionWorkspaceState,
+    updatedAt: Date = Date()
+  ) throws {
+    self.provider = provider
+    self.selectedRepositoryPathsData = try JSONEncoder().encode(state.selectedRepositoryPaths)
+    self.monitoredSessionIdsData = try JSONEncoder().encode(state.monitoredSessionIds)
+    self.expansionStateData = try JSONEncoder().encode(state.expansionState)
+    self.updatedAt = updatedAt
+  }
+
+  public func decodedState() -> SessionWorkspaceState {
+    SessionWorkspaceState(
+      selectedRepositoryPaths: (try? JSONDecoder().decode([String].self, from: selectedRepositoryPathsData)) ?? [],
+      monitoredSessionIds: (try? JSONDecoder().decode([String].self, from: monitoredSessionIdsData)) ?? [],
+      expansionState: (try? JSONDecoder().decode([String: Bool].self, from: expansionStateData)) ?? [:]
+    )
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/SessionMetadataStore.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/SessionMetadataStore.swift
@@ -14,6 +14,24 @@ public actor SessionMetadataStore: TerminalWorkspaceStoreProtocol {
 
   // MARK: - Properties
 
+  enum MigrationID {
+    static let createSessionMetadata = "v1_create_session_metadata"
+    static let createSessionRepoMapping = "v2_create_session_repo_mapping"
+    static let createAIConfig = "v3_create_ai_config"
+    static let addPinned = "v4_add_pinned"
+    static let createTerminalWorkspaces = "v5_create_terminal_workspaces"
+    static let createSessionWorkspaceState = "v6_create_session_workspace_state"
+  }
+
+  static let migrationIdentifiers = [
+    MigrationID.createSessionMetadata,
+    MigrationID.createSessionRepoMapping,
+    MigrationID.createAIConfig,
+    MigrationID.addPinned,
+    MigrationID.createTerminalWorkspaces,
+    MigrationID.createSessionWorkspaceState
+  ]
+
   private let dbQueue: DatabaseQueue
 
   // MARK: - Initialization
@@ -49,7 +67,7 @@ public actor SessionMetadataStore: TerminalWorkspaceStoreProtocol {
   private nonisolated var migrator: DatabaseMigrator {
     var migrator = DatabaseMigrator()
 
-    migrator.registerMigration("v1_create_session_metadata") { db in
+    migrator.registerMigration(MigrationID.createSessionMetadata) { db in
       try db.create(table: "session_metadata") { t in
         t.column("sessionId", .text).primaryKey()
         t.column("customName", .text)
@@ -58,7 +76,7 @@ public actor SessionMetadataStore: TerminalWorkspaceStoreProtocol {
       }
     }
 
-    migrator.registerMigration("v2_create_session_repo_mapping") { db in
+    migrator.registerMigration(MigrationID.createSessionRepoMapping) { db in
       try db.create(table: "session_repo_mapping") { t in
         t.column("sessionId", .text).primaryKey()
         t.column("parentRepoPath", .text).notNull().indexed()
@@ -67,7 +85,7 @@ public actor SessionMetadataStore: TerminalWorkspaceStoreProtocol {
       }
     }
 
-    migrator.registerMigration("v3_create_ai_config") { db in
+    migrator.registerMigration(MigrationID.createAIConfig) { db in
       try db.create(table: "ai_config") { t in
         t.column("provider", .text).primaryKey()
         t.column("defaultModel", .text).notNull().defaults(to: "")
@@ -79,13 +97,13 @@ public actor SessionMetadataStore: TerminalWorkspaceStoreProtocol {
       }
     }
 
-    migrator.registerMigration("v4_add_pinned") { db in
+    migrator.registerMigration(MigrationID.addPinned) { db in
       try db.alter(table: "session_metadata") { t in
         t.add(column: "isPinned", .boolean).notNull().defaults(to: false)
       }
     }
 
-    migrator.registerMigration("v5_create_terminal_workspaces") { db in
+    migrator.registerMigration(MigrationID.createTerminalWorkspaces) { db in
       try db.create(table: "terminal_workspaces") { t in
         t.column("provider", .text).notNull()
         t.column("sessionId", .text).notNull()
@@ -93,6 +111,16 @@ public actor SessionMetadataStore: TerminalWorkspaceStoreProtocol {
         t.column("snapshotData", .blob).notNull()
         t.column("updatedAt", .datetime).notNull()
         t.primaryKey(["provider", "sessionId", "backend"], onConflict: .replace)
+      }
+    }
+
+    migrator.registerMigration(MigrationID.createSessionWorkspaceState) { db in
+      try db.create(table: "session_workspace_state") { t in
+        t.column("provider", .text).primaryKey()
+        t.column("selectedRepositoryPathsData", .blob).notNull()
+        t.column("monitoredSessionIdsData", .blob).notNull()
+        t.column("expansionStateData", .blob).notNull()
+        t.column("updatedAt", .datetime).notNull()
       }
     }
 
@@ -192,9 +220,28 @@ public actor SessionMetadataStore: TerminalWorkspaceStoreProtocol {
   public func clearAll() throws {
     try dbQueue.write { db in
       _ = try TerminalWorkspaceRecord.deleteAll(db)
+      _ = try SessionWorkspaceStateRecord.deleteAll(db)
       _ = try AIConfigRecord.deleteAll(db)
       _ = try SessionRepoMapping.deleteAll(db)
       _ = try SessionMetadata.deleteAll(db)
+    }
+  }
+
+  // MARK: - Workspace State
+
+  public nonisolated func getWorkspaceStateSync(for provider: SessionProviderKind) -> SessionWorkspaceState {
+    (try? dbQueue.read { db in
+      try SessionWorkspaceStateRecord
+        .filter(Column("provider") == provider.rawValue)
+        .fetchOne(db)?
+        .decodedState()
+    }) ?? SessionWorkspaceState()
+  }
+
+  public func saveWorkspaceState(_ state: SessionWorkspaceState, for provider: SessionProviderKind) async throws {
+    let record = try SessionWorkspaceStateRecord(provider: provider.rawValue, state: state)
+    try await dbQueue.write { db in
+      try record.save(db)
     }
   }
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/GitHubContextDragPayload.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/GitHubContextDragPayload.swift
@@ -1,0 +1,98 @@
+//
+//  GitHubContextDragPayload.swift
+//  AgentHub
+//
+
+import AgentHubGitHub
+import Foundation
+import UniformTypeIdentifiers
+
+extension UTType {
+  static let agentHubGitHubContextItem = UTType(exportedAs: "com.agenthub.github.context-item")
+}
+
+struct GitHubContextDragPayload: Codable, Equatable, Sendable {
+  enum Kind: String, Codable, Sendable {
+    case pullRequest
+    case issue
+  }
+
+  static let typeIdentifier = UTType.agentHubGitHubContextItem.identifier
+
+  let kind: Kind
+  let number: Int
+  let title: String
+  let url: String
+
+  init(kind: Kind, number: Int, title: String, url: String) {
+    self.kind = kind
+    self.number = number
+    self.title = title
+    self.url = url
+  }
+
+  init(pullRequest: GitHubPullRequest) {
+    self.init(
+      kind: .pullRequest,
+      number: pullRequest.number,
+      title: pullRequest.title,
+      url: pullRequest.url
+    )
+  }
+
+  init(issue: GitHubIssue) {
+    self.init(
+      kind: .issue,
+      number: issue.number,
+      title: issue.title,
+      url: issue.url
+    )
+  }
+
+  var commandText: String {
+    switch kind {
+    case .pullRequest:
+      "/review \(url)"
+    case .issue:
+      "fix \(url)"
+    }
+  }
+
+  func makeItemProvider() -> NSItemProvider {
+    let provider = NSItemProvider()
+
+    if let data = try? JSONEncoder().encode(self) {
+      provider.registerDataRepresentation(
+        forTypeIdentifier: Self.typeIdentifier,
+        visibility: .all
+      ) { completion in
+        completion(data, nil)
+        return nil
+      }
+    }
+
+    if let data = commandText.data(using: .utf8) {
+      provider.registerDataRepresentation(
+        forTypeIdentifier: UTType.utf8PlainText.identifier,
+        visibility: .all
+      ) { completion in
+        completion(data, nil)
+        return nil
+      }
+    }
+
+    return provider
+  }
+
+  static func load(from provider: NSItemProvider, completion: @escaping (GitHubContextDragPayload?) -> Void) {
+    provider.loadDataRepresentation(forTypeIdentifier: Self.typeIdentifier) { data, _ in
+      guard let data,
+            let payload = try? JSONDecoder().decode(GitHubContextDragPayload.self, from: data) else {
+        completion(nil)
+        return
+      }
+
+      completion(payload)
+    }
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/GitHubPanelView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/GitHubPanelView.swift
@@ -760,6 +760,9 @@ struct GitHubPRRow: View {
     }
     .buttonStyle(.plain)
     .agentHubFlatRow(isHighlighted: isCurrentBranch)
+    .onDrag {
+      GitHubContextDragPayload(pullRequest: pr).makeItemProvider()
+    }
     .contextMenu {
       Button {
         if let url = URL(string: pr.url) {
@@ -887,6 +890,9 @@ struct GitHubIssueRow: View {
     }
     .buttonStyle(.plain)
     .agentHubFlatRow()
+    .onDrag {
+      GitHubContextDragPayload(issue: issue).makeItemProvider()
+    }
   }
 }
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/GitHubPanelView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/GitHubPanelView.swift
@@ -56,7 +56,7 @@ public struct GitHubPanelView: View {
     .background(panelBackground)
     .task {
       await viewModel.setup(repoPath: projectPath)
-      if viewModel.isGHInstalled && viewModel.isAuthenticated {
+      if viewModel.setupState == .ready {
         await viewModel.loadPullRequests()
         await viewModel.loadCurrentBranchPR()
       }
@@ -126,11 +126,14 @@ public struct GitHubPanelView: View {
 
   @ViewBuilder
   private var content: some View {
-    if !viewModel.isGHInstalled {
+    switch viewModel.setupState {
+    case .checking:
+      loadingView("Checking GitHub setup...")
+    case .ghNotInstalled:
       ghNotInstalledView
-    } else if !viewModel.isAuthenticated {
+    case .notAuthenticated:
       ghNotAuthenticatedView
-    } else {
+    case .ready:
       mainContent
     }
   }

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringCardView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringCardView.swift
@@ -258,10 +258,10 @@ public struct MonitoringCardView: View {
       }
     }
     .onDrop(
-      of: [.fileURL, .png, .tiff, .image, .pdf],
+      of: [.agentHubGitHubContextItem, .fileURL, .png, .tiff, .image, .pdf],
       isTargeted: $isDragging
     ) { providers in
-      handleDroppedFiles(providers)
+      handleDroppedItems(providers)
       return true
     }
     .sheet(item: $simulatorSheetSession) { session in
@@ -309,10 +309,47 @@ public struct MonitoringCardView: View {
 
   // MARK: - Drag and Drop
 
-  /// Handles dropped file providers by extracting paths and typing them into terminal
-  private func handleDroppedFiles(_ providers: [NSItemProvider]) {
+  /// Handles dropped providers by typing context into the terminal without submitting.
+  private func handleDroppedItems(_ providers: [NSItemProvider]) {
     guard let key = terminalKey, let viewModel = viewModel else { return }
 
+    if handleDroppedGitHubContext(providers, key: key, viewModel: viewModel) {
+      return
+    }
+
+    handleDroppedFiles(providers, key: key, viewModel: viewModel)
+  }
+
+  private func handleDroppedGitHubContext(
+    _ providers: [NSItemProvider],
+    key: String,
+    viewModel: CLISessionsViewModel
+  ) -> Bool {
+    guard let provider = providers.first(where: {
+      $0.hasItemConformingToTypeIdentifier(GitHubContextDragPayload.typeIdentifier)
+    }) else {
+      return false
+    }
+
+    GitHubContextDragPayload.load(from: provider) { payload in
+      guard let payload else { return }
+
+      Task { @MainActor in
+        contentMode = .terminal
+        viewModel.typeToTerminal(forKey: key, text: payload.commandText + " ")
+        viewModel.focusTerminal(forKey: key)
+      }
+    }
+
+    return true
+  }
+
+  /// Handles dropped file providers by extracting paths and typing them into terminal.
+  private func handleDroppedFiles(
+    _ providers: [NSItemProvider],
+    key: String,
+    viewModel: CLISessionsViewModel
+  ) {
     for provider in providers {
       // Handle file URLs (files dragged from Finder)
       if provider.hasItemConformingToTypeIdentifier(UTType.fileURL.identifier) {

--- a/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/CLISessionsViewModel.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/CLISessionsViewModel.swift
@@ -129,6 +129,13 @@ public final class CLISessionsViewModel {
   ///   with the terminal's input buffer (see `EmbeddedTerminalView.sendPromptIfNeeded`).
   public var pendingTerminalPrompts: [String: String] = [:]
 
+  /// Maps terminal keys to text that should be typed without submitting once the terminal exists.
+  ///
+  /// This is used for contextual prefill flows such as dragging files or GitHub items onto a
+  /// session card while the terminal surface has not been mounted yet.
+  @ObservationIgnored
+  public var pendingTerminalInputTexts: [String: String] = [:]
+
   /// Pending file open request from Cmd+Click in terminal.
   /// Set by TerminalContainerView, consumed by MultiProviderMonitoringPanelView.
   public var pendingFileOpen: (sessionId: String, filePath: String, lineNumber: Int?)? = nil
@@ -239,6 +246,15 @@ public final class CLISessionsViewModel {
   /// Clears the pending prompt after terminal has started (call from onAppear)
   public func clearPendingPrompt(for sessionId: String) {
     pendingTerminalPrompts.removeValue(forKey: sessionId)
+  }
+
+  /// Returns and clears pending terminal input text for a terminal key.
+  public func consumePendingTerminalInputText(for key: String) -> String? {
+    guard let text = pendingTerminalInputTexts[key], !text.isEmpty else {
+      return nil
+    }
+    pendingTerminalInputTexts.removeValue(forKey: key)
+    return text
   }
 
   public func sendPromptToActiveTerminal(forKey key: String, prompt: String) -> Bool {
@@ -515,6 +531,15 @@ public final class CLISessionsViewModel {
     }
   }
 
+  private func combinedInputText(_ first: String?, _ second: String?) -> String? {
+    let combined = [first, second]
+      .compactMap { $0 }
+      .filter { !$0.isEmpty }
+      .joined()
+
+    return combined.isEmpty ? nil : combined
+  }
+
   /// Gets an existing terminal or creates a new one for the given key.
   /// Key should be session ID for real sessions, or "pending-{pendingId}" for pending sessions.
   /// This preserves the terminal PTY across pending → real session transitions.
@@ -531,12 +556,15 @@ public final class CLISessionsViewModel {
     worktreeName: String? = nil
   ) -> any EmbeddedTerminalSurface {
     let config = cliConfiguration ?? self.currentCLIConfiguration
+    let queuedInputText = consumePendingTerminalInputText(for: key)
+    let descriptorInputText = key.hasPrefix("pending-") ? combinedInputText(initialInputText, queuedInputText) : queuedInputText
+    let createInputText = combinedInputText(initialInputText, queuedInputText)
     let descriptor = TerminalSurfaceDescriptor.cli(
       sessionId: sessionId,
       projectPath: projectPath,
       cliConfiguration: config,
       initialPrompt: key.hasPrefix("pending-") ? initialPrompt : nil,
-      initialInputText: key.hasPrefix("pending-") ? initialInputText : nil,
+      initialInputText: descriptorInputText,
       isDark: isDark,
       dangerouslySkipPermissions: dangerouslySkipPermissions,
       permissionModePlan: permissionModePlan,
@@ -560,6 +588,9 @@ public final class CLISessionsViewModel {
       if let inputText = initialInputText, !inputText.isEmpty {
         existing.typeInitialTextIfNeeded(inputText)
       }
+      if let queuedInputText, !queuedInputText.isEmpty {
+        existing.typeText(queuedInputText)
+      }
       existing.updateContext(terminalSessionKey: key, sessionViewModel: self)
       configureTerminalWorkspacePersistence(for: existing, key: key, sessionId: sessionId)
       return existing
@@ -573,7 +604,7 @@ public final class CLISessionsViewModel {
       projectPath: projectPath,
       cliConfiguration: config,
       initialPrompt: initialPrompt,
-      initialInputText: initialInputText,
+      initialInputText: createInputText,
       isDark: isDark,
       dangerouslySkipPermissions: dangerouslySkipPermissions,
       permissionModePlan: permissionModePlan,
@@ -693,7 +724,11 @@ public final class CLISessionsViewModel {
   /// Types text into the terminal for a given key without pressing Enter.
   /// Used for drag-and-drop file paths where user adds context before submitting.
   public func typeToTerminal(forKey key: String, text: String) {
-    guard let terminal = activeTerminals[key] else { return }
+    guard !text.isEmpty else { return }
+    guard let terminal = activeTerminals[key] else {
+      pendingTerminalInputTexts[key, default: ""] += text
+      return
+    }
     terminal.typeText(text)
   }
 
@@ -783,18 +818,6 @@ public final class CLISessionsViewModel {
   // MARK: - Private
 
   private var subscriptionTask: Task<Void, Never>?
-  private var persistenceKey: String {
-    AgentHubDefaults.selectedRepositories + "." + providerDefaultsSuffix
-  }
-  private var expansionStateKey: String {
-    AgentHubDefaults.keyPrefix + "sessions.expansionState." + providerDefaultsSuffix
-  }
-  private var providerDefaultsSuffix: String {
-    providerKind == .claude ? "claude" : "codex"
-  }
-  private var monitoredSessionsKey: String {
-    AgentHubDefaults.monitoredSessionIds + "." + providerDefaultsSuffix
-  }
   // MARK: - Initialization
 
   public init(
@@ -833,9 +856,7 @@ public final class CLISessionsViewModel {
     self.approvalTimeoutSeconds = savedTimeout > 0 ? savedTimeout : 5
 
     // Set loading state synchronously so the UI never shows empty state during restoration
-    if let data = UserDefaults.standard.data(forKey: persistenceKey),
-       let paths = try? JSONDecoder().decode([String].self, from: data),
-       !paths.isEmpty {
+    if metadataStore?.getWorkspaceStateSync(for: providerKind).selectedRepositoryPaths.isEmpty == false {
       loadingState = .restoringRepositories
     }
 
@@ -1054,15 +1075,14 @@ public final class CLISessionsViewModel {
 
   private func restorePersistedRepositories() {
     Task {
-      // Load persisted repository paths
-      guard let data = UserDefaults.standard.data(forKey: persistenceKey),
-            let paths = try? JSONDecoder().decode([String].self, from: data),
-            !paths.isEmpty else {
+      let workspaceState = metadataStore?.getWorkspaceStateSync(for: providerKind) ?? SessionWorkspaceState()
+      let paths = workspaceState.selectedRepositoryPaths
+      guard !paths.isEmpty else {
         return
       }
 
       // Store persisted session IDs for progressive restoration
-      let persistedSessionIds = loadPersistedSessionIds()
+      let persistedSessionIds = Set(workspaceState.monitoredSessionIds)
       if !persistedSessionIds.isEmpty {
         pendingRestorationSessionIds = persistedSessionIds
       }
@@ -1070,7 +1090,7 @@ public final class CLISessionsViewModel {
       // Add repositories (triggers refreshSessions → setupSubscriptions)
       loadingState = .restoringRepositories
       await monitorService.addRepositories(paths)
-      restoreExpansionState()
+      restoreExpansionState(workspaceState.expansionState)
       loadingState = .idle
 
       // Safety timeout: stop trying to restore after 10 seconds
@@ -1078,16 +1098,6 @@ public final class CLISessionsViewModel {
       pendingRestorationSessionIds.removeAll()
     }
   }
-
-  /// Loads persisted session IDs from UserDefaults
-  private func loadPersistedSessionIds() -> Set<String> {
-    guard let data = UserDefaults.standard.data(forKey: monitoredSessionsKey),
-          let sessionIds = try? JSONDecoder().decode([String].self, from: data) else {
-      return []
-    }
-    return Set(sessionIds)
-  }
-
 
   /// Progressively restores sessions as they become available via setupSubscriptions.
   /// Called each time selectedRepositories is updated. Populates monitoring state directly
@@ -1119,12 +1129,7 @@ public final class CLISessionsViewModel {
     }
   }
 
-  private func restoreExpansionState() {
-    guard let data = UserDefaults.standard.data(forKey: expansionStateKey),
-          let state = try? JSONDecoder().decode([String: Bool].self, from: data) else {
-      return
-    }
-
+  private func restoreExpansionState(_ state: [String: Bool]) {
     for i in selectedRepositories.indices {
       if let expanded = state["repo:" + selectedRepositories[i].path] {
         selectedRepositories[i].isExpanded = expanded
@@ -1138,14 +1143,10 @@ public final class CLISessionsViewModel {
   }
 
   private func persistSelectedRepositories() {
-    let paths = selectedRepositories.map { $0.path }
-    if let data = try? JSONEncoder().encode(paths) {
-      UserDefaults.standard.set(data, forKey: persistenceKey)
-    }
-    persistExpansionState()
+    persistWorkspaceState()
   }
 
-  private func persistExpansionState() {
+  private func currentWorkspaceState() -> SessionWorkspaceState {
     var state: [String: Bool] = [:]
     for repo in selectedRepositories {
       state["repo:" + repo.path] = repo.isExpanded
@@ -1153,17 +1154,33 @@ public final class CLISessionsViewModel {
         state["wt:" + worktree.path] = worktree.isExpanded
       }
     }
-    if let data = try? JSONEncoder().encode(state) {
-      UserDefaults.standard.set(data, forKey: expansionStateKey)
+
+    let sessionIdsToPersist = monitoredSessionIds.union(pendingRestorationSessionIds)
+
+    return SessionWorkspaceState(
+      selectedRepositoryPaths: selectedRepositories.map(\.path),
+      monitoredSessionIds: Array(sessionIdsToPersist).sorted(),
+      expansionState: state
+    )
+  }
+
+  private func persistWorkspaceState() {
+    guard let metadataStore else { return }
+    let state = currentWorkspaceState()
+    let providerKind = providerKind
+
+    Task {
+      do {
+        try await metadataStore.saveWorkspaceState(state, for: providerKind)
+      } catch {
+        AppLogger.session.error("Failed to save workspace state: \(error.localizedDescription)")
+      }
     }
   }
 
-  /// Persists the currently monitored session IDs to UserDefaults
+  /// Persists the currently monitored session IDs to SQLite-backed workspace state.
   private func persistMonitoredSessions() {
-    let sessionIds = Array(monitoredSessionIds)
-    if let data = try? JSONEncoder().encode(sessionIds) {
-      UserDefaults.standard.set(data, forKey: monitoredSessionsKey)
-    }
+    persistWorkspaceState()
   }
 
   /// Syncs the backup store with latest session data from allSessions.
@@ -1494,6 +1511,7 @@ public final class CLISessionsViewModel {
   public func toggleRepositoryExpanded(_ repository: SelectedRepository) {
     guard let index = selectedRepositories.firstIndex(where: { $0.id == repository.id }) else { return }
     selectedRepositories[index].isExpanded.toggle()
+    persistWorkspaceState()
   }
 
   /// Toggles the expanded state of a worktree/branch
@@ -1503,6 +1521,7 @@ public final class CLISessionsViewModel {
       return
     }
     selectedRepositories[repoIndex].worktrees[worktreeIndex].isExpanded.toggle()
+    persistWorkspaceState()
   }
 
   // MARK: - Session Actions

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/AuxiliaryShellTerminalManagementTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/AuxiliaryShellTerminalManagementTests.swift
@@ -61,6 +61,9 @@ private final class TestTerminalSurface: NSView, EmbeddedTerminalSurface {
   var onWorkspaceChanged: ((TerminalWorkspaceSnapshot) -> Void)?
   private(set) var configuredProjectPath: String?
   private(set) var configuredShellPath: String?
+  private(set) var configuredInitialInputText: String?
+  private(set) var typedTexts: [String] = []
+  private(set) var initialTypedTexts: [String] = []
   private(set) var restoredWorkspaceSnapshot: TerminalWorkspaceSnapshot?
   var workspaceSnapshotToCapture: TerminalWorkspaceSnapshot?
   private(set) var configureCallCount = 0
@@ -81,6 +84,7 @@ private final class TestTerminalSurface: NSView, EmbeddedTerminalSurface {
     metadataStore: SessionMetadataStore?
   ) {
     configuredProjectPath = projectPath
+    configuredInitialInputText = initialInputText
     configureCallCount += 1
   }
 
@@ -99,8 +103,12 @@ private final class TestTerminalSurface: NSView, EmbeddedTerminalSurface {
   func resetPromptDeliveryFlag() {}
   func sendPromptIfNeeded(_ prompt: String) {}
   func submitPromptImmediately(_ prompt: String) -> Bool { true }
-  func typeText(_ text: String) {}
-  func typeInitialTextIfNeeded(_ text: String) {}
+  func typeText(_ text: String) {
+    typedTexts.append(text)
+  }
+  func typeInitialTextIfNeeded(_ text: String) {
+    initialTypedTexts.append(text)
+  }
   func syncAppearance(isDark: Bool, fontSize: CGFloat, fontFamily: String, theme: RuntimeTheme?) {}
   func focus() {}
   func captureWorkspaceSnapshot() -> TerminalWorkspaceSnapshot? {
@@ -192,6 +200,45 @@ private final class RecordingTerminalSurfaceFactory: EmbeddedTerminalSurfaceFact
 
 @Suite("Auxiliary shell terminal management", .serialized)
 struct AuxiliaryShellTerminalManagementTests {
+
+  @Test("Typing to an active terminal sends text immediately")
+  @MainActor
+  func typeToTerminalUsesActiveTerminal() {
+    let viewModel = makeAuxiliaryShellViewModel()
+    let terminal = TestTerminalSurface()
+    viewModel.activeTerminals["session-123"] = terminal
+
+    viewModel.typeToTerminal(forKey: "session-123", text: "/review https://github.com/example/repo/pull/1 ")
+
+    #expect(terminal.typedTexts == ["/review https://github.com/example/repo/pull/1 "])
+    #expect(viewModel.pendingTerminalInputTexts["session-123"] == nil)
+  }
+
+  @Test("Typing to a missing terminal queues text for creation")
+  @MainActor
+  func typeToTerminalQueuesUntilTerminalCreation() {
+    let terminal = TestTerminalSurface()
+    let factory = RecordingTerminalSurfaceFactory(surfaces: [terminal])
+    let viewModel = makeAuxiliaryShellViewModel(terminalSurfaceFactory: factory, terminalBackend: .swiftTerm)
+    let command = "fix https://github.com/example/repo/issues/7 "
+
+    viewModel.typeToTerminal(forKey: "session-123", text: command)
+
+    #expect(viewModel.pendingTerminalInputTexts["session-123"] == command)
+
+    _ = viewModel.getOrCreateTerminal(
+      forKey: "session-123",
+      sessionId: "session-123",
+      projectPath: "/tmp/repo",
+      cliConfiguration: CLICommandConfiguration(command: "claude", mode: .claude),
+      initialPrompt: nil,
+      initialInputText: nil,
+      isDark: true
+    )
+
+    #expect(terminal.configuredInitialInputText == command)
+    #expect(viewModel.pendingTerminalInputTexts["session-123"] == nil)
+  }
 
   @Test("Transfers auxiliary shell terminal from pending key to resolved session ID")
   @MainActor

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/GitHubContextDragPayloadTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/GitHubContextDragPayloadTests.swift
@@ -1,0 +1,47 @@
+import Foundation
+import Testing
+
+@testable import AgentHubCore
+
+@Suite("GitHubContextDragPayload")
+struct GitHubContextDragPayloadTests {
+
+  @Test("Pull request payload formats review command")
+  func pullRequestPayloadFormatsReviewCommand() {
+    let payload = GitHubContextDragPayload(
+      kind: .pullRequest,
+      number: 42,
+      title: "Add drag support",
+      url: "https://github.com/example/repo/pull/42"
+    )
+
+    #expect(payload.commandText == "/review https://github.com/example/repo/pull/42")
+  }
+
+  @Test("Issue payload formats fix command")
+  func issuePayloadFormatsFixCommand() {
+    let payload = GitHubContextDragPayload(
+      kind: .issue,
+      number: 7,
+      title: "Fix login state",
+      url: "https://github.com/example/repo/issues/7"
+    )
+
+    #expect(payload.commandText == "fix https://github.com/example/repo/issues/7")
+  }
+
+  @Test("Payload round trips through JSON")
+  func payloadRoundTripsThroughJSON() throws {
+    let payload = GitHubContextDragPayload(
+      kind: .pullRequest,
+      number: 108,
+      title: "Review panel drag payload",
+      url: "https://github.com/example/repo/pull/108"
+    )
+
+    let data = try JSONEncoder().encode(payload)
+    let decoded = try JSONDecoder().decode(GitHubContextDragPayload.self, from: data)
+
+    #expect(decoded == payload)
+  }
+}

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/SessionWorkspaceStatePersistenceTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/SessionWorkspaceStatePersistenceTests.swift
@@ -1,0 +1,49 @@
+import Foundation
+import Testing
+
+@testable import AgentHubCore
+
+@Suite("Session workspace state persistence")
+struct SessionWorkspaceStatePersistenceTests {
+
+  @Test("Workspace state round-trips and is provider scoped")
+  func workspaceStateRoundTrip() async throws {
+    let store = try SessionMetadataStore(path: temporaryWorkspaceStateDatabasePath())
+    let state = SessionWorkspaceState(
+      selectedRepositoryPaths: ["/tmp/project-a", "/tmp/project-b"],
+      monitoredSessionIds: ["session-1", "session-2"],
+      expansionState: [
+        "repo:/tmp/project-a": true,
+        "wt:/tmp/project-a/worktrees/feature": false
+      ]
+    )
+
+    try await store.saveWorkspaceState(state, for: .claude)
+
+    #expect(store.getWorkspaceStateSync(for: .claude) == state)
+    #expect(store.getWorkspaceStateSync(for: .codex) == SessionWorkspaceState())
+  }
+
+  @Test("Clear all removes workspace state")
+  func clearAllRemovesWorkspaceState() async throws {
+    let store = try SessionMetadataStore(path: temporaryWorkspaceStateDatabasePath())
+    try await store.saveWorkspaceState(
+      SessionWorkspaceState(
+        selectedRepositoryPaths: ["/tmp/project"],
+        monitoredSessionIds: ["session-1"],
+        expansionState: ["repo:/tmp/project": true]
+      ),
+      for: .claude
+    )
+
+    try await store.clearAll()
+
+    #expect(store.getWorkspaceStateSync(for: .claude) == SessionWorkspaceState())
+  }
+}
+
+private func temporaryWorkspaceStateDatabasePath() -> String {
+  FileManager.default.temporaryDirectory
+    .appending(path: "test_workspace_state_\(UUID().uuidString).sqlite")
+    .path
+}

--- a/app/modules/AgentHubGitHub/Sources/AgentHubGitHub/ViewModels/GitHubViewModel.swift
+++ b/app/modules/AgentHubGitHub/Sources/AgentHubGitHub/ViewModels/GitHubViewModel.swift
@@ -74,6 +74,15 @@ public enum GitHubLoadingState: Equatable, Sendable {
   case error(String)
 }
 
+// MARK: - Setup State
+
+public enum GitHubSetupState: Equatable, Sendable {
+  case checking
+  case ghNotInstalled
+  case notAuthenticated
+  case ready
+}
+
 // MARK: - Checkout State
 
 public enum CheckoutState: Equatable, Sendable {
@@ -96,6 +105,9 @@ public final class GitHubViewModel {
 
   /// Whether user is authenticated
   public var isAuthenticated: Bool = false
+
+  /// Current setup state for gh availability, authentication, and repository metadata.
+  public var setupState: GitHubSetupState = .checking
 
   /// Repository info
   public var repoInfo: GitHubRepoInfo?
@@ -174,18 +186,29 @@ public final class GitHubViewModel {
   /// Initializes the GitHub integration for a repository path
   public func setup(repoPath: String) async {
     currentRepoPath = repoPath
+    setupState = .checking
+    repoInfo = nil
 
     isGHInstalled = await service.isInstalled()
-    guard isGHInstalled else { return }
+    guard isGHInstalled else {
+      isAuthenticated = false
+      setupState = .ghNotInstalled
+      return
+    }
 
     isAuthenticated = await service.isAuthenticated(at: repoPath)
-    guard isAuthenticated else { return }
+    guard isAuthenticated else {
+      setupState = .notAuthenticated
+      return
+    }
 
     do {
       repoInfo = try await service.getRepoInfo(at: repoPath)
     } catch {
       GitHubLogger.github.error("Failed to get repo info: \(error.localizedDescription)")
     }
+
+    setupState = .ready
   }
 
   // MARK: - Pull Requests

--- a/app/modules/AgentHubGitHub/Tests/AgentHubGitHubTests/GitHubViewModelTests.swift
+++ b/app/modules/AgentHubGitHub/Tests/AgentHubGitHubTests/GitHubViewModelTests.swift
@@ -96,6 +96,16 @@ private func makeCheck(
 @Suite("GitHubViewModel Setup")
 struct GitHubViewModelSetupTests {
 
+  @Test("initial setup state checks GitHub setup")
+  @MainActor
+  func initialSetupStateChecksGitHubSetup() {
+    let vm = GitHubViewModel(service: MockGitHubCLIService())
+
+    #expect(vm.setupState == .checking)
+    #expect(vm.isGHInstalled == false)
+    #expect(vm.isAuthenticated == false)
+  }
+
   @Test("setup detects gh installation and authentication")
   @MainActor
   func setupDetectsInstallAndAuth() async {
@@ -107,6 +117,7 @@ struct GitHubViewModelSetupTests {
 
     #expect(vm.isGHInstalled == true)
     #expect(vm.isAuthenticated == true)
+    #expect(vm.setupState == .ready)
     #expect(vm.repoInfo?.fullName == "testowner/testrepo")
     #expect(mock.getRepoInfoCalled == true)
   }
@@ -122,6 +133,7 @@ struct GitHubViewModelSetupTests {
 
     #expect(vm.isGHInstalled == false)
     #expect(vm.isAuthenticated == false)
+    #expect(vm.setupState == .ghNotInstalled)
     #expect(vm.repoInfo == nil)
   }
 
@@ -136,6 +148,7 @@ struct GitHubViewModelSetupTests {
 
     #expect(vm.isGHInstalled == true)
     #expect(vm.isAuthenticated == false)
+    #expect(vm.setupState == .notAuthenticated)
     #expect(vm.repoInfo == nil)
   }
 }


### PR DESCRIPTION
## Summary
- Add draggable GitHub PR/issue rows and drop handling on monitor cards to prefill terminal review/fix context.
- Move session workspace state to SQLite-backed persistence and remove session-management UserDefaults keys.
- Add migration guardrail tests and document SQLite/UserDefaults ownership in AGENTS.md and CLAUDE.md.

## Validation
- xcodebuild -project app/AgentHub.xcodeproj -scheme AgentHub -destination 'platform=macOS' -only-testing:AgentHubTests/SessionMetadataMigrationSafetyTests -only-testing:AgentHubTests/SessionWorkspaceStatePersistenceTests test
- xcodebuild -project app/AgentHub.xcodeproj -scheme AgentHub -destination 'platform=macOS' -quiet build
- git diff --check
- plutil -lint app/AgentHub/Info.plist
