### PR TITLE
Move process registry to SQLite

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,8 @@ Concrete types: `CLISessionMonitorService` / `CodexSessionMonitorService`, `Sess
 - Production migrations must be additive or explicit data transforms. Do not use broad `delete`, `drop table`, `clearAll()`, or `eraseDatabaseOnSchemaChange` in app migrations.
 - Every `SessionMetadataStore` schema change must include a migration-preservation test that seeds the current baseline DB and proves existing rows survive migration.
 - Process cleanup must verify persisted PID identity before terminating. If PID start time/process group no longer matches the row, delete the stale row without killing.
+- Process group cleanup is only allowed for groups AgentHub owns. Persist/use a process group only when the child is its own group leader (`pgid == pid`); inherited PGIDs must fall back to PID-only termination.
+- Keep launch/crash-recovery cleanup broad, but user-triggered orphan cleanup must be scoped to inactive terminal rows for the relevant provider/PIDs. It must not sweep dev-server rows or active terminals.
 
 ```swift
 protocol SessionSearchServiceProtocol {

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,10 +45,13 @@ Concrete types: `CLISessionMonitorService` / `CodexSessionMonitorService`, `Sess
 - AI override flags are applied only when starting a new CLI session, never when resuming an existing one
 - Empty or unsupported saved provider settings must fall back to the CLI's own defaults instead of emitting override flags
 - UserDefaults is only for app/UI preferences. Session/workspace management state must live in SQLite via `SessionMetadataStore`.
-- Never add `AgentHubDefaults` keys for selected repositories, monitored session IDs, session restore state, repo mappings, or terminal workspace state.
+- Never add `AgentHubDefaults` keys for selected repositories, monitored session IDs, session restore state, repo mappings, terminal workspace state, or terminal/dev-server process cleanup state.
+- `managed_processes` is the SQLite authority for app-spawned terminal/dev-server cleanup. Process rows must store only process identity/routing metadata needed for cleanup (PID, process group, process start time, kind/provider/session/project context), never prompts, full environment, terminal contents, or other sensitive runtime payloads.
 - Schema changes must append a new `DatabaseMigrator` migration. Never edit, rename, reorder, or delete existing migration identifiers or bodies.
+- Table versions are the ordered `vN_*` migration identifiers in `SessionMetadataStore`; do not add ad hoc per-table schema version columns unless a table-specific encoded payload requires one.
 - Production migrations must be additive or explicit data transforms. Do not use broad `delete`, `drop table`, `clearAll()`, or `eraseDatabaseOnSchemaChange` in app migrations.
 - Every `SessionMetadataStore` schema change must include a migration-preservation test that seeds the current baseline DB and proves existing rows survive migration.
+- Process cleanup must verify persisted PID identity before terminating. If PID start time/process group no longer matches the row, delete the stale row without killing.
 
 ```swift
 protocol SessionSearchServiceProtocol {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,6 +121,8 @@ final class MockSessionMonitorService: SessionMonitorServiceProtocol { ... }
 - Production migrations must preserve existing rows. Do not use broad `delete`, `drop table`, `clearAll()`, or `eraseDatabaseOnSchemaChange` in migrations.
 - Any `SessionMetadataStore` schema change must add or update migration-preservation tests that seed the current baseline database and verify all existing metadata still reads back after migration.
 - Process cleanup must verify persisted PID identity before terminating. If PID start time/process group no longer matches the row, delete the stale row without killing.
+- Process group cleanup is only allowed for groups AgentHub owns. Persist/use a process group only when the child is its own group leader (`pgid == pid`); inherited PGIDs must fall back to PID-only termination.
+- Keep launch/crash-recovery cleanup broad, but user-triggered orphan cleanup must be scoped to inactive terminal rows for the relevant provider/PIDs. It must not sweep dev-server rows or active terminals.
 
 ## SwiftUI View Guidelines
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,10 +114,13 @@ final class MockSessionMonitorService: SessionMonitorServiceProtocol { ... }
 ### Database Migration Rules
 
 - Session/workspace management state belongs in `SessionMetadataStore` / SQLite, not UserDefaults.
-- Do not add `AgentHubDefaults` keys for selected repositories, monitored session IDs, session restore state, repo mappings, or terminal workspace state.
+- Do not add `AgentHubDefaults` keys for selected repositories, monitored session IDs, session restore state, repo mappings, terminal workspace state, or terminal/dev-server process cleanup state.
+- `managed_processes` is the SQLite authority for app-spawned terminal/dev-server cleanup. Store only process identity/routing metadata needed for cleanup (PID, process group, process start time, kind/provider/session/project context), never prompts, full environment, terminal contents, or other sensitive runtime payloads.
 - Never edit, rename, reorder, or delete existing `DatabaseMigrator` migrations. Add a new `vN_*` migration for every schema change.
+- Treat the ordered `vN_*` migration identifiers in `SessionMetadataStore` as table versioning. Do not add ad hoc per-table schema version columns unless a table-specific encoded payload requires one.
 - Production migrations must preserve existing rows. Do not use broad `delete`, `drop table`, `clearAll()`, or `eraseDatabaseOnSchemaChange` in migrations.
 - Any `SessionMetadataStore` schema change must add or update migration-preservation tests that seed the current baseline database and verify all existing metadata still reads back after migration.
+- Process cleanup must verify persisted PID identity before terminating. If PID start time/process group no longer matches the row, delete the stale row without killing.
 
 ## SwiftUI View Guidelines
 

--- a/app/AgentHub/AgentHubApp.swift
+++ b/app/AgentHub/AgentHubApp.swift
@@ -35,6 +35,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
     // before sessions start restoring. Re-installs happen naturally as each
     // session begins monitoring.
     provider.reconcileClaudeHooksOnLaunch()
+    provider.cleanupOrphanedProcesses()
   }
 
   /// Register all bundled fonts (Geist, GeistMono, JetBrains Mono)

--- a/app/AgentHubTests/ManagedProcessRegistryTests.swift
+++ b/app/AgentHubTests/ManagedProcessRegistryTests.swift
@@ -1,0 +1,189 @@
+import Foundation
+import Testing
+
+@testable import AgentHubCore
+
+@Suite("Managed process registry")
+struct ManagedProcessRegistryTests {
+  @Test("SQLite store saves and deletes managed process rows without touching session metadata")
+  func sqliteStoreSavesAndDeletesManagedProcessRows() async throws {
+    let store = try SessionMetadataStore(path: temporaryManagedProcessRegistryDatabasePath())
+    try await store.setCustomName("Important session", for: "session-1")
+
+    let record = managedProcessRegistryRow(pid: 101, kind: .agentTerminal, startTime: 10)
+    try await store.saveManagedProcess(record)
+    #expect(try await store.getManagedProcesses() == [record])
+
+    try await store.deleteManagedProcess(pid: 101)
+    #expect(try await store.getManagedProcesses().isEmpty)
+    #expect(try await store.getCustomName(for: "session-1") == "Important session")
+  }
+
+  @Test("Registry cleanup terminates matching app-owned identities")
+  func registryCleanupTerminatesMatchingIdentities() async throws {
+    let store = RootMockManagedProcessStore(records: [
+      managedProcessRegistryRow(pid: 111, kind: .agentTerminal, startTime: 10),
+      managedProcessRegistryRow(pid: 222, kind: .devServer, startTime: 20)
+    ])
+    let terminator = RootMockProcessTerminator()
+    let registry = TerminalProcessRegistry(
+      store: store,
+      processInspector: RootMockProcessInspector(identities: [
+        111: managedProcessIdentity(pid: 111, groupId: 111, startTime: 10),
+        222: managedProcessIdentity(pid: 222, groupId: 222, startTime: 20)
+      ]),
+      processTerminator: terminator
+    )
+
+    await registry.cleanupRegisteredProcesses()
+
+    #expect(await terminator.terminatedPIDs().sorted() == [111, 222])
+    #expect(try await store.getManagedProcesses().isEmpty)
+  }
+
+  @Test("Registry cleanup prunes PID reuse without terminating")
+  func registryCleanupPrunesPIDReuseWithoutTerminating() async throws {
+    let store = RootMockManagedProcessStore(records: [
+      managedProcessRegistryRow(pid: 111, kind: .agentTerminal, startTime: 10)
+    ])
+    let terminator = RootMockProcessTerminator()
+    let registry = TerminalProcessRegistry(
+      store: store,
+      processInspector: RootMockProcessInspector(identities: [
+        111: managedProcessIdentity(pid: 111, groupId: 111, startTime: 99)
+      ]),
+      processTerminator: terminator
+    )
+
+    await registry.cleanupRegisteredProcesses()
+
+    #expect(await terminator.terminatedPIDs().isEmpty)
+    #expect(try await store.getManagedProcesses().isEmpty)
+  }
+
+  @Test("Alive terminal PID query excludes dev servers and prunes dead terminal rows")
+  func aliveTerminalPIDQueryExcludesDevServersAndPrunesDeadRows() async throws {
+    let store = RootMockManagedProcessStore(records: [
+      managedProcessRegistryRow(pid: 111, kind: .agentTerminal, startTime: 10),
+      managedProcessRegistryRow(pid: 222, kind: .auxiliaryShell, startTime: 20),
+      managedProcessRegistryRow(pid: 333, kind: .devServer, startTime: 30),
+      managedProcessRegistryRow(pid: 444, kind: .agentTerminal, startTime: 40)
+    ])
+    let registry = TerminalProcessRegistry(
+      store: store,
+      processInspector: RootMockProcessInspector(identities: [
+        111: managedProcessIdentity(pid: 111, groupId: 111, startTime: 10),
+        222: managedProcessIdentity(pid: 222, groupId: 222, startTime: 20),
+        333: managedProcessIdentity(pid: 333, groupId: 333, startTime: 30)
+      ]),
+      processTerminator: RootMockProcessTerminator()
+    )
+
+    #expect(await registry.getAliveRegisteredPIDs() == Set<Int32>([111, 222]))
+    #expect(try await store.getManagedProcesses().map(\.pid).sorted() == [111, 222, 333])
+  }
+
+  @Test("Legacy UserDefaults process registry data is ignored")
+  func legacyUserDefaultsProcessRegistryDataIsIgnored() async throws {
+    let legacyKey = "AgentHub.TerminalProcessRegistry"
+    UserDefaults.standard.set(["111": 1_700_000_000.0], forKey: legacyKey)
+    defer { UserDefaults.standard.removeObject(forKey: legacyKey) }
+
+    let store = RootMockManagedProcessStore()
+    let registry = TerminalProcessRegistry(
+      store: store,
+      processInspector: RootMockProcessInspector(identities: [
+        111: managedProcessIdentity(pid: 111, groupId: 111, startTime: 10)
+      ]),
+      processTerminator: RootMockProcessTerminator()
+    )
+
+    #expect(await registry.getAliveRegisteredPIDs().isEmpty)
+    #expect(try await store.getManagedProcesses().isEmpty)
+  }
+}
+
+private actor RootMockManagedProcessStore: ManagedProcessStoreProtocol {
+  private var records: [Int32: ManagedProcessRecord]
+
+  init(records: [ManagedProcessRecord] = []) {
+    self.records = Dictionary(uniqueKeysWithValues: records.map { ($0.pid, $0) })
+  }
+
+  func saveManagedProcess(_ record: ManagedProcessRecord) async throws {
+    records[record.pid] = record
+  }
+
+  func deleteManagedProcess(pid: Int32) async throws {
+    records.removeValue(forKey: pid)
+  }
+
+  func deleteManagedProcesses(pids: [Int32]) async throws {
+    for pid in pids {
+      records.removeValue(forKey: pid)
+    }
+  }
+
+  func getManagedProcesses() async throws -> [ManagedProcessRecord] {
+    records.values.sorted { $0.pid < $1.pid }
+  }
+}
+
+private actor RootMockProcessInspector: ProcessInspecting {
+  private var identities: [pid_t: ManagedProcessIdentity]
+
+  init(identities: [pid_t: ManagedProcessIdentity]) {
+    self.identities = identities
+  }
+
+  func identity(for pid: pid_t) async -> ManagedProcessIdentity? {
+    identities[pid]
+  }
+}
+
+private actor RootMockProcessTerminator: ProcessTerminating {
+  private var pids: [pid_t] = []
+
+  func terminate(pid: pid_t, processGroupId: pid_t?) async {
+    pids.append(pid)
+  }
+
+  func terminatedPIDs() -> [pid_t] {
+    pids
+  }
+}
+
+private func managedProcessIdentity(pid: pid_t, groupId: pid_t, startTime: Int64) -> ManagedProcessIdentity {
+  ManagedProcessIdentity(
+    pid: pid,
+    processGroupId: groupId,
+    startTimeSeconds: startTime,
+    commandLine: nil
+  )
+}
+
+private func managedProcessRegistryRow(
+  pid: Int32,
+  kind: ManagedProcessKind,
+  startTime: Int64
+) -> ManagedProcessRecord {
+  ManagedProcessRecord(
+    pid: pid,
+    processGroupId: pid,
+    processStartTimeSeconds: startTime,
+    kind: kind,
+    provider: nil,
+    terminalKey: nil,
+    sessionId: nil,
+    projectPath: nil,
+    expectedExecutable: nil,
+    registeredAt: Date(timeIntervalSince1970: 1),
+    updatedAt: Date(timeIntervalSince1970: 2)
+  )
+}
+
+private func temporaryManagedProcessRegistryDatabasePath() -> String {
+  FileManager.default.temporaryDirectory
+    .appending(path: "test_managed_process_registry_\(UUID().uuidString).sqlite")
+    .path
+}

--- a/app/AgentHubTests/ManagedProcessRegistryTests.swift
+++ b/app/AgentHubTests/ManagedProcessRegistryTests.swift
@@ -41,6 +41,55 @@ struct ManagedProcessRegistryTests {
     #expect(try await store.getManagedProcesses().isEmpty)
   }
 
+  @Test("Registry cleanup terminates inherited process group rows by PID only")
+  func registryCleanupTerminatesInheritedProcessGroupRowsByPIDOnly() async throws {
+    let store = RootMockManagedProcessStore(records: [
+      managedProcessRegistryRow(pid: 111, kind: .agentTerminal, startTime: 10, processGroupId: 999)
+    ])
+    let terminator = RootMockProcessTerminator()
+    let registry = TerminalProcessRegistry(
+      store: store,
+      processInspector: RootMockProcessInspector(identities: [
+        111: managedProcessIdentity(pid: 111, groupId: 999, startTime: 10)
+      ]),
+      processTerminator: terminator
+    )
+
+    await registry.cleanupRegisteredProcesses()
+
+    #expect(await terminator.terminationRequests() == [
+      RootTerminationRequest(pid: 111, processGroupId: nil)
+    ])
+    #expect(try await store.getManagedProcesses().isEmpty)
+  }
+
+  @Test("Orphan cleanup only terminates scoped inactive terminal rows")
+  func orphanCleanupOnlyTerminatesScopedInactiveTerminalRows() async throws {
+    let store = RootMockManagedProcessStore(records: [
+      managedProcessRegistryRow(pid: 111, kind: .agentTerminal, startTime: 10, provider: .claude),
+      managedProcessRegistryRow(pid: 222, kind: .auxiliaryShell, startTime: 20, provider: .claude),
+      managedProcessRegistryRow(pid: 333, kind: .devServer, startTime: 30, provider: .claude),
+      managedProcessRegistryRow(pid: 444, kind: .agentTerminal, startTime: 40, provider: .codex),
+      managedProcessRegistryRow(pid: 555, kind: .agentTerminal, startTime: 50, provider: .claude)
+    ])
+    let terminator = RootMockProcessTerminator()
+    let registry = TerminalProcessRegistry(
+      store: store,
+      processInspector: RootMockProcessInspector(identities: [
+        111: managedProcessIdentity(pid: 111, groupId: 111, startTime: 10),
+        222: managedProcessIdentity(pid: 222, groupId: 222, startTime: 20),
+        333: managedProcessIdentity(pid: 333, groupId: 333, startTime: 30),
+        444: managedProcessIdentity(pid: 444, groupId: 444, startTime: 40)
+      ]),
+      processTerminator: terminator
+    )
+
+    await registry.cleanupOrphanedTerminalProcesses(provider: .claude, activePIDs: [222])
+
+    #expect(await terminator.terminatedPIDs() == [111])
+    #expect(try await store.getManagedProcesses().map(\.pid).sorted() == [222, 333, 444])
+  }
+
   @Test("Registry cleanup prunes PID reuse without terminating")
   func registryCleanupPrunesPIDReuseWithoutTerminating() async throws {
     let store = RootMockManagedProcessStore(records: [
@@ -141,15 +190,24 @@ private actor RootMockProcessInspector: ProcessInspecting {
   }
 }
 
+private struct RootTerminationRequest: Equatable, Sendable {
+  let pid: pid_t
+  let processGroupId: pid_t?
+}
+
 private actor RootMockProcessTerminator: ProcessTerminating {
-  private var pids: [pid_t] = []
+  private var requests: [RootTerminationRequest] = []
 
   func terminate(pid: pid_t, processGroupId: pid_t?) async {
-    pids.append(pid)
+    requests.append(RootTerminationRequest(pid: pid, processGroupId: processGroupId))
   }
 
   func terminatedPIDs() -> [pid_t] {
-    pids
+    requests.map(\.pid)
+  }
+
+  func terminationRequests() -> [RootTerminationRequest] {
+    requests
   }
 }
 
@@ -165,14 +223,31 @@ private func managedProcessIdentity(pid: pid_t, groupId: pid_t, startTime: Int64
 private func managedProcessRegistryRow(
   pid: Int32,
   kind: ManagedProcessKind,
-  startTime: Int64
+  startTime: Int64,
+  provider: SessionProviderKind? = nil
+) -> ManagedProcessRecord {
+  managedProcessRegistryRow(
+    pid: pid,
+    kind: kind,
+    startTime: startTime,
+    processGroupId: pid,
+    provider: provider
+  )
+}
+
+private func managedProcessRegistryRow(
+  pid: Int32,
+  kind: ManagedProcessKind,
+  startTime: Int64,
+  processGroupId: Int32,
+  provider: SessionProviderKind? = nil
 ) -> ManagedProcessRecord {
   ManagedProcessRecord(
     pid: pid,
-    processGroupId: pid,
+    processGroupId: processGroupId,
     processStartTimeSeconds: startTime,
     kind: kind,
-    provider: nil,
+    provider: provider?.rawValue,
     terminalKey: nil,
     sessionId: nil,
     projectPath: nil,

--- a/app/AgentHubTests/SessionMetadataMigrationSafetyTests.swift
+++ b/app/AgentHubTests/SessionMetadataMigrationSafetyTests.swift
@@ -52,6 +52,7 @@ struct SessionMetadataMigrationSafetyTests {
       ) == seed.terminalWorkspace
     )
     #expect(store.getWorkspaceStateSync(for: .claude) == seed.workspaceState)
+    #expect(try await store.getManagedProcesses().isEmpty)
   }
 }
 
@@ -128,7 +129,7 @@ private func seedCurrentBaselineDatabase(at dbPath: String) throws -> MigrationS
       state: workspaceState
     ).insert(db)
 
-    for migrationIdentifier in SessionMetadataStore.migrationIdentifiers {
+    for migrationIdentifier in SessionMetadataStore.migrationIdentifiers where migrationIdentifier != "v7_create_managed_processes" {
       try db.execute(
         sql: "INSERT INTO grdb_migrations (identifier) VALUES (?)",
         arguments: [migrationIdentifier]

--- a/app/AgentHubTests/SessionMetadataMigrationSafetyTests.swift
+++ b/app/AgentHubTests/SessionMetadataMigrationSafetyTests.swift
@@ -129,7 +129,10 @@ private func seedCurrentBaselineDatabase(at dbPath: String) throws -> MigrationS
       state: workspaceState
     ).insert(db)
 
-    for migrationIdentifier in SessionMetadataStore.migrationIdentifiers where migrationIdentifier != "v7_create_managed_processes" {
+    // Mark the database as fully migrated through v6 so opening
+    // SessionMetadataStore exercises only the v7 managed_processes migration.
+    for migrationIdentifier in SessionMetadataStore.migrationIdentifiers
+      where migrationIdentifier != SessionMetadataStore.MigrationID.createManagedProcesses {
       try db.execute(
         sql: "INSERT INTO grdb_migrations (identifier) VALUES (?)",
         arguments: [migrationIdentifier]

--- a/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubProvider.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubProvider.swift
@@ -214,6 +214,11 @@ public final class AgentHubProvider {
     self.terminalBackend = .storedPreference
     self.terminalSurfaceFactory = terminalSurfaceFactory
     self.metadataStoreOverride = metadataStore
+    if let metadataStore {
+      Task {
+        await TerminalProcessRegistry.shared.configure(store: metadataStore)
+      }
+    }
 
     // Persist developer-provided commands to UserDefaults
     let defaults = UserDefaults.standard
@@ -336,7 +341,9 @@ public final class AgentHubProvider {
   /// Call this on app launch to terminate any Claude processes that were orphaned
   /// when the app crashed or was force-quit.
   public func cleanupOrphanedProcesses() {
-    TerminalProcessRegistry.shared.cleanupRegisteredProcesses()
+    Task(priority: .utility) {
+      await TerminalProcessRegistry.shared.cleanupRegisteredProcesses()
+    }
   }
 
   /// Sweeps any previously-installed approval hooks, wipes stale claim files,

--- a/app/modules/AgentHubCore/Sources/AgentHub/Models/ManagedProcessRecord.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Models/ManagedProcessRecord.swift
@@ -1,0 +1,70 @@
+//
+//  ManagedProcessRecord.swift
+//  AgentHub
+//
+//  SQLite record for app-spawned processes that may need crash recovery cleanup.
+//
+
+import Foundation
+import GRDB
+
+public enum ManagedProcessKind: String, Codable, CaseIterable, Sendable {
+  case agentTerminal
+  case auxiliaryShell
+  case devServer
+
+  var isTerminalProcess: Bool {
+    switch self {
+    case .agentTerminal, .auxiliaryShell:
+      true
+    case .devServer:
+      false
+    }
+  }
+}
+
+public struct ManagedProcessRecord: Codable, Equatable, Sendable, FetchableRecord, PersistableRecord {
+  public var pid: Int32
+  public var processGroupId: Int32?
+  public var processStartTimeSeconds: Int64?
+  public var kind: String
+  public var provider: String?
+  public var terminalKey: String?
+  public var sessionId: String?
+  public var projectPath: String?
+  public var expectedExecutable: String?
+  public var registeredAt: Date
+  public var updatedAt: Date
+
+  public static var databaseTableName: String { "managed_processes" }
+
+  public init(
+    pid: Int32,
+    processGroupId: Int32?,
+    processStartTimeSeconds: Int64?,
+    kind: ManagedProcessKind,
+    provider: String?,
+    terminalKey: String?,
+    sessionId: String?,
+    projectPath: String?,
+    expectedExecutable: String?,
+    registeredAt: Date = Date.now,
+    updatedAt: Date = Date.now
+  ) {
+    self.pid = pid
+    self.processGroupId = processGroupId
+    self.processStartTimeSeconds = processStartTimeSeconds
+    self.kind = kind.rawValue
+    self.provider = provider
+    self.terminalKey = terminalKey
+    self.sessionId = sessionId
+    self.projectPath = projectPath
+    self.expectedExecutable = expectedExecutable
+    self.registeredAt = registeredAt
+    self.updatedAt = updatedAt
+  }
+
+  public var processKind: ManagedProcessKind? {
+    ManagedProcessKind(rawValue: kind)
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/DevServerManager.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/DevServerManager.swift
@@ -141,7 +141,15 @@ public final class DevServerManager {
       )
 
       processes[key] = process
-      TerminalProcessRegistry.shared.register(pid: process.processIdentifier)
+      Task {
+        await TerminalProcessRegistry.shared.register(
+          pid: process.processIdentifier,
+          kind: .devServer,
+          terminalKey: key,
+          projectPath: projectPath,
+          expectedExecutable: URL(fileURLWithPath: executablePath).lastPathComponent
+        )
+      }
 
       servers[key] = .waitingForReady
 
@@ -243,7 +251,9 @@ public final class DevServerManager {
       }
     }
 
-    TerminalProcessRegistry.shared.unregister(pid: pid)
+    Task {
+      await TerminalProcessRegistry.shared.unregister(pid: pid)
+    }
     processes.removeValue(forKey: key)
     assignedPorts.removeValue(forKey: key)
     servers[key] = finalState

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/ManagedProcessStoreProtocol.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/ManagedProcessStoreProtocol.swift
@@ -1,0 +1,15 @@
+//
+//  ManagedProcessStoreProtocol.swift
+//  AgentHub
+//
+//  Persistence API for app-spawned process cleanup state.
+//
+
+import Foundation
+
+public protocol ManagedProcessStoreProtocol: Sendable {
+  func saveManagedProcess(_ record: ManagedProcessRecord) async throws
+  func deleteManagedProcess(pid: Int32) async throws
+  func deleteManagedProcesses(pids: [Int32]) async throws
+  func getManagedProcesses() async throws -> [ManagedProcessRecord]
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/SessionMetadataStore.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/SessionMetadataStore.swift
@@ -21,6 +21,7 @@ public actor SessionMetadataStore: TerminalWorkspaceStoreProtocol {
     static let addPinned = "v4_add_pinned"
     static let createTerminalWorkspaces = "v5_create_terminal_workspaces"
     static let createSessionWorkspaceState = "v6_create_session_workspace_state"
+    static let createManagedProcesses = "v7_create_managed_processes"
   }
 
   static let migrationIdentifiers = [
@@ -29,7 +30,8 @@ public actor SessionMetadataStore: TerminalWorkspaceStoreProtocol {
     MigrationID.createAIConfig,
     MigrationID.addPinned,
     MigrationID.createTerminalWorkspaces,
-    MigrationID.createSessionWorkspaceState
+    MigrationID.createSessionWorkspaceState,
+    MigrationID.createManagedProcesses
   ]
 
   private let dbQueue: DatabaseQueue
@@ -122,6 +124,24 @@ public actor SessionMetadataStore: TerminalWorkspaceStoreProtocol {
         t.column("expansionStateData", .blob).notNull()
         t.column("updatedAt", .datetime).notNull()
       }
+    }
+
+    migrator.registerMigration(MigrationID.createManagedProcesses) { db in
+      try db.create(table: "managed_processes") { t in
+        t.column("pid", .integer).primaryKey(onConflict: .replace)
+        t.column("processGroupId", .integer)
+        t.column("processStartTimeSeconds", .integer)
+        t.column("kind", .text).notNull()
+        t.column("provider", .text)
+        t.column("terminalKey", .text)
+        t.column("sessionId", .text)
+        t.column("projectPath", .text)
+        t.column("expectedExecutable", .text)
+        t.column("registeredAt", .datetime).notNull()
+        t.column("updatedAt", .datetime).notNull()
+      }
+      try db.create(index: "idx_managed_processes_kind", on: "managed_processes", columns: ["kind"])
+      try db.create(index: "idx_managed_processes_session", on: "managed_processes", columns: ["provider", "sessionId"])
     }
 
     return migrator
@@ -221,6 +241,7 @@ public actor SessionMetadataStore: TerminalWorkspaceStoreProtocol {
     try dbQueue.write { db in
       _ = try TerminalWorkspaceRecord.deleteAll(db)
       _ = try SessionWorkspaceStateRecord.deleteAll(db)
+      _ = try ManagedProcessRecord.deleteAll(db)
       _ = try AIConfigRecord.deleteAll(db)
       _ = try SessionRepoMapping.deleteAll(db)
       _ = try SessionMetadata.deleteAll(db)
@@ -363,6 +384,35 @@ public actor SessionMetadataStore: TerminalWorkspaceStoreProtocol {
         .filter(Column("sessionId") == sessionId)
         .filter(Column("backend") == backend.rawValue)
         .deleteAll(db)
+    }
+  }
+}
+
+extension SessionMetadataStore: ManagedProcessStoreProtocol {
+  public func saveManagedProcess(_ record: ManagedProcessRecord) async throws {
+    try await dbQueue.write { db in
+      try record.save(db)
+    }
+  }
+
+  public func deleteManagedProcess(pid: Int32) async throws {
+    try await dbQueue.write { db in
+      _ = try ManagedProcessRecord.deleteOne(db, key: pid)
+    }
+  }
+
+  public func deleteManagedProcesses(pids: [Int32]) async throws {
+    guard !pids.isEmpty else { return }
+    try await dbQueue.write { db in
+      _ = try ManagedProcessRecord
+        .filter(pids.contains(Column("pid")))
+        .deleteAll(db)
+    }
+  }
+
+  public func getManagedProcesses() async throws -> [ManagedProcessRecord] {
+    try await dbQueue.read { db in
+      try ManagedProcessRecord.fetchAll(db)
     }
   }
 }

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/SessionProviderProtocols.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/SessionProviderProtocols.swift
@@ -13,6 +13,15 @@ import Foundation
 public enum SessionProviderKind: String, CaseIterable, Sendable {
   case claude = "Claude"
   case codex = "Codex"
+
+  public init(cliMode: CLICommandMode) {
+    switch cliMode {
+    case .claude:
+      self = .claude
+    case .codex:
+      self = .codex
+    }
+  }
 }
 
 // MARK: - SessionMonitorServiceProtocol

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/TerminalProcessRegistry.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/TerminalProcessRegistry.swift
@@ -2,128 +2,60 @@
 //  TerminalProcessRegistry.swift
 //  AgentHub
 //
-//  Tracks embedded-terminal PIDs so only app-spawned sessions are terminated.
+//  Tracks app-spawned process identities so crash recovery can clean them up
+//  without relying on UserDefaults or killing unrelated PID-reused processes.
 //
 
 import Darwin
 import Foundation
 
-public final class TerminalProcessRegistry {
-  public static let shared = TerminalProcessRegistry()
+struct ManagedProcessIdentity: Equatable, Sendable {
+  let pid: pid_t
+  let processGroupId: pid_t
+  let startTimeSeconds: Int64
+  let commandLine: String?
+}
 
-  private let lock = NSLock()
-  private let storageKey = "AgentHub.TerminalProcessRegistry"
-  private var entries: [Int32: TimeInterval] = [:]
+protocol ProcessInspecting: Sendable {
+  func identity(for pid: pid_t) async -> ManagedProcessIdentity?
+}
 
-  private init() {
-    load()
+protocol ProcessTerminating: Sendable {
+  func terminate(pid: pid_t, processGroupId: pid_t?) async
+}
+
+struct DarwinProcessInspector: ProcessInspecting {
+  func identity(for pid: pid_t) async -> ManagedProcessIdentity? {
+    guard pid > 0, kill(pid, 0) == 0 else { return nil }
+    guard let bsdInfo = bsdInfo(for: pid) else { return nil }
+
+    return ManagedProcessIdentity(
+      pid: pid,
+      processGroupId: pid_t(bsdInfo.pbi_pgid),
+      startTimeSeconds: Int64(bsdInfo.pbi_start_tvsec),
+      commandLine: commandLine(for: pid)
+    )
   }
 
-  public func register(pid: pid_t) {
-    guard pid > 0 else { return }
-    lock.lock()
-    entries[pid] = Date().timeIntervalSince1970
-    pruneTerminatedLocked()
-    persistLocked()
-    lock.unlock()
-  }
-
-  public func unregister(pid: pid_t) {
-    guard pid > 0 else { return }
-    lock.lock()
-    entries.removeValue(forKey: pid)
-    persistLocked()
-    lock.unlock()
-  }
-
-  /// Returns a snapshot of currently registered PIDs that are still alive and are Claude processes.
-  func getAliveRegisteredPIDs() -> Set<Int32> {
-    let snapshot = snapshotEntries()
-    var alivePIDs: Set<Int32> = []
-
-    for (pid, _) in snapshot {
-      guard pid > 0, isProcessAlive(pid) else { continue }
-      if let command = processCommandLine(pid),
-         command.localizedCaseInsensitiveContains("claude") {
-        alivePIDs.insert(pid)
-      }
-    }
-    return alivePIDs
-  }
-
-  /// Kills only processes previously spawned by the app.
-  func cleanupRegisteredProcesses() {
-    let snapshot = snapshotEntries()
-    guard !snapshot.isEmpty else { return }
-
-    for (pid, _) in snapshot {
-      guard pid > 0 else {
-        unregister(pid: pid)
-        continue
-      }
-
-      guard isProcessAlive(pid) else {
-        unregister(pid: pid)
-        continue
-      }
-
-      if let command = processCommandLine(pid),
-         !command.localizedCaseInsensitiveContains("claude") {
-        // PID reused or not a Claude process; avoid killing.
-        unregister(pid: pid)
-        continue
-      }
-
-      terminateProcessGroup(pid)
-
-      // Always unregister after kill attempt - if still running,
-      // it will be re-detected on next getAliveRegisteredPIDs() call
-      unregister(pid: pid)
-    }
-  }
-
-  // MARK: - Private
-
-  private func snapshotEntries() -> [Int32: TimeInterval] {
-    lock.lock()
-    let copy = entries
-    lock.unlock()
-    return copy
-  }
-
-  private func load() {
-    guard let dict = UserDefaults.standard.dictionary(forKey: storageKey) as? [String: Double] else {
-      return
+  private func bsdInfo(for pid: pid_t) -> proc_bsdinfo? {
+    var info = proc_bsdinfo()
+    let result = withUnsafeMutableBytes(of: &info) { buffer in
+      proc_pidinfo(
+        pid,
+        PROC_PIDTBSDINFO,
+        0,
+        buffer.baseAddress,
+        Int32(buffer.count)
+      )
     }
 
-    for (key, value) in dict {
-      if let pid = Int32(key) {
-        entries[pid] = value
-      }
+    guard result == Int32(MemoryLayout<proc_bsdinfo>.size) else {
+      return nil
     }
+    return info
   }
 
-  private func persistLocked() {
-    var dict: [String: Double] = [:]
-    for (pid, value) in entries {
-      dict[String(pid)] = value
-    }
-    UserDefaults.standard.set(dict, forKey: storageKey)
-  }
-
-  private func pruneTerminatedLocked() {
-    for pid in Array(entries.keys) {
-      if !isProcessAlive(pid) {
-        entries.removeValue(forKey: pid)
-      }
-    }
-  }
-
-  private func isProcessAlive(_ pid: pid_t) -> Bool {
-    kill(pid, 0) == 0
-  }
-
-  private func processCommandLine(_ pid: pid_t) -> String? {
+  private func commandLine(for pid: pid_t) -> String? {
     let task = Process()
     task.executableURL = URL(fileURLWithPath: "/bin/ps")
     task.arguments = ["-p", "\(pid)", "-o", "command="]
@@ -136,27 +68,233 @@ public final class TerminalProcessRegistry {
       try task.run()
       task.waitUntilExit()
       let data = pipe.fileHandleForReading.readDataToEndOfFile()
-      return String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines)
+      let command = String(data: data, encoding: .utf8)?
+        .trimmingCharacters(in: .whitespacesAndNewlines)
+      return command?.isEmpty == false ? command : nil
     } catch {
       return nil
     }
   }
+}
 
-  private func terminateProcessGroup(_ pid: pid_t) {
-    // Try SIGTERM on process group first, then individual process
-    if killpg(pid, SIGTERM) != 0 {
+struct DarwinProcessTerminator: ProcessTerminating {
+  func terminate(pid: pid_t, processGroupId: pid_t?) async {
+    guard pid > 0 else { return }
+
+    let groupId = processGroupId.flatMap { $0 > 0 ? $0 : nil } ?? pid
+    if killpg(groupId, SIGTERM) != 0 {
       _ = kill(pid, SIGTERM)
     }
 
-    // Wait 300ms for graceful shutdown
-    usleep(300_000)
+    try? await Task.sleep(for: .milliseconds(300))
 
-    // If still alive, force kill
-    if isProcessAlive(pid) {
-      if killpg(pid, SIGKILL) != 0 {
-        _ = kill(pid, SIGKILL)
-      }
-      usleep(100_000) // Wait for SIGKILL to take effect
+    guard kill(pid, 0) == 0 else { return }
+    if killpg(groupId, SIGKILL) != 0 {
+      _ = kill(pid, SIGKILL)
     }
+
+    try? await Task.sleep(for: .milliseconds(100))
+  }
+}
+
+public actor TerminalProcessRegistry {
+  public static let shared = TerminalProcessRegistry()
+
+  private let processInspector: any ProcessInspecting
+  private let processTerminator: any ProcessTerminating
+  private var processStore: (any ManagedProcessStoreProtocol)?
+  private var didAttemptDefaultStore = false
+  private var unregisterRequests: [pid_t: Date] = [:]
+
+  init(
+    store: (any ManagedProcessStoreProtocol)? = nil,
+    processInspector: any ProcessInspecting = DarwinProcessInspector(),
+    processTerminator: any ProcessTerminating = DarwinProcessTerminator()
+  ) {
+    self.processStore = store
+    self.processInspector = processInspector
+    self.processTerminator = processTerminator
+    self.didAttemptDefaultStore = store != nil
+  }
+
+  public func configure(store: (any ManagedProcessStoreProtocol)?) {
+    processStore = store
+    didAttemptDefaultStore = store != nil
+  }
+
+  public func register(
+    pid: pid_t,
+    kind: ManagedProcessKind = .agentTerminal,
+    provider: SessionProviderKind? = nil,
+    terminalKey: String? = nil,
+    sessionId: String? = nil,
+    projectPath: String? = nil,
+    expectedExecutable: String? = nil,
+    requestedAt: Date = Date.now
+  ) async {
+    guard pid > 0 else { return }
+    guard !shouldIgnoreRegistration(pid: pid, requestedAt: requestedAt) else { return }
+    guard let identity = await processInspector.identity(for: pid) else {
+      await deleteManagedProcess(pid: pid)
+      return
+    }
+    guard !shouldIgnoreRegistration(pid: pid, requestedAt: requestedAt) else { return }
+    guard let store = await resolvedProcessStore() else { return }
+
+    let record = ManagedProcessRecord(
+      pid: pid,
+      processGroupId: identity.processGroupId > 0 ? identity.processGroupId : nil,
+      processStartTimeSeconds: identity.startTimeSeconds,
+      kind: kind,
+      provider: provider?.rawValue,
+      terminalKey: normalized(terminalKey),
+      sessionId: normalized(sessionId),
+      projectPath: normalized(projectPath),
+      expectedExecutable: normalized(expectedExecutable),
+      registeredAt: requestedAt,
+      updatedAt: Date.now
+    )
+
+    do {
+      try await store.saveManagedProcess(record)
+    } catch {
+      AppLogger.session.error("Failed to persist managed process PID=\(pid): \(error.localizedDescription)")
+    }
+  }
+
+  public func unregister(pid: pid_t, requestedAt: Date = Date.now) async {
+    guard pid > 0 else { return }
+    unregisterRequests[pid] = requestedAt
+    pruneOldUnregisterRequests(relativeTo: requestedAt)
+    await deleteManagedProcess(pid: pid)
+  }
+
+  /// Returns live terminal PIDs still owned by AgentHub. Dev-server rows are
+  /// intentionally excluded because this count backs the terminal orphan UI.
+  public func getAliveRegisteredPIDs() async -> Set<Int32> {
+    guard let store = await resolvedProcessStore() else { return [] }
+
+    do {
+      let rows = try await store.getManagedProcesses()
+      var stalePIDs: [Int32] = []
+      var alivePIDs: Set<Int32> = []
+
+      for row in rows where row.processKind?.isTerminalProcess == true {
+        guard let identity = await processInspector.identity(for: row.pid) else {
+          stalePIDs.append(row.pid)
+          continue
+        }
+        guard matchesStoredIdentity(row, identity: identity) else {
+          stalePIDs.append(row.pid)
+          continue
+        }
+        alivePIDs.insert(row.pid)
+      }
+
+      try await store.deleteManagedProcesses(pids: stalePIDs)
+      return alivePIDs
+    } catch {
+      AppLogger.session.error("Failed to load managed process rows: \(error.localizedDescription)")
+      return []
+    }
+  }
+
+  /// Terminates every live process still matching its persisted app-spawned
+  /// identity, and prunes stale rows without killing PID-reused processes.
+  public func cleanupRegisteredProcesses() async {
+    guard let store = await resolvedProcessStore() else { return }
+
+    do {
+      let rows = try await store.getManagedProcesses()
+      guard !rows.isEmpty else { return }
+
+      var completedPIDs: [Int32] = []
+      for row in rows {
+        guard row.processKind != nil else {
+          completedPIDs.append(row.pid)
+          continue
+        }
+
+        guard let identity = await processInspector.identity(for: row.pid) else {
+          completedPIDs.append(row.pid)
+          continue
+        }
+
+        guard matchesStoredIdentity(row, identity: identity) else {
+          completedPIDs.append(row.pid)
+          continue
+        }
+
+        await processTerminator.terminate(pid: row.pid, processGroupId: row.processGroupId)
+        completedPIDs.append(row.pid)
+      }
+
+      try await store.deleteManagedProcesses(pids: completedPIDs)
+    } catch {
+      AppLogger.session.error("Failed to clean up managed processes: \(error.localizedDescription)")
+    }
+  }
+
+  private func resolvedProcessStore() async -> (any ManagedProcessStoreProtocol)? {
+    if let processStore {
+      return processStore
+    }
+
+    guard !didAttemptDefaultStore else { return nil }
+    didAttemptDefaultStore = true
+
+    do {
+      let store = try SessionMetadataStore()
+      processStore = store
+      return store
+    } catch {
+      AppLogger.session.error("Failed to create managed process store: \(error.localizedDescription)")
+      return nil
+    }
+  }
+
+  private func deleteManagedProcess(pid: pid_t) async {
+    guard let store = await resolvedProcessStore() else { return }
+    do {
+      try await store.deleteManagedProcess(pid: pid)
+    } catch {
+      AppLogger.session.error("Failed to delete managed process PID=\(pid): \(error.localizedDescription)")
+    }
+  }
+
+  private func matchesStoredIdentity(
+    _ row: ManagedProcessRecord,
+    identity: ManagedProcessIdentity
+  ) -> Bool {
+    guard let storedStartTime = row.processStartTimeSeconds else {
+      return false
+    }
+    guard storedStartTime == identity.startTimeSeconds else {
+      return false
+    }
+
+    if let storedGroupId = row.processGroupId, storedGroupId > 0 {
+      return storedGroupId == identity.processGroupId
+    }
+    return true
+  }
+
+  private func shouldIgnoreRegistration(pid: pid_t, requestedAt: Date) -> Bool {
+    guard let unregisterDate = unregisterRequests[pid] else { return false }
+    return requestedAt <= unregisterDate
+  }
+
+  private func pruneOldUnregisterRequests(relativeTo now: Date) {
+    guard unregisterRequests.count > 128 else { return }
+    unregisterRequests = unregisterRequests.filter { _, date in
+      now.timeIntervalSince(date) < 60
+    }
+  }
+
+  private func normalized(_ value: String?) -> String? {
+    guard let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines), !trimmed.isEmpty else {
+      return nil
+    }
+    return trimmed
   }
 }

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/TerminalProcessRegistry.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/TerminalProcessRegistry.swift
@@ -81,24 +81,43 @@ struct DarwinProcessTerminator: ProcessTerminating {
   func terminate(pid: pid_t, processGroupId: pid_t?) async {
     guard pid > 0 else { return }
 
-    let groupId = processGroupId.flatMap { $0 > 0 ? $0 : nil } ?? pid
-    if killpg(groupId, SIGTERM) != 0 {
+    if let groupId = ownedProcessGroupId(pid: pid, processGroupId: processGroupId) {
+      if killpg(groupId, SIGTERM) != 0 {
+        _ = kill(pid, SIGTERM)
+      }
+    } else {
       _ = kill(pid, SIGTERM)
     }
 
     try? await Task.sleep(for: .milliseconds(300))
 
     guard kill(pid, 0) == 0 else { return }
-    if killpg(groupId, SIGKILL) != 0 {
+    if let groupId = ownedProcessGroupId(pid: pid, processGroupId: processGroupId) {
+      if killpg(groupId, SIGKILL) != 0 {
+        _ = kill(pid, SIGKILL)
+      }
+    } else {
       _ = kill(pid, SIGKILL)
     }
 
     try? await Task.sleep(for: .milliseconds(100))
   }
+
+  private func ownedProcessGroupId(pid: pid_t, processGroupId: pid_t?) -> pid_t? {
+    guard let processGroupId, processGroupId > 0, processGroupId == pid else {
+      return nil
+    }
+    return processGroupId
+  }
 }
 
 public actor TerminalProcessRegistry {
   public static let shared = TerminalProcessRegistry()
+
+  private enum CleanupScope {
+    case allRegistered
+    case orphanedTerminals(provider: SessionProviderKind?, activePIDs: Set<Int32>)
+  }
 
   private let processInspector: any ProcessInspecting
   private let processTerminator: any ProcessTerminating
@@ -143,7 +162,7 @@ public actor TerminalProcessRegistry {
 
     let record = ManagedProcessRecord(
       pid: pid,
-      processGroupId: identity.processGroupId > 0 ? identity.processGroupId : nil,
+      processGroupId: ownedProcessGroupId(for: identity),
       processStartTimeSeconds: identity.startTimeSeconds,
       kind: kind,
       provider: provider?.rawValue,
@@ -171,7 +190,7 @@ public actor TerminalProcessRegistry {
 
   /// Returns live terminal PIDs still owned by AgentHub. Dev-server rows are
   /// intentionally excluded because this count backs the terminal orphan UI.
-  public func getAliveRegisteredPIDs() async -> Set<Int32> {
+  public func getAliveRegisteredPIDs(provider: SessionProviderKind? = nil) async -> Set<Int32> {
     guard let store = await resolvedProcessStore() else { return [] }
 
     do {
@@ -179,7 +198,8 @@ public actor TerminalProcessRegistry {
       var stalePIDs: [Int32] = []
       var alivePIDs: Set<Int32> = []
 
-      for row in rows where row.processKind?.isTerminalProcess == true {
+      for row in rows where row.processKind?.isTerminalProcess == true
+        && matchesProvider(row, provider: provider) {
         guard let identity = await processInspector.identity(for: row.pid) else {
           stalePIDs.append(row.pid)
           continue
@@ -202,6 +222,22 @@ public actor TerminalProcessRegistry {
   /// Terminates every live process still matching its persisted app-spawned
   /// identity, and prunes stale rows without killing PID-reused processes.
   public func cleanupRegisteredProcesses() async {
+    await cleanupManagedProcesses(scope: .allRegistered)
+  }
+
+  /// Terminates terminal rows that are live, provider-scoped, and no longer
+  /// attached to active UI terminals. Dev servers and active terminal rows are
+  /// intentionally left alone because this backs the menu-bar orphan action.
+  public func cleanupOrphanedTerminalProcesses(
+    provider: SessionProviderKind? = nil,
+    activePIDs: Set<Int32>
+  ) async {
+    await cleanupManagedProcesses(
+      scope: .orphanedTerminals(provider: provider, activePIDs: activePIDs)
+    )
+  }
+
+  private func cleanupManagedProcesses(scope: CleanupScope) async {
     guard let store = await resolvedProcessStore() else { return }
 
     do {
@@ -209,7 +245,7 @@ public actor TerminalProcessRegistry {
       guard !rows.isEmpty else { return }
 
       var completedPIDs: [Int32] = []
-      for row in rows {
+      for row in rows where shouldCleanup(row, scope: scope) {
         guard row.processKind != nil else {
           completedPIDs.append(row.pid)
           continue
@@ -225,13 +261,27 @@ public actor TerminalProcessRegistry {
           continue
         }
 
-        await processTerminator.terminate(pid: row.pid, processGroupId: row.processGroupId)
+        await processTerminator.terminate(
+          pid: row.pid,
+          processGroupId: ownedProcessGroupId(for: row, identity: identity)
+        )
         completedPIDs.append(row.pid)
       }
 
       try await store.deleteManagedProcesses(pids: completedPIDs)
     } catch {
       AppLogger.session.error("Failed to clean up managed processes: \(error.localizedDescription)")
+    }
+  }
+
+  private func shouldCleanup(_ row: ManagedProcessRecord, scope: CleanupScope) -> Bool {
+    switch scope {
+    case .allRegistered:
+      return true
+    case .orphanedTerminals(let provider, let activePIDs):
+      guard row.processKind?.isTerminalProcess == true else { return false }
+      guard matchesProvider(row, provider: provider) else { return false }
+      return !activePIDs.contains(row.pid)
     }
   }
 
@@ -296,5 +346,27 @@ public actor TerminalProcessRegistry {
       return nil
     }
     return trimmed
+  }
+
+  private func matchesProvider(_ row: ManagedProcessRecord, provider: SessionProviderKind?) -> Bool {
+    guard let provider else { return true }
+    return row.provider == provider.rawValue
+  }
+
+  private func ownedProcessGroupId(for identity: ManagedProcessIdentity) -> pid_t? {
+    guard identity.processGroupId > 0, identity.processGroupId == identity.pid else {
+      return nil
+    }
+    return identity.processGroupId
+  }
+
+  private func ownedProcessGroupId(
+    for row: ManagedProcessRecord,
+    identity: ManagedProcessIdentity
+  ) -> pid_t? {
+    guard row.processGroupId == identity.processGroupId else {
+      return nil
+    }
+    return ownedProcessGroupId(for: identity)
   }
 }

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/EmbeddedTerminalView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/EmbeddedTerminalView.swift
@@ -314,7 +314,14 @@ public class TerminalContainerView: NSView, ManagedLocalProcessTerminalViewDeleg
       permissionModePlan: permissionModePlan,
       worktreeName: worktreeName
     )
-    registerProcessIfNeeded(for: terminal)
+    registerProcessIfNeeded(
+      for: terminal,
+      kind: .agentTerminal,
+      provider: SessionProviderKind(cliMode: cliConfiguration.mode),
+      sessionId: sessionId,
+      projectPath: projectPath,
+      expectedExecutable: cliConfiguration.executableName
+    )
 
     if let initialInputText, !initialInputText.isEmpty {
       terminal.onProcessReady = { [weak self] in
@@ -339,7 +346,14 @@ public class TerminalContainerView: NSView, ManagedLocalProcessTerminalViewDeleg
       projectPath: projectPath,
       shellPath: shellPath
     )
-    registerProcessIfNeeded(for: terminal)
+    registerProcessIfNeeded(
+      for: terminal,
+      kind: .auxiliaryShell,
+      provider: sessionViewModel?.providerKind,
+      sessionId: terminalSessionKey,
+      projectPath: projectPath,
+      expectedExecutable: nil
+    )
   }
 
   /// Resets the prompt delivery flag so a new prompt can be sent.
@@ -707,11 +721,29 @@ public class TerminalContainerView: NSView, ManagedLocalProcessTerminalViewDeleg
     )
   }
 
-  private func registerProcessIfNeeded(for terminal: SafeLocalProcessTerminalView) {
+  private func registerProcessIfNeeded(
+    for terminal: SafeLocalProcessTerminalView,
+    kind: ManagedProcessKind,
+    provider: SessionProviderKind?,
+    sessionId: String?,
+    projectPath: String,
+    expectedExecutable: String?
+  ) {
     guard let pid = terminal.currentProcessId, pid > 0 else { return }
     let key = ObjectIdentifier(terminal)
     terminalPidMap[key] = pid
-    TerminalProcessRegistry.shared.register(pid: pid)
+    let terminalKey = terminalSessionKey
+    Task {
+      await TerminalProcessRegistry.shared.register(
+        pid: pid,
+        kind: kind,
+        provider: provider,
+        terminalKey: terminalKey,
+        sessionId: sessionId,
+        projectPath: projectPath,
+        expectedExecutable: expectedExecutable
+      )
+    }
   }
 
   // MARK: - ManagedLocalProcessTerminalViewDelegate
@@ -725,7 +757,9 @@ public class TerminalContainerView: NSView, ManagedLocalProcessTerminalViewDeleg
   public func processTerminated(source: TerminalView, exitCode: Int32?) {
     let key = ObjectIdentifier(source)
     if let pid = terminalPidMap[key] {
-      TerminalProcessRegistry.shared.unregister(pid: pid)
+      Task {
+        await TerminalProcessRegistry.shared.unregister(pid: pid)
+      }
       terminalPidMap.removeValue(forKey: key)
     }
   }

--- a/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/CLISessionsViewModel.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/CLISessionsViewModel.swift
@@ -2581,14 +2581,11 @@ public final class CLISessionsViewModel {
   /// Refreshes the orphaned process count asynchronously.
   /// Call this when the menu bar opens to update the cached value.
   public func refreshOrphanedProcessCount() {
-    Task.detached { [weak self] in
-      let registeredPIDs = TerminalProcessRegistry.shared.getAliveRegisteredPIDs()
-
-      await MainActor.run { [weak self] in
-        guard let self else { return }
-        let activePIDs = self.activeTerminalPIDs
-        self.orphanedProcessCount = registeredPIDs.subtracting(activePIDs).count
-      }
+    Task { [weak self] in
+      let registeredPIDs = await TerminalProcessRegistry.shared.getAliveRegisteredPIDs()
+      guard let self else { return }
+      let activePIDs = self.activeTerminalPIDs
+      self.orphanedProcessCount = registeredPIDs.subtracting(activePIDs).count
     }
   }
 
@@ -2605,13 +2602,9 @@ public final class CLISessionsViewModel {
 
   /// Kills all orphaned Claude processes and refreshes the count
   public func killOrphanedProcesses() {
-    Task.detached { [weak self] in
-      TerminalProcessRegistry.shared.cleanupRegisteredProcesses()
-
-      // Refresh count after killing
-      await MainActor.run { [weak self] in
-        self?.refreshOrphanedProcessCount()
-      }
+    Task { [weak self] in
+      await TerminalProcessRegistry.shared.cleanupRegisteredProcesses()
+      self?.refreshOrphanedProcessCount()
     }
   }
 }

--- a/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/CLISessionsViewModel.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/CLISessionsViewModel.swift
@@ -2575,14 +2575,17 @@ public final class CLISessionsViewModel {
 
   // MARK: - Orphaned Sessions Detection
 
-  /// Cached count of orphaned Claude processes (updated async, read sync)
+  /// Cached count of orphaned terminal processes for this provider (updated async, read sync)
   public private(set) var orphanedProcessCount: Int = 0
 
   /// Refreshes the orphaned process count asynchronously.
   /// Call this when the menu bar opens to update the cached value.
   public func refreshOrphanedProcessCount() {
-    Task { [weak self] in
-      let registeredPIDs = await TerminalProcessRegistry.shared.getAliveRegisteredPIDs()
+    let currentProvider = providerKind
+    Task { [weak self, currentProvider] in
+      let registeredPIDs = await TerminalProcessRegistry.shared.getAliveRegisteredPIDs(
+        provider: currentProvider
+      )
       guard let self else { return }
       let activePIDs = self.activeTerminalPIDs
       self.orphanedProcessCount = registeredPIDs.subtracting(activePIDs).count
@@ -2600,10 +2603,15 @@ public final class CLISessionsViewModel {
     return pids
   }
 
-  /// Kills all orphaned Claude processes and refreshes the count
+  /// Kills all orphaned terminal processes for this provider and refreshes the count
   public func killOrphanedProcesses() {
-    Task { [weak self] in
-      await TerminalProcessRegistry.shared.cleanupRegisteredProcesses()
+    let currentProvider = providerKind
+    let activePIDs = activeTerminalPIDs
+    Task { [weak self, currentProvider, activePIDs] in
+      await TerminalProcessRegistry.shared.cleanupOrphanedTerminalProcesses(
+        provider: currentProvider,
+        activePIDs: activePIDs
+      )
       self?.refreshOrphanedProcessCount()
     }
   }

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/ManagedProcessStoreTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/ManagedProcessStoreTests.swift
@@ -1,0 +1,82 @@
+import Foundation
+import Testing
+
+@testable import AgentHubCore
+
+@Suite("Managed process store")
+struct ManagedProcessStoreTests {
+  @Test("Saves updates and deletes managed process rows without touching metadata")
+  func savesUpdatesAndDeletesManagedProcesses() async throws {
+    let store = try SessionMetadataStore(path: temporaryManagedProcessDatabasePath())
+    try await store.setCustomName("Important session", for: "session-1")
+
+    let first = managedProcessRecord(
+      pid: 101,
+      kind: .agentTerminal,
+      provider: SessionProviderKind.claude.rawValue,
+      sessionId: "session-1",
+      projectPath: "/tmp/project"
+    )
+    try await store.saveManagedProcess(first)
+
+    var rows = try await store.getManagedProcesses()
+    #expect(rows == [first])
+
+    let updated = managedProcessRecord(
+      pid: 101,
+      kind: .devServer,
+      provider: nil,
+      terminalKey: "session-1:storybook",
+      sessionId: nil,
+      projectPath: "/tmp/project"
+    )
+    try await store.saveManagedProcess(updated)
+
+    rows = try await store.getManagedProcesses()
+    #expect(rows == [updated])
+
+    try await store.deleteManagedProcess(pid: 101)
+    #expect(try await store.getManagedProcesses().isEmpty)
+    #expect(try await store.getCustomName(for: "session-1") == "Important session")
+  }
+
+  @Test("clearAll removes managed process rows")
+  func clearAllRemovesManagedProcessRows() async throws {
+    let store = try SessionMetadataStore(path: temporaryManagedProcessDatabasePath())
+    try await store.saveManagedProcess(managedProcessRecord(pid: 202, kind: .auxiliaryShell))
+
+    #expect(try await store.getManagedProcesses().count == 1)
+
+    try await store.clearAll()
+    #expect(try await store.getManagedProcesses().isEmpty)
+  }
+}
+
+private func managedProcessRecord(
+  pid: Int32,
+  kind: ManagedProcessKind,
+  provider: String? = nil,
+  terminalKey: String? = "terminal-\(UUID().uuidString)",
+  sessionId: String? = nil,
+  projectPath: String? = nil
+) -> ManagedProcessRecord {
+  ManagedProcessRecord(
+    pid: pid,
+    processGroupId: pid,
+    processStartTimeSeconds: 1_700_000_000 + Int64(pid),
+    kind: kind,
+    provider: provider,
+    terminalKey: terminalKey,
+    sessionId: sessionId,
+    projectPath: projectPath,
+    expectedExecutable: nil,
+    registeredAt: Date(timeIntervalSince1970: 1_700_000_000),
+    updatedAt: Date(timeIntervalSince1970: 1_700_000_001)
+  )
+}
+
+private func temporaryManagedProcessDatabasePath() -> String {
+  FileManager.default.temporaryDirectory
+    .appending(path: "test_managed_processes_\(UUID().uuidString).sqlite")
+    .path
+}

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/TerminalProcessRegistryTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/TerminalProcessRegistryTests.swift
@@ -1,0 +1,263 @@
+import Foundation
+import Testing
+
+@testable import AgentHubCore
+
+@Suite("Terminal process registry")
+struct TerminalProcessRegistryTests {
+  @Test("Register persists process identity and metadata")
+  func registerPersistsProcessIdentityAndMetadata() async throws {
+    let store = MockManagedProcessStore()
+    let inspector = MockProcessInspector(identities: [
+      123: identity(pid: 123, groupId: 123, startTime: 1_000)
+    ])
+    let registry = TerminalProcessRegistry(
+      store: store,
+      processInspector: inspector,
+      processTerminator: MockProcessTerminator()
+    )
+    let registeredAt = Date(timeIntervalSince1970: 42)
+
+    await registry.register(
+      pid: 123,
+      kind: .agentTerminal,
+      provider: .claude,
+      terminalKey: "session-1",
+      sessionId: "session-1",
+      projectPath: "/tmp/project",
+      expectedExecutable: "claude",
+      requestedAt: registeredAt
+    )
+
+    let rows = try await store.getManagedProcesses()
+    #expect(rows.count == 1)
+    #expect(rows.first?.pid == 123)
+    #expect(rows.first?.processGroupId == 123)
+    #expect(rows.first?.processStartTimeSeconds == 1_000)
+    #expect(rows.first?.processKind == .agentTerminal)
+    #expect(rows.first?.provider == SessionProviderKind.claude.rawValue)
+    #expect(rows.first?.terminalKey == "session-1")
+    #expect(rows.first?.sessionId == "session-1")
+    #expect(rows.first?.projectPath == "/tmp/project")
+    #expect(rows.first?.expectedExecutable == "claude")
+    #expect(rows.first?.registeredAt == registeredAt)
+  }
+
+  @Test("Unregister removes persisted row")
+  func unregisterRemovesPersistedRow() async throws {
+    let store = MockManagedProcessStore()
+    let registry = TerminalProcessRegistry(
+      store: store,
+      processInspector: MockProcessInspector(identities: [
+        123: identity(pid: 123, groupId: 123, startTime: 1_000)
+      ]),
+      processTerminator: MockProcessTerminator()
+    )
+
+    await registry.register(pid: 123)
+    #expect(try await store.getManagedProcesses().count == 1)
+
+    await registry.unregister(pid: 123)
+    #expect(try await store.getManagedProcesses().isEmpty)
+  }
+
+  @Test("Alive registered PIDs excludes dev servers and prunes stale terminal rows")
+  func aliveRegisteredPIDsExcludeDevServersAndPruneStaleRows() async throws {
+    let store = MockManagedProcessStore(records: [
+      processRow(pid: 111, kind: .agentTerminal, startTime: 10),
+      processRow(pid: 222, kind: .auxiliaryShell, startTime: 20),
+      processRow(pid: 333, kind: .devServer, startTime: 30),
+      processRow(pid: 444, kind: .agentTerminal, startTime: 40)
+    ])
+    let registry = TerminalProcessRegistry(
+      store: store,
+      processInspector: MockProcessInspector(identities: [
+        111: identity(pid: 111, groupId: 111, startTime: 10),
+        222: identity(pid: 222, groupId: 222, startTime: 20),
+        333: identity(pid: 333, groupId: 333, startTime: 30)
+      ]),
+      processTerminator: MockProcessTerminator()
+    )
+
+    let alive = await registry.getAliveRegisteredPIDs()
+
+    #expect(alive == Set<Int32>([111, 222]))
+    let remainingPIDs = try await store.getManagedProcesses().map(\.pid).sorted()
+    #expect(remainingPIDs == [111, 222, 333])
+  }
+
+  @Test("Cleanup terminates matching identities and removes rows")
+  func cleanupTerminatesMatchingIdentitiesAndRemovesRows() async throws {
+    let store = MockManagedProcessStore(records: [
+      processRow(pid: 111, kind: .agentTerminal, startTime: 10),
+      processRow(pid: 222, kind: .devServer, startTime: 20)
+    ])
+    let terminator = MockProcessTerminator()
+    let registry = TerminalProcessRegistry(
+      store: store,
+      processInspector: MockProcessInspector(identities: [
+        111: identity(pid: 111, groupId: 111, startTime: 10),
+        222: identity(pid: 222, groupId: 222, startTime: 20)
+      ]),
+      processTerminator: terminator
+    )
+
+    await registry.cleanupRegisteredProcesses()
+
+    #expect(await terminator.terminatedPIDs().sorted() == [111, 222])
+    #expect(try await store.getManagedProcesses().isEmpty)
+  }
+
+  @Test("Cleanup prunes PID reuse without terminating")
+  func cleanupPrunesPIDReuseWithoutTerminating() async throws {
+    let store = MockManagedProcessStore(records: [
+      processRow(pid: 111, kind: .agentTerminal, startTime: 10)
+    ])
+    let terminator = MockProcessTerminator()
+    let registry = TerminalProcessRegistry(
+      store: store,
+      processInspector: MockProcessInspector(identities: [
+        111: identity(pid: 111, groupId: 111, startTime: 99)
+      ]),
+      processTerminator: terminator
+    )
+
+    await registry.cleanupRegisteredProcesses()
+
+    #expect(await terminator.terminatedPIDs().isEmpty)
+    #expect(try await store.getManagedProcesses().isEmpty)
+  }
+
+  @Test("Cleanup prunes dead processes without terminating")
+  func cleanupPrunesDeadProcessesWithoutTerminating() async throws {
+    let store = MockManagedProcessStore(records: [
+      processRow(pid: 111, kind: .agentTerminal, startTime: 10)
+    ])
+    let terminator = MockProcessTerminator()
+    let registry = TerminalProcessRegistry(
+      store: store,
+      processInspector: MockProcessInspector(identities: [:]),
+      processTerminator: terminator
+    )
+
+    await registry.cleanupRegisteredProcesses()
+
+    #expect(await terminator.terminatedPIDs().isEmpty)
+    #expect(try await store.getManagedProcesses().isEmpty)
+  }
+
+  @Test("Late register request is ignored after unregister")
+  func lateRegisterRequestIsIgnoredAfterUnregister() async throws {
+    let store = MockManagedProcessStore()
+    let registry = TerminalProcessRegistry(
+      store: store,
+      processInspector: MockProcessInspector(identities: [
+        111: identity(pid: 111, groupId: 111, startTime: 10)
+      ]),
+      processTerminator: MockProcessTerminator()
+    )
+
+    await registry.unregister(pid: 111, requestedAt: Date(timeIntervalSince1970: 20))
+    await registry.register(pid: 111, requestedAt: Date(timeIntervalSince1970: 10))
+
+    #expect(try await store.getManagedProcesses().isEmpty)
+  }
+
+  @Test("Legacy UserDefaults registry data is ignored")
+  func legacyUserDefaultsRegistryDataIsIgnored() async throws {
+    let legacyKey = "AgentHub.TerminalProcessRegistry"
+    UserDefaults.standard.set(["111": 1_700_000_000.0], forKey: legacyKey)
+    defer { UserDefaults.standard.removeObject(forKey: legacyKey) }
+
+    let store = MockManagedProcessStore()
+    let registry = TerminalProcessRegistry(
+      store: store,
+      processInspector: MockProcessInspector(identities: [
+        111: identity(pid: 111, groupId: 111, startTime: 10)
+      ]),
+      processTerminator: MockProcessTerminator()
+    )
+
+    #expect(await registry.getAliveRegisteredPIDs().isEmpty)
+    #expect(try await store.getManagedProcesses().isEmpty)
+  }
+}
+
+private actor MockManagedProcessStore: ManagedProcessStoreProtocol {
+  private var records: [Int32: ManagedProcessRecord]
+
+  init(records: [ManagedProcessRecord] = []) {
+    self.records = Dictionary(uniqueKeysWithValues: records.map { ($0.pid, $0) })
+  }
+
+  func saveManagedProcess(_ record: ManagedProcessRecord) async throws {
+    records[record.pid] = record
+  }
+
+  func deleteManagedProcess(pid: Int32) async throws {
+    records.removeValue(forKey: pid)
+  }
+
+  func deleteManagedProcesses(pids: [Int32]) async throws {
+    for pid in pids {
+      records.removeValue(forKey: pid)
+    }
+  }
+
+  func getManagedProcesses() async throws -> [ManagedProcessRecord] {
+    records.values.sorted { $0.pid < $1.pid }
+  }
+}
+
+private actor MockProcessInspector: ProcessInspecting {
+  private var identities: [pid_t: ManagedProcessIdentity]
+
+  init(identities: [pid_t: ManagedProcessIdentity]) {
+    self.identities = identities
+  }
+
+  func identity(for pid: pid_t) async -> ManagedProcessIdentity? {
+    identities[pid]
+  }
+}
+
+private actor MockProcessTerminator: ProcessTerminating {
+  private var pids: [pid_t] = []
+
+  func terminate(pid: pid_t, processGroupId: pid_t?) async {
+    pids.append(pid)
+  }
+
+  func terminatedPIDs() -> [pid_t] {
+    pids
+  }
+}
+
+private func identity(pid: pid_t, groupId: pid_t, startTime: Int64) -> ManagedProcessIdentity {
+  ManagedProcessIdentity(
+    pid: pid,
+    processGroupId: groupId,
+    startTimeSeconds: startTime,
+    commandLine: nil
+  )
+}
+
+private func processRow(
+  pid: Int32,
+  kind: ManagedProcessKind,
+  startTime: Int64
+) -> ManagedProcessRecord {
+  ManagedProcessRecord(
+    pid: pid,
+    processGroupId: pid,
+    processStartTimeSeconds: startTime,
+    kind: kind,
+    provider: nil,
+    terminalKey: nil,
+    sessionId: nil,
+    projectPath: nil,
+    expectedExecutable: nil,
+    registeredAt: Date(timeIntervalSince1970: 1),
+    updatedAt: Date(timeIntervalSince1970: 2)
+  )
+}

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/TerminalProcessRegistryTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/TerminalProcessRegistryTests.swift
@@ -43,6 +43,24 @@ struct TerminalProcessRegistryTests {
     #expect(rows.first?.registeredAt == registeredAt)
   }
 
+  @Test("Register only persists owned process groups")
+  func registerOnlyPersistsOwnedProcessGroups() async throws {
+    let store = MockManagedProcessStore()
+    let registry = TerminalProcessRegistry(
+      store: store,
+      processInspector: MockProcessInspector(identities: [
+        123: identity(pid: 123, groupId: 999, startTime: 1_000)
+      ]),
+      processTerminator: MockProcessTerminator()
+    )
+
+    await registry.register(pid: 123)
+
+    let rows = try await store.getManagedProcesses()
+    #expect(rows.count == 1)
+    #expect(rows.first?.processGroupId == nil)
+  }
+
   @Test("Unregister removes persisted row")
   func unregisterRemovesPersistedRow() async throws {
     let store = MockManagedProcessStore()
@@ -106,6 +124,55 @@ struct TerminalProcessRegistryTests {
 
     #expect(await terminator.terminatedPIDs().sorted() == [111, 222])
     #expect(try await store.getManagedProcesses().isEmpty)
+  }
+
+  @Test("Cleanup terminates inherited process group rows by PID only")
+  func cleanupTerminatesInheritedProcessGroupRowsByPIDOnly() async throws {
+    let store = MockManagedProcessStore(records: [
+      processRow(pid: 111, kind: .agentTerminal, startTime: 10, processGroupId: 999)
+    ])
+    let terminator = MockProcessTerminator()
+    let registry = TerminalProcessRegistry(
+      store: store,
+      processInspector: MockProcessInspector(identities: [
+        111: identity(pid: 111, groupId: 999, startTime: 10)
+      ]),
+      processTerminator: terminator
+    )
+
+    await registry.cleanupRegisteredProcesses()
+
+    #expect(await terminator.terminationRequests() == [
+      TerminationRequest(pid: 111, processGroupId: nil)
+    ])
+    #expect(try await store.getManagedProcesses().isEmpty)
+  }
+
+  @Test("Orphan cleanup only terminates scoped inactive terminal rows")
+  func orphanCleanupOnlyTerminatesScopedInactiveTerminalRows() async throws {
+    let store = MockManagedProcessStore(records: [
+      processRow(pid: 111, kind: .agentTerminal, startTime: 10, provider: .claude),
+      processRow(pid: 222, kind: .auxiliaryShell, startTime: 20, provider: .claude),
+      processRow(pid: 333, kind: .devServer, startTime: 30, provider: .claude),
+      processRow(pid: 444, kind: .agentTerminal, startTime: 40, provider: .codex),
+      processRow(pid: 555, kind: .agentTerminal, startTime: 50, provider: .claude)
+    ])
+    let terminator = MockProcessTerminator()
+    let registry = TerminalProcessRegistry(
+      store: store,
+      processInspector: MockProcessInspector(identities: [
+        111: identity(pid: 111, groupId: 111, startTime: 10),
+        222: identity(pid: 222, groupId: 222, startTime: 20),
+        333: identity(pid: 333, groupId: 333, startTime: 30),
+        444: identity(pid: 444, groupId: 444, startTime: 40)
+      ]),
+      processTerminator: terminator
+    )
+
+    await registry.cleanupOrphanedTerminalProcesses(provider: .claude, activePIDs: [222])
+
+    #expect(await terminator.terminatedPIDs() == [111])
+    #expect(try await store.getManagedProcesses().map(\.pid).sorted() == [222, 333, 444])
   }
 
   @Test("Cleanup prunes PID reuse without terminating")
@@ -221,15 +288,24 @@ private actor MockProcessInspector: ProcessInspecting {
   }
 }
 
+private struct TerminationRequest: Equatable, Sendable {
+  let pid: pid_t
+  let processGroupId: pid_t?
+}
+
 private actor MockProcessTerminator: ProcessTerminating {
-  private var pids: [pid_t] = []
+  private var requests: [TerminationRequest] = []
 
   func terminate(pid: pid_t, processGroupId: pid_t?) async {
-    pids.append(pid)
+    requests.append(TerminationRequest(pid: pid, processGroupId: processGroupId))
   }
 
   func terminatedPIDs() -> [pid_t] {
-    pids
+    requests.map(\.pid)
+  }
+
+  func terminationRequests() -> [TerminationRequest] {
+    requests
   }
 }
 
@@ -245,14 +321,31 @@ private func identity(pid: pid_t, groupId: pid_t, startTime: Int64) -> ManagedPr
 private func processRow(
   pid: Int32,
   kind: ManagedProcessKind,
-  startTime: Int64
+  startTime: Int64,
+  provider: SessionProviderKind? = nil
+) -> ManagedProcessRecord {
+  processRow(
+    pid: pid,
+    kind: kind,
+    startTime: startTime,
+    processGroupId: pid,
+    provider: provider
+  )
+}
+
+private func processRow(
+  pid: Int32,
+  kind: ManagedProcessKind,
+  startTime: Int64,
+  processGroupId: Int32,
+  provider: SessionProviderKind? = nil
 ) -> ManagedProcessRecord {
   ManagedProcessRecord(
     pid: pid,
-    processGroupId: pid,
+    processGroupId: processGroupId,
     processStartTimeSeconds: startTime,
     kind: kind,
-    provider: nil,
+    provider: provider?.rawValue,
     terminalKey: nil,
     sessionId: nil,
     projectPath: nil,

--- a/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalSurface.swift
+++ b/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalSurface.swift
@@ -39,6 +39,9 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
   private var projectPath: String = ""
   private var isRestoringWorkspace = false
   private var lastWorkspaceSnapshot: TerminalWorkspaceSnapshot?
+  private var configuredSessionId: String?
+  private var configuredProcessProvider: SessionProviderKind?
+  private var configuredExpectedExecutable: String?
   private static let terminalPaneDividerSize: CGFloat = 1
   private static let terminalTabStripHeight: CGFloat = 28
   private static let shellStartupFallbackDelay: Duration = .milliseconds(900)
@@ -121,6 +124,9 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
     guard !isConfigured else { return }
     isConfigured = true
     self.projectPath = projectPath
+    configuredSessionId = sessionId
+    configuredProcessProvider = SessionProviderKind(cliMode: cliConfiguration.mode)
+    configuredExpectedExecutable = cliConfiguration.executableName
 
     let launch = EmbeddedTerminalLaunchBuilder.cliLaunch(
       sessionId: sessionId,
@@ -153,6 +159,9 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
     guard !isConfigured else { return }
     isConfigured = true
     self.projectPath = projectPath
+    configuredSessionId = nil
+    configuredProcessProvider = sessionViewModel?.providerKind
+    configuredExpectedExecutable = nil
 
     let launch = EmbeddedTerminalLaunchBuilder.shellLaunch(
       projectPath: projectPath,
@@ -182,6 +191,7 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
     isConfigured = false
     hasDeliveredInitialPrompt = false
     hasPrefilledInitialInputText = false
+    configuredSessionId = sessionId
     configure(
       sessionId: sessionId,
       projectPath: projectPath,
@@ -1465,7 +1475,27 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
         guard let located = self.locateController(controller) else { return }
         if let pid = controller.foregroundProcessID, pid > 0 {
           self.registeredPIDs[id] = pid
-          TerminalProcessRegistry.shared.register(pid: pid)
+          let kind: ManagedProcessKind = self.isProtectedAgentTab(located.tab, in: located.panel.id)
+            ? .agentTerminal
+            : .auxiliaryShell
+          let provider = self.sessionViewModel?.providerKind ?? self.configuredProcessProvider
+          let terminalKey = self.terminalSessionKey
+          let sessionId = kind == .agentTerminal
+            ? self.configuredSessionId ?? terminalKey
+            : terminalKey
+          let projectPath = self.projectPath
+          let expectedExecutable = kind == .agentTerminal ? self.configuredExpectedExecutable : nil
+          Task {
+            await TerminalProcessRegistry.shared.register(
+              pid: pid,
+              kind: kind,
+              provider: provider,
+              terminalKey: terminalKey,
+              sessionId: sessionId,
+              projectPath: projectPath,
+              expectedExecutable: expectedExecutable
+            )
+          }
           self.pidRegistrationTasks[id] = nil
           self.finishPaneStarting(located.panel.id)
           return
@@ -1481,7 +1511,9 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
     pidRegistrationTasks[id]?.cancel()
     pidRegistrationTasks[id] = nil
     if let registeredPID = registeredPIDs.removeValue(forKey: id) {
-      TerminalProcessRegistry.shared.unregister(pid: registeredPID)
+      Task {
+        await TerminalProcessRegistry.shared.unregister(pid: registeredPID)
+      }
     }
   }
 
@@ -1494,7 +1526,9 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
 
   private func unregisterAllPIDs() {
     for pid in registeredPIDs.values {
-      TerminalProcessRegistry.shared.unregister(pid: pid)
+      Task {
+        await TerminalProcessRegistry.shared.unregister(pid: pid)
+      }
     }
     registeredPIDs.removeAll()
   }


### PR DESCRIPTION
## Summary
- move terminal/dev-server managed process persistence from UserDefaults into SessionMetadataStore managed_processes table
- add v7 migration plus store APIs and registry cleanup using PID + PGID + start-time identity checks
- register embedded/Ghostty/dev-server processes in SQLite and run orphan cleanup on launch
- document migration/versioning rules in AGENTS.md and CLAUDE.md

## Tests
- xcodebuild test -project app/AgentHub.xcodeproj -scheme AgentHub -destination "platform=macOS" -derivedDataPath /private/tmp/AgentHubProcessTableDerivedData -only-testing:AgentHubTests/SessionMetadataMigrationSafetyTests -only-testing:AgentHubTests/ManagedProcessRegistryTests

## Notes
- test-traces/ profiling artifacts are intentionally untracked and not included.
- swift build --package-path app/modules/AgentHubCore is currently blocked before this target by the existing CodeEditSymbols Bundle.module issue.