### PR TITLE
[codex] Stabilize Claude hook sync

### DIFF
--- a/app/AgentHubTests/ClaudeHookInstallerTests.swift
+++ b/app/AgentHubTests/ClaudeHookInstallerTests.swift
@@ -2,6 +2,19 @@ import Foundation
 import Testing
 @testable import AgentHubCore
 
+private final class CountingUserDefaults: UserDefaults, @unchecked Sendable {
+  private var setCounts: [String: Int] = [:]
+
+  override func set(_ value: Any?, forKey defaultName: String) {
+    setCounts[defaultName, default: 0] += 1
+    super.set(value, forKey: defaultName)
+  }
+
+  func setCount(forKey key: String) -> Int {
+    setCounts[key, default: 0]
+  }
+}
+
 @Suite("ClaudeHookInstaller")
 struct ClaudeHookInstallerTests {
 
@@ -13,7 +26,7 @@ struct ClaudeHookInstallerTests {
     let projectB: URL
     let bundledScriptURL: URL
     let sharedScriptURL: URL
-    let defaults: UserDefaults
+    let defaults: CountingUserDefaults
     let installer: ClaudeHookInstaller
     let suiteName: String
 
@@ -33,7 +46,7 @@ struct ClaudeHookInstallerTests {
       self.sharedScriptURL = base.appendingPathComponent("shared/hooks/agenthub-approval.sh")
 
       self.suiteName = "ClaudeHookInstallerTests.\(name).\(UUID().uuidString)"
-      guard let defaults = UserDefaults(suiteName: suiteName) else {
+      guard let defaults = CountingUserDefaults(suiteName: suiteName) else {
         throw NSError(domain: "fixture", code: 1)
       }
       self.defaults = defaults
@@ -70,6 +83,24 @@ struct ClaudeHookInstallerTests {
       return (hooks["PreToolUse"] as? [[String: Any]]) ?? []
     }
 
+    func postEntries(in settings: [String: Any]) -> [[String: Any]] {
+      let hooks = settings["hooks"] as? [String: Any] ?? [:]
+      return (hooks["PostToolUse"] as? [[String: Any]]) ?? []
+    }
+
+    func writeSettings(_ settings: [String: Any], for project: URL) throws {
+      let url = settingsLocal(for: project)
+      try FileManager.default.createDirectory(
+        at: url.deletingLastPathComponent(),
+        withIntermediateDirectories: true
+      )
+      try JSONSerialization.data(withJSONObject: settings).write(to: url)
+    }
+
+    func modificationDate(of url: URL) throws -> Date {
+      try FileManager.default.attributesOfItem(atPath: url.path)[.modificationDate] as? Date ?? .distantPast
+    }
+
     func hasAgentHubEntry(in entries: [[String: Any]], scriptPath: String) -> Bool {
       let quoted = ClaudeHookInstaller.shellQuoted(scriptPath)
       return entries.contains { entry in
@@ -78,6 +109,17 @@ struct ClaudeHookInstallerTests {
           let cmd = $0["command"] as? String
           return cmd == scriptPath || cmd == quoted
         }
+      }
+    }
+
+    func agentHubEntryCount(in entries: [[String: Any]], scriptPath: String) -> Int {
+      let quoted = ClaudeHookInstaller.shellQuoted(scriptPath)
+      return entries.reduce(0) { count, entry in
+        let inner = entry["hooks"] as? [[String: Any]] ?? []
+        return count + inner.filter {
+          let cmd = $0["command"] as? String
+          return cmd == scriptPath || cmd == quoted
+        }.count
       }
     }
   }
@@ -163,6 +205,117 @@ struct ClaudeHookInstallerTests {
     #expect(matches.count == 1)
   }
 
+  @Test("same sync input twice does not rewrite settings or defaults")
+  func sameSyncInputTwiceDoesNotRewriteSettingsOrDefaults() async throws {
+    let fx = try Fixture(name: "sameInputNoRewrite")
+    defer { fx.teardown() }
+
+    await fx.installer.syncInstalledPaths([fx.projectA.path])
+
+    let settingsURL = fx.settingsLocal(for: fx.projectA)
+    let modifiedAt = try fx.modificationDate(of: settingsURL)
+    let defaultsWrites = fx.defaults.setCount(forKey: ClaudeHookInstaller.installedPathsKey)
+
+    try await Task.sleep(for: .milliseconds(20))
+    await fx.installer.syncInstalledPaths([fx.projectA.path])
+
+    #expect(try fx.modificationDate(of: settingsURL) == modifiedAt)
+    #expect(fx.defaults.setCount(forKey: ClaudeHookInstaller.installedPathsKey) == defaultsWrites)
+  }
+
+  @Test("adding one new path does not rewrite already-correct paths")
+  func addingNewPathDoesNotRewriteExistingPath() async throws {
+    let fx = try Fixture(name: "addOneNoRewriteExisting")
+    defer { fx.teardown() }
+
+    await fx.installer.syncInstalledPaths([fx.projectA.path])
+
+    let settingsA = fx.settingsLocal(for: fx.projectA)
+    let modifiedA = try fx.modificationDate(of: settingsA)
+    let defaultsWrites = fx.defaults.setCount(forKey: ClaudeHookInstaller.installedPathsKey)
+
+    try await Task.sleep(for: .milliseconds(20))
+    await fx.installer.syncInstalledPaths([fx.projectA.path, fx.projectB.path])
+
+    #expect(try fx.modificationDate(of: settingsA) == modifiedA)
+    #expect(FileManager.default.fileExists(atPath: fx.settingsLocal(for: fx.projectB).path))
+    #expect(fx.defaults.setCount(forKey: ClaudeHookInstaller.installedPathsKey) == defaultsWrites + 1)
+  }
+
+  @Test("installed path with missing settings is repaired without rewriting defaults")
+  func missingSettingsForInstalledPathIsRepaired() async throws {
+    let fx = try Fixture(name: "repairMissingSettings")
+    defer { fx.teardown() }
+
+    await fx.installer.syncInstalledPaths([fx.projectA.path])
+    try FileManager.default.removeItem(at: fx.settingsLocal(for: fx.projectA))
+    let defaultsWrites = fx.defaults.setCount(forKey: ClaudeHookInstaller.installedPathsKey)
+
+    await fx.installer.syncInstalledPaths([fx.projectA.path])
+
+    let settings = try fx.readSettings(at: fx.settingsLocal(for: fx.projectA))
+    #expect(fx.hasAgentHubEntry(in: fx.preEntries(in: settings), scriptPath: fx.sharedScriptURL.path))
+    #expect(fx.hasAgentHubEntry(in: fx.postEntries(in: settings), scriptPath: fx.sharedScriptURL.path))
+    #expect(fx.defaults.setCount(forKey: ClaudeHookInstaller.installedPathsKey) == defaultsWrites)
+  }
+
+  @Test("installed path with duplicate hook entries is repaired")
+  func duplicateHookEntriesAreRepaired() async throws {
+    let fx = try Fixture(name: "repairDuplicateEntries")
+    defer { fx.teardown() }
+
+    await fx.installer.syncInstalledPaths([fx.projectA.path])
+    let quoted = ClaudeHookInstaller.shellQuoted(fx.sharedScriptURL.path)
+    let duplicated: [String: Any] = [
+      "hooks": [
+        "PreToolUse": [
+          ["matcher": "*", "hooks": [["type": "command", "command": quoted]]],
+          ["matcher": "*", "hooks": [["type": "command", "command": quoted]]],
+        ],
+        "PostToolUse": [
+          ["matcher": "*", "hooks": [["type": "command", "command": quoted]]],
+          ["matcher": "*", "hooks": [["type": "command", "command": quoted]]],
+        ],
+      ],
+    ]
+    try fx.writeSettings(duplicated, for: fx.projectA)
+
+    await fx.installer.syncInstalledPaths([fx.projectA.path])
+
+    let settings = try fx.readSettings(at: fx.settingsLocal(for: fx.projectA))
+    #expect(fx.agentHubEntryCount(in: fx.preEntries(in: settings), scriptPath: fx.sharedScriptURL.path) == 1)
+    #expect(fx.agentHubEntryCount(in: fx.postEntries(in: settings), scriptPath: fx.sharedScriptURL.path) == 1)
+  }
+
+  @Test("installed path with legacy per-project hook reference is repaired")
+  func legacyPerProjectHookReferenceIsRepaired() async throws {
+    let fx = try Fixture(name: "repairLegacyPerProject")
+    defer { fx.teardown() }
+
+    await fx.installer.syncInstalledPaths([fx.projectA.path])
+    let legacyScript = fx.projectHooksDir(for: fx.projectA)
+      .appendingPathComponent("agenthub-approval.sh")
+    let legacy: [String: Any] = [
+      "hooks": [
+        "PreToolUse": [
+          ["matcher": "*", "hooks": [["type": "command", "command": legacyScript.path]]]
+        ],
+        "PostToolUse": [
+          ["matcher": "*", "hooks": [["type": "command", "command": legacyScript.path]]]
+        ],
+      ],
+    ]
+    try fx.writeSettings(legacy, for: fx.projectA)
+
+    await fx.installer.syncInstalledPaths([fx.projectA.path])
+
+    let settings = try fx.readSettings(at: fx.settingsLocal(for: fx.projectA))
+    #expect(fx.hasAgentHubEntry(in: fx.preEntries(in: settings), scriptPath: fx.sharedScriptURL.path))
+    #expect(fx.hasAgentHubEntry(in: fx.postEntries(in: settings), scriptPath: fx.sharedScriptURL.path))
+    #expect(!fx.hasAgentHubEntry(in: fx.preEntries(in: settings), scriptPath: legacyScript.path))
+    #expect(!fx.hasAgentHubEntry(in: fx.postEntries(in: settings), scriptPath: legacyScript.path))
+  }
+
   @Test("sync removes entries from paths that dropped out of the set")
   func syncRemovesDroppedPaths() async throws {
     let fx = try Fixture(name: "removesDropped")
@@ -171,8 +324,10 @@ struct ClaudeHookInstallerTests {
     await fx.installer.syncInstalledPaths([fx.projectA.path, fx.projectB.path])
     #expect(FileManager.default.fileExists(atPath: fx.settingsLocal(for: fx.projectA).path))
     #expect(FileManager.default.fileExists(atPath: fx.settingsLocal(for: fx.projectB).path))
+    let defaultsWrites = fx.defaults.setCount(forKey: ClaudeHookInstaller.installedPathsKey)
 
     await fx.installer.syncInstalledPaths([fx.projectA.path])
+    #expect(fx.defaults.setCount(forKey: ClaudeHookInstaller.installedPathsKey) == defaultsWrites + 1)
 
     let a = try fx.readSettings(at: fx.settingsLocal(for: fx.projectA))
     #expect(fx.hasAgentHubEntry(in: fx.preEntries(in: a), scriptPath: fx.sharedScriptURL.path))
@@ -182,6 +337,10 @@ struct ClaudeHookInstallerTests {
       let b = try fx.readSettings(at: bURL)
       #expect(!fx.hasAgentHubEntry(in: fx.preEntries(in: b), scriptPath: fx.sharedScriptURL.path))
     }
+
+    try await Task.sleep(for: .milliseconds(20))
+    await fx.installer.syncInstalledPaths([fx.projectA.path])
+    #expect(fx.defaults.setCount(forKey: ClaudeHookInstaller.installedPathsKey) == defaultsWrites + 1)
   }
 
   @Test("uninstall preserves unrelated user hooks")
@@ -336,5 +495,6 @@ struct ClaudeHookInstallerTests {
       let settings = try fx.readSettings(at: url)
       #expect(!fx.hasAgentHubEntry(in: fx.preEntries(in: settings), scriptPath: fx.sharedScriptURL.path))
     }
+    #expect((fx.defaults.array(forKey: ClaudeHookInstaller.installedPathsKey) as? [String]) == [])
   }
 }

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/ClaudeHookInstaller.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/ClaudeHookInstaller.swift
@@ -88,19 +88,38 @@ public actor ClaudeHookInstaller: ClaudeHookInstallerProtocol {
       sweepAllInstalledPaths()
       return
     }
-    ensureSharedScript()
 
     let previously = Set(loadInstalledPaths())
     let toInstall = paths.subtracting(previously)
     let toUninstall = previously.subtracting(paths)
-    let toRepair = paths.intersection(previously) // ensure content is up to date
+    let toRepair = paths
+      .intersection(previously)
+      .filter { installNeedsRepair(atProjectPath: $0) }
 
+    if toInstall.isEmpty && toUninstall.isEmpty && toRepair.isEmpty {
+      saveInstalledPathsIfChanged(Array(previously))
+      return
+    }
+
+    if !toInstall.isEmpty || !toRepair.isEmpty {
+      ensureSharedScript()
+    }
+
+    var finalInstalled = previously
     for path in toUninstall {
-      uninstall(atProjectPath: path)
+      if uninstall(atProjectPath: path) {
+        finalInstalled.remove(path)
+      }
     }
-    for path in toInstall.union(toRepair) {
-      install(atProjectPath: path)
+    for path in toInstall {
+      if install(atProjectPath: path) {
+        finalInstalled.insert(path)
+      }
     }
+    for path in toRepair {
+      _ = install(atProjectPath: path)
+    }
+    saveInstalledPathsIfChanged(Array(finalInstalled))
   }
 
   public func flushAll() async {
@@ -111,37 +130,52 @@ public actor ClaudeHookInstaller: ClaudeHookInstallerProtocol {
     let expected = Set(expectedPaths)
     let previouslyInstalled = Set(loadInstalledPaths())
     let stale = previouslyInstalled.subtracting(expected)
+    var finalInstalled = previouslyInstalled
     for path in stale {
-      uninstall(atProjectPath: path, updatesInstalledPaths: false)
+      if uninstall(atProjectPath: path) {
+        finalInstalled.remove(path)
+      }
     }
-    saveInstalledPaths(Array(previouslyInstalled.subtracting(stale)))
+    saveInstalledPathsIfChanged(Array(finalInstalled))
   }
 
   // MARK: - Install / uninstall mechanics
 
-  private func install(atProjectPath path: String) {
+  @discardableResult
+  private func install(atProjectPath path: String) -> Bool {
     let settingsURL = ClaudeHookPaths.settingsLocalURL(inProjectAt: path)
     do {
-      migrateLegacyPerProjectScript(atProjectPath: path, settingsURL: settingsURL)
-      try mergeSettingsLocal(at: settingsURL, scriptPath: sharedScriptURL.path)
-      rememberInstalled(path: path)
+      removeLegacyPerProjectScriptIfPresent(atProjectPath: path)
+      try mergeSettingsLocal(
+        at: settingsURL,
+        scriptPath: sharedScriptURL.path,
+        legacyScriptPath: legacyPerProjectScriptURL(atProjectPath: path).path
+      )
+      return true
     } catch {
       AppLogger.watcher.error("[ClaudeHookInstaller] install failed for \(path): \(error.localizedDescription)")
+      return false
     }
   }
 
-  private func uninstall(atProjectPath path: String, updatesInstalledPaths: Bool = true) {
+  @discardableResult
+  private func uninstall(atProjectPath path: String) -> Bool {
     let settingsURL = ClaudeHookPaths.settingsLocalURL(inProjectAt: path)
     do {
-      migrateLegacyPerProjectScript(atProjectPath: path, settingsURL: settingsURL)
+      removeLegacyPerProjectScriptIfPresent(atProjectPath: path)
       if fileManager.fileExists(atPath: settingsURL.path) {
-        try unmergeSettingsLocal(at: settingsURL, scriptPath: sharedScriptURL.path)
+        try unmergeSettingsLocal(
+          at: settingsURL,
+          scriptPaths: [
+            sharedScriptURL.path,
+            legacyPerProjectScriptURL(atProjectPath: path).path,
+          ]
+        )
       }
-      if updatesInstalledPaths {
-        forgetInstalled(path: path)
-      }
+      return true
     } catch {
       AppLogger.watcher.error("[ClaudeHookInstaller] uninstall failed for \(path): \(error.localizedDescription)")
+      return false
     }
   }
 
@@ -150,25 +184,29 @@ public actor ClaudeHookInstaller: ClaudeHookInstallerProtocol {
   /// directory. Removes the legacy script and any `settings.local.json` entry
   /// that still references it. Safe to run on every install/uninstall call
   /// because it only acts on our uniquely-named script.
-  private func migrateLegacyPerProjectScript(atProjectPath path: String, settingsURL: URL) {
-    let legacyScript = URL(fileURLWithPath: path, isDirectory: true)
+  private func legacyPerProjectScriptURL(atProjectPath path: String) -> URL {
+    URL(fileURLWithPath: path, isDirectory: true)
       .appendingPathComponent(".claude", isDirectory: true)
       .appendingPathComponent("hooks", isDirectory: true)
       .appendingPathComponent("agenthub-approval.sh", isDirectory: false)
+  }
+
+  private func removeLegacyPerProjectScriptIfPresent(atProjectPath path: String) {
+    let legacyScript = legacyPerProjectScriptURL(atProjectPath: path)
     if fileManager.fileExists(atPath: legacyScript.path) {
       try? fileManager.removeItem(at: legacyScript)
-    }
-    // Also strip any `settings.local.json` entry that still points at the old
-    // per-project path — we re-add ours pointing at the shared script next.
-    if fileManager.fileExists(atPath: settingsURL.path) {
-      try? unmergeSettingsLocal(at: settingsURL, scriptPath: legacyScript.path)
     }
   }
 
   private func sweepAllInstalledPaths() {
-    for path in loadInstalledPaths() {
-      uninstall(atProjectPath: path)
+    let previouslyInstalled = Set(loadInstalledPaths())
+    var finalInstalled = previouslyInstalled
+    for path in previouslyInstalled {
+      if uninstall(atProjectPath: path) {
+        finalInstalled.remove(path)
+      }
     }
+    saveInstalledPathsIfChanged(Array(finalInstalled))
   }
 
   // MARK: - Shared script management
@@ -204,27 +242,82 @@ public actor ClaudeHookInstaller: ClaudeHookInstallerProtocol {
 
   // MARK: - settings.local.json merge
 
-  private func mergeSettingsLocal(at url: URL, scriptPath: String) throws {
+  private func installNeedsRepair(atProjectPath path: String) -> Bool {
+    let settingsURL = ClaudeHookPaths.settingsLocalURL(inProjectAt: path)
+    guard fileManager.fileExists(atPath: settingsURL.path),
+          let data = try? Data(contentsOf: settingsURL),
+          let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+          let hooks = root["hooks"] as? [String: Any] else {
+      return true
+    }
+
+    let legacyScriptPath = legacyPerProjectScriptURL(atProjectPath: path).path
+    let pre = inspectEventEntry(
+      hooks["PreToolUse"],
+      scriptPath: sharedScriptURL.path,
+      legacyScriptPath: legacyScriptPath
+    )
+    let post = inspectEventEntry(
+      hooks["PostToolUse"],
+      scriptPath: sharedScriptURL.path,
+      legacyScriptPath: legacyScriptPath
+    )
+
+    return !pre.hasCurrentEntry
+      || !post.hasCurrentEntry
+      || pre.hasDuplicateAgentHubEntries
+      || post.hasDuplicateAgentHubEntries
+      || pre.hasLegacyPerProjectReference
+      || post.hasLegacyPerProjectReference
+  }
+
+  private func mergeSettingsLocal(at url: URL, scriptPath: String, legacyScriptPath: String) throws {
     var root: [String: Any] = [:]
     if let data = try? Data(contentsOf: url),
        let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
       root = parsed
     }
     var hooks = root["hooks"] as? [String: Any] ?? [:]
-    hooks = upsertEventEntry(in: hooks, event: "PreToolUse", scriptPath: scriptPath)
-    hooks = upsertEventEntry(in: hooks, event: "PostToolUse", scriptPath: scriptPath)
+    var didChange = false
+    let pre = upsertEventEntry(
+      in: hooks,
+      event: "PreToolUse",
+      scriptPath: scriptPath,
+      legacyScriptPath: legacyScriptPath
+    )
+    hooks = pre.hooks
+    didChange = didChange || pre.didChange
+
+    let post = upsertEventEntry(
+      in: hooks,
+      event: "PostToolUse",
+      scriptPath: scriptPath,
+      legacyScriptPath: legacyScriptPath
+    )
+    hooks = post.hooks
+    didChange = didChange || post.didChange
+
+    guard didChange else { return }
     root["hooks"] = hooks
     try writeJSON(root, to: url)
   }
 
-  private func unmergeSettingsLocal(at url: URL, scriptPath: String) throws {
+  private func unmergeSettingsLocal(at url: URL, scriptPaths: [String]) throws {
     guard let data = try? Data(contentsOf: url),
           var root = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
       return
     }
     guard var hooks = root["hooks"] as? [String: Any] else { return }
-    hooks = removeEventEntry(in: hooks, event: "PreToolUse", scriptPath: scriptPath)
-    hooks = removeEventEntry(in: hooks, event: "PostToolUse", scriptPath: scriptPath)
+    var didChange = false
+    let pre = removeEventEntry(in: hooks, event: "PreToolUse", scriptPaths: scriptPaths)
+    hooks = pre.hooks
+    didChange = didChange || pre.didChange
+
+    let post = removeEventEntry(in: hooks, event: "PostToolUse", scriptPaths: scriptPaths)
+    hooks = post.hooks
+    didChange = didChange || post.didChange
+
+    guard didChange else { return }
     if hooks.isEmpty {
       root.removeValue(forKey: "hooks")
     } else {
@@ -240,14 +333,28 @@ public actor ClaudeHookInstaller: ClaudeHookInstallerProtocol {
   private func upsertEventEntry(
     in hooks: [String: Any],
     event: String,
-    scriptPath: String
-  ) -> [String: Any] {
+    scriptPath: String,
+    legacyScriptPath: String
+  ) -> (hooks: [String: Any], didChange: Bool) {
     var result = hooks
-    var entries = result[event] as? [[String: Any]] ?? []
-    entries.removeAll { entry in
-      guard let inner = entry["hooks"] as? [[String: Any]] else { return false }
-      return inner.contains { isOurCommand($0["command"] as? String, scriptPath: scriptPath) }
+    let eventValue = result[event]
+    let inspection = inspectEventEntry(
+      eventValue,
+      scriptPath: scriptPath,
+      legacyScriptPath: legacyScriptPath
+    )
+
+    if inspection.hasCurrentEntry,
+       !inspection.hasDuplicateAgentHubEntries,
+       !inspection.hasLegacyPerProjectReference {
+      return (result, false)
     }
+
+    var entries = (eventValue as? [[String: Any]]) ?? []
+    entries = removeAgentHubCommands(
+      from: entries,
+      scriptPaths: [scriptPath, legacyScriptPath]
+    )
     entries.append([
       "matcher": "*",
       "hooks": [
@@ -258,33 +365,108 @@ public actor ClaudeHookInstaller: ClaudeHookInstallerProtocol {
       ],
     ])
     result[event] = entries
-    return result
+    return (result, true)
   }
 
   private func removeEventEntry(
     in hooks: [String: Any],
     event: String,
-    scriptPath: String
-  ) -> [String: Any] {
+    scriptPaths: [String]
+  ) -> (hooks: [String: Any], didChange: Bool) {
     var result = hooks
-    guard var entries = result[event] as? [[String: Any]] else { return result }
-    entries.removeAll { entry in
-      guard let inner = entry["hooks"] as? [[String: Any]] else { return false }
-      return inner.contains { isOurCommand($0["command"] as? String, scriptPath: scriptPath) }
+    guard let originalEntries = result[event] as? [[String: Any]] else {
+      return (result, false)
     }
+    let entries = removeAgentHubCommands(from: originalEntries, scriptPaths: scriptPaths)
+    let didChange = agentHubCommandCount(in: originalEntries, scriptPaths: scriptPaths) > 0
+    guard didChange else { return (result, false) }
     if entries.isEmpty {
       result.removeValue(forKey: event)
     } else {
       result[event] = entries
     }
-    return result
+    return (result, true)
+  }
+
+  private struct EventEntryInspection {
+    let hasCurrentEntry: Bool
+    let hasDuplicateAgentHubEntries: Bool
+    let hasLegacyPerProjectReference: Bool
+  }
+
+  private func inspectEventEntry(
+    _ eventValue: Any?,
+    scriptPath: String,
+    legacyScriptPath: String
+  ) -> EventEntryInspection {
+    guard let entries = eventValue as? [[String: Any]] else {
+      return EventEntryInspection(
+        hasCurrentEntry: false,
+        hasDuplicateAgentHubEntries: false,
+        hasLegacyPerProjectReference: false
+      )
+    }
+
+    var currentCount = 0
+    var agentHubCount = 0
+    var hasLegacy = false
+    let currentCommand = Self.shellQuoted(scriptPath)
+    let legacyCommands = Set([legacyScriptPath, Self.shellQuoted(legacyScriptPath)])
+
+    for entry in entries {
+      let inner = entry["hooks"] as? [[String: Any]] ?? []
+      for hook in inner {
+        guard let command = hook["command"] as? String else { continue }
+        if command == currentCommand {
+          currentCount += 1
+          agentHubCount += 1
+        } else if command == scriptPath || legacyCommands.contains(command) {
+          agentHubCount += 1
+          if legacyCommands.contains(command) {
+            hasLegacy = true
+          }
+        }
+      }
+    }
+
+    return EventEntryInspection(
+      hasCurrentEntry: currentCount == 1,
+      hasDuplicateAgentHubEntries: agentHubCount > 1,
+      hasLegacyPerProjectReference: hasLegacy
+    )
+  }
+
+  private func removeAgentHubCommands(
+    from entries: [[String: Any]],
+    scriptPaths: [String]
+  ) -> [[String: Any]] {
+    entries.compactMap { entry in
+      guard let inner = entry["hooks"] as? [[String: Any]] else { return entry }
+      var cleaned = entry
+      let filtered = inner.filter {
+        !isOurCommand($0["command"] as? String, scriptPaths: scriptPaths)
+      }
+      guard filtered.count != inner.count else { return entry }
+      guard !filtered.isEmpty else { return nil }
+      cleaned["hooks"] = filtered
+      return cleaned
+    }
+  }
+
+  private func agentHubCommandCount(in entries: [[String: Any]], scriptPaths: [String]) -> Int {
+    entries.reduce(0) { count, entry in
+      let inner = entry["hooks"] as? [[String: Any]] ?? []
+      return count + inner.filter {
+        isOurCommand($0["command"] as? String, scriptPaths: scriptPaths)
+      }.count
+    }
   }
 
   /// Matches both the current shell-quoted form and the legacy unquoted form
   /// so that older installations get cleanly upgraded on the next sync.
-  private func isOurCommand(_ command: String?, scriptPath: String) -> Bool {
+  private func isOurCommand(_ command: String?, scriptPaths: [String]) -> Bool {
     guard let command else { return false }
-    return command == scriptPath || command == Self.shellQuoted(scriptPath)
+    return scriptPaths.contains { command == $0 || command == Self.shellQuoted($0) }
   }
 
   /// Wraps a path in single quotes so `/bin/sh -c` doesn't word-split on
@@ -316,15 +498,9 @@ public actor ClaudeHookInstaller: ClaudeHookInstallerProtocol {
     defaults.set(paths.sorted(), forKey: Self.installedPathsKey)
   }
 
-  private func rememberInstalled(path: String) {
-    var set = Set(loadInstalledPaths())
-    set.insert(path)
-    saveInstalledPaths(Array(set))
-  }
-
-  private func forgetInstalled(path: String) {
-    var set = Set(loadInstalledPaths())
-    set.remove(path)
-    saveInstalledPaths(Array(set))
+  private func saveInstalledPathsIfChanged(_ paths: [String]) {
+    let sortedPaths = paths.sorted()
+    guard loadInstalledPaths().sorted() != sortedPaths else { return }
+    saveInstalledPaths(sortedPaths)
   }
 }

--- a/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/CLISessionsViewModel.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/CLISessionsViewModel.swift
@@ -48,6 +48,9 @@ public final class CLISessionsViewModel {
   public private(set) var error: Error?
   @ObservationIgnored private var browseSessionsLoadTask: Task<Void, Never>?
   @ObservationIgnored private var shouldLoadBrowseSessionsAfterRepositoryRestore = false
+  @ObservationIgnored private var isLaunchRestoreInProgress = false
+  @ObservationIgnored private var skippedLaunchRestoreRepositoryHookSync = false
+  @ObservationIgnored private var pendingLaunchRestoreRepositoryHookSyncSkip: Set<String>?
 
   // MARK: - Session Naming State
 
@@ -993,8 +996,16 @@ public final class CLISessionsViewModel {
     subscriptionTask = Task { [weak self] in
       guard let self = self else { return }
 
+      var hasHandledInitialEmission = false
       for await repositories in self.monitorService.repositoriesPublisher.values {
         guard !Task.isCancelled else { break }
+
+        if !hasHandledInitialEmission {
+          hasHandledInitialEmission = true
+          if repositories.isEmpty {
+            continue
+          }
+        }
 
         await MainActor.run { [weak self] in
           guard let self = self else { return }
@@ -1027,7 +1038,10 @@ public final class CLISessionsViewModel {
           // `.claude/settings.local.json`. Claude Code reads that file once
           // at session start, so we install eagerly here rather than on
           // per-session startup. Codex injects nil → no-op.
-          self.syncClaudeHookInstalls()
+          let hookPaths = self.claudeHookInstallPaths(from: self.selectedRepositories)
+          if !self.shouldSkipRepositorySubscriptionHookSync(for: hookPaths) {
+            self.syncClaudeHookInstalls(paths: hookPaths)
+          }
         }
       }
     }
@@ -1037,17 +1051,41 @@ public final class CLISessionsViewModel {
   /// registered and hands it to the installer. Safe to call repeatedly —
   /// the installer is idempotent.
   private func syncClaudeHookInstalls() {
+    syncClaudeHookInstalls(paths: claudeHookInstallPaths(from: selectedRepositories))
+  }
+
+  private func syncClaudeHookInstalls(paths: Set<String>) {
     guard let installer = hookInstaller else { return }
+    Task {
+      await installer.syncInstalledPaths(paths)
+    }
+  }
+
+  private func claudeHookInstallPaths(from repositories: [SelectedRepository]) -> Set<String> {
     var paths: Set<String> = []
-    for repo in selectedRepositories {
+    for repo in repositories {
       paths.insert(repo.path)
       for worktree in repo.worktrees {
         paths.insert(worktree.path)
       }
     }
-    Task {
-      await installer.syncInstalledPaths(paths)
+    return paths
+  }
+
+  private func shouldSkipRepositorySubscriptionHookSync(for paths: Set<String>) -> Bool {
+    if isLaunchRestoreInProgress {
+      skippedLaunchRestoreRepositoryHookSync = true
+      pendingLaunchRestoreRepositoryHookSyncSkip = nil
+      return true
     }
+
+    if pendingLaunchRestoreRepositoryHookSyncSkip == paths {
+      pendingLaunchRestoreRepositoryHookSyncSkip = nil
+      return true
+    }
+
+    pendingLaunchRestoreRepositoryHookSyncSkip = nil
+    return false
   }
 
   /// Merges updated repositories while preserving expanded state from current repositories
@@ -1092,6 +1130,10 @@ public final class CLISessionsViewModel {
         return
       }
 
+      isLaunchRestoreInProgress = true
+      skippedLaunchRestoreRepositoryHookSync = false
+      pendingLaunchRestoreRepositoryHookSyncSkip = nil
+
       // Store persisted session IDs for progressive restoration
       let persistedSessionIds = Set(workspaceState.monitoredSessionIds)
       if !persistedSessionIds.isEmpty {
@@ -1102,13 +1144,17 @@ public final class CLISessionsViewModel {
       // deferred until the Browse panel is opened.
       loadingState = .restoringRepositories
       let restoredRepositories = await monitorService.restoreRepositoriesSkeleton(paths)
+      let restoredHookPaths = claudeHookInstallPaths(from: restoredRepositories)
+      if !skippedLaunchRestoreRepositoryHookSync {
+        pendingLaunchRestoreRepositoryHookSyncSkip = restoredHookPaths
+      }
       selectedRepositories = mergePreservingExpandedState(
         current: selectedRepositories,
         updated: restoredRepositories
       )
       restoreExpansionState(workspaceState.expansionState)
       persistSelectedRepositories()
-      syncClaudeHookInstalls()
+      syncClaudeHookInstalls(paths: restoredHookPaths)
 
       if !persistedSessionIds.isEmpty {
         loadingState = .restoringMonitoredSessions
@@ -1118,6 +1164,7 @@ public final class CLISessionsViewModel {
       }
 
       loadingState = .idle
+      isLaunchRestoreInProgress = false
       loadDeferredBrowseSessionsIfNeeded()
 
       // Safety timeout: stop trying to restore after 10 seconds

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/LazyBrowseSessionsLoadingTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/LazyBrowseSessionsLoadingTests.swift
@@ -58,6 +58,83 @@ struct LazyBrowseSessionsLoadingTests {
     #expect(await watcher.startedSessionIds() == ["session-1"])
   }
 
+  @Test("Launch restore syncs Claude hooks once for restored repo and worktree paths")
+  func launchRestoreSyncsClaudeHooksOnce() async throws {
+    let store = try SessionMetadataStore(path: temporaryDatabasePath())
+    try await store.saveWorkspaceState(
+      SessionWorkspaceState(selectedRepositoryPaths: ["/tmp/project"]),
+      for: .claude
+    )
+
+    let restoredRepository = repositoryWithWorktree(
+      path: "/tmp/project",
+      worktreePath: "/tmp/project-feature"
+    )
+    let monitor = LazyBrowseMockMonitorService(
+      skeletonRepositories: [restoredRepository],
+      browseRepositories: [restoredRepository]
+    )
+    let hookInstaller = RecordingClaudeHookInstaller()
+
+    let viewModel = CLISessionsViewModel(
+      monitorService: monitor,
+      fileWatcher: RecordingFileWatcher(),
+      searchService: nil,
+      cliConfiguration: CLICommandConfiguration(command: "claude", mode: .claude),
+      providerKind: .claude,
+      metadataStore: store,
+      approvalNotificationService: NoOpApprovalNotificationService(),
+      hookInstaller: hookInstaller
+    )
+
+    await waitUntil {
+      viewModel.loadingState == .idle && viewModel.selectedRepositories.count == 1
+    }
+    await waitUntilAsync {
+      await hookInstaller.syncRequests().count == 1
+    }
+
+    #expect(await hookInstaller.syncRequests() == [
+      Set(["/tmp/project", "/tmp/project-feature"])
+    ])
+  }
+
+  @Test("Idle repository changes still trigger Claude hook sync")
+  func idleRepositoryChangesTriggerClaudeHookSync() async throws {
+    let store = try SessionMetadataStore(path: temporaryDatabasePath())
+    let repository = repositoryWithWorktree(
+      path: "/tmp/project",
+      worktreePath: "/tmp/project-feature"
+    )
+    let monitor = LazyBrowseMockMonitorService(
+      skeletonRepositories: [],
+      browseRepositories: [repository]
+    )
+    let hookInstaller = RecordingClaudeHookInstaller()
+
+    let viewModel = CLISessionsViewModel(
+      monitorService: monitor,
+      fileWatcher: RecordingFileWatcher(),
+      searchService: nil,
+      cliConfiguration: CLICommandConfiguration(command: "claude", mode: .claude),
+      providerKind: .claude,
+      metadataStore: store,
+      approvalNotificationService: NoOpApprovalNotificationService(),
+      hookInstaller: hookInstaller
+    )
+
+    try await Task.sleep(for: .milliseconds(50))
+    let baselineCount = await hookInstaller.syncRequests().count
+
+    await monitor.setSelectedRepositories([repository])
+
+    await waitUntilAsync {
+      await hookInstaller.syncRequests().count == baselineCount + 1
+    }
+    #expect(viewModel.selectedRepositories.map(\.path) == ["/tmp/project"])
+    #expect(await hookInstaller.syncRequests().last == Set(["/tmp/project", "/tmp/project-feature"]))
+  }
+
   @Test("Launch targeted restore skips sessions outside restored roots")
   func launchTargetedRestoreSkipsSessionsOutsideRestoredRoots() async throws {
     let store = try SessionMetadataStore(path: temporaryDatabasePath())
@@ -496,11 +573,46 @@ private actor RecordingFileWatcher: SessionFileWatcherProtocol {
   }
 }
 
+private actor RecordingClaudeHookInstaller: ClaudeHookInstallerProtocol {
+  private var requests: [Set<String>] = []
+  private var enabled = true
+
+  func isEnabled() async -> Bool {
+    enabled
+  }
+
+  func setEnabled(_ enabled: Bool) async {
+    self.enabled = enabled
+  }
+
+  func syncInstalledPaths(_ paths: Set<String>) async {
+    requests.append(paths)
+  }
+
+  func flushAll() async {}
+
+  func reconcileOnLaunch(expectedPaths: [String]) async {}
+
+  func syncRequests() -> [Set<String>] {
+    requests
+  }
+}
+
 private func repository(path: String, sessions: [CLISession] = []) -> SelectedRepository {
   SelectedRepository(
     path: path,
     worktrees: [
       WorktreeBranch(name: "main", path: path, isWorktree: false, sessions: sessions)
+    ]
+  )
+}
+
+private func repositoryWithWorktree(path: String, worktreePath: String) -> SelectedRepository {
+  SelectedRepository(
+    path: path,
+    worktrees: [
+      WorktreeBranch(name: "main", path: path, isWorktree: false),
+      WorktreeBranch(name: "feature", path: worktreePath, isWorktree: true),
     ]
   )
 }


### PR DESCRIPTION
## Summary

This stabilizes Claude approval hook sync so AgentHub keeps the shared hook entry registered for the currently monitored repository/worktree paths without repeatedly rewriting already-correct settings.

## What changed

- Make `ClaudeHookInstaller.syncInstalledPaths` compute install, uninstall, and repair sets before touching the filesystem.
- Repair missing, duplicate, unquoted, or legacy per-project hook entries while preserving unrelated user settings and non-AgentHub hook entries.
- Keep the hook script shared outside user repos and remove only the legacy AgentHub per-project script if found.
- Avoid duplicate launch-restore hook syncs while still syncing restored repo and worktree paths once.
- Add focused tests for idempotency, repair, uninstall/flush, launch restore, and idle repository updates.

## Lifecycle behavior

Hooks are installed per monitored repo/worktree path, not per session. That is intentional because Claude Code reads `.claude/settings.local.json` once at session start. Per-session behavior is still retained through approval claims when AgentHub starts monitoring a session; unclaimed external sessions remain silent no-ops.

Removal is still handled by `syncInstalledPaths([])`, dropped-path syncs, Settings toggle off, launch reconcile, and terminate flush. The uninstaller removes only AgentHub commands from `PreToolUse` and `PostToolUse` and preserves unrelated settings/hooks.

## Validation

- `swift test --filter LazyBrowseSessionsLoadingTests` passed.
- `xcodebuild test -project app/AgentHub.xcodeproj -scheme AgentHub -destination 'platform=macOS' -only-testing:AgentHubTests/ClaudeHookInstallerTests -skipPackagePluginValidation -skipMacroValidation` passed.