### PR TITLE
[codex] Move Claude hook install state to SQLite

### DIFF
--- a/app/AgentHubTests/ClaudeHookInstallerTests.swift
+++ b/app/AgentHubTests/ClaudeHookInstallerTests.swift
@@ -15,6 +15,53 @@ private final class CountingUserDefaults: UserDefaults, @unchecked Sendable {
   }
 }
 
+private actor RecordingClaudeHookInstallStateStore: ClaudeHookInstallStateStoreProtocol {
+  enum StoreError: Error {
+    case loadFailed
+    case replaceFailed
+  }
+
+  private var paths: Set<String> = []
+  private var replaceCount = 0
+  private var shouldFailLoads = false
+  private var shouldFailReplaces = false
+
+  func loadClaudeHookInstalledPaths() async throws -> Set<String> {
+    if shouldFailLoads {
+      throw StoreError.loadFailed
+    }
+    return paths
+  }
+
+  func replaceClaudeHookInstalledPaths(_ paths: Set<String>) async throws {
+    if shouldFailReplaces {
+      throw StoreError.replaceFailed
+    }
+    replaceCount += 1
+    self.paths = paths
+  }
+
+  func seedInstalledPaths(_ paths: Set<String>) {
+    self.paths = paths
+  }
+
+  func installedPaths() -> Set<String> {
+    paths
+  }
+
+  func replaceCallCount() -> Int {
+    replaceCount
+  }
+
+  func setLoadFailure(_ shouldFail: Bool) {
+    shouldFailLoads = shouldFail
+  }
+
+  func setReplaceFailure(_ shouldFail: Bool) {
+    shouldFailReplaces = shouldFail
+  }
+}
+
 @Suite("ClaudeHookInstaller")
 struct ClaudeHookInstallerTests {
 
@@ -27,6 +74,7 @@ struct ClaudeHookInstallerTests {
     let bundledScriptURL: URL
     let sharedScriptURL: URL
     let defaults: CountingUserDefaults
+    let stateStore: RecordingClaudeHookInstallStateStore
     let installer: ClaudeHookInstaller
     let suiteName: String
 
@@ -50,8 +98,10 @@ struct ClaudeHookInstallerTests {
         throw NSError(domain: "fixture", code: 1)
       }
       self.defaults = defaults
+      self.stateStore = RecordingClaudeHookInstallStateStore()
 
       self.installer = ClaudeHookInstaller(
+        stateStore: stateStore,
         fileManager: .default,
         defaults: defaults,
         bundledScriptURL: bundledScriptURL,
@@ -150,6 +200,32 @@ struct ClaudeHookInstallerTests {
     #expect(!FileManager.default.fileExists(atPath: fx.projectHooksDir(for: fx.projectA).path))
   }
 
+  @Test("sync skips filesystem changes when installed-path load fails")
+  func syncSkipsFilesystemChangesWhenStateLoadFails() async throws {
+    let fx = try Fixture(name: "stateLoadFailure")
+    defer { fx.teardown() }
+
+    await fx.stateStore.setLoadFailure(true)
+
+    await fx.installer.syncInstalledPaths([fx.projectA.path])
+
+    #expect(!FileManager.default.fileExists(atPath: fx.sharedScriptURL.path))
+    #expect(!FileManager.default.fileExists(atPath: fx.settingsLocal(for: fx.projectA).path))
+  }
+
+  @Test("sync skips filesystem changes when install path persistence fails")
+  func syncSkipsFilesystemChangesWhenStateReplaceFails() async throws {
+    let fx = try Fixture(name: "stateReplaceFailure")
+    defer { fx.teardown() }
+
+    await fx.stateStore.setReplaceFailure(true)
+
+    await fx.installer.syncInstalledPaths([fx.projectA.path])
+
+    #expect(!FileManager.default.fileExists(atPath: fx.sharedScriptURL.path))
+    #expect(!FileManager.default.fileExists(atPath: fx.settingsLocal(for: fx.projectA).path))
+  }
+
   @Test("sync preserves unrelated keys in settings.local.json")
   func preservesExistingKeys() async throws {
     let fx = try Fixture(name: "preservesKeys")
@@ -205,8 +281,8 @@ struct ClaudeHookInstallerTests {
     #expect(matches.count == 1)
   }
 
-  @Test("same sync input twice does not rewrite settings or defaults")
-  func sameSyncInputTwiceDoesNotRewriteSettingsOrDefaults() async throws {
+  @Test("same sync input twice does not rewrite settings or state store")
+  func sameSyncInputTwiceDoesNotRewriteSettingsOrStateStore() async throws {
     let fx = try Fixture(name: "sameInputNoRewrite")
     defer { fx.teardown() }
 
@@ -214,13 +290,13 @@ struct ClaudeHookInstallerTests {
 
     let settingsURL = fx.settingsLocal(for: fx.projectA)
     let modifiedAt = try fx.modificationDate(of: settingsURL)
-    let defaultsWrites = fx.defaults.setCount(forKey: ClaudeHookInstaller.installedPathsKey)
+    let stateStoreWrites = await fx.stateStore.replaceCallCount()
 
     try await Task.sleep(for: .milliseconds(20))
     await fx.installer.syncInstalledPaths([fx.projectA.path])
 
     #expect(try fx.modificationDate(of: settingsURL) == modifiedAt)
-    #expect(fx.defaults.setCount(forKey: ClaudeHookInstaller.installedPathsKey) == defaultsWrites)
+    #expect(await fx.stateStore.replaceCallCount() == stateStoreWrites)
   }
 
   @Test("adding one new path does not rewrite already-correct paths")
@@ -232,31 +308,31 @@ struct ClaudeHookInstallerTests {
 
     let settingsA = fx.settingsLocal(for: fx.projectA)
     let modifiedA = try fx.modificationDate(of: settingsA)
-    let defaultsWrites = fx.defaults.setCount(forKey: ClaudeHookInstaller.installedPathsKey)
+    let stateStoreWrites = await fx.stateStore.replaceCallCount()
 
     try await Task.sleep(for: .milliseconds(20))
     await fx.installer.syncInstalledPaths([fx.projectA.path, fx.projectB.path])
 
     #expect(try fx.modificationDate(of: settingsA) == modifiedA)
     #expect(FileManager.default.fileExists(atPath: fx.settingsLocal(for: fx.projectB).path))
-    #expect(fx.defaults.setCount(forKey: ClaudeHookInstaller.installedPathsKey) == defaultsWrites + 1)
+    #expect(await fx.stateStore.replaceCallCount() == stateStoreWrites + 1)
   }
 
-  @Test("installed path with missing settings is repaired without rewriting defaults")
+  @Test("installed path with missing settings is repaired without rewriting state store")
   func missingSettingsForInstalledPathIsRepaired() async throws {
     let fx = try Fixture(name: "repairMissingSettings")
     defer { fx.teardown() }
 
     await fx.installer.syncInstalledPaths([fx.projectA.path])
     try FileManager.default.removeItem(at: fx.settingsLocal(for: fx.projectA))
-    let defaultsWrites = fx.defaults.setCount(forKey: ClaudeHookInstaller.installedPathsKey)
+    let stateStoreWrites = await fx.stateStore.replaceCallCount()
 
     await fx.installer.syncInstalledPaths([fx.projectA.path])
 
     let settings = try fx.readSettings(at: fx.settingsLocal(for: fx.projectA))
     #expect(fx.hasAgentHubEntry(in: fx.preEntries(in: settings), scriptPath: fx.sharedScriptURL.path))
     #expect(fx.hasAgentHubEntry(in: fx.postEntries(in: settings), scriptPath: fx.sharedScriptURL.path))
-    #expect(fx.defaults.setCount(forKey: ClaudeHookInstaller.installedPathsKey) == defaultsWrites)
+    #expect(await fx.stateStore.replaceCallCount() == stateStoreWrites)
   }
 
   @Test("installed path with duplicate hook entries is repaired")
@@ -324,10 +400,10 @@ struct ClaudeHookInstallerTests {
     await fx.installer.syncInstalledPaths([fx.projectA.path, fx.projectB.path])
     #expect(FileManager.default.fileExists(atPath: fx.settingsLocal(for: fx.projectA).path))
     #expect(FileManager.default.fileExists(atPath: fx.settingsLocal(for: fx.projectB).path))
-    let defaultsWrites = fx.defaults.setCount(forKey: ClaudeHookInstaller.installedPathsKey)
+    let stateStoreWrites = await fx.stateStore.replaceCallCount()
 
     await fx.installer.syncInstalledPaths([fx.projectA.path])
-    #expect(fx.defaults.setCount(forKey: ClaudeHookInstaller.installedPathsKey) == defaultsWrites + 1)
+    #expect(await fx.stateStore.replaceCallCount() == stateStoreWrites + 1)
 
     let a = try fx.readSettings(at: fx.settingsLocal(for: fx.projectA))
     #expect(fx.hasAgentHubEntry(in: fx.preEntries(in: a), scriptPath: fx.sharedScriptURL.path))
@@ -340,7 +416,7 @@ struct ClaudeHookInstallerTests {
 
     try await Task.sleep(for: .milliseconds(20))
     await fx.installer.syncInstalledPaths([fx.projectA.path])
-    #expect(fx.defaults.setCount(forKey: ClaudeHookInstaller.installedPathsKey) == defaultsWrites + 1)
+    #expect(await fx.stateStore.replaceCallCount() == stateStoreWrites + 1)
   }
 
   @Test("uninstall preserves unrelated user hooks")
@@ -470,7 +546,7 @@ struct ClaudeHookInstallerTests {
     )
     try JSONSerialization.data(withJSONObject: legacy).write(to: fx.settingsLocal(for: fx.projectA))
     // Pretend installer had previously written this path so uninstall sees it.
-    fx.defaults.set([fx.projectA.path], forKey: ClaudeHookInstaller.installedPathsKey)
+    await fx.stateStore.seedInstalledPaths([fx.projectA.path])
 
     await fx.installer.syncInstalledPaths([])
 
@@ -495,6 +571,6 @@ struct ClaudeHookInstallerTests {
       let settings = try fx.readSettings(at: url)
       #expect(!fx.hasAgentHubEntry(in: fx.preEntries(in: settings), scriptPath: fx.sharedScriptURL.path))
     }
-    #expect((fx.defaults.array(forKey: ClaudeHookInstaller.installedPathsKey) as? [String]) == [])
+    #expect(await fx.stateStore.installedPaths().isEmpty)
   }
 }

--- a/app/AgentHubTests/SessionMetadataMigrationSafetyTests.swift
+++ b/app/AgentHubTests/SessionMetadataMigrationSafetyTests.swift
@@ -15,7 +15,9 @@ struct SessionMetadataMigrationSafetyTests {
       "v3_create_ai_config",
       "v4_add_pinned",
       "v5_create_terminal_workspaces",
-      "v6_create_session_workspace_state"
+      "v6_create_session_workspace_state",
+      "v7_create_managed_processes",
+      "v8_create_claude_hook_installations"
     ]
 
     #expect(Array(SessionMetadataStore.migrationIdentifiers.prefix(baseline.count)) == baseline)
@@ -52,7 +54,8 @@ struct SessionMetadataMigrationSafetyTests {
       ) == seed.terminalWorkspace
     )
     #expect(store.getWorkspaceStateSync(for: .claude) == seed.workspaceState)
-    #expect(try await store.getManagedProcesses().isEmpty)
+    #expect(try await store.getManagedProcesses() == [seed.managedProcess])
+    #expect(try await store.loadClaudeHookInstalledPaths().isEmpty)
   }
 }
 
@@ -62,6 +65,7 @@ private struct MigrationSafetySeed {
   let worktreePath: String
   let terminalWorkspace: TerminalWorkspaceSnapshot
   let workspaceState: SessionWorkspaceState
+  let managedProcess: ManagedProcessRecord
 }
 
 private func seedCurrentBaselineDatabase(at dbPath: String) throws -> MigrationSafetySeed {
@@ -90,6 +94,19 @@ private func seedCurrentBaselineDatabase(at dbPath: String) throws -> MigrationS
       "repo:\(parentRepoPath)": true,
       "wt:\(worktreePath)": true
     ]
+  )
+  let managedProcess = ManagedProcessRecord(
+    pid: 42,
+    processGroupId: 42,
+    processStartTimeSeconds: 1_700_000_000,
+    kind: .agentTerminal,
+    provider: SessionProviderKind.claude.rawValue,
+    terminalKey: "terminal-session-1",
+    sessionId: sessionId,
+    projectPath: parentRepoPath,
+    expectedExecutable: "/bin/zsh",
+    registeredAt: Date(timeIntervalSince1970: 1_700_000_010),
+    updatedAt: Date(timeIntervalSince1970: 1_700_000_020)
   )
 
   let queue = try DatabaseQueue(path: dbPath)
@@ -129,10 +146,12 @@ private func seedCurrentBaselineDatabase(at dbPath: String) throws -> MigrationS
       state: workspaceState
     ).insert(db)
 
-    // Mark the database as fully migrated through v6 so opening
-    // SessionMetadataStore exercises only the v7 managed_processes migration.
+    try managedProcess.insert(db)
+
+    // Mark the database as fully migrated through v7 so opening
+    // SessionMetadataStore exercises only the v8 claude_hook_installations migration.
     for migrationIdentifier in SessionMetadataStore.migrationIdentifiers
-      where migrationIdentifier != SessionMetadataStore.MigrationID.createManagedProcesses {
+      where migrationIdentifier != SessionMetadataStore.MigrationID.createClaudeHookInstallations {
       try db.execute(
         sql: "INSERT INTO grdb_migrations (identifier) VALUES (?)",
         arguments: [migrationIdentifier]
@@ -145,7 +164,8 @@ private func seedCurrentBaselineDatabase(at dbPath: String) throws -> MigrationS
     parentRepoPath: parentRepoPath,
     worktreePath: worktreePath,
     terminalWorkspace: terminalWorkspace,
-    workspaceState: workspaceState
+    workspaceState: workspaceState,
+    managedProcess: managedProcess
   )
 }
 
@@ -191,6 +211,22 @@ private func createCurrentBaselineSchema(in db: Database) throws {
     t.column("expansionStateData", .blob).notNull()
     t.column("updatedAt", .datetime).notNull()
   }
+
+  try db.create(table: "managed_processes") { t in
+    t.column("pid", .integer).primaryKey(onConflict: .replace)
+    t.column("processGroupId", .integer)
+    t.column("processStartTimeSeconds", .integer)
+    t.column("kind", .text).notNull()
+    t.column("provider", .text)
+    t.column("terminalKey", .text)
+    t.column("sessionId", .text)
+    t.column("projectPath", .text)
+    t.column("expectedExecutable", .text)
+    t.column("registeredAt", .datetime).notNull()
+    t.column("updatedAt", .datetime).notNull()
+  }
+  try db.create(index: "idx_managed_processes_kind", on: "managed_processes", columns: ["kind"])
+  try db.create(index: "idx_managed_processes_session", on: "managed_processes", columns: ["provider", "sessionId"])
 
   try db.execute(sql: "CREATE TABLE grdb_migrations (identifier TEXT NOT NULL PRIMARY KEY)")
 }

--- a/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubProvider.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubProvider.swift
@@ -101,7 +101,11 @@ public final class AgentHubProvider {
 
   /// Installs/uninstalls the AgentHub approval hook per worktree.
   public private(set) lazy var claudeHookInstaller: any ClaudeHookInstallerProtocol = {
-    ClaudeHookInstaller()
+    guard let metadataStore else {
+      AppLogger.session.error("[ClaudeHook] SessionMetadataStore unavailable; approval hook installation disabled")
+      return NoOpClaudeHookInstaller()
+    }
+    return ClaudeHookInstaller(stateStore: metadataStore)
   }()
 
   /// Claude search service

--- a/app/modules/AgentHubCore/Sources/AgentHub/Models/ClaudeHookInstallationRecord.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Models/ClaudeHookInstallationRecord.swift
@@ -1,0 +1,27 @@
+//
+//  ClaudeHookInstallationRecord.swift
+//  AgentHub
+//
+//  SQLite record for Claude approval hook paths AgentHub owns.
+//
+
+import Foundation
+import GRDB
+
+public struct ClaudeHookInstallationRecord: Codable, Equatable, Sendable, FetchableRecord, PersistableRecord {
+  public var projectPath: String
+  public var installedAt: Date
+  public var updatedAt: Date
+
+  public static var databaseTableName: String { "claude_hook_installations" }
+
+  public init(
+    projectPath: String,
+    installedAt: Date = Date.now,
+    updatedAt: Date = Date.now
+  ) {
+    self.projectPath = projectPath
+    self.installedAt = installedAt
+    self.updatedAt = updatedAt
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/ClaudeHookInstaller.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/ClaudeHookInstaller.swift
@@ -24,6 +24,11 @@ public protocol ClaudeHookInstallerProtocol: AnyObject, Sendable {
   func reconcileOnLaunch(expectedPaths: [String]) async
 }
 
+public protocol ClaudeHookInstallStateStoreProtocol: Sendable {
+  func loadClaudeHookInstalledPaths() async throws -> Set<String>
+  func replaceClaudeHookInstalledPaths(_ paths: Set<String>) async throws
+}
+
 // MARK: - ClaudeHookInstaller
 
 /// Registers the AgentHub approval hook in each monitored project's
@@ -36,10 +41,6 @@ public actor ClaudeHookInstaller: ClaudeHookInstallerProtocol {
 
   // MARK: - Constants
 
-  /// UserDefaults key storing the set of paths where the hook entry has been
-  /// written, so `reconcileOnLaunch` and `flushAll` can sweep correctly.
-  public static let installedPathsKey = "com.agenthub.claudeHook.installedPaths"
-
   /// UserDefaults key for the master toggle. Default on.
   public static let enabledKey = "com.agenthub.claudeHook.enabled"
 
@@ -47,12 +48,14 @@ public actor ClaudeHookInstaller: ClaudeHookInstallerProtocol {
 
   private let fileManager: FileManager
   private let defaults: UserDefaults
+  private let stateStore: any ClaudeHookInstallStateStoreProtocol
   private let bundledScriptURL: URL?
   private let sharedScriptURL: URL
 
   // MARK: - Initialization
 
   public init(
+    stateStore: any ClaudeHookInstallStateStoreProtocol,
     fileManager: FileManager = .default,
     defaults: UserDefaults = .standard,
     bundledScriptURL: URL? = ClaudeHookPaths.bundledScriptURL(),
@@ -60,6 +63,7 @@ public actor ClaudeHookInstaller: ClaudeHookInstallerProtocol {
   ) {
     self.fileManager = fileManager
     self.defaults = defaults
+    self.stateStore = stateStore
     self.bundledScriptURL = bundledScriptURL
     self.sharedScriptURL = sharedScriptURL
   }
@@ -74,7 +78,7 @@ public actor ClaudeHookInstaller: ClaudeHookInstallerProtocol {
   public func setEnabled(_ enabled: Bool) async {
     defaults.set(enabled, forKey: Self.enabledKey)
     if !enabled {
-      sweepAllInstalledPaths()
+      await sweepAllInstalledPaths()
     }
     // Re-enable is intentionally a no-op here; the next `syncInstalledPaths`
     // call from the repositories subscription will re-install wherever needed.
@@ -85,50 +89,58 @@ public actor ClaudeHookInstaller: ClaudeHookInstallerProtocol {
   public func syncInstalledPaths(_ paths: Set<String>) async {
     guard await isEnabled() else {
       // Feature disabled: make sure nothing is installed anywhere.
-      sweepAllInstalledPaths()
+      await sweepAllInstalledPaths()
       return
     }
 
-    let previously = Set(loadInstalledPaths())
-    let toInstall = paths.subtracting(previously)
-    let toUninstall = previously.subtracting(paths)
+    guard var trackedPaths = await loadInstalledPaths() else { return }
+
+    let toInstall = paths.subtracting(trackedPaths)
+    let toUninstall = trackedPaths.subtracting(paths)
     let toRepair = paths
-      .intersection(previously)
+      .intersection(trackedPaths)
       .filter { installNeedsRepair(atProjectPath: $0) }
 
     if toInstall.isEmpty && toUninstall.isEmpty && toRepair.isEmpty {
-      saveInstalledPathsIfChanged(Array(previously))
       return
     }
+
+    if !toInstall.isEmpty {
+      let expandedPaths = trackedPaths.union(toInstall)
+      guard await replaceInstalledPaths(expandedPaths) else { return }
+      trackedPaths = expandedPaths
+    }
+
+    let persistedPaths = trackedPaths
 
     if !toInstall.isEmpty || !toRepair.isEmpty {
       ensureSharedScript()
     }
 
-    var finalInstalled = previously
     for path in toUninstall {
       if uninstall(atProjectPath: path) {
-        finalInstalled.remove(path)
+        trackedPaths.remove(path)
       }
     }
     for path in toInstall {
-      if install(atProjectPath: path) {
-        finalInstalled.insert(path)
-      }
+      _ = install(atProjectPath: path)
     }
     for path in toRepair {
       _ = install(atProjectPath: path)
     }
-    saveInstalledPathsIfChanged(Array(finalInstalled))
+
+    if trackedPaths != persistedPaths {
+      _ = await replaceInstalledPaths(trackedPaths)
+    }
   }
 
   public func flushAll() async {
-    sweepAllInstalledPaths()
+    await sweepAllInstalledPaths()
   }
 
   public func reconcileOnLaunch(expectedPaths: [String]) async {
     let expected = Set(expectedPaths)
-    let previouslyInstalled = Set(loadInstalledPaths())
+    guard let previouslyInstalled = await loadInstalledPaths() else { return }
     let stale = previouslyInstalled.subtracting(expected)
     var finalInstalled = previouslyInstalled
     for path in stale {
@@ -136,7 +148,9 @@ public actor ClaudeHookInstaller: ClaudeHookInstallerProtocol {
         finalInstalled.remove(path)
       }
     }
-    saveInstalledPathsIfChanged(Array(finalInstalled))
+    if finalInstalled != previouslyInstalled {
+      _ = await replaceInstalledPaths(finalInstalled)
+    }
   }
 
   // MARK: - Install / uninstall mechanics
@@ -198,15 +212,17 @@ public actor ClaudeHookInstaller: ClaudeHookInstallerProtocol {
     }
   }
 
-  private func sweepAllInstalledPaths() {
-    let previouslyInstalled = Set(loadInstalledPaths())
+  private func sweepAllInstalledPaths() async {
+    guard let previouslyInstalled = await loadInstalledPaths() else { return }
     var finalInstalled = previouslyInstalled
     for path in previouslyInstalled {
       if uninstall(atProjectPath: path) {
         finalInstalled.remove(path)
       }
     }
-    saveInstalledPathsIfChanged(Array(finalInstalled))
+    if finalInstalled != previouslyInstalled {
+      _ = await replaceInstalledPaths(finalInstalled)
+    }
   }
 
   // MARK: - Shared script management
@@ -490,17 +506,43 @@ public actor ClaudeHookInstaller: ClaudeHookInstallerProtocol {
 
   // MARK: - Persistence of installed paths
 
-  private func loadInstalledPaths() -> [String] {
-    (defaults.array(forKey: Self.installedPathsKey) as? [String]) ?? []
+  private func loadInstalledPaths() async -> Set<String>? {
+    do {
+      return try await stateStore.loadClaudeHookInstalledPaths()
+    } catch {
+      AppLogger.watcher.error("[ClaudeHookInstaller] failed to load installed paths; skipping hook changes: \(error.localizedDescription)")
+      return nil
+    }
   }
 
-  private func saveInstalledPaths(_ paths: [String]) {
-    defaults.set(paths.sorted(), forKey: Self.installedPathsKey)
+  private func replaceInstalledPaths(_ paths: Set<String>) async -> Bool {
+    do {
+      try await stateStore.replaceClaudeHookInstalledPaths(paths)
+      return true
+    } catch {
+      AppLogger.watcher.error("[ClaudeHookInstaller] failed to save installed paths; skipping hook changes: \(error.localizedDescription)")
+      return false
+    }
+  }
+}
+
+actor NoOpClaudeHookInstaller: ClaudeHookInstallerProtocol {
+  private let defaults: UserDefaults
+
+  init(defaults: UserDefaults = .standard) {
+    self.defaults = defaults
   }
 
-  private func saveInstalledPathsIfChanged(_ paths: [String]) {
-    let sortedPaths = paths.sorted()
-    guard loadInstalledPaths().sorted() != sortedPaths else { return }
-    saveInstalledPaths(sortedPaths)
+  func isEnabled() async -> Bool {
+    if defaults.object(forKey: ClaudeHookInstaller.enabledKey) == nil { return true }
+    return defaults.bool(forKey: ClaudeHookInstaller.enabledKey)
   }
+
+  func setEnabled(_ enabled: Bool) async {
+    defaults.set(enabled, forKey: ClaudeHookInstaller.enabledKey)
+  }
+
+  func syncInstalledPaths(_ paths: Set<String>) async {}
+  func flushAll() async {}
+  func reconcileOnLaunch(expectedPaths: [String]) async {}
 }

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/SessionMetadataStore.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/SessionMetadataStore.swift
@@ -22,6 +22,7 @@ public actor SessionMetadataStore: TerminalWorkspaceStoreProtocol {
     static let createTerminalWorkspaces = "v5_create_terminal_workspaces"
     static let createSessionWorkspaceState = "v6_create_session_workspace_state"
     static let createManagedProcesses = "v7_create_managed_processes"
+    static let createClaudeHookInstallations = "v8_create_claude_hook_installations"
   }
 
   static let migrationIdentifiers = [
@@ -31,7 +32,8 @@ public actor SessionMetadataStore: TerminalWorkspaceStoreProtocol {
     MigrationID.addPinned,
     MigrationID.createTerminalWorkspaces,
     MigrationID.createSessionWorkspaceState,
-    MigrationID.createManagedProcesses
+    MigrationID.createManagedProcesses,
+    MigrationID.createClaudeHookInstallations
   ]
 
   private let dbQueue: DatabaseQueue
@@ -144,6 +146,14 @@ public actor SessionMetadataStore: TerminalWorkspaceStoreProtocol {
       try db.create(index: "idx_managed_processes_session", on: "managed_processes", columns: ["provider", "sessionId"])
     }
 
+    migrator.registerMigration(MigrationID.createClaudeHookInstallations) { db in
+      try db.create(table: "claude_hook_installations") { t in
+        t.column("projectPath", .text).primaryKey()
+        t.column("installedAt", .datetime).notNull()
+        t.column("updatedAt", .datetime).notNull()
+      }
+    }
+
     return migrator
   }
 
@@ -241,6 +251,7 @@ public actor SessionMetadataStore: TerminalWorkspaceStoreProtocol {
     try dbQueue.write { db in
       _ = try TerminalWorkspaceRecord.deleteAll(db)
       _ = try SessionWorkspaceStateRecord.deleteAll(db)
+      _ = try ClaudeHookInstallationRecord.deleteAll(db)
       _ = try ManagedProcessRecord.deleteAll(db)
       _ = try AIConfigRecord.deleteAll(db)
       _ = try SessionRepoMapping.deleteAll(db)
@@ -413,6 +424,36 @@ extension SessionMetadataStore: ManagedProcessStoreProtocol {
   public func getManagedProcesses() async throws -> [ManagedProcessRecord] {
     try await dbQueue.read { db in
       try ManagedProcessRecord.fetchAll(db)
+    }
+  }
+}
+
+extension SessionMetadataStore: ClaudeHookInstallStateStoreProtocol {
+  public func loadClaudeHookInstalledPaths() async throws -> Set<String> {
+    try await dbQueue.read { db in
+      let records = try ClaudeHookInstallationRecord.fetchAll(db)
+      return Set(records.map(\.projectPath))
+    }
+  }
+
+  public func replaceClaudeHookInstalledPaths(_ paths: Set<String>) async throws {
+    try await dbQueue.write { db in
+      let existingRecords = try ClaudeHookInstallationRecord.fetchAll(db)
+      let existingByPath = Dictionary(uniqueKeysWithValues: existingRecords.map { ($0.projectPath, $0) })
+      let pathsToDelete = Array(Set(existingByPath.keys).subtracting(paths))
+      let now = Date.now
+
+      if !pathsToDelete.isEmpty {
+        _ = try ClaudeHookInstallationRecord
+          .filter(pathsToDelete.contains(Column("projectPath")))
+          .deleteAll(db)
+      }
+
+      for path in paths.sorted() {
+        var record = existingByPath[path] ?? ClaudeHookInstallationRecord(projectPath: path, installedAt: now)
+        record.updatedAt = now
+        try record.save(db)
+      }
     }
   }
 }

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/ClaudeHookInstallStateStoreTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/ClaudeHookInstallStateStoreTests.swift
@@ -1,0 +1,52 @@
+import Foundation
+import Testing
+
+@testable import AgentHubCore
+
+@Suite("Claude hook install state store")
+struct ClaudeHookInstallStateStoreTests {
+  @Test("Loads empty installed paths")
+  func loadsEmptyInstalledPaths() async throws {
+    let store = try SessionMetadataStore(path: temporaryClaudeHookInstallStateDatabasePath())
+
+    #expect(try await store.loadClaudeHookInstalledPaths().isEmpty)
+  }
+
+  @Test("Replaces installed paths")
+  func replacesInstalledPaths() async throws {
+    let store = try SessionMetadataStore(path: temporaryClaudeHookInstallStateDatabasePath())
+
+    try await store.replaceClaudeHookInstalledPaths(["/tmp/project-a", "/tmp/project-b"])
+    #expect(try await store.loadClaudeHookInstalledPaths() == Set(["/tmp/project-a", "/tmp/project-b"]))
+
+    try await store.replaceClaudeHookInstalledPaths(["/tmp/project-b", "/tmp/project-c"])
+    #expect(try await store.loadClaudeHookInstalledPaths() == Set(["/tmp/project-b", "/tmp/project-c"]))
+  }
+
+  @Test("Empty replacement clears installed paths")
+  func emptyReplacementClearsInstalledPaths() async throws {
+    let store = try SessionMetadataStore(path: temporaryClaudeHookInstallStateDatabasePath())
+
+    try await store.replaceClaudeHookInstalledPaths(["/tmp/project-a"])
+    try await store.replaceClaudeHookInstalledPaths([])
+
+    #expect(try await store.loadClaudeHookInstalledPaths().isEmpty)
+  }
+
+  @Test("Installed paths persist across store instances")
+  func installedPathsPersistAcrossStoreInstances() async throws {
+    let dbPath = temporaryClaudeHookInstallStateDatabasePath()
+    let firstStore = try SessionMetadataStore(path: dbPath)
+
+    try await firstStore.replaceClaudeHookInstalledPaths(["/tmp/project-a", "/tmp/project-b"])
+
+    let secondStore = try SessionMetadataStore(path: dbPath)
+    #expect(try await secondStore.loadClaudeHookInstalledPaths() == Set(["/tmp/project-a", "/tmp/project-b"]))
+  }
+}
+
+private func temporaryClaudeHookInstallStateDatabasePath() -> String {
+  FileManager.default.temporaryDirectory
+    .appending(path: "test_claude_hook_install_state_\(UUID().uuidString).sqlite")
+    .path
+}


### PR DESCRIPTION
## Summary

Moves Claude hook installed-path state out of UserDefaults and into SessionMetadataStore-backed SQLite, while keeping the user-facing hook enabled toggle in UserDefaults.

## Changes

- Adds the additive `v8_create_claude_hook_installations` migration and `ClaudeHookInstallationRecord`.
- Adds `ClaudeHookInstallStateStoreProtocol` and implements it in `SessionMetadataStore`.
- Updates `ClaudeHookInstaller` to use the injected state store for installed-path persistence and to skip filesystem hook changes if state load/save fails.
- Wires `AgentHubProvider` to build the installer with `metadataStore`, with a no-op fallback when SQLite is unavailable.
- Updates installer and migration safety tests, including v7-to-v8 preservation coverage.

## Validation

- `swift test --filter LazyBrowseSessionsLoadingTests`
- `xcodebuild test -project app/AgentHub.xcodeproj -scheme AgentHub -destination 'platform=macOS' -only-testing:AgentHubTests/ClaudeHookInstallerTests -skipPackagePluginValidation -skipMacroValidation`
- `swift test --filter ClaudeHookInstallStateStoreTests`
- `xcodebuild test -project app/AgentHub.xcodeproj -scheme AgentHub -destination 'platform=macOS' -only-testing:AgentHubTests/SessionMetadataMigrationSafetyTests -skipPackagePluginValidation -skipMacroValidation`
- Manual smoke check with `/Users/jamesrochabrun/Desktop/git/Easel`: hook install wrote shared-script entries and SQLite rows; dropped-path removal removed hook entries and SQLite rows while preserving unrelated settings.