### PR TITLE
[codex] Add Ghostty terminal pane controls

### DIFF
--- a/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyPendingTerminalPaneView.swift
+++ b/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyPendingTerminalPaneView.swift
@@ -1,0 +1,51 @@
+//
+//  AgentHubGhosttyPendingTerminalPaneView.swift
+//  AgentHub
+//
+
+import SwiftUI
+
+@MainActor
+struct AgentHubGhosttyPendingTerminalPaneView: View {
+  let activity: AgentHubGhosttyTerminalPaneActivity
+
+  var body: some View {
+    VStack(spacing: 0) {
+      HStack(spacing: 0) {
+        Text("Shell")
+          .font(.caption2.weight(.medium))
+          .lineLimit(1)
+          .frame(minWidth: 76, maxWidth: 150, alignment: .leading)
+          .frame(height: 28)
+          .padding(.leading, 10)
+          .padding(.trailing, 10)
+          .foregroundStyle(Color.primary)
+          .background(Color.primary.opacity(0.12))
+          .overlay(alignment: .trailing) {
+            Rectangle()
+              .fill(Color.primary.opacity(0.14))
+              .frame(width: 1)
+          }
+          .overlay(alignment: .bottom) {
+            Rectangle()
+              .fill(Color.accentColor.opacity(0.75))
+              .frame(height: 2)
+          }
+
+        Spacer(minLength: 0)
+      }
+      .frame(height: 28)
+      .background(Color(nsColor: .windowBackgroundColor).opacity(0.72))
+      .overlay(alignment: .bottom) {
+        Rectangle()
+          .fill(Color.secondary.opacity(0.18))
+          .frame(height: 1)
+      }
+
+      AgentHubGhosttyTerminalPaneActivityOverlay(activity: activity)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+    .background(Color.clear)
+  }
+}

--- a/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttySplitLayoutBuilder.swift
+++ b/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttySplitLayoutBuilder.swift
@@ -1,0 +1,79 @@
+//
+//  AgentHubGhosttySplitLayoutBuilder.swift
+//  AgentHub
+//
+
+import GhosttySwift
+
+enum AgentHubGhosttySplitLayoutBuilder {
+  static func addingPanel(
+    _ newPanelID: TerminalPanelID,
+    to root: TerminalSplitLayout.Node,
+    beside anchorPanelID: TerminalPanelID,
+    axis: TerminalSplitAxis
+  ) -> TerminalSplitLayout.Node {
+    switch root {
+    case .panel(let panelID):
+      guard panelID == anchorPanelID else { return root }
+      return .split(axis: axis, children: [.panel(panelID), .panel(newPanelID)])
+
+    case .split(let splitAxis, let children):
+      let updatedChildren = children.map { child in
+        guard child.containsPanel(anchorPanelID) else { return child }
+        return addingPanel(newPanelID, to: child, beside: anchorPanelID, axis: axis)
+      }
+      return .split(axis: splitAxis, children: updatedChildren)
+    }
+  }
+
+  static func removingPanel(
+    _ panelID: TerminalPanelID,
+    from root: TerminalSplitLayout.Node
+  ) -> TerminalSplitLayout.Node? {
+    switch root {
+    case .panel(let currentPanelID):
+      return currentPanelID == panelID ? nil : root
+
+    case .split(let axis, let children):
+      let remainingChildren = children.compactMap { removingPanel(panelID, from: $0) }
+      switch remainingChildren.count {
+      case 0:
+        return nil
+      case 1:
+        return remainingChildren[0]
+      default:
+        return .split(axis: axis, children: remainingChildren)
+      }
+    }
+  }
+
+  static func replacingPanel(
+    _ currentPanelID: TerminalPanelID,
+    with replacementPanelID: TerminalPanelID,
+    in root: TerminalSplitLayout.Node
+  ) -> TerminalSplitLayout.Node {
+    switch root {
+    case .panel(let panelID):
+      return .panel(panelID == currentPanelID ? replacementPanelID : panelID)
+
+    case .split(let axis, let children):
+      return .split(
+        axis: axis,
+        children: children.map {
+          replacingPanel(currentPanelID, with: replacementPanelID, in: $0)
+        }
+      )
+    }
+  }
+}
+
+private extension TerminalSplitLayout.Node {
+  func containsPanel(_ panelID: TerminalPanelID) -> Bool {
+    switch self {
+    case .panel(let currentPanelID):
+      return currentPanelID == panelID
+    case .split(_, let children):
+      return children.contains { $0.containsPanel(panelID) }
+    }
+  }
+}

--- a/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalContainerRepresentable.swift
+++ b/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalContainerRepresentable.swift
@@ -1,0 +1,18 @@
+//
+//  AgentHubGhosttyTerminalContainerRepresentable.swift
+//  AgentHub
+//
+
+import GhosttySwift
+import SwiftUI
+
+@MainActor
+struct AgentHubGhosttyTerminalContainerRepresentable: NSViewRepresentable {
+  let tab: TerminalTab
+
+  func makeNSView(context: Context) -> GhosttyTerminalContainerView {
+    tab.containerView
+  }
+
+  func updateNSView(_ nsView: GhosttyTerminalContainerView, context: Context) {}
+}

--- a/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalPaneActivity.swift
+++ b/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalPaneActivity.swift
@@ -1,0 +1,52 @@
+//
+//  AgentHubGhosttyTerminalPaneActivity.swift
+//  AgentHub
+//
+
+import GhosttySwift
+
+enum AgentHubGhosttyTerminalPaneActivity: Equatable {
+  case starting
+  case closingPanel
+  case closingTerminal
+
+  var message: String {
+    switch self {
+    case .starting:
+      return "Starting terminal..."
+    case .closingPanel:
+      return "Closing panel..."
+    case .closingTerminal:
+      return "Closing terminal..."
+    }
+  }
+}
+
+final class AgentHubGhosttyPaneActivityRegistry {
+  private var activities: [TerminalPanelID: AgentHubGhosttyTerminalPaneActivity] = [:]
+
+  func markStarting(_ panelID: TerminalPanelID) {
+    activities[panelID] = .starting
+  }
+
+  func markClosingPanel(_ panelID: TerminalPanelID) {
+    activities[panelID] = .closingPanel
+  }
+
+  func markClosingTerminal(_ panelID: TerminalPanelID) {
+    activities[panelID] = .closingTerminal
+  }
+
+  @discardableResult
+  func clear(_ panelID: TerminalPanelID) -> Bool {
+    activities.removeValue(forKey: panelID) != nil
+  }
+
+  func reset() {
+    activities.removeAll()
+  }
+
+  func activity(for panelID: TerminalPanelID) -> AgentHubGhosttyTerminalPaneActivity? {
+    activities[panelID]
+  }
+}

--- a/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalPaneActivityOverlay.swift
+++ b/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalPaneActivityOverlay.swift
@@ -1,0 +1,30 @@
+//
+//  AgentHubGhosttyTerminalPaneActivityOverlay.swift
+//  AgentHub
+//
+
+import SwiftUI
+
+struct AgentHubGhosttyTerminalPaneActivityOverlay: View {
+  let activity: AgentHubGhosttyTerminalPaneActivity
+
+  var body: some View {
+    ZStack {
+      Color(nsColor: .textBackgroundColor)
+        .opacity(0.86)
+
+      HStack(spacing: 8) {
+        ProgressView()
+          .controlSize(.small)
+
+        Text(activity.message)
+          .font(.system(size: 12, weight: .medium))
+          .foregroundStyle(.secondary)
+          .lineLimit(1)
+      }
+    }
+    .allowsHitTesting(false)
+    .accessibilityElement(children: .combine)
+    .accessibilityLabel(activity.message)
+  }
+}

--- a/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalPaneHeader.swift
+++ b/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalPaneHeader.swift
@@ -1,0 +1,146 @@
+//
+//  AgentHubGhosttyTerminalPaneHeader.swift
+//  AgentHub
+//
+
+import GhosttySwift
+import SwiftUI
+
+@MainActor
+struct AgentHubGhosttyTerminalPaneHeader: View {
+  let panel: TerminalPanel
+  let canSplit: Bool
+  let canClosePanel: Bool
+  let canCloseTab: (TerminalTab) -> Bool
+  let onSelectTab: (TerminalTab) -> Void
+  let onCloseTab: (TerminalTab) -> Void
+  let onOpenTab: () -> Void
+  let onSplitRight: () -> Void
+  let onSplitBelow: () -> Void
+  let onClosePanel: () -> Void
+
+  var body: some View {
+    HStack(spacing: 6) {
+      ScrollView(.horizontal, showsIndicators: false) {
+        HStack(spacing: 0) {
+          ForEach(Array(panel.tabs.enumerated()), id: \.element.id) { index, tab in
+            tabButton(tab: tab, index: index)
+          }
+        }
+      }
+
+      Spacer(minLength: 4)
+
+      HStack(spacing: 4) {
+        headerIconButton(
+          title: "New Tab",
+          systemImage: "plus",
+          help: "New terminal tab",
+          action: onOpenTab
+        )
+
+        headerIconButton(
+          title: "Split Right",
+          systemImage: "rectangle.split.2x1",
+          help: "Split terminal to the right",
+          isDisabled: !canSplit,
+          action: onSplitRight
+        )
+
+        headerIconButton(
+          title: "Split Below",
+          systemImage: "rectangle.split.1x2",
+          help: "Split terminal below",
+          isDisabled: !canSplit,
+          action: onSplitBelow
+        )
+
+        if canClosePanel {
+          headerIconButton(
+            title: "Close Pane",
+            systemImage: "xmark",
+            help: "Close terminal pane",
+            action: onClosePanel
+          )
+        }
+      }
+      .font(.system(size: 12, weight: .medium))
+      .foregroundStyle(.secondary)
+      .padding(.trailing, 6)
+    }
+    .frame(height: 28)
+    .background(Color(nsColor: .windowBackgroundColor).opacity(0.72))
+    .overlay(alignment: .bottom) {
+      Rectangle()
+        .fill(Color.secondary.opacity(0.18))
+        .frame(height: 1)
+    }
+  }
+
+  private func headerIconButton(
+    title: String,
+    systemImage: String,
+    help: String,
+    isDisabled: Bool = false,
+    action: @escaping () -> Void
+  ) -> some View {
+    Button(title, systemImage: systemImage, action: action)
+      .labelStyle(.iconOnly)
+      .buttonStyle(.plain)
+      .frame(width: 24, height: 24)
+      .contentShape(Rectangle())
+      .disabled(isDisabled)
+      .help(help)
+  }
+
+  private func tabButton(tab: TerminalTab, index: Int) -> some View {
+    let isActive = tab.id == panel.activeTabID
+    let title = tab.displayName(index: index)
+
+    return HStack(spacing: 5) {
+      Button(action: { onSelectTab(tab) }) {
+        Text(title)
+          .font(.caption2.weight(isActive ? .medium : .regular))
+          .lineLimit(1)
+          .frame(minWidth: 76, maxWidth: 150, alignment: .leading)
+          .contentShape(Rectangle())
+      }
+      .buttonStyle(.plain)
+
+      if canCloseTab(tab) {
+        Button(action: { onCloseTab(tab) }) {
+          Label("Close Tab", systemImage: "xmark")
+            .labelStyle(.iconOnly)
+            .font(.system(size: 9, weight: .medium))
+            .frame(width: 14, height: 14)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .help("Close Tab")
+      }
+    }
+    .frame(height: 28)
+    .padding(.leading, 10)
+    .padding(.trailing, canCloseTab(tab) ? 7 : 10)
+    .foregroundStyle(isActive ? Color.primary : Color.secondary)
+    .background {
+      Rectangle()
+        .fill(isActive ? Color.primary.opacity(0.12) : Color.clear)
+    }
+    .overlay(alignment: .trailing) {
+      Rectangle()
+        .fill(Color.primary.opacity(0.14))
+        .frame(width: 1)
+    }
+    .overlay(alignment: .bottom) {
+      if isActive {
+        Rectangle()
+          .fill(Color.accentColor.opacity(0.75))
+          .frame(height: 2)
+      }
+    }
+    .contentShape(Rectangle())
+    .help(title)
+    .zIndex(isActive ? 1 : 0)
+  }
+}

--- a/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalPaneHeader.swift
+++ b/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalPaneHeader.swift
@@ -87,7 +87,7 @@ struct AgentHubGhosttyTerminalPaneHeader: View {
     Button(title, systemImage: systemImage, action: action)
       .labelStyle(.iconOnly)
       .buttonStyle(.plain)
-      .frame(width: 24, height: 24)
+      .frame(width: 32, height: 28)
       .contentShape(Rectangle())
       .disabled(isDisabled)
       .help(help)

--- a/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalPaneView.swift
+++ b/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalPaneView.swift
@@ -1,0 +1,92 @@
+//
+//  AgentHubGhosttyTerminalPaneView.swift
+//  AgentHub
+//
+
+import GhosttySwift
+import SwiftUI
+
+@MainActor
+struct AgentHubGhosttyTerminalPaneView: View {
+  @State private var immediateActivity: AgentHubGhosttyTerminalPaneActivity?
+
+  let panel: TerminalPanel
+  let session: TerminalSession
+  let canClosePanel: (TerminalPanel) -> Bool
+  let canCloseTab: (TerminalPanel, TerminalTab) -> Bool
+  let onActivatePanel: (TerminalPanel) -> Void
+  let onSelectTab: (TerminalPanel, TerminalTab) -> Void
+  let onClosePanel: (TerminalPanel) -> Void
+  let onCloseTab: (TerminalPanel, TerminalTab) -> Void
+  let onOpenTab: (TerminalPanel) -> Void
+  let onSplitPanel: (TerminalPanel, TerminalSplitAxis) -> Void
+  let activity: AgentHubGhosttyTerminalPaneActivity?
+
+  var body: some View {
+    VStack(spacing: 0) {
+      AgentHubGhosttyTerminalPaneHeader(
+        panel: panel,
+        canSplit: session.canOpenPanel,
+        canClosePanel: canClosePanel(panel),
+        canCloseTab: { tab in canCloseTab(panel, tab) },
+        onSelectTab: { tab in onSelectTab(panel, tab) },
+        onCloseTab: closeTab,
+        onOpenTab: { onOpenTab(panel) },
+        onSplitRight: { onSplitPanel(panel, .horizontal) },
+        onSplitBelow: { onSplitPanel(panel, .vertical) },
+        onClosePanel: closePanel
+      )
+
+      if let activeTab = panel.activeTab {
+        ZStack {
+          AgentHubGhosttyTerminalContainerRepresentable(tab: activeTab)
+            .id(activeTab.id)
+
+          if let visibleActivity {
+            AgentHubGhosttyTerminalPaneActivityOverlay(activity: visibleActivity)
+          }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+      } else {
+        Text("No tab available")
+          .foregroundStyle(.secondary)
+          .frame(maxWidth: .infinity, maxHeight: .infinity)
+      }
+    }
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+    .background(Color.clear)
+    .overlay {
+      if panel.id == session.activePanelID && session.visiblePanels.count > 1 {
+        Rectangle()
+          .stroke(Color.accentColor.opacity(0.55), lineWidth: 1)
+      }
+    }
+    .onChange(of: activity) { _, newActivity in
+      if newActivity == nil {
+        immediateActivity = nil
+      }
+    }
+  }
+
+  private var visibleActivity: AgentHubGhosttyTerminalPaneActivity? {
+    immediateActivity ?? activity
+  }
+
+  private func closePanel() {
+    guard immediateActivity == nil else { return }
+    immediateActivity = .closingPanel
+    Task { @MainActor in
+      await Task.yield()
+      onClosePanel(panel)
+    }
+  }
+
+  private func closeTab(_ tab: TerminalTab) {
+    guard immediateActivity == nil else { return }
+    immediateActivity = .closingTerminal
+    Task { @MainActor in
+      await Task.yield()
+      onCloseTab(panel, tab)
+    }
+  }
+}

--- a/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalShortcut.swift
+++ b/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalShortcut.swift
@@ -11,7 +11,7 @@ public enum AgentHubGhosttyTerminalShortcut: Equatable {
   case searchNext
   case searchPrevious
   case openTab
-  case openPane
+  case openPane(axis: TerminalSplitAxis)
   case closePanel
   case focusPanel(TerminalPanelNavigationDirection)
   case selectTab(TerminalTabNavigationDirection)
@@ -46,7 +46,7 @@ public enum AgentHubGhosttyTerminalShortcut: Equatable {
       case "f": return .startSearch
       case "g": return .searchNext
       case "t": return .openTab
-      case "d": return .openPane
+      case "d": return .openPane(axis: .horizontal)
       default: return nil
       }
     }
@@ -60,6 +60,7 @@ public enum AgentHubGhosttyTerminalShortcut: Equatable {
       }
 
       switch key {
+      case "d": return .openPane(axis: .vertical)
       case "g": return .searchPrevious
       case "w": return .closePanel
       default: return nil

--- a/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalSplitView.swift
+++ b/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalSplitView.swift
@@ -1,0 +1,146 @@
+//
+//  AgentHubGhosttyTerminalSplitView.swift
+//  AgentHub
+//
+
+import GhosttySwift
+import SwiftUI
+
+@MainActor
+struct AgentHubGhosttyTerminalSplitView: View {
+  let node: TerminalSplitLayout.Node
+  let session: TerminalSession
+  let canClosePanel: (TerminalPanel) -> Bool
+  let canCloseTab: (TerminalPanel, TerminalTab) -> Bool
+  let onActivatePanel: (TerminalPanel) -> Void
+  let onSelectTab: (TerminalPanel, TerminalTab) -> Void
+  let onClosePanel: (TerminalPanel) -> Void
+  let onCloseTab: (TerminalPanel, TerminalTab) -> Void
+  let onOpenTab: (TerminalPanel) -> Void
+  let onSplitPanel: (TerminalPanel, TerminalSplitAxis) -> Void
+  let activityForPanel: (TerminalPanelID) -> AgentHubGhosttyTerminalPaneActivity?
+
+  var body: some View {
+    content(for: node)
+  }
+
+  @ViewBuilder
+  private func content(for node: TerminalSplitLayout.Node) -> some View {
+    switch node {
+    case .panel(let panelID):
+      if let panel = session.panel(for: panelID) {
+        AgentHubGhosttyTerminalPaneView(
+          panel: panel,
+          session: session,
+          canClosePanel: canClosePanel,
+          canCloseTab: canCloseTab,
+          onActivatePanel: onActivatePanel,
+          onSelectTab: onSelectTab,
+          onClosePanel: onClosePanel,
+          onCloseTab: onCloseTab,
+          onOpenTab: onOpenTab,
+          onSplitPanel: onSplitPanel,
+          activity: activityForPanel(panel.id)
+        )
+      } else if let activity = activityForPanel(panelID) {
+        AgentHubGhosttyPendingTerminalPaneView(activity: activity)
+      } else {
+        EmptyView()
+      }
+
+    case .split(let axis, let children):
+      split(axis: axis, children: children)
+    }
+  }
+
+  @ViewBuilder
+  private func split(
+    axis: TerminalSplitAxis,
+    children: [TerminalSplitLayout.Node]
+  ) -> some View {
+    GeometryReader { proxy in
+      switch axis {
+      case .horizontal:
+        horizontalSplit(children: children, size: proxy.size)
+      case .vertical:
+        verticalSplit(children: children, size: proxy.size)
+      }
+    }
+  }
+
+  private func horizontalSplit(
+    children: [TerminalSplitLayout.Node],
+    size: CGSize
+  ) -> some View {
+    let dividerSize: CGFloat = 1
+    let childCount = CGFloat(max(children.count, 1))
+    let totalDividerWidth = dividerSize * CGFloat(max(children.count - 1, 0))
+    let childWidth = max(0, size.width - totalDividerWidth) / childCount
+
+    return HStack(spacing: 0) {
+      ForEach(Array(children.enumerated()), id: \.offset) { offset, child in
+        if offset > 0 {
+          divider(axis: .horizontal)
+        }
+        AgentHubGhosttyTerminalSplitView(
+          node: child,
+          session: session,
+          canClosePanel: canClosePanel,
+          canCloseTab: canCloseTab,
+          onActivatePanel: onActivatePanel,
+          onSelectTab: onSelectTab,
+          onClosePanel: onClosePanel,
+          onCloseTab: onCloseTab,
+          onOpenTab: onOpenTab,
+          onSplitPanel: onSplitPanel,
+          activityForPanel: activityForPanel
+        )
+        .frame(width: childWidth, height: size.height)
+      }
+    }
+  }
+
+  private func verticalSplit(
+    children: [TerminalSplitLayout.Node],
+    size: CGSize
+  ) -> some View {
+    let dividerSize: CGFloat = 1
+    let childCount = CGFloat(max(children.count, 1))
+    let totalDividerHeight = dividerSize * CGFloat(max(children.count - 1, 0))
+    let childHeight = max(0, size.height - totalDividerHeight) / childCount
+
+    return VStack(spacing: 0) {
+      ForEach(Array(children.enumerated()), id: \.offset) { offset, child in
+        if offset > 0 {
+          divider(axis: .vertical)
+        }
+        AgentHubGhosttyTerminalSplitView(
+          node: child,
+          session: session,
+          canClosePanel: canClosePanel,
+          canCloseTab: canCloseTab,
+          onActivatePanel: onActivatePanel,
+          onSelectTab: onSelectTab,
+          onClosePanel: onClosePanel,
+          onCloseTab: onCloseTab,
+          onOpenTab: onOpenTab,
+          onSplitPanel: onSplitPanel,
+          activityForPanel: activityForPanel
+        )
+        .frame(width: size.width, height: childHeight)
+      }
+    }
+  }
+
+  @ViewBuilder
+  private func divider(axis: TerminalSplitAxis) -> some View {
+    switch axis {
+    case .horizontal:
+      Color.primary.opacity(0.35)
+        .frame(width: 1)
+    case .vertical:
+      Color.primary.opacity(0.35)
+        .frame(height: 1)
+    }
+  }
+}

--- a/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalSurface.swift
+++ b/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalSurface.swift
@@ -43,7 +43,6 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
   private static let terminalTabStripHeight: CGFloat = 28
   private static let shellStartupFallbackDelay: Duration = .milliseconds(900)
   private static let pendingPaneRenderDelay: Duration = .milliseconds(16)
-  private static let closingPaneRenderDelay: Duration = .milliseconds(450)
 
   public var onUserInteraction: (() -> Void)?
   public var onRequestShowEditor: (() -> Void)?
@@ -1010,7 +1009,7 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
     guard pendingPaneCloseTasks[panel.id] == nil else { return }
     markPaneClosingPanel(panel.id)
     pendingPaneCloseTasks[panel.id] = Task { @MainActor [weak self] in
-      try? await Task.sleep(for: Self.closingPaneRenderDelay)
+      await Task.yield()
       guard !Task.isCancelled else { return }
       self?.finishCloseGhosttyPanel(panel.id)
     }
@@ -1048,7 +1047,7 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
     guard pendingTabCloseTasks[tab.id] == nil else { return }
     markPaneClosingTerminal(panel.id)
     pendingTabCloseTasks[tab.id] = Task { @MainActor [weak self] in
-      try? await Task.sleep(for: Self.closingPaneRenderDelay)
+      await Task.yield()
       guard !Task.isCancelled else { return }
       self?.finishCloseGhosttyTab(tab.id, in: panel.id)
     }

--- a/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalSurface.swift
+++ b/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalSurface.swift
@@ -19,9 +19,10 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
   }
 
   private var terminalSession: TerminalSession?
-  private var hostingView: NSHostingView<TerminalSurfaceView>?
+  private var hostingView: NSHostingView<AgentHubGhosttyTerminalWorkspaceView>?
   private var protectedAgentPanelID: TerminalPanelID?
   private var protectedAgentTabID: TerminalTabID?
+  private var splitRoot: TerminalSplitLayout.Node?
   private var pendingMount: PendingMount?
   private var pendingWorkspaceSnapshot: TerminalWorkspaceSnapshot?
   private var isConfigured = false
@@ -29,12 +30,20 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
   private var hasPrefilledInitialInputText = false
   private var registeredPIDs: [ObjectIdentifier: pid_t] = [:]
   private var pidRegistrationTasks: [ObjectIdentifier: Task<Void, Never>] = [:]
+  private var paneActivityRegistry = AgentHubGhosttyPaneActivityRegistry()
+  private var paneActivityTasks: [TerminalPanelID: Task<Void, Never>] = [:]
+  private var pendingPaneOpenTasks: [TerminalPanelID: Task<Void, Never>] = [:]
+  private var pendingPaneCloseTasks: [TerminalPanelID: Task<Void, Never>] = [:]
+  private var pendingTabCloseTasks: [TerminalTabID: Task<Void, Never>] = [:]
   private var localEventMonitor: Any?
   private var projectPath: String = ""
   private var isRestoringWorkspace = false
   private var lastWorkspaceSnapshot: TerminalWorkspaceSnapshot?
   private static let terminalPaneDividerSize: CGFloat = 1
-  private static let terminalTabStripHeight: CGFloat = 24
+  private static let terminalTabStripHeight: CGFloat = 28
+  private static let shellStartupFallbackDelay: Duration = .milliseconds(900)
+  private static let pendingPaneRenderDelay: Duration = .milliseconds(16)
+  private static let closingPaneRenderDelay: Duration = .milliseconds(450)
 
   public var onUserInteraction: (() -> Void)?
   public var onRequestShowEditor: (() -> Void)?
@@ -85,6 +94,9 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
     }
     MainActor.assumeIsolated {
       terminalSession?.requestCloseAll()
+      cancelPendingPaneOpenTasks()
+      cancelPendingCloseTasks()
+      cancelPaneActivityTasks()
       cancelPIDRegistrationTasks()
       unregisterAllPIDs()
     }
@@ -166,6 +178,8 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
     pendingWorkspaceSnapshot = nil
     protectedAgentPanelID = nil
     protectedAgentTabID = nil
+    splitRoot = nil
+    resetPaneActivities()
     isConfigured = false
     hasDeliveredInitialPrompt = false
     hasPrefilledInitialInputText = false
@@ -186,6 +200,9 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
   public func terminateProcess() {
     terminateProcessCallCount += 1
     terminalSession?.requestCloseAll()
+    cancelPendingPaneOpenTasks()
+    cancelPendingCloseTasks()
+    resetPaneActivities()
     cancelPIDRegistrationTasks()
     unregisterAllPIDs()
   }
@@ -342,6 +359,8 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
     }
 
     terminalSession.showPrimaryAndAuxiliaries()
+    splitRoot = terminalSession.splitLayout?.root ?? .panel(terminalSession.primaryPanelID)
+    refreshWorkspaceRootView()
     restoreActiveSelection(
       from: snapshot,
       panelIDs: restoredPanelIDs,
@@ -383,6 +402,7 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
         protectedAgentPanelID = session.primaryPanelID
         protectedAgentTabID = primaryTab.id
       }
+      splitRoot = .panel(session.primaryPanelID)
       configureControllerHooks(for: session.primaryPanel.activeTab?.controller)
       mount(session)
       terminalSession = session
@@ -434,38 +454,50 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
 
   private func mount(_ session: TerminalSession) {
     let host = NSHostingView(
-      rootView: TerminalSurfaceView(
-        session: session,
-        showsPaneLabels: false,
-        showsTabBar: true,
-        allowsClosingPanels: true,
-        allowsClosingTabs: true,
-        panelClosePolicy: { [weak self] panel in
-          self?.canCloseGhosttyPanel(panel) ?? false
-        },
-        tabClosePolicy: { [weak self] panel, tab in
-          self?.canCloseGhosttyTab(tab, in: panel) ?? false
-        },
-        onActivatePanel: { [weak self] panel in
-          self?.activateGhosttyPanel(panel)
-        },
-        onSelectTab: { [weak self] panel, tab in
-          self?.selectGhosttyTab(tab, in: panel)
-        },
-        onClosePanel: { [weak self] panel in
-          self?.closeGhosttyPanel(panel)
-        },
-        onCloseTab: { [weak self] panel, tab in
-          self?.closeGhosttyTab(tab, in: panel)
-        },
-        onOpenTab: { [weak self] panel in
-          self?.openShellTab(in: panel.id)
-        }
-      )
+      rootView: makeWorkspaceRootView(for: session)
     )
     makeViewTransparent(host)
     mount(host)
     hostingView = host
+  }
+
+  private func makeWorkspaceRootView(for session: TerminalSession) -> AgentHubGhosttyTerminalWorkspaceView {
+    AgentHubGhosttyTerminalWorkspaceView(
+      session: session,
+      splitRoot: splitRoot,
+      canClosePanel: { [weak self] panel in
+        self?.canCloseGhosttyPanel(panel) ?? false
+      },
+      canCloseTab: { [weak self] panel, tab in
+        self?.canCloseGhosttyTab(tab, in: panel) ?? false
+      },
+      onActivatePanel: { [weak self] panel in
+        self?.activateGhosttyPanel(panel)
+      },
+      onSelectTab: { [weak self] panel, tab in
+        self?.selectGhosttyTab(tab, in: panel)
+      },
+      onClosePanel: { [weak self] panel in
+        self?.closeGhosttyPanel(panel)
+      },
+      onCloseTab: { [weak self] panel, tab in
+        self?.closeGhosttyTab(tab, in: panel)
+      },
+      onOpenTab: { [weak self] panel in
+        self?.openShellTab(in: panel.id)
+      },
+      onSplitPanel: { [weak self] panel, axis in
+        self?.openShellPane(axis: axis, anchorPanelID: panel.id)
+      },
+      activityForPanel: { [weak self] panelID in
+        self?.paneActivityRegistry.activity(for: panelID)
+      }
+    )
+  }
+
+  private func refreshWorkspaceRootView() {
+    guard let terminalSession, let hostingView else { return }
+    hostingView.rootView = makeWorkspaceRootView(for: terminalSession)
   }
 
   private func mount(_ child: NSView) {
@@ -526,7 +558,11 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
     )
   }
 
-  private func shellConfigurationForNewTerminal(in panelID: TerminalPanelID? = nil) -> GhosttySurfaceConfiguration {
+  private func shellConfigurationForNewTerminal(
+    in panelID: TerminalPanelID? = nil,
+    splitAxis: TerminalSplitAxis = .horizontal,
+    anchorPanelID: TerminalPanelID? = nil
+  ) -> GhosttySurfaceConfiguration {
     let sourceController = panelID
       .flatMap { terminalSession?.panel(for: $0)?.activeTab?.controller }
       ?? activeController
@@ -539,7 +575,11 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
       environment: launch.environment,
       initialInput: nil,
       workingDirectory: workingDirectory,
-      initialSize: predictedInitialSizeForNewTerminal(in: panelID)
+      initialSize: predictedInitialSizeForNewTerminal(
+        in: panelID,
+        splitAxis: splitAxis,
+        anchorPanelID: anchorPanelID
+      )
     )
   }
 
@@ -559,10 +599,19 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
   }
 
   private func currentInitialSurfaceSize() -> GhosttySurfaceInitialSize? {
-    initialSurfaceSize(from: bounds.size)
+    initialSurfaceSize(
+      from: Self.terminalContentSize(
+        forPaneSize: bounds.size,
+        showsTabStrip: true
+      )
+    )
   }
 
-  private func predictedInitialSizeForNewTerminal(in panelID: TerminalPanelID? = nil) -> GhosttySurfaceInitialSize? {
+  private func predictedInitialSizeForNewTerminal(
+    in panelID: TerminalPanelID? = nil,
+    splitAxis: TerminalSplitAxis = .horizontal,
+    anchorPanelID: TerminalPanelID? = nil
+  ) -> GhosttySurfaceInitialSize? {
     guard let terminalSession else {
       return currentInitialSurfaceSize()
     }
@@ -577,10 +626,13 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
     }
 
     let newPanelID = TerminalPanelID()
-    let projectedPanelIDs = terminalSession.visiblePanels.map(\.id) + [newPanelID]
-    let projectedLayout = TerminalSplitLayout(axis: .horizontal, panelIDs: projectedPanelIDs)
+    let projectedRoot = projectedSplitRoot(
+      adding: newPanelID,
+      axis: splitAxis,
+      anchorPanelID: anchorPanelID ?? terminalSession.activePanelID
+    )
     let frames = Self.panelFrames(
-      for: projectedLayout.root,
+      for: projectedRoot,
       in: CGRect(origin: .zero, size: bounds.size)
     )
 
@@ -629,6 +681,7 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
     }
 
     focusProtectedAgentTab()
+    splitRoot = .panel(terminalSession.primaryPanelID)
   }
 
   private func restoreShellTabs(
@@ -820,8 +873,8 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
       _ = activeController?.navigateSearchPrevious()
     case .openTab:
       openShellTab()
-    case .openPane:
-      openShellPane()
+    case .openPane(let axis):
+      openShellPane(axis: axis)
     case .closePanel:
       closeActiveOrLastAuxiliaryPanel()
     case .focusPanel(let direction):
@@ -844,25 +897,77 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
         configuration: shellConfigurationForNewTerminal(in: panelID)
       )
       configureControllerHooks(for: tab.controller)
+      markPaneStarting(panelID ?? terminalSession.activePanelID)
+      refreshWorkspaceRootView()
       notifyWorkspaceChanged()
     } catch {
       AppLogger.session.error("Failed to open Ghostty shell tab: \(error.localizedDescription)")
     }
   }
 
-  private func openShellPane() {
+  private func openShellPane(
+    axis: TerminalSplitAxis = .horizontal,
+    anchorPanelID: TerminalPanelID? = nil
+  ) {
     guard let terminalSession, terminalSession.canOpenPanel else { return }
-    do {
-      prepareVisiblePanelsForPaneTransition(
-        projectedPanelIDs: terminalSession.visiblePanels.map(\.id) + [TerminalPanelID()]
+    let resolvedAnchorPanelID = anchorPanelID ?? terminalSession.activePanelID
+    let projectedPlaceholderID = TerminalPanelID()
+    let projectedRoot = projectedSplitRoot(
+      adding: projectedPlaceholderID,
+      axis: axis,
+      anchorPanelID: resolvedAnchorPanelID
+    )
+    prepareVisiblePanelsForPaneTransition(projectedRoot: projectedRoot)
+    splitRoot = projectedRoot
+    paneActivityRegistry.markStarting(projectedPlaceholderID)
+    refreshWorkspaceRootView()
+
+    pendingPaneOpenTasks[projectedPlaceholderID]?.cancel()
+    pendingPaneOpenTasks[projectedPlaceholderID] = Task { @MainActor [weak self] in
+      try? await Task.sleep(for: Self.pendingPaneRenderDelay)
+      guard !Task.isCancelled else { return }
+      self?.pendingPaneOpenTasks[projectedPlaceholderID] = nil
+      self?.finishOpeningShellPane(
+        axis: axis,
+        anchorPanelID: resolvedAnchorPanelID,
+        placeholderPanelID: projectedPlaceholderID,
+        projectedRoot: projectedRoot
       )
+    }
+  }
+
+  private func finishOpeningShellPane(
+    axis: TerminalSplitAxis,
+    anchorPanelID: TerminalPanelID,
+    placeholderPanelID: TerminalPanelID,
+    projectedRoot: TerminalSplitLayout.Node
+  ) {
+    guard let terminalSession, terminalSession.canOpenPanel else {
+      removePendingShellPane(placeholderPanelID)
+      return
+    }
+    do {
+      _ = terminalSession.focusPanel(anchorPanelID)
       let panel = try terminalSession.openPanel(
         named: "Shell",
-        configuration: shellConfigurationForNewTerminal()
+        configuration: shellConfigurationForNewTerminal(
+          splitAxis: axis,
+          anchorPanelID: anchorPanelID
+        ),
+        axis: axis
       )
+      splitRoot = AgentHubGhosttySplitLayoutBuilder.replacingPanel(
+        placeholderPanelID,
+        with: panel.id,
+        in: splitRoot ?? projectedRoot
+      )
+      clearPaneActivity(placeholderPanelID)
       configureControllerHooks(for: panel.activeTab?.controller)
+      markPaneStarting(panel.id)
+      refreshWorkspaceRootView()
       notifyWorkspaceChanged()
     } catch {
+      removePendingShellPane(placeholderPanelID)
       AppLogger.session.error("Failed to open Ghostty shell pane: \(error.localizedDescription)")
     }
   }
@@ -901,21 +1006,79 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
   }
 
   private func closeGhosttyPanel(_ panel: TerminalPanel) {
-    guard let terminalSession, canCloseGhosttyPanel(panel) else { return }
-    prepareVisiblePanelsForPaneTransition(
-      projectedPanelIDs: terminalSession.visiblePanels.map(\.id).filter { $0 != panel.id }
-    )
+    guard terminalSession != nil, canCloseGhosttyPanel(panel) else { return }
+    guard pendingPaneCloseTasks[panel.id] == nil else { return }
+    markPaneClosingPanel(panel.id)
+    pendingPaneCloseTasks[panel.id] = Task { @MainActor [weak self] in
+      try? await Task.sleep(for: Self.closingPaneRenderDelay)
+      guard !Task.isCancelled else { return }
+      self?.finishCloseGhosttyPanel(panel.id)
+    }
+  }
+
+  private func finishCloseGhosttyPanel(_ panelID: TerminalPanelID) {
+    pendingPaneCloseTasks[panelID] = nil
+    guard
+      let terminalSession,
+      let panel = terminalSession.panel(for: panelID),
+      canCloseGhosttyPanel(panel)
+    else {
+      clearPaneActivity(panelID)
+      refreshWorkspaceRootView()
+      return
+    }
+    let projectedRoot = projectedSplitRoot(removing: panel.id)
+    if let projectedRoot {
+      prepareVisiblePanelsForPaneTransition(projectedRoot: projectedRoot)
+    }
     requestClose(panel)
     if terminalSession.closePanel(panel.id) {
+      clearPaneActivity(panel.id)
+      splitRoot = projectedRoot
+      refreshWorkspaceRootView()
       notifyWorkspaceChanged()
+    } else {
+      clearPaneActivity(panel.id)
+      refreshWorkspaceRootView()
     }
   }
 
   private func closeGhosttyTab(_ tab: TerminalTab, in panel: TerminalPanel) {
-    guard let terminalSession, canCloseGhosttyTab(tab, in: panel) else { return }
+    guard terminalSession != nil, canCloseGhosttyTab(tab, in: panel) else { return }
+    guard pendingTabCloseTasks[tab.id] == nil else { return }
+    markPaneClosingTerminal(panel.id)
+    pendingTabCloseTasks[tab.id] = Task { @MainActor [weak self] in
+      try? await Task.sleep(for: Self.closingPaneRenderDelay)
+      guard !Task.isCancelled else { return }
+      self?.finishCloseGhosttyTab(tab.id, in: panel.id)
+    }
+  }
+
+  private func finishCloseGhosttyTab(_ tabID: TerminalTabID, in panelID: TerminalPanelID) {
+    pendingTabCloseTasks[tabID] = nil
+    guard
+      let terminalSession,
+      let panel = terminalSession.panel(for: panelID),
+      let tab = panel.tabs.first(where: { $0.id == tabID }),
+      canCloseGhosttyTab(tab, in: panel)
+    else {
+      clearPaneActivity(panelID)
+      refreshWorkspaceRootView()
+      return
+    }
+    let closesPanel = panel.tabs.count == 1
+    let projectedRoot = closesPanel ? projectedSplitRoot(removing: panel.id) : splitRoot
     requestClose(tab)
     if terminalSession.closeTab(tab.id, in: panel.id) {
+      clearPaneActivity(panel.id)
+      if closesPanel {
+        splitRoot = projectedRoot
+      }
+      refreshWorkspaceRootView()
       notifyWorkspaceChanged()
+    } else {
+      clearPaneActivity(panel.id)
+      refreshWorkspaceRootView()
     }
   }
 
@@ -925,13 +1088,10 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
     }
   }
 
-  private func prepareVisiblePanelsForPaneTransition(projectedPanelIDs: [TerminalPanelID]) {
+  private func prepareVisiblePanelsForPaneTransition(projectedRoot: TerminalSplitLayout.Node) {
     guard let terminalSession, bounds.width > 0, bounds.height > 0 else { return }
-    guard !projectedPanelIDs.isEmpty else { return }
-
-    let layout = TerminalSplitLayout(axis: .horizontal, panelIDs: projectedPanelIDs)
     let frames = Self.panelFrames(
-      for: layout.root,
+      for: projectedRoot,
       in: CGRect(origin: .zero, size: bounds.size)
     )
 
@@ -950,7 +1110,33 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
   }
 
   private func shouldShowTabStrip(for panel: TerminalPanel) -> Bool {
-    panel.tabs.count > 1 || canCloseGhosttyPanel(panel)
+    true
+  }
+
+  private func currentSplitRoot() -> TerminalSplitLayout.Node? {
+    guard let terminalSession else { return nil }
+    return splitRoot ?? terminalSession.splitLayout?.root ?? .panel(terminalSession.primaryPanelID)
+  }
+
+  private func projectedSplitRoot(
+    adding newPanelID: TerminalPanelID,
+    axis: TerminalSplitAxis,
+    anchorPanelID: TerminalPanelID
+  ) -> TerminalSplitLayout.Node {
+    guard let root = currentSplitRoot() else {
+      return .panel(newPanelID)
+    }
+    return AgentHubGhosttySplitLayoutBuilder.addingPanel(
+      newPanelID,
+      to: root,
+      beside: anchorPanelID,
+      axis: axis
+    )
+  }
+
+  private func projectedSplitRoot(removing panelID: TerminalPanelID) -> TerminalSplitLayout.Node? {
+    guard let root = currentSplitRoot() else { return nil }
+    return AgentHubGhosttySplitLayoutBuilder.removingPanel(panelID, from: root)
   }
 
   private static func terminalContentSize(forPaneSize paneSize: CGSize, showsTabStrip: Bool) -> CGSize {
@@ -1049,8 +1235,10 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
       guard let self, let controller else { return }
       self.closeControllerIfAllowed(controller)
     }
-    controller.onStateChange = { [weak self] _ in
-      self?.notifyWorkspaceChanged()
+    controller.onStateChange = { [weak self] controller in
+      guard let self else { return }
+      self.finishPaneStarting(for: controller)
+      self.notifyWorkspaceChanged()
     }
     controller.onOpenURL = { [weak self] url in
       self?.handleOpenURL(url) ?? false
@@ -1066,8 +1254,15 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
       return
     }
     guard !isProtectedAgentTab(located.tab, in: located.panel.id) else { return }
+    let closesPanel = located.panel.tabs.count == 1
+    let projectedRoot = closesPanel ? projectedSplitRoot(removing: located.panel.id) : splitRoot
     requestClose(located.tab)
     if terminalSession.closeTab(located.tab.id, in: located.panel.id) {
+      if closesPanel {
+        clearPaneActivity(located.panel.id)
+        splitRoot = projectedRoot
+      }
+      refreshWorkspaceRootView()
       notifyWorkspaceChanged()
     }
   }
@@ -1157,17 +1352,123 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
     onWorkspaceChanged?(snapshot)
   }
 
+  private func markPaneStarting(_ panelID: TerminalPanelID) {
+    paneActivityRegistry.markStarting(panelID)
+    schedulePaneActivityClear(panelID)
+    refreshWorkspaceRootView()
+    finishPaneStartingIfReady(panelID)
+  }
+
+  private func markPaneClosingPanel(_ panelID: TerminalPanelID) {
+    paneActivityTasks[panelID]?.cancel()
+    paneActivityTasks[panelID] = nil
+    paneActivityRegistry.markClosingPanel(panelID)
+    refreshWorkspaceRootView()
+  }
+
+  private func markPaneClosingTerminal(_ panelID: TerminalPanelID) {
+    paneActivityTasks[panelID]?.cancel()
+    paneActivityTasks[panelID] = nil
+    paneActivityRegistry.markClosingTerminal(panelID)
+    refreshWorkspaceRootView()
+  }
+
+  private func schedulePaneActivityClear(_ panelID: TerminalPanelID) {
+    paneActivityTasks[panelID]?.cancel()
+    paneActivityTasks[panelID] = Task { @MainActor [weak self] in
+      try? await Task.sleep(for: Self.shellStartupFallbackDelay)
+      guard !Task.isCancelled else { return }
+      self?.finishPaneStarting(panelID)
+    }
+  }
+
+  private func clearPaneActivity(_ panelID: TerminalPanelID) {
+    paneActivityTasks[panelID]?.cancel()
+    paneActivityTasks[panelID] = nil
+    paneActivityRegistry.clear(panelID)
+  }
+
+  private func removePendingShellPane(_ panelID: TerminalPanelID) {
+    pendingPaneOpenTasks[panelID]?.cancel()
+    pendingPaneOpenTasks[panelID] = nil
+    clearPaneActivity(panelID)
+    if let root = currentSplitRoot() {
+      splitRoot = AgentHubGhosttySplitLayoutBuilder.removingPanel(panelID, from: root)
+    }
+    refreshWorkspaceRootView()
+  }
+
+  private func finishPaneStarting(_ panelID: TerminalPanelID) {
+    paneActivityTasks[panelID]?.cancel()
+    paneActivityTasks[panelID] = nil
+    guard paneActivityRegistry.clear(panelID) else { return }
+    refreshWorkspaceRootView()
+  }
+
+  private func finishPaneStarting(for controller: GhosttyTerminalController) {
+    guard let located = locateController(controller) else { return }
+    guard let foregroundProcessID = controller.foregroundProcessID, foregroundProcessID > 0 else {
+      return
+    }
+    finishPaneStarting(located.panel.id)
+  }
+
+  private func finishPaneStartingIfReady(_ panelID: TerminalPanelID) {
+    guard paneHasForegroundProcess(panelID) else { return }
+    finishPaneStarting(panelID)
+  }
+
+  private func paneHasForegroundProcess(_ panelID: TerminalPanelID) -> Bool {
+    guard let panel = terminalSession?.panel(for: panelID) else { return false }
+    return panel.tabs.contains { tab in
+      guard let foregroundProcessID = tab.controller.foregroundProcessID else { return false }
+      return foregroundProcessID > 0
+    }
+  }
+
+  private func resetPaneActivities() {
+    cancelPaneActivityTasks()
+    paneActivityRegistry.reset()
+  }
+
+  private func cancelPaneActivityTasks() {
+    for task in paneActivityTasks.values {
+      task.cancel()
+    }
+    paneActivityTasks.removeAll()
+  }
+
+  private func cancelPendingPaneOpenTasks() {
+    for task in pendingPaneOpenTasks.values {
+      task.cancel()
+    }
+    pendingPaneOpenTasks.removeAll()
+  }
+
+  private func cancelPendingCloseTasks() {
+    for task in pendingPaneCloseTasks.values {
+      task.cancel()
+    }
+    pendingPaneCloseTasks.removeAll()
+
+    for task in pendingTabCloseTasks.values {
+      task.cancel()
+    }
+    pendingTabCloseTasks.removeAll()
+  }
+
   private func registerPIDWhenAvailable(for controller: GhosttyTerminalController) {
     let id = ObjectIdentifier(controller)
     pidRegistrationTasks[id]?.cancel()
     pidRegistrationTasks[id] = Task { @MainActor [weak self, weak controller] in
       for _ in 0..<10 {
         guard let self, let controller else { return }
-        guard self.locateController(controller) != nil else { return }
+        guard let located = self.locateController(controller) else { return }
         if let pid = controller.foregroundProcessID, pid > 0 {
           self.registeredPIDs[id] = pid
           TerminalProcessRegistry.shared.register(pid: pid)
           self.pidRegistrationTasks[id] = nil
+          self.finishPaneStarting(located.panel.id)
           return
         }
         try? await Task.sleep(for: .milliseconds(100))

--- a/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalWorkspaceView.swift
+++ b/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalWorkspaceView.swift
@@ -1,0 +1,48 @@
+//
+//  AgentHubGhosttyTerminalWorkspaceView.swift
+//  AgentHub
+//
+
+import GhosttySwift
+import SwiftUI
+
+@MainActor
+struct AgentHubGhosttyTerminalWorkspaceView: View {
+  let session: TerminalSession
+  let splitRoot: TerminalSplitLayout.Node?
+  let canClosePanel: (TerminalPanel) -> Bool
+  let canCloseTab: (TerminalPanel, TerminalTab) -> Bool
+  let onActivatePanel: (TerminalPanel) -> Void
+  let onSelectTab: (TerminalPanel, TerminalTab) -> Void
+  let onClosePanel: (TerminalPanel) -> Void
+  let onCloseTab: (TerminalPanel, TerminalTab) -> Void
+  let onOpenTab: (TerminalPanel) -> Void
+  let onSplitPanel: (TerminalPanel, TerminalSplitAxis) -> Void
+  let activityForPanel: (TerminalPanelID) -> AgentHubGhosttyTerminalPaneActivity?
+
+  var body: some View {
+    if session.visiblePanels.isEmpty {
+      Text("No terminal available")
+        .foregroundStyle(.secondary)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    } else {
+      AgentHubGhosttyTerminalSplitView(
+        node: resolvedSplitRoot,
+        session: session,
+        canClosePanel: canClosePanel,
+        canCloseTab: canCloseTab,
+        onActivatePanel: onActivatePanel,
+        onSelectTab: onSelectTab,
+        onClosePanel: onClosePanel,
+        onCloseTab: onCloseTab,
+        onOpenTab: onOpenTab,
+        onSplitPanel: onSplitPanel,
+        activityForPanel: activityForPanel
+      )
+    }
+  }
+
+  private var resolvedSplitRoot: TerminalSplitLayout.Node {
+    splitRoot ?? session.splitLayout?.root ?? .panel(session.primaryPanelID)
+  }
+}

--- a/app/modules/Ghostty/Tests/GhosttyTests/AgentHubGhosttyPaneActivityRegistryTests.swift
+++ b/app/modules/Ghostty/Tests/GhosttyTests/AgentHubGhosttyPaneActivityRegistryTests.swift
@@ -1,0 +1,78 @@
+import Foundation
+import GhosttySwift
+import Testing
+
+@testable import Ghostty
+
+@Suite("AgentHub Ghostty pane activity registry")
+struct AgentHubGhosttyPaneActivityRegistryTests {
+
+  @Test("Marking a pane as starting exposes the starting activity")
+  func markingPaneStartingExposesStartingActivity() {
+    let registry = AgentHubGhosttyPaneActivityRegistry()
+    let panelID = TerminalPanelID(UUID(uuidString: "00000000-0000-0000-0000-000000000001")!)
+
+    registry.markStarting(panelID)
+
+    #expect(registry.activity(for: panelID) == .starting)
+    #expect(registry.activity(for: panelID)?.message == "Starting terminal...")
+  }
+
+  @Test("Marking a pane as closing panel exposes the closing panel activity")
+  func markingPaneClosingPanelExposesClosingPanelActivity() {
+    let registry = AgentHubGhosttyPaneActivityRegistry()
+    let panelID = TerminalPanelID(UUID(uuidString: "00000000-0000-0000-0000-000000000001")!)
+
+    registry.markClosingPanel(panelID)
+
+    #expect(registry.activity(for: panelID) == .closingPanel)
+    #expect(registry.activity(for: panelID)?.message == "Closing panel...")
+  }
+
+  @Test("Marking a pane as closing terminal exposes the closing terminal activity")
+  func markingPaneClosingTerminalExposesClosingTerminalActivity() {
+    let registry = AgentHubGhosttyPaneActivityRegistry()
+    let panelID = TerminalPanelID(UUID(uuidString: "00000000-0000-0000-0000-000000000001")!)
+
+    registry.markClosingTerminal(panelID)
+
+    #expect(registry.activity(for: panelID) == .closingTerminal)
+    #expect(registry.activity(for: panelID)?.message == "Closing terminal...")
+  }
+
+  @Test("Clearing a pane removes its activity")
+  func clearingPaneRemovesActivity() {
+    let registry = AgentHubGhosttyPaneActivityRegistry()
+    let panelID = TerminalPanelID(UUID(uuidString: "00000000-0000-0000-0000-000000000001")!)
+    registry.markStarting(panelID)
+
+    let didClearActivity = registry.clear(panelID)
+
+    #expect(didClearActivity)
+    #expect(registry.activity(for: panelID) == nil)
+  }
+
+  @Test("Clearing a pane without activity reports no change")
+  func clearingPaneWithoutActivityReportsNoChange() {
+    let registry = AgentHubGhosttyPaneActivityRegistry()
+    let panelID = TerminalPanelID(UUID(uuidString: "00000000-0000-0000-0000-000000000001")!)
+
+    let didClearActivity = registry.clear(panelID)
+
+    #expect(!didClearActivity)
+  }
+
+  @Test("Reset removes all pane activities")
+  func resetRemovesAllActivities() {
+    let registry = AgentHubGhosttyPaneActivityRegistry()
+    let firstPanelID = TerminalPanelID(UUID(uuidString: "00000000-0000-0000-0000-000000000001")!)
+    let secondPanelID = TerminalPanelID(UUID(uuidString: "00000000-0000-0000-0000-000000000002")!)
+    registry.markStarting(firstPanelID)
+    registry.markStarting(secondPanelID)
+
+    registry.reset()
+
+    #expect(registry.activity(for: firstPanelID) == nil)
+    #expect(registry.activity(for: secondPanelID) == nil)
+  }
+}

--- a/app/modules/Ghostty/Tests/GhosttyTests/AgentHubGhosttySplitLayoutBuilderTests.swift
+++ b/app/modules/Ghostty/Tests/GhosttyTests/AgentHubGhosttySplitLayoutBuilderTests.swift
@@ -1,0 +1,90 @@
+import Foundation
+import GhosttySwift
+import Testing
+
+@testable import Ghostty
+
+@Suite("AgentHub Ghostty split layout builder")
+struct AgentHubGhosttySplitLayoutBuilderTests {
+
+  @Test("Split right adds the new panel beside the active panel")
+  func splitRightAddsSiblingBesideActivePanel() {
+    let primary = TerminalPanelID(UUID(uuidString: "00000000-0000-0000-0000-000000000001")!)
+    let shell = TerminalPanelID(UUID(uuidString: "00000000-0000-0000-0000-000000000002")!)
+
+    let result = AgentHubGhosttySplitLayoutBuilder.addingPanel(
+      shell,
+      to: .panel(primary),
+      beside: primary,
+      axis: .horizontal
+    )
+
+    #expect(result == .split(axis: .horizontal, children: [.panel(primary), .panel(shell)]))
+  }
+
+  @Test("Split below nests the new panel under the active panel")
+  func splitBelowNestsPanelUnderActivePanel() {
+    let primary = TerminalPanelID(UUID(uuidString: "00000000-0000-0000-0000-000000000001")!)
+    let shell1 = TerminalPanelID(UUID(uuidString: "00000000-0000-0000-0000-000000000002")!)
+    let shell2 = TerminalPanelID(UUID(uuidString: "00000000-0000-0000-0000-000000000003")!)
+
+    let root = TerminalSplitLayout.Node.split(
+      axis: .horizontal,
+      children: [.panel(primary), .panel(shell1)]
+    )
+
+    let result = AgentHubGhosttySplitLayoutBuilder.addingPanel(
+      shell2,
+      to: root,
+      beside: shell1,
+      axis: .vertical
+    )
+
+    #expect(
+      result == .split(
+        axis: .horizontal,
+        children: [
+          .panel(primary),
+          .split(axis: .vertical, children: [.panel(shell1), .panel(shell2)])
+        ]
+      )
+    )
+  }
+
+  @Test("Removing a panel collapses single-child split groups")
+  func removingPanelCollapsesSingleChildSplitGroups() {
+    let primary = TerminalPanelID(UUID(uuidString: "00000000-0000-0000-0000-000000000001")!)
+    let shell1 = TerminalPanelID(UUID(uuidString: "00000000-0000-0000-0000-000000000002")!)
+    let shell2 = TerminalPanelID(UUID(uuidString: "00000000-0000-0000-0000-000000000003")!)
+    let root = TerminalSplitLayout.Node.split(
+      axis: .horizontal,
+      children: [
+        .panel(primary),
+        .split(axis: .vertical, children: [.panel(shell1), .panel(shell2)])
+      ]
+    )
+
+    let result = AgentHubGhosttySplitLayoutBuilder.removingPanel(shell1, from: root)
+
+    #expect(result == .split(axis: .horizontal, children: [.panel(primary), .panel(shell2)]))
+  }
+
+  @Test("Replacing a placeholder panel preserves the split structure")
+  func replacingPlaceholderPanelPreservesSplitStructure() {
+    let primary = TerminalPanelID(UUID(uuidString: "00000000-0000-0000-0000-000000000001")!)
+    let placeholder = TerminalPanelID(UUID(uuidString: "00000000-0000-0000-0000-000000000002")!)
+    let shell = TerminalPanelID(UUID(uuidString: "00000000-0000-0000-0000-000000000003")!)
+    let root = TerminalSplitLayout.Node.split(
+      axis: .vertical,
+      children: [.panel(primary), .panel(placeholder)]
+    )
+
+    let result = AgentHubGhosttySplitLayoutBuilder.replacingPanel(
+      placeholder,
+      with: shell,
+      in: root
+    )
+
+    #expect(result == .split(axis: .vertical, children: [.panel(primary), .panel(shell)]))
+  }
+}

--- a/app/modules/Ghostty/Tests/GhosttyTests/AgentHubGhosttyTerminalShortcutTests.swift
+++ b/app/modules/Ghostty/Tests/GhosttyTests/AgentHubGhosttyTerminalShortcutTests.swift
@@ -10,7 +10,7 @@ struct AgentHubGhosttyTerminalShortcutTests {
   @Test("Command shortcuts match Ghostty terminal actions")
   func commandShortcuts() {
     expectAction(.openTab, key: "t", flags: .command)
-    expectAction(.openPane, key: "d", flags: .command)
+    expectAction(.openPane(axis: .horizontal), key: "d", flags: .command)
     expectAction(.startSearch, key: "f", flags: .command)
     expectAction(.searchNext, key: "g", flags: .command)
     expectNoAction(key: "w", flags: .command)
@@ -18,6 +18,7 @@ struct AgentHubGhosttyTerminalShortcutTests {
 
   @Test("Shift-command shortcuts match Ghostty terminal actions")
   func shiftedCommandShortcuts() {
+    expectAction(.openPane(axis: .vertical), key: "d", flags: [.command, .shift])
     expectAction(.searchPrevious, key: "g", flags: [.command, .shift])
     expectAction(.closePanel, key: "w", flags: [.command, .shift])
   }


### PR DESCRIPTION
## Summary

Adds AgentHub-owned Ghostty terminal pane chrome with a flat tab/header design, pane splitting controls, and pane activity overlays.

## Changes

- Add toolbar controls for new tab, split right, split below, and close pane.
- Render Ghostty panes through AgentHub SwiftUI views so horizontal and vertical split layout is controlled by the app.
- Add starting and closing overlays for terminal panes, including immediate close feedback when tapping the close buttons.
- Increase terminal toolbar button hit targets without increasing the bar height.
- Add focused tests for pane activity registry behavior, split layout building, and updated shortcuts.

## Validation

- `git diff --check`
- `xcodebuild build -project app/AgentHub.xcodeproj -scheme AgentHub -destination 'platform=macOS'`

Note: SwiftPM package tests for `app/modules/Ghostty` are still blocked by the existing transitive `CodeEditSymbols` `Bundle.module` compile issue.