### PR TITLE
[codex] Lazy load browse sessions

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/Models/CLISession.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Models/CLISession.swift
@@ -156,6 +156,30 @@ public enum CLILoadingState: Equatable, Sendable {
   }
 }
 
+public enum BrowseSessionsLoadState: Equatable, Sendable {
+  case notLoaded
+  case loading
+  case loaded
+  case failed(String)
+
+  public var isLoading: Bool {
+    self == .loading
+  }
+
+  public var isLoaded: Bool {
+    self == .loaded
+  }
+
+  public var message: String {
+    switch self {
+    case .notLoaded: return ""
+    case .loading: return "Loading sessions..."
+    case .loaded: return ""
+    case .failed(let message): return message
+    }
+  }
+}
+
 // MARK: - SelectedRepository
 
 /// A repository selected by the user for CLI session monitoring

--- a/app/modules/AgentHubCore/Sources/AgentHub/Models/MonitoredSessionPresentation.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Models/MonitoredSessionPresentation.swift
@@ -1,0 +1,23 @@
+//
+//  MonitoredSessionPresentation.swift
+//  AgentHub
+//
+
+import Foundation
+
+// MARK: - MonitoredSessionPresentation
+
+public struct MonitoredSessionPresentation: Identifiable {
+  public var id: String { session.id }
+
+  public let session: CLISession
+  public let stateModel: SessionMonitorStateModel
+
+  public init(
+    session: CLISession,
+    stateModel: SessionMonitorStateModel
+  ) {
+    self.session = session
+    self.stateModel = stateModel
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/Models/SessionMonitorStateModel.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Models/SessionMonitorStateModel.swift
@@ -1,0 +1,26 @@
+//
+//  SessionMonitorStateModel.swift
+//  AgentHub
+//
+
+import Foundation
+
+// MARK: - SessionMonitorStateModel
+
+/// Per-session observable state used to keep monitor updates scoped to the
+/// views that render a single session.
+@MainActor
+@Observable
+public final class SessionMonitorStateModel {
+  public let sessionId: String
+  public private(set) var state: SessionMonitorState?
+
+  public init(sessionId: String, state: SessionMonitorState? = nil) {
+    self.sessionId = sessionId
+    self.state = state
+  }
+
+  public func update(_ state: SessionMonitorState?) {
+    self.state = state
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/CLISessionMonitorService.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/CLISessionMonitorService.swift
@@ -56,12 +56,12 @@ public actor CLISessionMonitorService {
 
   /// Adds a repository to monitor and detects its worktrees
   /// - Parameter path: Path to the git repository
-  /// - Returns: The created SelectedRepository with detected worktrees
+  /// - Returns: The created SelectedRepository with detected worktrees, or nil for a duplicate add
   @discardableResult
   public func addRepository(_ path: String) async -> SelectedRepository? {
     // Check if already added
     guard !selectedRepositories.contains(where: { $0.path == path }) else {
-      return selectedRepositories.first { $0.path == path }
+      return nil
     }
 
     // Detect worktrees for this repository

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/CLISessionMonitorService.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/CLISessionMonitorService.swift
@@ -111,6 +111,32 @@ public actor CLISessionMonitorService {
     await refreshSessions(skipWorktreeRedetection: true)
   }
 
+  /// Restores selected repositories and worktrees without scanning every session.
+  /// Used on app launch so the main monitored-session list can appear quickly.
+  public func restoreRepositoriesSkeleton(_ paths: [String]) async -> [SelectedRepository] {
+    var seen: Set<String> = []
+    let uniquePaths = paths.filter { seen.insert($0).inserted }
+
+    guard !uniquePaths.isEmpty else {
+      selectedRepositories = []
+      invalidateHistoryCache()
+      repositoriesSubject.send([])
+      return []
+    }
+
+    let allWorktrees = await detectWorktreesBatch(repoPaths: uniquePaths)
+    selectedRepositories = uniquePaths.map { path in
+      SelectedRepository(
+        path: path,
+        worktrees: allWorktrees[path] ?? [],
+        isExpanded: true
+      )
+    }
+    invalidateHistoryCache()
+    repositoriesSubject.send(selectedRepositories)
+    return selectedRepositories
+  }
+
   /// Removes a repository from monitoring
   /// - Parameter path: Path to the repository to remove
   public func removeRepository(_ path: String) async {
@@ -129,6 +155,30 @@ public actor CLISessionMonitorService {
     selectedRepositories = repositories
     invalidateHistoryCache()
     await refreshSessions()
+  }
+
+  /// Loads only the requested Claude sessions from their JSONL files.
+  /// This avoids parsing the global history file during app launch.
+  public func loadSessions(ids: Set<String>) async -> [CLISession] {
+    guard !ids.isEmpty else { return [] }
+    let claudeDataPath = claudeDataPath
+    let filesBySessionId = await Task.detached(priority: .userInitiated) {
+      CLISessionMonitorService.findClaudeSessionFiles(
+        sessionIds: ids,
+        claudeDataPath: claudeDataPath
+      )
+    }.value
+
+    var sessions: [CLISession] = []
+    for sessionId in ids {
+      guard let filePath = filesBySessionId[sessionId],
+            let session = restoreSession(sessionId: sessionId, filePath: filePath) else {
+        continue
+      }
+      sessions.append(session)
+    }
+
+    return sessions.sorted { $0.lastActivityAt > $1.lastActivityAt }
   }
 
   // MARK: - Session Scanning
@@ -463,6 +513,156 @@ public actor CLISessionMonitorService {
       }
     }
     return paths
+  }
+
+  private func restoreSession(sessionId: String, filePath: String) -> CLISession? {
+    guard let data = FileManager.default.contents(atPath: filePath),
+          let content = String(data: data, encoding: .utf8) else {
+      return nil
+    }
+
+    var projectPath: String?
+    var branchName: String?
+    var slug: String?
+    var firstMessage: String?
+    var lastMessage: String?
+    var messageCount = 0
+    var lastActivityAt: Date?
+
+    for line in content.split(separator: "\n", omittingEmptySubsequences: true) {
+      guard let lineData = line.data(using: .utf8),
+            let json = try? JSONSerialization.jsonObject(with: lineData) as? [String: Any] else {
+        continue
+      }
+
+      if let lineSessionId = json["sessionId"] as? String, lineSessionId != sessionId {
+        return nil
+      }
+      if projectPath == nil, let cwd = json["cwd"] as? String {
+        projectPath = cwd
+      }
+      if branchName == nil, let gitBranch = json["gitBranch"] as? String {
+        branchName = gitBranch
+      }
+      if slug == nil, let sessionSlug = json["slug"] as? String {
+        slug = sessionSlug
+      }
+      if let timestamp = Self.parseISO8601Date(json["timestamp"] as? String),
+         lastActivityAt.map({ timestamp > $0 }) ?? true {
+        lastActivityAt = timestamp
+      }
+
+      guard let type = json["type"] as? String else { continue }
+      if type == "user" || type == "assistant" {
+        messageCount += 1
+      }
+      if type == "user",
+         let preview = Self.extractClaudeTextPreview(from: json),
+         !preview.isEmpty {
+        if firstMessage == nil {
+          firstMessage = preview
+        }
+        lastMessage = preview
+      }
+    }
+
+    guard let projectPath else { return nil }
+    let worktree = worktreeInfo(containing: projectPath)
+    let fileModifiedAt = fileModificationDate(filePath)
+    let activityAt = [lastActivityAt, fileModifiedAt].compactMap { $0 }.max() ?? Date()
+
+    return CLISession(
+      id: sessionId,
+      projectPath: projectPath,
+      branchName: branchName ?? worktree.branchName,
+      isWorktree: worktree.isWorktree,
+      lastActivityAt: activityAt,
+      messageCount: messageCount,
+      isActive: fileModifiedAt.map { Date().timeIntervalSince($0) < 60 } ?? false,
+      firstMessage: firstMessage,
+      lastMessage: lastMessage,
+      slug: slug,
+      sessionFilePath: filePath
+    )
+  }
+
+  private func worktreeInfo(containing projectPath: String) -> (branchName: String?, isWorktree: Bool) {
+    let matchingWorktree = selectedRepositories
+      .flatMap(\.worktrees)
+      .filter { projectPath == $0.path || projectPath.hasPrefix($0.path + "/") }
+      .max { $0.path.count < $1.path.count }
+
+    return (matchingWorktree?.name, matchingWorktree?.isWorktree ?? false)
+  }
+
+  private func fileModificationDate(_ path: String) -> Date? {
+    guard let attrs = try? FileManager.default.attributesOfItem(atPath: path),
+          let modDate = attrs[.modificationDate] as? Date else {
+      return nil
+    }
+    return modDate
+  }
+
+  private static func findClaudeSessionFiles(
+    sessionIds: Set<String>,
+    claudeDataPath: String
+  ) -> [String: String] {
+    let projectsRoot = URL(fileURLWithPath: claudeDataPath).appendingPathComponent("projects")
+    guard let enumerator = FileManager.default.enumerator(
+      at: projectsRoot,
+      includingPropertiesForKeys: [.isRegularFileKey],
+      options: [.skipsHiddenFiles]
+    ) else {
+      return [:]
+    }
+
+    var results: [String: String] = [:]
+    let expectedFileNames = Dictionary(uniqueKeysWithValues: sessionIds.map { ("\($0).jsonl", $0) })
+
+    for case let url as URL in enumerator {
+      guard url.pathExtension == "jsonl",
+            !url.path.contains("/subagents/"),
+            let sessionId = expectedFileNames[url.lastPathComponent],
+            results[sessionId] == nil else {
+        continue
+      }
+      results[sessionId] = url.path
+    }
+
+    return results
+  }
+
+  private static func extractClaudeTextPreview(from json: [String: Any]) -> String? {
+    guard let message = json["message"] as? [String: Any] else { return nil }
+
+    if let text = message["content"] as? String {
+      return cleanPreview(text)
+    }
+
+    guard let blocks = message["content"] as? [[String: Any]] else { return nil }
+    let text = blocks.compactMap { block -> String? in
+      guard block["type"] as? String == "text" else { return nil }
+      return block["text"] as? String
+    }.joined(separator: " ")
+
+    return cleanPreview(text)
+  }
+
+  private static func cleanPreview(_ text: String) -> String? {
+    let cleaned = text.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !cleaned.isEmpty else { return nil }
+    return String(cleaned.prefix(500))
+  }
+
+  private static func parseISO8601Date(_ string: String?) -> Date? {
+    guard let string else { return nil }
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+    if let date = formatter.date(from: string) {
+      return date
+    }
+    formatter.formatOptions = [.withInternetDateTime]
+    return formatter.date(from: string)
   }
 
   // MARK: - Session File Parsing

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/CodexSessionMonitorService.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/CodexSessionMonitorService.swift
@@ -53,6 +53,28 @@ public actor CodexSessionMonitorService {
     return repository
   }
 
+  public func restoreRepositoriesSkeleton(_ paths: [String]) async -> [SelectedRepository] {
+    var seen: Set<String> = []
+    let uniquePaths = paths.filter { seen.insert($0).inserted }
+
+    guard !uniquePaths.isEmpty else {
+      selectedRepositories = []
+      repositoriesSubject.send([])
+      return []
+    }
+
+    let allWorktrees = await detectWorktreesBatch(repoPaths: uniquePaths)
+    selectedRepositories = uniquePaths.map { path in
+      SelectedRepository(
+        path: path,
+        worktrees: allWorktrees[path] ?? [],
+        isExpanded: true
+      )
+    }
+    repositoriesSubject.send(selectedRepositories)
+    return selectedRepositories
+  }
+
   public func removeRepository(_ path: String) async {
     selectedRepositories.removeAll { $0.path == path }
     repositoriesSubject.send(selectedRepositories)
@@ -65,6 +87,42 @@ public actor CodexSessionMonitorService {
   public func setSelectedRepositories(_ repositories: [SelectedRepository]) async {
     selectedRepositories = repositories
     await refreshSessions()
+  }
+
+  public func loadSessions(ids: Set<String>) async -> [CLISession] {
+    guard !ids.isEmpty else { return [] }
+    let files = CodexSessionFileScanner.listSessionFiles(codexDataPath: codexDataPath)
+    var sessions: [CLISession] = []
+
+    for path in files where ids.contains(where: { sessionId in
+      URL(fileURLWithPath: path).deletingPathExtension().lastPathComponent.hasSuffix(sessionId)
+    }) {
+      guard let meta = CodexSessionFileScanner.readSessionMeta(from: path),
+            ids.contains(meta.sessionId) else {
+        continue
+      }
+
+      let parsed = CodexSessionJSONLParser.parseSessionFile(at: path)
+      let userMessages = Self.userMessagePreviews(from: path)
+      let worktree = worktreeInfo(containing: meta.projectPath)
+      let lastActivity = [parsed.lastActivityAt, fileModificationDate(path)].compactMap { $0 }.max()
+      let session = CLISession(
+        id: meta.sessionId,
+        projectPath: meta.projectPath,
+        branchName: meta.branch ?? worktree.branchName,
+        isWorktree: worktree.isWorktree,
+        lastActivityAt: lastActivity ?? meta.startedAt ?? Date(),
+        messageCount: parsed.messageCount,
+        isActive: isSessionFileActive(path),
+        firstMessage: userMessages.first,
+        lastMessage: userMessages.last,
+        slug: nil,
+        sessionFilePath: path
+      )
+      sessions.append(session)
+    }
+
+    return sessions.sorted { $0.lastActivityAt > $1.lastActivityAt }
   }
 
   // MARK: - Session Scanning
@@ -239,6 +297,46 @@ public actor CodexSessionMonitorService {
       return nil
     }
     return modDate
+  }
+
+  private func worktreeInfo(containing projectPath: String) -> (branchName: String?, isWorktree: Bool) {
+    let matchingWorktree = selectedRepositories
+      .flatMap(\.worktrees)
+      .filter { projectPath == $0.path || projectPath.hasPrefix($0.path + "/") }
+      .max { $0.path.count < $1.path.count }
+
+    return (matchingWorktree?.name, matchingWorktree?.isWorktree ?? false)
+  }
+
+  private static func userMessagePreviews(from path: String) -> (first: String?, last: String?) {
+    guard let data = FileManager.default.contents(atPath: path),
+          let content = String(data: data, encoding: .utf8) else {
+      return (nil, nil)
+    }
+
+    var first: String?
+    var last: String?
+
+    for line in content.split(separator: "\n", omittingEmptySubsequences: true) {
+      guard let lineData = line.data(using: .utf8),
+            let json = try? JSONSerialization.jsonObject(with: lineData) as? [String: Any],
+            json["type"] as? String == "event_msg",
+            let payload = json["payload"] as? [String: Any],
+            payload["type"] as? String == "user_message",
+            let message = payload["message"] as? String else {
+        continue
+      }
+
+      let cleaned = message.trimmingCharacters(in: .whitespacesAndNewlines)
+      guard !cleaned.isEmpty else { continue }
+      let preview = String(cleaned.prefix(500))
+      if first == nil {
+        first = preview
+      }
+      last = preview
+    }
+
+    return (first, last)
   }
 
   // MARK: - Worktree Detection

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/CodexSessionMonitorService.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/CodexSessionMonitorService.swift
@@ -38,7 +38,7 @@ public actor CodexSessionMonitorService {
   @discardableResult
   public func addRepository(_ path: String) async -> SelectedRepository? {
     guard !selectedRepositories.contains(where: { $0.path == path }) else {
-      return selectedRepositories.first { $0.path == path }
+      return nil
     }
 
     let worktrees = await detectWorktrees(at: path)

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/SessionProviderProtocols.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/SessionProviderProtocols.swift
@@ -32,6 +32,8 @@ public protocol SessionMonitorServiceProtocol: AnyObject, Sendable {
   @discardableResult
   func addRepository(_ path: String) async -> SelectedRepository?
   func addRepositories(_ paths: [String]) async
+  func restoreRepositoriesSkeleton(_ paths: [String]) async -> [SelectedRepository]
+  func loadSessions(ids: Set<String>) async -> [CLISession]
   func removeRepository(_ path: String) async
   func getSelectedRepositories() async -> [SelectedRepository]
   func setSelectedRepositories(_ repositories: [SelectedRepository]) async
@@ -50,6 +52,19 @@ public extension SessionMonitorServiceProtocol {
     for path in paths {
       await addRepository(path)
     }
+  }
+
+  func restoreRepositoriesSkeleton(_ paths: [String]) async -> [SelectedRepository] {
+    await addRepositories(paths)
+    return await getSelectedRepositories()
+  }
+
+  func loadSessions(ids: Set<String>) async -> [CLISession] {
+    let repositories = await getSelectedRepositories()
+    return repositories
+      .flatMap { $0.worktrees }
+      .flatMap { $0.sessions }
+      .filter { ids.contains($0.id) }
   }
 }
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/SessionProviderProtocols.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/SessionProviderProtocols.swift
@@ -29,6 +29,8 @@ public enum SessionProviderKind: String, CaseIterable, Sendable {
 public protocol SessionMonitorServiceProtocol: AnyObject, Sendable {
   var repositoriesPublisher: AnyPublisher<[SelectedRepository], Never> { get }
 
+  /// Adds a repository and returns it when a refresh was performed.
+  /// Returns nil for duplicate/no-op adds.
   @discardableResult
   func addRepository(_ path: String) async -> SelectedRepository?
   func addRepositories(_ paths: [String]) async

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
@@ -248,10 +248,6 @@ public struct MultiProviderSessionsListView: View {
       commandPaletteOverlay
     }
     .onAppear {
-      if hasRepositories {
-        claudeViewModel.refresh()
-        codexViewModel.refresh()
-      }
       if multiLaunchViewModel == nil {
         multiLaunchViewModel = MultiSessionLaunchViewModel(
           claudeViewModel: claudeViewModel,
@@ -1127,9 +1123,7 @@ public struct MultiProviderSessionsListView: View {
   private var browseHeaderView: some View {
     HStack(spacing: 8) {
       Button {
-        withAnimation(browseAnimation) {
-          isBrowseExpanded.toggle()
-        }
+        toggleBrowseExpanded()
       } label: {
         HStack(spacing: 6) {
           Image(systemName: isBrowseExpanded ? "chevron.down" : "chevron.up")
@@ -1164,6 +1158,18 @@ public struct MultiProviderSessionsListView: View {
     }
   }
 
+  private func toggleBrowseExpanded() {
+    let willExpand = !isBrowseExpanded
+    withAnimation(browseAnimation) {
+      isBrowseExpanded = willExpand
+    }
+
+    if willExpand {
+      claudeViewModel.ensureBrowseSessionsLoaded()
+      codexViewModel.ensureBrowseSessionsLoaded()
+    }
+  }
+
   /// Expandable content shown inside the scroll view when browse is expanded.
   private var browseExpandedContent: some View {
     VStack(spacing: 6) {
@@ -1180,22 +1186,80 @@ public struct MultiProviderSessionsListView: View {
         statusHeader
       }
 
-      if isSearchExpanded {
-        expandedSearchBar
-      } else {
-        collapsedSearchButton
-      }
+      switch currentViewModel.browseSessionsLoadState {
+      case .loading, .notLoaded:
+        browseLoadingView
 
-      LazyVStack(spacing: 16) {
-        selectedProviderContent
+      case .failed(let message):
+        browseErrorView(message: message)
+
+      case .loaded:
+        if isSearchExpanded {
+          expandedSearchBar
+        } else {
+          collapsedSearchButton
+        }
+
+        LazyVStack(spacing: 16) {
+          selectedProviderContent
+        }
+        .padding(.vertical, 4)
       }
-      .padding(.vertical, 4)
     }
+  }
+
+  private var browseLoadingView: some View {
+    HStack(spacing: 8) {
+      ProgressView()
+        .scaleEffect(0.7)
+      Text("Loading sessions...")
+        .font(.secondaryCaption)
+        .foregroundColor(.secondary)
+      Spacer()
+    }
+    .padding(.horizontal, 10)
+    .padding(.vertical, 12)
+    .background(
+      RoundedRectangle(cornerRadius: DesignTokens.Radius.sm)
+        .fill(Color.surfaceOverlay)
+    )
+    .overlay(
+      RoundedRectangle(cornerRadius: DesignTokens.Radius.sm)
+        .stroke(Color.borderSubtle, lineWidth: 1)
+    )
+  }
+
+  private func browseErrorView(message: String) -> some View {
+    HStack(spacing: 8) {
+      Image(systemName: "exclamationmark.triangle")
+        .font(.system(size: DesignTokens.IconSize.sm))
+        .foregroundColor(.orange)
+      Text(message)
+        .font(.secondaryCaption)
+        .foregroundColor(.secondary)
+        .lineLimit(2)
+      Spacer()
+      Button("Retry") {
+        currentViewModel.refreshBrowseSessions()
+      }
+      .buttonStyle(.borderless)
+      .font(.secondaryCaption)
+    }
+    .padding(.horizontal, 10)
+    .padding(.vertical, 12)
+    .background(
+      RoundedRectangle(cornerRadius: DesignTokens.Radius.sm)
+        .fill(Color.surfaceOverlay)
+    )
+    .overlay(
+      RoundedRectangle(cornerRadius: DesignTokens.Radius.sm)
+        .stroke(Color.borderSubtle, lineWidth: 1)
+    )
   }
 
   private var statusHeader: some View {
     VStack(spacing: 8) {
-      if isLoading {
+      if currentViewModel.browseSessionsLoadState.isLoading {
         HStack(spacing: 8) {
           ProgressView().scaleEffect(0.7)
           Text("Refreshing sessions...")
@@ -1241,7 +1305,7 @@ public struct MultiProviderSessionsListView: View {
         .help(currentViewModel.showLastMessage ? "Showing last message" : "Showing first message")
 
         // Refresh button
-        Button(action: { currentViewModel.refresh() }) {
+        Button(action: { currentViewModel.refreshBrowseSessions() }) {
           Image(systemName: "arrow.clockwise")
             .font(.system(size: DesignTokens.IconSize.md))
             .frame(width: 28, height: 28)
@@ -1255,7 +1319,7 @@ public struct MultiProviderSessionsListView: View {
             )
         }
         .buttonStyle(.plain)
-        .disabled(isLoading)
+        .disabled(currentViewModel.browseSessionsLoadState.isLoading)
         .help("Refresh sessions")
       }
       .padding(.horizontal, 4)
@@ -1394,10 +1458,6 @@ public struct MultiProviderSessionsListView: View {
     claudeViewModel.totalSessionCount + codexViewModel.totalSessionCount
   }
 
-  private var isLoading: Bool {
-    claudeViewModel.isLoading || codexViewModel.isLoading
-  }
-
   // MARK: - Keyboard Shortcuts
 
   private func makeCommandPaletteSessions() -> [CommandPaletteSession] {
@@ -1475,6 +1535,8 @@ public struct MultiProviderSessionsListView: View {
     withAnimation(browseAnimation) {
       isBrowseExpanded = true
     }
+    claudeViewModel.ensureBrowseSessionsLoaded()
+    codexViewModel.ensureBrowseSessionsLoaded()
     launchExpandRequestID += 1
 
     guard let multiLaunchViewModel else { return }

--- a/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/CLISessionsViewModel.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/CLISessionsViewModel.swift
@@ -1109,8 +1109,9 @@ public final class CLISessionsViewModel {
 
       if !persistedSessionIds.isEmpty {
         loadingState = .restoringMonitoredSessions
+        let restorableProjectRoots = projectRoots(from: selectedRepositories)
         let sessions = await monitorService.loadSessions(ids: persistedSessionIds)
-        restoreLoadedMonitoredSessions(sessions)
+        restoreLoadedMonitoredSessions(sessions, allowedProjectRoots: restorableProjectRoots)
       }
 
       loadingState = .idle
@@ -1123,11 +1124,22 @@ public final class CLISessionsViewModel {
     }
   }
 
-  private func restoreLoadedMonitoredSessions(_ sessions: [CLISession]) {
+  private func restoreLoadedMonitoredSessions(_ sessions: [CLISession], allowedProjectRoots: [String]) {
     guard !sessions.isEmpty else { return }
 
+    let restorableSessions = sessions.filter {
+      isProjectPath($0.projectPath, containedInAnyOf: allowedProjectRoots)
+    }
+    let rejectedIds = Set(sessions.map(\.id)).subtracting(restorableSessions.map(\.id))
+    if !rejectedIds.isEmpty {
+      pendingRestorationSessionIds.subtract(rejectedIds)
+      persistMonitoredSessions()
+    }
+
+    guard !restorableSessions.isEmpty else { return }
+
     var restoredIds: Set<String> = []
-    for session in sessions {
+    for session in restorableSessions {
       monitoredSessionIds.insert(session.id)
       monitoredSessionBackup[session.id] = session
       startPolling(session: session)
@@ -1135,7 +1147,7 @@ public final class CLISessionsViewModel {
     }
 
     pendingRestorationSessionIds.subtract(restoredIds)
-    expandItemsContainingLoadedSessions(sessions)
+    expandItemsContainingLoadedSessions(restorableSessions)
     loadCustomNames()
     loadPinnedSessions()
   }
@@ -1380,11 +1392,12 @@ public final class CLISessionsViewModel {
     Task {
       // [CLISessionsVM] loadingState = .addingRepository(\(repoName))")
       loadingState = .addingRepository(name: repoName)
+      let previousBrowseSessionsLoadState = browseSessionsLoadState
       browseSessionsLoadState = .loading
       // [CLISessionsVM] Calling monitorService.addRepository...")
-      await monitorService.addRepository(path)
+      let addedRepository = await monitorService.addRepository(path)
       // [CLISessionsVM] monitorService.addRepository completed")
-      browseSessionsLoadState = .loaded
+      browseSessionsLoadState = addedRepository == nil ? previousBrowseSessionsLoadState : .loaded
       loadingState = .idle
       // [CLISessionsVM] loadingState = .idle")
     }
@@ -1644,6 +1657,10 @@ public final class CLISessionsViewModel {
     var roots = [repository.path]
     roots.append(contentsOf: repository.worktrees.map(\.path))
     return Array(Set(roots))
+  }
+
+  private func projectRoots(from repositories: [SelectedRepository]) -> [String] {
+    Array(Set(repositories.flatMap { removableProjectRoots(for: $0) }))
   }
 
   private func isProjectPath(_ path: String, containedInAnyOf roots: [String]) -> Bool {

--- a/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/CLISessionsViewModel.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/CLISessionsViewModel.swift
@@ -44,7 +44,9 @@ public final class CLISessionsViewModel {
 
   public private(set) var selectedRepositories: [SelectedRepository] = []
   public private(set) var loadingState: CLILoadingState = .idle
+  public private(set) var browseSessionsLoadState: BrowseSessionsLoadState = .notLoaded
   public private(set) var error: Error?
+  @ObservationIgnored private var browseSessionsLoadTask: Task<Void, Never>?
 
   // MARK: - Session Naming State
 
@@ -993,6 +995,11 @@ public final class CLISessionsViewModel {
         await MainActor.run { [weak self] in
           guard let self = self else { return }
 
+          if (self.loadingState == .restoringRepositories || self.loadingState == .restoringMonitoredSessions),
+             repositories.isEmpty {
+            return
+          }
+
           // Preserve expanded state from current repositories
           self.selectedRepositories = self.mergePreservingExpandedState(
             current: self.selectedRepositories,
@@ -1087,15 +1094,75 @@ public final class CLISessionsViewModel {
         pendingRestorationSessionIds = persistedSessionIds
       }
 
-      // Add repositories (triggers refreshSessions → setupSubscriptions)
+      // Restore repository/worktree shells first. Full all-session scanning is
+      // deferred until the Browse panel is opened.
       loadingState = .restoringRepositories
-      await monitorService.addRepositories(paths)
+      let restoredRepositories = await monitorService.restoreRepositoriesSkeleton(paths)
+      selectedRepositories = mergePreservingExpandedState(
+        current: selectedRepositories,
+        updated: restoredRepositories
+      )
       restoreExpansionState(workspaceState.expansionState)
+      persistSelectedRepositories()
+      syncClaudeHookInstalls()
+
+      if !persistedSessionIds.isEmpty {
+        loadingState = .restoringMonitoredSessions
+        let sessions = await monitorService.loadSessions(ids: persistedSessionIds)
+        restoreLoadedMonitoredSessions(sessions)
+      }
+
       loadingState = .idle
 
       // Safety timeout: stop trying to restore after 10 seconds
       try? await Task.sleep(for: .seconds(10))
       pendingRestorationSessionIds.removeAll()
+      persistMonitoredSessions()
+    }
+  }
+
+  private func restoreLoadedMonitoredSessions(_ sessions: [CLISession]) {
+    guard !sessions.isEmpty else { return }
+
+    var restoredIds: Set<String> = []
+    for session in sessions {
+      monitoredSessionIds.insert(session.id)
+      monitoredSessionBackup[session.id] = session
+      startPolling(session: session)
+      restoredIds.insert(session.id)
+    }
+
+    pendingRestorationSessionIds.subtract(restoredIds)
+    expandItemsContainingLoadedSessions(sessions)
+    loadCustomNames()
+    loadPinnedSessions()
+  }
+
+  private func expandItemsContainingLoadedSessions(_ sessions: [CLISession]) {
+    guard !sessions.isEmpty else { return }
+    let paths = Set(sessions.map(\.projectPath))
+
+    for repoIndex in selectedRepositories.indices {
+      var shouldExpandRepo = paths.contains { path in
+        path == selectedRepositories[repoIndex].path ||
+        path.hasPrefix(selectedRepositories[repoIndex].path + "/")
+      }
+
+      for worktreeIndex in selectedRepositories[repoIndex].worktrees.indices {
+        let worktreePath = selectedRepositories[repoIndex].worktrees[worktreeIndex].path
+        let shouldExpandWorktree = paths.contains { path in
+          path == worktreePath || path.hasPrefix(worktreePath + "/")
+        }
+
+        if shouldExpandWorktree {
+          selectedRepositories[repoIndex].worktrees[worktreeIndex].isExpanded = true
+          shouldExpandRepo = true
+        }
+      }
+
+      if shouldExpandRepo {
+        selectedRepositories[repoIndex].isExpanded = true
+      }
     }
   }
 
@@ -1311,9 +1378,11 @@ public final class CLISessionsViewModel {
     Task {
       // [CLISessionsVM] loadingState = .addingRepository(\(repoName))")
       loadingState = .addingRepository(name: repoName)
+      browseSessionsLoadState = .loading
       // [CLISessionsVM] Calling monitorService.addRepository...")
       await monitorService.addRepository(path)
       // [CLISessionsVM] monitorService.addRepository completed")
+      browseSessionsLoadState = .loaded
       loadingState = .idle
       // [CLISessionsVM] loadingState = .idle")
     }
@@ -1504,6 +1573,30 @@ public final class CLISessionsViewModel {
       // [CLISessionsVM] refreshSessions completed")
       loadingState = .idle
       // [CLISessionsVM] loadingState = .idle")
+    }
+  }
+
+  public func ensureBrowseSessionsLoaded() {
+    guard browseSessionsLoadState == .notLoaded else { return }
+    refreshBrowseSessions()
+  }
+
+  public func refreshBrowseSessions() {
+    browseSessionsLoadTask?.cancel()
+
+    guard hasRepositories else {
+      browseSessionsLoadState = .loaded
+      return
+    }
+
+    browseSessionsLoadState = .loading
+    browseSessionsLoadTask = Task { [weak self] in
+      guard let self else { return }
+      await self.monitorService.refreshSessions()
+      guard !Task.isCancelled else { return }
+      await MainActor.run { [weak self] in
+        self?.browseSessionsLoadState = .loaded
+      }
     }
   }
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/CLISessionsViewModel.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/CLISessionsViewModel.swift
@@ -47,6 +47,7 @@ public final class CLISessionsViewModel {
   public private(set) var browseSessionsLoadState: BrowseSessionsLoadState = .notLoaded
   public private(set) var error: Error?
   @ObservationIgnored private var browseSessionsLoadTask: Task<Void, Never>?
+  @ObservationIgnored private var shouldLoadBrowseSessionsAfterRepositoryRestore = false
 
   // MARK: - Session Naming State
 
@@ -1113,6 +1114,7 @@ public final class CLISessionsViewModel {
       }
 
       loadingState = .idle
+      loadDeferredBrowseSessionsIfNeeded()
 
       // Safety timeout: stop trying to restore after 10 seconds
       try? await Task.sleep(for: .seconds(10))
@@ -1390,19 +1392,20 @@ public final class CLISessionsViewModel {
 
   /// Removes a repository from monitoring
   public func removeRepository(_ repository: SelectedRepository) {
+    let repositoryPaths = removableProjectRoots(for: repository)
+
     // Cancel any pending hub sessions in this repository
-    let pendingToCancel = pendingHubSessions.filter { $0.worktree.path.hasPrefix(repository.path) }
+    let pendingToCancel = pendingHubSessions.filter {
+      isProjectPath($0.worktree.path, containedInAnyOf: repositoryPaths)
+    }
     for pending in pendingToCancel {
       cancelPendingSession(pending)
     }
 
     // Stop monitoring all sessions from this repository
-    for worktree in repository.worktrees {
-      for session in worktree.sessions {
-        if monitoredSessionIds.contains(session.id) {
-          stopMonitoring(sessionId: session.id)
-        }
-      }
+    let sessionIdsToStop = monitoredSessionIdsToStop(whenRemoving: repository, projectRoots: repositoryPaths)
+    for sessionId in sessionIdsToStop {
+      stopMonitoring(sessionId: sessionId)
     }
 
     Task {
@@ -1585,10 +1588,16 @@ public final class CLISessionsViewModel {
     browseSessionsLoadTask?.cancel()
 
     guard hasRepositories else {
+      if isRestoringPersistedWorkspace {
+        shouldLoadBrowseSessionsAfterRepositoryRestore = true
+        browseSessionsLoadState = .loading
+        return
+      }
       browseSessionsLoadState = .loaded
       return
     }
 
+    shouldLoadBrowseSessionsAfterRepositoryRestore = false
     browseSessionsLoadState = .loading
     browseSessionsLoadTask = Task { [weak self] in
       guard let self else { return }
@@ -1598,6 +1607,63 @@ public final class CLISessionsViewModel {
         self?.browseSessionsLoadState = .loaded
       }
     }
+  }
+
+  private var isRestoringPersistedWorkspace: Bool {
+    switch loadingState {
+    case .restoringRepositories, .restoringMonitoredSessions:
+      return true
+    default:
+      return false
+    }
+  }
+
+  private func loadDeferredBrowseSessionsIfNeeded() {
+    guard shouldLoadBrowseSessionsAfterRepositoryRestore else { return }
+    shouldLoadBrowseSessionsAfterRepositoryRestore = false
+    refreshBrowseSessions()
+  }
+
+  private func monitoredSessionIdsToStop(
+    whenRemoving repository: SelectedRepository,
+    projectRoots: [String]
+  ) -> Set<String> {
+    let worktreeSessionIds = repository.worktrees
+      .flatMap(\.sessions)
+      .map(\.id)
+
+    let restoredBackupSessionIds = monitoredSessionBackup.values
+      .filter { isProjectPath($0.projectPath, containedInAnyOf: projectRoots) }
+      .map(\.id)
+
+    return Set(worktreeSessionIds + restoredBackupSessionIds)
+      .intersection(monitoredSessionIds)
+  }
+
+  private func removableProjectRoots(for repository: SelectedRepository) -> [String] {
+    var roots = [repository.path]
+    roots.append(contentsOf: repository.worktrees.map(\.path))
+    return Array(Set(roots))
+  }
+
+  private func isProjectPath(_ path: String, containedInAnyOf roots: [String]) -> Bool {
+    roots.contains { root in
+      isProjectPath(path, containedIn: root)
+    }
+  }
+
+  private func isProjectPath(_ path: String, containedIn root: String) -> Bool {
+    let path = normalizedDirectoryPath(path)
+    let root = normalizedDirectoryPath(root)
+    return path == root || path.hasPrefix(root + "/")
+  }
+
+  private func normalizedDirectoryPath(_ path: String) -> String {
+    var normalized = path
+    while normalized.count > 1 && normalized.hasSuffix("/") {
+      normalized.removeLast()
+    }
+    return normalized
   }
 
   /// Toggles the expanded state of a repository

--- a/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/CLISessionsViewModel.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/CLISessionsViewModel.swift
@@ -188,7 +188,7 @@ public final class CLISessionsViewModel {
       .filter { $0.sessionId == session.id }
       .receive(on: DispatchQueue.main)
       .sink { [weak self] update in
-        self?.monitorStates[session.id] = update.state
+        self?.updateMonitorState(update.state, for: session.id)
       }
 
     monitoringCancellables[session.id] = cancellable
@@ -217,7 +217,7 @@ public final class CLISessionsViewModel {
     AppLogger.session.info("[Polling] stopPolling called for session: \(sessionId.prefix(8), privacy: .public)")
 
     monitoringCancellables.removeValue(forKey: sessionId)
-    monitorStates.removeValue(forKey: sessionId)
+    removeMonitorState(for: sessionId)
 
     let claimStore = approvalClaimStore
 
@@ -789,6 +789,9 @@ public final class CLISessionsViewModel {
 
   /// Current monitoring states keyed by session ID
   public private(set) var monitorStates: [String: SessionMonitorState] = [:]
+
+  /// Per-session state models keyed by session ID.
+  private var monitorStateModels: [String: SessionMonitorStateModel] = [:]
 
   /// Cached project-level preview eligibility keyed by normalized project path.
   public private(set) var webPreviewCandidates: [String: WebPreviewCandidateStatus] = [:]
@@ -2534,7 +2537,7 @@ public final class CLISessionsViewModel {
   public func stopMonitoring(sessionId: String) {
     monitoredSessionIds.remove(sessionId)
     monitoredSessionBackup.removeValue(forKey: sessionId)
-    monitorStates.removeValue(forKey: sessionId)
+    removeMonitorState(for: sessionId)
     monitoringCancellables.removeValue(forKey: sessionId)
 
     // Remove and terminate the terminal process
@@ -2568,6 +2571,43 @@ public final class CLISessionsViewModel {
       // Session not found anywhere - should not happen, but handle gracefully
       return nil
     }
+  }
+
+  public func monitorStateModel(for sessionId: String) -> SessionMonitorStateModel {
+    if let stateModel = monitorStateModels[sessionId] {
+      return stateModel
+    }
+
+    let stateModel = SessionMonitorStateModel(
+      sessionId: sessionId,
+      state: monitorStates[sessionId]
+    )
+    monitorStateModels[sessionId] = stateModel
+    return stateModel
+  }
+
+  public func existingMonitorStateModel(for sessionId: String) -> SessionMonitorStateModel? {
+    monitorStateModels[sessionId]
+  }
+
+  public var monitoredSessionPresentations: [MonitoredSessionPresentation] {
+    monitoredSessions.map { item in
+      MonitoredSessionPresentation(
+        session: item.session,
+        stateModel: monitorStateModel(for: item.session.id)
+      )
+    }
+  }
+
+  private func updateMonitorState(_ state: SessionMonitorState, for sessionId: String) {
+    monitorStates[sessionId] = state
+    monitorStateModels[sessionId]?.update(state)
+  }
+
+  private func removeMonitorState(for sessionId: String) {
+    monitorStates.removeValue(forKey: sessionId)
+    monitorStateModels[sessionId]?.update(nil)
+    monitorStateModels.removeValue(forKey: sessionId)
   }
 
   // MARK: - Search

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/AuxiliaryShellTerminalManagementTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/AuxiliaryShellTerminalManagementTests.swift
@@ -219,7 +219,7 @@ struct AuxiliaryShellTerminalManagementTests {
   func typeToTerminalQueuesUntilTerminalCreation() {
     let terminal = TestTerminalSurface()
     let factory = RecordingTerminalSurfaceFactory(surfaces: [terminal])
-    let viewModel = makeAuxiliaryShellViewModel(terminalSurfaceFactory: factory, terminalBackend: .swiftTerm)
+    let viewModel = makeAuxiliaryShellViewModel(terminalSurfaceFactory: factory, terminalBackend: .regular)
     let command = "fix https://github.com/example/repo/issues/7 "
 
     viewModel.typeToTerminal(forKey: "session-123", text: command)

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/CLISessionsViewModelMonitorStateModelTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/CLISessionsViewModelMonitorStateModelTests.swift
@@ -1,0 +1,122 @@
+import Combine
+import Foundation
+import Testing
+
+@testable import AgentHubCore
+
+private final class MonitorStateModelMonitorService: SessionMonitorServiceProtocol, @unchecked Sendable {
+  private let subject = PassthroughSubject<[SelectedRepository], Never>()
+
+  var repositoriesPublisher: AnyPublisher<[SelectedRepository], Never> {
+    subject.eraseToAnyPublisher()
+  }
+
+  func addRepository(_ path: String) async -> SelectedRepository? { nil }
+  func removeRepository(_ path: String) async {}
+  func getSelectedRepositories() async -> [SelectedRepository] { [] }
+  func setSelectedRepositories(_ repositories: [SelectedRepository]) async {}
+  func refreshSessions(skipWorktreeRedetection: Bool) async {}
+}
+
+private final class MonitorStateModelFileWatcher: SessionFileWatcherProtocol, @unchecked Sendable {
+  private let subject = PassthroughSubject<SessionFileWatcher.StateUpdate, Never>()
+
+  var statePublisher: AnyPublisher<SessionFileWatcher.StateUpdate, Never> {
+    subject.eraseToAnyPublisher()
+  }
+
+  func send(sessionId: String, state: SessionMonitorState) {
+    subject.send(SessionFileWatcher.StateUpdate(sessionId: sessionId, state: state))
+  }
+
+  func startMonitoring(sessionId: String, projectPath: String, sessionFilePath: String?) async {}
+  func stopMonitoring(sessionId: String) async {}
+  func getState(sessionId: String) async -> SessionMonitorState? { nil }
+  func refreshState(sessionId: String) async {}
+  func setApprovalTimeout(_ seconds: Int) async {}
+}
+
+@MainActor
+private func makeMonitorStateModelViewModel(
+  fileWatcher: MonitorStateModelFileWatcher
+) -> CLISessionsViewModel {
+  CLISessionsViewModel(
+    monitorService: MonitorStateModelMonitorService(),
+    fileWatcher: fileWatcher,
+    searchService: nil,
+    cliConfiguration: CLICommandConfiguration(command: "claude", mode: .claude),
+    providerKind: .claude,
+    approvalNotificationService: NoOpApprovalNotificationService()
+  )
+}
+
+@MainActor
+private func waitUntil(
+  _ condition: () -> Bool,
+  timeoutAttempts: Int = 50
+) async throws {
+  for _ in 0..<timeoutAttempts {
+    if condition() {
+      return
+    }
+    try await Task.sleep(for: .milliseconds(20))
+  }
+  #expect(condition())
+}
+
+@Suite("CLISessionsViewModel monitor state models")
+struct CLISessionsViewModelMonitorStateModelTests {
+  @Test("State publisher updates only the matching per-session state model")
+  @MainActor
+  func statePublisherUpdatesMatchingStateModel() async throws {
+    let fileWatcher = MonitorStateModelFileWatcher()
+    let viewModel = makeMonitorStateModelViewModel(fileWatcher: fileWatcher)
+    let first = CLISession(id: "session-1", projectPath: "/tmp/project-a")
+    let second = CLISession(id: "session-2", projectPath: "/tmp/project-b")
+
+    viewModel.startMonitoring(session: first)
+    viewModel.startMonitoring(session: second)
+
+    let firstModel = viewModel.monitorStateModel(for: first.id)
+    let secondModel = viewModel.monitorStateModel(for: second.id)
+    let updatedState = SessionMonitorState(
+      status: .thinking,
+      lastActivityAt: Date(timeIntervalSince1970: 1_000),
+      messageCount: 3
+    )
+
+    fileWatcher.send(sessionId: first.id, state: updatedState)
+
+    try await waitUntil {
+      firstModel.state == updatedState
+    }
+
+    #expect(secondModel.state == nil)
+    #expect(viewModel.monitorStates[first.id] == updatedState)
+    #expect(viewModel.monitorStateModel(for: first.id) === firstModel)
+
+    let presentation = try #require(
+      viewModel.monitoredSessionPresentations.first { $0.session.id == first.id }
+    )
+    #expect(presentation.stateModel === firstModel)
+  }
+
+  @Test("Stopping monitoring removes the per-session state model")
+  @MainActor
+  func stoppingMonitoringRemovesStateModel() {
+    let fileWatcher = MonitorStateModelFileWatcher()
+    let viewModel = makeMonitorStateModelViewModel(fileWatcher: fileWatcher)
+    let session = CLISession(id: "session-1", projectPath: "/tmp/project")
+
+    viewModel.startMonitoring(session: session)
+    let stateModel = viewModel.monitorStateModel(for: session.id)
+
+    #expect(viewModel.existingMonitorStateModel(for: session.id) === stateModel)
+
+    viewModel.stopMonitoring(session: session)
+
+    #expect(viewModel.existingMonitorStateModel(for: session.id) == nil)
+    #expect(viewModel.monitorStates[session.id] == nil)
+    #expect(viewModel.monitoredSessionPresentations.isEmpty)
+  }
+}

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/DevServerManagerTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/DevServerManagerTests.swift
@@ -65,7 +65,8 @@ struct DevServerManagerTests {
     DevServerManager.shared.connectToExistingServer(for: key, url: malformedURL)
     defer { DevServerManager.shared.stopServer(for: key) }
 
-    guard case .ready(let url) = DevServerManager.shared.state(for: key) else {
+    let state: DevServerState = DevServerManager.shared.state(for: key)
+    guard case .ready(let url) = state else {
       Issue.record("Expected ready server state")
       return
     }
@@ -81,7 +82,8 @@ struct DevServerManagerTests {
     DevServerManager.shared.failServer(for: key, error: "Connection refused")
     defer { DevServerManager.shared.stopServer(for: key) }
 
-    guard case .failed(let error) = DevServerManager.shared.state(for: key) else {
+    let state: DevServerState = DevServerManager.shared.state(for: key)
+    guard case .failed(let error) = state else {
       Issue.record("Expected failed server state")
       return
     }
@@ -95,7 +97,8 @@ struct DevServerManagerTests {
     let sessionId = "test-\(UUID().uuidString)"
     let storybookKey = "\(sessionId):storybook"
 
-    #expect(DevServerManager.shared.state(for: storybookKey) == .idle)
+    let initialStorybookState: DevServerState = DevServerManager.shared.state(for: storybookKey)
+    #expect(initialStorybookState == .idle)
 
     let url = URL(string: "http://localhost:6006")!
     DevServerManager.shared.connectToExistingServer(for: storybookKey, url: url)
@@ -107,7 +110,8 @@ struct DevServerManagerTests {
     }
     #expect(readyURL.absoluteString == "http://localhost:6006")
 
-    #expect(DevServerManager.shared.state(for: sessionId) == .idle)
+    let appState: DevServerState = DevServerManager.shared.state(for: sessionId)
+    #expect(appState == .idle)
   }
 
   private func makeProjectFixture(packageJSON: String) throws -> URL {

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/LazyBrowseSessionsLoadingTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/LazyBrowseSessionsLoadingTests.swift
@@ -58,6 +58,96 @@ struct LazyBrowseSessionsLoadingTests {
     #expect(await watcher.startedSessionIds() == ["session-1"])
   }
 
+  @Test("Removing repository stops monitored sessions restored before browse load")
+  func removingRepositoryStopsRestoredBackupSessionsBeforeBrowseLoad() async throws {
+    let store = try SessionMetadataStore(path: temporaryDatabasePath())
+    try await store.saveWorkspaceState(
+      SessionWorkspaceState(
+        selectedRepositoryPaths: ["/tmp/project"],
+        monitoredSessionIds: ["session-1"]
+      ),
+      for: .claude
+    )
+
+    let session = CLISession(
+      id: "session-1",
+      projectPath: "/tmp/project",
+      branchName: "main",
+      firstMessage: "first",
+      sessionFilePath: "/tmp/session-1.jsonl"
+    )
+    let monitor = LazyBrowseMockMonitorService(
+      skeletonRepositories: [repository(path: "/tmp/project")],
+      browseRepositories: [repository(path: "/tmp/project", sessions: [session])],
+      sessionsById: ["session-1": session]
+    )
+    let watcher = RecordingFileWatcher()
+
+    let viewModel = CLISessionsViewModel(
+      monitorService: monitor,
+      fileWatcher: watcher,
+      searchService: nil,
+      cliConfiguration: CLICommandConfiguration(command: "claude", mode: .claude),
+      providerKind: .claude,
+      metadataStore: store,
+      approvalNotificationService: NoOpApprovalNotificationService()
+    )
+
+    await waitUntil {
+      viewModel.loadingState == .idle && viewModel.monitoredSessions.count == 1
+    }
+
+    let repository = try #require(viewModel.selectedRepositories.first)
+    #expect(repository.totalSessionCount == 0)
+
+    viewModel.removeRepository(repository)
+
+    #expect(!viewModel.isMonitoring(sessionId: "session-1"))
+    await waitUntilAsync {
+      await watcher.stoppedSessionIds() == ["session-1"]
+    }
+  }
+
+  @Test("Browse request during repository restore scans after repositories arrive")
+  func browseRequestDuringRepositoryRestoreScansAfterRepositoriesArrive() async throws {
+    let store = try SessionMetadataStore(path: temporaryDatabasePath())
+    try await store.saveWorkspaceState(
+      SessionWorkspaceState(selectedRepositoryPaths: ["/tmp/project"]),
+      for: .codex
+    )
+
+    let session = CLISession(id: "session-1", projectPath: "/tmp/project")
+    let monitor = LazyBrowseMockMonitorService(
+      skeletonRepositories: [repository(path: "/tmp/project")],
+      browseRepositories: [repository(path: "/tmp/project", sessions: [session])],
+      restoreSkeletonDelay: .milliseconds(150)
+    )
+
+    let viewModel = CLISessionsViewModel(
+      monitorService: monitor,
+      fileWatcher: RecordingFileWatcher(),
+      searchService: nil,
+      cliConfiguration: CLICommandConfiguration(command: "codex", mode: .codex),
+      providerKind: .codex,
+      metadataStore: store,
+      approvalNotificationService: NoOpApprovalNotificationService()
+    )
+
+    viewModel.ensureBrowseSessionsLoaded()
+    #expect(viewModel.browseSessionsLoadState == .loading)
+
+    try await Task.sleep(for: .milliseconds(50))
+    var calls = await monitor.calls()
+    #expect(calls.refreshCount == 0)
+
+    await waitUntil { viewModel.browseSessionsLoadState == .loaded }
+
+    calls = await monitor.calls()
+    #expect(calls.restoreSkeletonCount == 1)
+    #expect(calls.refreshCount == 1)
+    #expect(viewModel.allSessions.map(\.id) == ["session-1"])
+  }
+
   @Test("Browse load scans once, then manual refresh scans again")
   func browseLoadScansOnceThenManualRefreshScansAgain() async throws {
     let store = try SessionMetadataStore(path: temporaryDatabasePath())
@@ -189,6 +279,7 @@ private actor LazyBrowseMockMonitorService: SessionMonitorServiceProtocol {
   private let skeletonRepositories: [SelectedRepository]
   private let browseRepositories: [SelectedRepository]
   private let sessionsById: [String: CLISession]
+  private let restoreSkeletonDelay: Duration?
   private var restoreSkeletonCount = 0
   private var addRepositoriesCount = 0
   private var refreshCount = 0
@@ -197,11 +288,13 @@ private actor LazyBrowseMockMonitorService: SessionMonitorServiceProtocol {
   init(
     skeletonRepositories: [SelectedRepository],
     browseRepositories: [SelectedRepository],
-    sessionsById: [String: CLISession] = [:]
+    sessionsById: [String: CLISession] = [:],
+    restoreSkeletonDelay: Duration? = nil
   ) {
     self.skeletonRepositories = skeletonRepositories
     self.browseRepositories = browseRepositories
     self.sessionsById = sessionsById
+    self.restoreSkeletonDelay = restoreSkeletonDelay
   }
 
   func addRepository(_ path: String) async -> SelectedRepository? {
@@ -214,6 +307,9 @@ private actor LazyBrowseMockMonitorService: SessionMonitorServiceProtocol {
   }
 
   func restoreRepositoriesSkeleton(_ paths: [String]) async -> [SelectedRepository] {
+    if let restoreSkeletonDelay {
+      try? await Task.sleep(for: restoreSkeletonDelay)
+    }
     restoreSkeletonCount += 1
     repositories = skeletonRepositories
     subject.send(repositories)
@@ -262,6 +358,7 @@ private struct LazyBrowseMockCalls: Sendable {
 private actor RecordingFileWatcher: SessionFileWatcherProtocol {
   nonisolated(unsafe) private let subject = PassthroughSubject<SessionFileWatcher.StateUpdate, Never>()
   private var started: [String] = []
+  private var stopped: [String] = []
 
   nonisolated var statePublisher: AnyPublisher<SessionFileWatcher.StateUpdate, Never> {
     subject.eraseToAnyPublisher()
@@ -271,13 +368,19 @@ private actor RecordingFileWatcher: SessionFileWatcherProtocol {
     started.append(sessionId)
   }
 
-  func stopMonitoring(sessionId: String) async {}
+  func stopMonitoring(sessionId: String) async {
+    stopped.append(sessionId)
+  }
   func getState(sessionId: String) async -> SessionMonitorState? { nil }
   func refreshState(sessionId: String) async {}
   func setApprovalTimeout(_ seconds: Int) async {}
 
   func startedSessionIds() -> [String] {
     started
+  }
+
+  func stoppedSessionIds() -> [String] {
+    stopped
   }
 }
 
@@ -300,6 +403,17 @@ private func waitUntil(
     try? await Task.sleep(for: .milliseconds(20))
   }
   #expect(condition())
+}
+
+private func waitUntilAsync(
+  timeout: Duration = .seconds(2),
+  condition: @escaping () async -> Bool
+) async {
+  let start = ContinuousClock.now
+  while !(await condition()), ContinuousClock.now - start < timeout {
+    try? await Task.sleep(for: .milliseconds(20))
+  }
+  #expect(await condition())
 }
 
 private func temporaryDatabasePath() -> String {

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/LazyBrowseSessionsLoadingTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/LazyBrowseSessionsLoadingTests.swift
@@ -1,0 +1,336 @@
+import Combine
+import Foundation
+import Testing
+
+@testable import AgentHubCore
+
+@Suite("Lazy browse session loading")
+@MainActor
+struct LazyBrowseSessionsLoadingTests {
+
+  @Test("Launch restores shells and monitored sessions without full browse scan")
+  func launchRestoresMonitoredSessionsWithoutFullScan() async throws {
+    let store = try SessionMetadataStore(path: temporaryDatabasePath())
+    try await store.saveWorkspaceState(
+      SessionWorkspaceState(
+        selectedRepositoryPaths: ["/tmp/project"],
+        monitoredSessionIds: ["session-1"],
+        expansionState: ["repo:/tmp/project": true]
+      ),
+      for: .claude
+    )
+
+    let session = CLISession(
+      id: "session-1",
+      projectPath: "/tmp/project",
+      branchName: "main",
+      firstMessage: "first",
+      sessionFilePath: "/tmp/session-1.jsonl"
+    )
+    let monitor = LazyBrowseMockMonitorService(
+      skeletonRepositories: [repository(path: "/tmp/project")],
+      browseRepositories: [repository(path: "/tmp/project", sessions: [session])],
+      sessionsById: ["session-1": session]
+    )
+    let watcher = RecordingFileWatcher()
+
+    let viewModel = CLISessionsViewModel(
+      monitorService: monitor,
+      fileWatcher: watcher,
+      searchService: nil,
+      cliConfiguration: CLICommandConfiguration(command: "claude", mode: .claude),
+      providerKind: .claude,
+      metadataStore: store,
+      approvalNotificationService: NoOpApprovalNotificationService()
+    )
+
+    await waitUntil {
+      viewModel.loadingState == .idle && viewModel.monitoredSessions.count == 1
+    }
+
+    let calls = await monitor.calls()
+    #expect(calls.restoreSkeletonCount == 1)
+    #expect(calls.addRepositoriesCount == 0)
+    #expect(calls.refreshCount == 0)
+    #expect(calls.loadSessionRequests == [Set(["session-1"])])
+    #expect(viewModel.selectedRepositories.map(\.path) == ["/tmp/project"])
+    #expect(viewModel.monitoredSessions.first?.session.id == "session-1")
+    #expect(await watcher.startedSessionIds() == ["session-1"])
+  }
+
+  @Test("Browse load scans once, then manual refresh scans again")
+  func browseLoadScansOnceThenManualRefreshScansAgain() async throws {
+    let store = try SessionMetadataStore(path: temporaryDatabasePath())
+    try await store.saveWorkspaceState(
+      SessionWorkspaceState(selectedRepositoryPaths: ["/tmp/project"]),
+      for: .codex
+    )
+
+    let session = CLISession(id: "session-1", projectPath: "/tmp/project")
+    let monitor = LazyBrowseMockMonitorService(
+      skeletonRepositories: [repository(path: "/tmp/project")],
+      browseRepositories: [repository(path: "/tmp/project", sessions: [session])]
+    )
+
+    let viewModel = CLISessionsViewModel(
+      monitorService: monitor,
+      fileWatcher: RecordingFileWatcher(),
+      searchService: nil,
+      cliConfiguration: CLICommandConfiguration(command: "codex", mode: .codex),
+      providerKind: .codex,
+      metadataStore: store,
+      approvalNotificationService: NoOpApprovalNotificationService()
+    )
+
+    await waitUntil {
+      viewModel.loadingState == .idle && viewModel.selectedRepositories.count == 1
+    }
+    #expect(viewModel.browseSessionsLoadState == .notLoaded)
+
+    viewModel.ensureBrowseSessionsLoaded()
+    await waitUntil { viewModel.browseSessionsLoadState == .loaded }
+
+    var calls = await monitor.calls()
+    #expect(calls.refreshCount == 1)
+    #expect(viewModel.allSessions.map(\.id) == ["session-1"])
+
+    viewModel.ensureBrowseSessionsLoaded()
+    try await Task.sleep(for: .milliseconds(50))
+    calls = await monitor.calls()
+    #expect(calls.refreshCount == 1)
+
+    viewModel.refreshBrowseSessions()
+    await waitUntil { viewModel.browseSessionsLoadState == .loaded }
+    calls = await monitor.calls()
+    #expect(calls.refreshCount == 2)
+  }
+
+  @Test("Claude targeted restore ignores subagent files")
+  func claudeTargetedRestoreIgnoresSubagents() async throws {
+    let root = try temporaryDirectory()
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    let projectPath = "/tmp/project"
+    let sessionId = "11111111-1111-1111-1111-111111111111"
+    let projectDir = root
+      .appending(path: "projects")
+      .appending(path: projectPath.claudeProjectPathEncoded)
+    let subagentDir = projectDir.appending(path: "subagents")
+    try FileManager.default.createDirectory(at: subagentDir, withIntermediateDirectories: true)
+
+    let mainFile = projectDir.appending(path: "\(sessionId).jsonl")
+    let subagentFile = subagentDir.appending(path: "\(sessionId).jsonl")
+    try claudeLine(
+      sessionId: sessionId,
+      cwd: projectPath,
+      message: "main session",
+      timestamp: "2026-05-05T12:00:00.000Z"
+    ).write(to: mainFile, atomically: true, encoding: .utf8)
+    try claudeLine(
+      sessionId: sessionId,
+      cwd: "/tmp/subagent",
+      message: "subagent session",
+      timestamp: "2026-05-05T12:01:00.000Z"
+    ).write(to: subagentFile, atomically: true, encoding: .utf8)
+
+    let service = CLISessionMonitorService(claudeDataPath: root.path)
+    let sessions = await service.loadSessions(ids: [sessionId])
+
+    #expect(sessions.count == 1)
+    #expect(sessions.first?.projectPath == projectPath)
+    #expect(sessions.first?.firstMessage == "main session")
+    #expect(sessions.first?.sessionFilePath == mainFile.path)
+  }
+
+  @Test("Codex targeted restore returns only requested sessions")
+  func codexTargetedRestoreReturnsOnlyRequestedSessions() async throws {
+    let root = try temporaryDirectory()
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    let sessionsDir = root
+      .appending(path: "sessions")
+      .appending(path: "2026")
+      .appending(path: "05")
+      .appending(path: "05")
+    try FileManager.default.createDirectory(at: sessionsDir, withIntermediateDirectories: true)
+
+    let requestedId = "22222222-2222-2222-2222-222222222222"
+    let otherId = "33333333-3333-3333-3333-333333333333"
+    try codexLines(sessionId: requestedId, cwd: "/tmp/project", message: "requested")
+      .write(
+        to: sessionsDir.appending(path: "rollout-2026-05-05T12-00-00-\(requestedId).jsonl"),
+        atomically: true,
+        encoding: .utf8
+      )
+    try codexLines(sessionId: otherId, cwd: "/tmp/other", message: "other")
+      .write(
+        to: sessionsDir.appending(path: "rollout-2026-05-05T12-01-00-\(otherId).jsonl"),
+        atomically: true,
+        encoding: .utf8
+      )
+
+    let service = CodexSessionMonitorService(codexDataPath: root.path)
+    let sessions = await service.loadSessions(ids: [requestedId])
+
+    #expect(sessions.map(\.id) == [requestedId])
+    #expect(sessions.first?.firstMessage == "requested")
+    #expect(sessions.first?.projectPath == "/tmp/project")
+  }
+}
+
+private actor LazyBrowseMockMonitorService: SessionMonitorServiceProtocol {
+  nonisolated(unsafe) private let subject = CurrentValueSubject<[SelectedRepository], Never>([])
+
+  nonisolated var repositoriesPublisher: AnyPublisher<[SelectedRepository], Never> {
+    subject.eraseToAnyPublisher()
+  }
+
+  private var repositories: [SelectedRepository] = []
+  private let skeletonRepositories: [SelectedRepository]
+  private let browseRepositories: [SelectedRepository]
+  private let sessionsById: [String: CLISession]
+  private var restoreSkeletonCount = 0
+  private var addRepositoriesCount = 0
+  private var refreshCount = 0
+  private var loadSessionRequests: [Set<String>] = []
+
+  init(
+    skeletonRepositories: [SelectedRepository],
+    browseRepositories: [SelectedRepository],
+    sessionsById: [String: CLISession] = [:]
+  ) {
+    self.skeletonRepositories = skeletonRepositories
+    self.browseRepositories = browseRepositories
+    self.sessionsById = sessionsById
+  }
+
+  func addRepository(_ path: String) async -> SelectedRepository? {
+    addRepositoriesCount += 1
+    return nil
+  }
+
+  func addRepositories(_ paths: [String]) async {
+    addRepositoriesCount += 1
+  }
+
+  func restoreRepositoriesSkeleton(_ paths: [String]) async -> [SelectedRepository] {
+    restoreSkeletonCount += 1
+    repositories = skeletonRepositories
+    subject.send(repositories)
+    return repositories
+  }
+
+  func loadSessions(ids: Set<String>) async -> [CLISession] {
+    loadSessionRequests.append(ids)
+    return ids.compactMap { sessionsById[$0] }
+  }
+
+  func removeRepository(_ path: String) async {}
+
+  func getSelectedRepositories() async -> [SelectedRepository] {
+    repositories
+  }
+
+  func setSelectedRepositories(_ repositories: [SelectedRepository]) async {
+    self.repositories = repositories
+    subject.send(repositories)
+  }
+
+  func refreshSessions(skipWorktreeRedetection: Bool) async {
+    refreshCount += 1
+    repositories = browseRepositories
+    subject.send(repositories)
+  }
+
+  func calls() -> LazyBrowseMockCalls {
+    LazyBrowseMockCalls(
+      restoreSkeletonCount: restoreSkeletonCount,
+      addRepositoriesCount: addRepositoriesCount,
+      refreshCount: refreshCount,
+      loadSessionRequests: loadSessionRequests
+    )
+  }
+}
+
+private struct LazyBrowseMockCalls: Sendable {
+  let restoreSkeletonCount: Int
+  let addRepositoriesCount: Int
+  let refreshCount: Int
+  let loadSessionRequests: [Set<String>]
+}
+
+private actor RecordingFileWatcher: SessionFileWatcherProtocol {
+  nonisolated(unsafe) private let subject = PassthroughSubject<SessionFileWatcher.StateUpdate, Never>()
+  private var started: [String] = []
+
+  nonisolated var statePublisher: AnyPublisher<SessionFileWatcher.StateUpdate, Never> {
+    subject.eraseToAnyPublisher()
+  }
+
+  func startMonitoring(sessionId: String, projectPath: String, sessionFilePath: String?) async {
+    started.append(sessionId)
+  }
+
+  func stopMonitoring(sessionId: String) async {}
+  func getState(sessionId: String) async -> SessionMonitorState? { nil }
+  func refreshState(sessionId: String) async {}
+  func setApprovalTimeout(_ seconds: Int) async {}
+
+  func startedSessionIds() -> [String] {
+    started
+  }
+}
+
+private func repository(path: String, sessions: [CLISession] = []) -> SelectedRepository {
+  SelectedRepository(
+    path: path,
+    worktrees: [
+      WorktreeBranch(name: "main", path: path, isWorktree: false, sessions: sessions)
+    ]
+  )
+}
+
+@MainActor
+private func waitUntil(
+  timeout: Duration = .seconds(2),
+  condition: @escaping @MainActor () -> Bool
+) async {
+  let start = ContinuousClock.now
+  while !condition(), ContinuousClock.now - start < timeout {
+    try? await Task.sleep(for: .milliseconds(20))
+  }
+  #expect(condition())
+}
+
+private func temporaryDatabasePath() -> String {
+  FileManager.default.temporaryDirectory
+    .appending(path: "lazy_browse_\(UUID().uuidString).sqlite")
+    .path
+}
+
+private func temporaryDirectory() throws -> URL {
+  let url = FileManager.default.temporaryDirectory
+    .appending(path: "lazy_browse_\(UUID().uuidString)", directoryHint: .isDirectory)
+  try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+  return url
+}
+
+private func claudeLine(
+  sessionId: String,
+  cwd: String,
+  message: String,
+  timestamp: String
+) -> String {
+  """
+  {"sessionId":"\(sessionId)","cwd":"\(cwd)","gitBranch":"main","slug":"test-slug","type":"user","timestamp":"\(timestamp)","message":{"role":"user","content":"\(message)"}}
+
+  """
+}
+
+private func codexLines(sessionId: String, cwd: String, message: String) -> String {
+  """
+  {"timestamp":"2026-05-05T12:00:00.000Z","type":"session_meta","payload":{"id":"\(sessionId)","timestamp":"2026-05-05T12:00:00.000Z","cwd":"\(cwd)","git":{"branch":"main"}}}
+  {"timestamp":"2026-05-05T12:00:01.000Z","type":"event_msg","payload":{"type":"user_message","message":"\(message)"}}
+
+  """
+}

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/LazyBrowseSessionsLoadingTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/LazyBrowseSessionsLoadingTests.swift
@@ -58,6 +58,63 @@ struct LazyBrowseSessionsLoadingTests {
     #expect(await watcher.startedSessionIds() == ["session-1"])
   }
 
+  @Test("Launch targeted restore skips sessions outside restored roots")
+  func launchTargetedRestoreSkipsSessionsOutsideRestoredRoots() async throws {
+    let store = try SessionMetadataStore(path: temporaryDatabasePath())
+    try await store.saveWorkspaceState(
+      SessionWorkspaceState(
+        selectedRepositoryPaths: ["/tmp/project"],
+        monitoredSessionIds: ["orphan-session", "session-1"]
+      ),
+      for: .claude
+    )
+
+    let session = CLISession(
+      id: "session-1",
+      projectPath: "/tmp/project",
+      branchName: "main",
+      firstMessage: "first",
+      sessionFilePath: "/tmp/session-1.jsonl"
+    )
+    let orphan = CLISession(
+      id: "orphan-session",
+      projectPath: "/tmp/deleted-worktree",
+      branchName: "feature",
+      firstMessage: "orphan",
+      sessionFilePath: "/tmp/orphan-session.jsonl"
+    )
+    let monitor = LazyBrowseMockMonitorService(
+      skeletonRepositories: [repository(path: "/tmp/project")],
+      browseRepositories: [repository(path: "/tmp/project", sessions: [session])],
+      sessionsById: [
+        "orphan-session": orphan,
+        "session-1": session
+      ]
+    )
+    let watcher = RecordingFileWatcher()
+
+    let viewModel = CLISessionsViewModel(
+      monitorService: monitor,
+      fileWatcher: watcher,
+      searchService: nil,
+      cliConfiguration: CLICommandConfiguration(command: "claude", mode: .claude),
+      providerKind: .claude,
+      metadataStore: store,
+      approvalNotificationService: NoOpApprovalNotificationService()
+    )
+
+    await waitUntil {
+      viewModel.loadingState == .idle && viewModel.monitoredSessions.count == 1
+    }
+
+    let calls = await monitor.calls()
+    #expect(calls.loadSessionRequests == [Set(["orphan-session", "session-1"])])
+    #expect(viewModel.isMonitoring(sessionId: "session-1"))
+    #expect(!viewModel.isMonitoring(sessionId: "orphan-session"))
+    #expect(Set(viewModel.monitoredSessions.map(\.session.id)) == ["session-1"])
+    #expect(await watcher.startedSessionIds() == ["session-1"])
+  }
+
   @Test("Removing repository stops monitored sessions restored before browse load")
   func removingRepositoryStopsRestoredBackupSessionsBeforeBrowseLoad() async throws {
     let store = try SessionMetadataStore(path: temporaryDatabasePath())
@@ -195,6 +252,48 @@ struct LazyBrowseSessionsLoadingTests {
     #expect(calls.refreshCount == 2)
   }
 
+  @Test("Duplicate add keeps Browse not loaded")
+  func duplicateAddKeepsBrowseNotLoaded() async throws {
+    let store = try SessionMetadataStore(path: temporaryDatabasePath())
+    try await store.saveWorkspaceState(
+      SessionWorkspaceState(selectedRepositoryPaths: ["/tmp/project"]),
+      for: .codex
+    )
+
+    let session = CLISession(id: "session-1", projectPath: "/tmp/project")
+    let monitor = LazyBrowseMockMonitorService(
+      skeletonRepositories: [repository(path: "/tmp/project")],
+      browseRepositories: [repository(path: "/tmp/project", sessions: [session])]
+    )
+
+    let viewModel = CLISessionsViewModel(
+      monitorService: monitor,
+      fileWatcher: RecordingFileWatcher(),
+      searchService: nil,
+      cliConfiguration: CLICommandConfiguration(command: "codex", mode: .codex),
+      providerKind: .codex,
+      metadataStore: store,
+      approvalNotificationService: NoOpApprovalNotificationService()
+    )
+
+    await waitUntil {
+      viewModel.loadingState == .idle && viewModel.selectedRepositories.count == 1
+    }
+    #expect(viewModel.browseSessionsLoadState == .notLoaded)
+
+    viewModel.addRepository(at: "/tmp/project")
+    await waitUntilAsync {
+      let calls = await monitor.calls()
+      return calls.addRepositoriesCount == 1
+    }
+    await waitUntil { viewModel.loadingState == .idle }
+
+    let calls = await monitor.calls()
+    #expect(calls.refreshCount == 0)
+    #expect(viewModel.browseSessionsLoadState == .notLoaded)
+    #expect(viewModel.allSessions.isEmpty)
+  }
+
   @Test("Claude targeted restore ignores subagent files")
   func claudeTargetedRestoreIgnoresSubagents() async throws {
     let root = try temporaryDirectory()
@@ -229,7 +328,11 @@ struct LazyBrowseSessionsLoadingTests {
     #expect(sessions.count == 1)
     #expect(sessions.first?.projectPath == projectPath)
     #expect(sessions.first?.firstMessage == "main session")
-    #expect(sessions.first?.sessionFilePath == mainFile.path)
+    let sessionFilePath = try #require(sessions.first?.sessionFilePath)
+    #expect(
+      URL(fileURLWithPath: sessionFilePath).resolvingSymlinksInPath().path
+        == mainFile.resolvingSymlinksInPath().path
+    )
   }
 
   @Test("Codex targeted restore returns only requested sessions")
@@ -299,7 +402,16 @@ private actor LazyBrowseMockMonitorService: SessionMonitorServiceProtocol {
 
   func addRepository(_ path: String) async -> SelectedRepository? {
     addRepositoriesCount += 1
-    return nil
+    guard !repositories.contains(where: { $0.path == path }) else {
+      return nil
+    }
+
+    let repositoryToAdd = browseRepositories.first { $0.path == path }
+      ?? skeletonRepositories.first { $0.path == path }
+      ?? repository(path: path)
+    repositories.append(repositoryToAdd)
+    subject.send(repositories)
+    return repositoryToAdd
   }
 
   func addRepositories(_ paths: [String]) async {

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/WebPreviewModeTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/WebPreviewModeTests.swift
@@ -45,13 +45,15 @@ struct WebPreviewModeTests {
 
     // The Storybook-mode key resolves to the running storybook server,
     // and the App-mode key for the same session stays idle.
-    guard case .ready(let storybookURL) = DevServerManager.shared.state(
+    let storybookState: DevServerState = DevServerManager.shared.state(
       for: WebPreviewMode.storybook.serverKey(for: sessionId)
-    ) else {
+    )
+    guard case .ready(let storybookURL) = storybookState else {
       Issue.record("Expected storybook key to be .ready")
       return
     }
     #expect(storybookURL.absoluteString == "http://localhost:6006")
-    #expect(DevServerManager.shared.state(for: WebPreviewMode.app.serverKey(for: sessionId)) == .idle)
+    let appState: DevServerState = DevServerManager.shared.state(for: WebPreviewMode.app.serverKey(for: sessionId))
+    #expect(appState == .idle)
   }
 }


### PR DESCRIPTION
## Summary

Lazy-loads the Browse all Sessions flow so app launch restores saved repositories, worktrees, and monitored sessions without doing the expensive all-session scan. The full scan now waits until Browse is opened or manually refreshed.

This also adds stable per-session monitor state models so monitored-session views can observe the state for a single session without depending on the whole monitor-state dictionary.

## Changes

- Added targeted Claude/Codex session restore by ID for saved monitored sessions.
- Added browse-load state so duplicate/no-op repository adds do not incorrectly mark Browse as loaded.
- Filter restored monitored sessions to the currently selected repo/worktree roots before polling or persisting them again.
- Preserved Claude branch validation during targeted restore, so stale sessions from reused worktree paths are not resurrected.
- Added immediate loading feedback when switching Browse between Claude and Codex, including tab spinners and a short switching placeholder for large session trees.
- Added `SessionMonitorStateModel` and `MonitoredSessionPresentation` for stable per-session observable monitor state.
- Added focused regression coverage for lazy browse loading and per-session monitor state model updates/removal.

## Validation

- `swift test --package-path app/modules/AgentHubCore --filter LazyBrowseSessionsLoadingTests`
- `swift test --package-path app/modules/AgentHubCore --filter CLISessionsViewModelMonitorStateModelTests`

Note: the full `swift test --package-path app/modules/AgentHubCore` run previously failed independently in `SessionJSONLParserURLTests.swift:19`, outside this PR path.
