### PR TITLE
[codex] Reduce launch render churn

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/AuxiliaryShellTerminalHostView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/AuxiliaryShellTerminalHostView.swift
@@ -13,6 +13,10 @@ public final class EmbeddedTerminalHostView: NSView {
     mountView(terminal.view, key: key)
   }
 
+  public func isMounted(_ terminal: any EmbeddedTerminalSurface, key: String) -> Bool {
+    mountedTerminalKey == key && mountedTerminalView === terminal.view
+  }
+
   private func mountView(_ terminalView: NSView, key: String) {
     guard mountedTerminalView !== terminalView else {
       mountedTerminalKey = key

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/EmbeddedTerminalSurface.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/EmbeddedTerminalSurface.swift
@@ -89,6 +89,7 @@ extension TerminalContainerView: EmbeddedTerminalSurface {
   public var view: NSView { self }
 
   public func updateContext(terminalSessionKey: String?, sessionViewModel: CLISessionsViewModel?) {
+    guard self.terminalSessionKey != terminalSessionKey || self.sessionViewModel !== sessionViewModel else { return }
     self.terminalSessionKey = terminalSessionKey
     self.sessionViewModel = sessionViewModel
   }

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/EmbeddedTerminalView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/EmbeddedTerminalView.swift
@@ -153,7 +153,9 @@ public struct EmbeddedTerminalView: NSViewRepresentable {
   public func updateNSView(_ nsView: EmbeddedTerminalHostView, context: Context) {
     let terminal = resolveTerminal(context: context, isDark: colorScheme == .dark)
     applyCallbacks(to: terminal)
-    nsView.mount(terminal, key: terminalKey)
+    if !nsView.isMounted(terminal, key: terminalKey) {
+      nsView.mount(terminal, key: terminalKey)
+    }
     terminal.syncAppearance(isDark: colorScheme == .dark, fontSize: CGFloat(terminalFontSize), fontFamily: terminalFontFamily, theme: runtimeTheme)
 
     // If there's a pending prompt in the viewModel, send it (and clear it)

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringCardView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringCardView.swift
@@ -57,6 +57,7 @@ public struct MonitoringCardView: View {
   @State private var showingFilePicker = false
   @State private var showingNameSheet = false
   @State private var showingRemixProviderPicker = false
+  @State private var isXcodeProject = false
   @Environment(\.agentHub) private var agentHub
   @Environment(\.colorScheme) private var colorScheme
 
@@ -228,6 +229,15 @@ public struct MonitoringCardView: View {
     .animation(.easeInOut(duration: 0.2), value: isDragging)
     .task(id: session.projectPath) {
       await loadWebPreviewCandidateIfNeeded()
+    }
+    .task(id: session.projectPath) {
+      let projectPath = session.projectPath
+      isXcodeProject = false
+      let detected = await Task.detached {
+        XcodeProjectDetector.isXcodeProject(at: projectPath)
+      }.value
+      guard !Task.isCancelled else { return }
+      isXcodeProject = detected
     }
     .task(id: SessionGitHubQuickAccessViewModel.repositoryKey(projectPath: session.projectPath, branchName: session.branchName)) {
       try? await Task.sleep(for: .seconds(2))
@@ -624,7 +634,7 @@ public struct MonitoringCardView: View {
         }
 
         // Simulator button (only visible for Xcode projects)
-        if XcodeProjectDetector.isXcodeProject(at: session.projectPath) {
+        if isXcodeProject {
           Button(action: {
             simulatorSheetSession = session
           }) {
@@ -746,53 +756,11 @@ public struct MonitoringCardView: View {
   // MARK: - Path Row
 
   private var pathRow: some View {
-    HStack(spacing: 8) {
-      // Folder icon and path
-      HStack(spacing: 4) {
-        Image(systemName: "folder")
-          .font(.caption)
-          .foregroundStyle(.secondary)
-
-        Text(session.projectPath)
-          .font(.primaryCaption)
-          .foregroundStyle(.secondary)
-          .lineLimit(1)
-          .truncationMode(.middle)
-      }
-      .layoutPriority(1)
-
-      // Branch name in brand color
-      if let branch = session.branchName {
-        Text(branch)
-          .font(.primaryCaption)
-          .foregroundStyle(Color.brandPrimary(for: providerKind))
-          .lineLimit(1)
-          .layoutPriority(1)
-      }
-
-      Spacer(minLength: 8)
-
-      contentModeToggle
-        .layoutPriority(2)
-    }
-    .frame(minHeight: 24)
-  }
-
-  // MARK: - Content Mode Toggle
-
-  private var contentModeToggle: some View {
-    BracketedSegmentedControl(
-      selection: $contentMode,
-      items: MonitoringCardContentMode.allCases.map { mode in
-        BracketedSegmentedControlItem(
-          value: mode,
-          title: mode.label.lowercased(),
-          helpText: mode.label
-        )
-      },
-      selectedColor: Color.brandPrimary(for: providerKind)
+    MonitoringCardPathRow(
+      session: session,
+      providerKind: providerKind,
+      contentMode: $contentMode
     )
-    .help("Switch between terminal and code")
   }
 
   // MARK: - Monitor Content
@@ -808,7 +776,7 @@ public struct MonitoringCardView: View {
   }
 
   private var terminalContent: some View {
-    EmbeddedTerminalView(
+    MonitoringCardTerminalContent(
       terminalKey: terminalKey ?? session.id,
       sessionId: session.id,
       projectPath: session.projectPath,
@@ -825,8 +793,6 @@ public struct MonitoringCardView: View {
         viewModel?.consumeQueuedWebPreviewContextPrompt(for: session.id)
       }
     )
-    .padding(DesignTokens.Spacing.sm)
-    .frame(minHeight: 300)
   }
 
   private var editorContent: some View {
@@ -852,6 +818,94 @@ public struct MonitoringCardView: View {
         Capsule()
           .fill(Color.secondary.opacity(0.15))
       )
+  }
+}
+
+private enum MonitoringCardContentModeItems {
+  static let items = MonitoringCardContentMode.allCases.map { mode in
+    BracketedSegmentedControlItem(
+      value: mode,
+      title: mode.label.lowercased(),
+      helpText: mode.label
+    )
+  }
+}
+
+private struct MonitoringCardPathRow: View {
+  let session: CLISession
+  let providerKind: SessionProviderKind
+  @Binding var contentMode: MonitoringCardContentMode
+
+  var body: some View {
+    HStack(spacing: 8) {
+      HStack(spacing: 4) {
+        Image(systemName: "folder")
+          .font(.caption)
+          .foregroundStyle(.secondary)
+
+        Text(session.projectPath)
+          .font(.primaryCaption)
+          .foregroundStyle(.secondary)
+          .lineLimit(1)
+          .truncationMode(.middle)
+      }
+      .layoutPriority(1)
+
+      if let branch = session.branchName {
+        Text(branch)
+          .font(.primaryCaption)
+          .foregroundStyle(Color.brandPrimary(for: providerKind))
+          .lineLimit(1)
+          .layoutPriority(1)
+      }
+
+      Spacer(minLength: 8)
+
+      BracketedSegmentedControl(
+        selection: $contentMode,
+        items: MonitoringCardContentModeItems.items,
+        selectedColor: Color.brandPrimary(for: providerKind)
+      )
+      .layoutPriority(2)
+      .help("Switch between terminal and code")
+    }
+    .frame(minHeight: 24)
+  }
+}
+
+private struct MonitoringCardTerminalContent: View {
+  let terminalKey: String
+  let sessionId: String?
+  let projectPath: String
+  let cliConfiguration: CLICommandConfiguration
+  let initialPrompt: String?
+  let initialInputText: String?
+  let viewModel: CLISessionsViewModel?
+  let dangerouslySkipPermissions: Bool
+  let permissionModePlan: Bool
+  let worktreeName: String?
+  let onUserInteraction: (() -> Void)?
+  let onRequestShowEditor: (() -> Void)?
+  let consumeQueuedWebPreviewContextOnSubmit: (() -> String?)?
+
+  var body: some View {
+    EmbeddedTerminalView(
+      terminalKey: terminalKey,
+      sessionId: sessionId,
+      projectPath: projectPath,
+      cliConfiguration: cliConfiguration,
+      initialPrompt: initialPrompt,
+      initialInputText: initialInputText,
+      viewModel: viewModel,
+      dangerouslySkipPermissions: dangerouslySkipPermissions,
+      permissionModePlan: permissionModePlan,
+      worktreeName: worktreeName,
+      onUserInteraction: onUserInteraction,
+      onRequestShowEditor: onRequestShowEditor,
+      consumeQueuedWebPreviewContextOnSubmit: consumeQueuedWebPreviewContextOnSubmit
+    )
+    .padding(DesignTokens.Spacing.sm)
+    .frame(minHeight: 300)
   }
 }
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringItemsSnapshot.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringItemsSnapshot.swift
@@ -1,0 +1,56 @@
+//
+//  MonitoringItemsSnapshot.swift
+//  AgentHub
+//
+
+import Foundation
+
+struct MonitoringItemsSnapshot<Item: Identifiable> where Item.ID == String {
+  let allItems: [Item]
+  let visibleItems: [Item]
+  let groupedItems: [(modulePath: String, items: [Item])]
+  let flatSortedItems: [Item]
+  let effectivePrimaryItem: Item?
+
+  var effectivePrimaryItemID: String? {
+    effectivePrimaryItem?.id
+  }
+
+  var itemIDs: [String] {
+    allItems.map(\.id)
+  }
+
+  init(
+    items: [Item],
+    primaryItemID: String?,
+    layoutMode: HubLayoutMode,
+    modulePath: (Item) -> String,
+    timestamp: (Item) -> Date
+  ) {
+    self.allItems = items
+
+    let sortedItems = items.sorted { timestamp($0) > timestamp($1) }
+    if let primaryItemID,
+       let selectedItem = items.first(where: { $0.id == primaryItemID }) {
+      self.effectivePrimaryItem = selectedItem
+    } else {
+      self.effectivePrimaryItem = sortedItems.first
+    }
+
+    if layoutMode == .single, let effectivePrimaryItem {
+      self.visibleItems = [effectivePrimaryItem]
+    } else {
+      self.visibleItems = items
+    }
+
+    self.groupedItems = Dictionary(grouping: visibleItems, by: modulePath)
+      .sorted { $0.key < $1.key }
+      .map { group in
+        (
+          modulePath: group.key,
+          items: group.value.sorted { timestamp($0) > timestamp($1) }
+        )
+      }
+    self.flatSortedItems = groupedItems.flatMap(\.items)
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderMonitoringPanelView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderMonitoringPanelView.swift
@@ -216,11 +216,15 @@ public struct MultiProviderMonitoringPanelView: View {
     )
   }
 
-  private var wantsEmbeddedSidePanelPresentation: Bool {
+  private func wantsEmbeddedSidePanelPresentation(snapshot: MonitoringItemsSnapshot<ProviderMonitoringItem>) -> Bool {
     layoutMode == .single
       && maximizedSessionId == nil
       && sidePanelContent != nil
-      && !visibleItems.isEmpty
+      && !snapshot.visibleItems.isEmpty
+  }
+
+  private var wantsEmbeddedSidePanelPresentation: Bool {
+    wantsEmbeddedSidePanelPresentation(snapshot: makeItemSnapshot())
   }
 
   private var embeddedSidePanelTransition: AnyTransition {
@@ -249,12 +253,16 @@ public struct MultiProviderMonitoringPanelView: View {
   }
 
   public var body: some View {
+    let snapshot = makeItemSnapshot()
+    let wantsSidePanelPresentation = wantsEmbeddedSidePanelPresentation(snapshot: snapshot)
+    let auxiliaryTarget = auxiliaryShellTarget(snapshot: snapshot)
+
     GeometryReader { geometry in
       VStack(spacing: 0) {
-        mainContent
+        mainContent(snapshot: snapshot)
           .frame(maxWidth: .infinity, maxHeight: .infinity)
 
-        if isAuxiliaryShellVisible, let target = auxiliaryShellTarget {
+        if isAuxiliaryShellVisible, let target = auxiliaryTarget {
           auxiliaryShellDock(
             for: target,
             availableHeight: geometry.size.height
@@ -269,17 +277,17 @@ public struct MultiProviderMonitoringPanelView: View {
     .background(monitorContainerBackgroundColor)
     .cornerRadius(8)
     .onAppear {
-      onEmbeddedSidePanelVisibilityChange(wantsEmbeddedSidePanelPresentation)
-      syncEditorStates()
-      syncAuxiliaryShellDockState()
+      onEmbeddedSidePanelVisibilityChange(wantsSidePanelPresentation)
+      syncEditorStates(snapshot: snapshot)
+      syncAuxiliaryShellDockState(target: auxiliaryTarget)
     }
-    .onChange(of: wantsEmbeddedSidePanelPresentation) { _, wantsPresentation in
+    .onChange(of: wantsSidePanelPresentation) { _, wantsPresentation in
       onEmbeddedSidePanelVisibilityChange(wantsPresentation)
     }
-    .onChange(of: allItems.map(\.id)) { _, _ in
+    .onChange(of: snapshot.itemIDs) { _, _ in
       syncEditorStates()
     }
-    .onChange(of: effectivePrimarySessionId) { _, _ in
+    .onChange(of: snapshot.effectivePrimaryItemID) { _, _ in
       syncAuxiliaryShellDockState()
     }
     .onChange(of: isAuxiliaryShellVisible) { _, _ in
@@ -306,7 +314,7 @@ public struct MultiProviderMonitoringPanelView: View {
       togglePrimarySessionContentMode()
     }
     .floatingPanel(isPresented: $showQuickFilePicker, defaultSize: CGSize(width: 680, height: 640)) {
-      if let primaryItem = effectivePrimaryItem {
+      if let primaryItem = snapshot.effectivePrimaryItem {
         QuickFilePickerView(
           isPresented: $showQuickFilePicker,
           projectPath: editorState(for: primaryItem).projectPath,
@@ -353,17 +361,18 @@ public struct MultiProviderMonitoringPanelView: View {
       return .ignored
     }
     .onAppear {
+      ensurePrimarySelection(snapshot: snapshot)
+    }
+    .onChange(of: snapshot.itemIDs) { _, _ in
       ensurePrimarySelection()
     }
-    .onChange(of: allItems.map(\.id)) { _, _ in
-      ensurePrimarySelection()
-    }
-    .onChange(of: effectivePrimarySessionId) { _, newId in
+    .onChange(of: snapshot.effectivePrimaryItemID) { _, newId in
       guard let currentSidePanelContent = sidePanelContent else { return }
+      let currentSnapshot = makeItemSnapshot()
       if case .webPreview(let sessionId, _, let projectPath, let mode) = currentSidePanelContent,
          sessionId.hasPrefix("pending-"),
          let newId,
-         let item = allItems.first(where: { $0.id == newId }),
+         let item = currentSnapshot.allItems.first(where: { $0.id == newId }),
          case .monitored(_, _, let session, _) = item,
          session.projectPath == projectPath {
         sidePanelContent = .webPreview(
@@ -378,7 +387,7 @@ public struct MultiProviderMonitoringPanelView: View {
     }
     .onChange(of: primarySessionId) { _, newId in
       guard let newId else { return }
-      if let item = allItems.first(where: { $0.id == newId }) {
+      if let item = makeItemSnapshot().allItems.first(where: { $0.id == newId }) {
         item.viewModel.focusTerminal(forKey: item.sessionId)
       }
     }
@@ -409,25 +418,25 @@ public struct MultiProviderMonitoringPanelView: View {
   }
 
   @ViewBuilder
-  private var mainContent: some View {
+  private func mainContent(snapshot: MonitoringItemsSnapshot<ProviderMonitoringItem>) -> some View {
     if let maximizedId = maximizedSessionId {
-      maximizedCardContent(for: maximizedId)
+      maximizedCardContent(for: maximizedId, snapshot: snapshot)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(maximizedContainerBackgroundColor)
     } else {
-      mainContentBody
+      mainContentBody(snapshot: snapshot)
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
     }
   }
 
   @ViewBuilder
-  private var mainContentBody: some View {
+  private func mainContentBody(snapshot: MonitoringItemsSnapshot<ProviderMonitoringItem>) -> some View {
     if isLoading {
       loadingState
-    } else if allItems.isEmpty {
+    } else if snapshot.allItems.isEmpty {
       emptyState
     } else {
-      monitoredSessionsList
+      monitoredSessionsList(snapshot: snapshot)
     }
   }
 
@@ -460,9 +469,9 @@ public struct MultiProviderMonitoringPanelView: View {
   // MARK: - Monitored Sessions List
 
   @ViewBuilder
-  private var monitoredSessionsList: some View {
+  private func monitoredSessionsList(snapshot: MonitoringItemsSnapshot<ProviderMonitoringItem>) -> some View {
     if layoutMode == .single {
-      singleModeContent
+      singleModeContent(snapshot: snapshot)
         .background(
           GeometryReader { geometry in
             Color.clear
@@ -476,20 +485,20 @@ public struct MultiProviderMonitoringPanelView: View {
       ScrollViewReader { proxy in
         ScrollView {
           if layoutMode == .list {
-            listModeContent
+            listModeContent(snapshot: snapshot)
           } else {
             let columns = Array(repeating: GridItem(.flexible(), alignment: .top), count: layoutMode.columnCount)
             if flatSessionLayout {
               LazyVGrid(columns: columns, spacing: 12) {
-                ForEach(flatSortedItems) { item in
-                  itemCardView(for: item)
+                ForEach(snapshot.flatSortedItems) { item in
+                  itemCardView(for: item, effectivePrimaryItemID: snapshot.effectivePrimaryItemID)
                 }
               }
               .padding(12)
               .transition(.opacity)
             } else {
               LazyVGrid(columns: columns, spacing: 12, pinnedViews: [.sectionHeaders]) {
-                monitoredSessionsGroupedContent
+                monitoredSessionsGroupedContent(snapshot: snapshot)
               }
               .padding(12)
               .transition(.opacity)
@@ -509,14 +518,14 @@ public struct MultiProviderMonitoringPanelView: View {
   }
 
   @ViewBuilder
-  private var listModeContent: some View {
+  private func listModeContent(snapshot: MonitoringItemsSnapshot<ProviderMonitoringItem>) -> some View {
     VStack(spacing: 12) {
       if flatSessionLayout {
-        ForEach(flatSortedItems) { item in
-          listModeCard(for: item)
+        ForEach(snapshot.flatSortedItems) { item in
+          listModeCard(for: item, effectivePrimaryItemID: snapshot.effectivePrimaryItemID)
         }
       } else {
-        listModeGroupedContent
+        listModeGroupedContent(snapshot: snapshot)
       }
     }
     .padding(12)
@@ -526,8 +535,8 @@ public struct MultiProviderMonitoringPanelView: View {
   // MARK: - Single Mode Content
 
   @ViewBuilder
-  private var singleModeContent: some View {
-    if let item = visibleItems.first {
+  private func singleModeContent(snapshot: MonitoringItemsSnapshot<ProviderMonitoringItem>) -> some View {
+    if let item = snapshot.visibleItems.first {
       switch item {
       case .pending(_, let viewModel, let pending):
         let pendingId = "pending-\(pending.id.uuidString)"
@@ -840,8 +849,11 @@ public struct MultiProviderMonitoringPanelView: View {
   // MARK: - Single Card View
 
   @ViewBuilder
-  private func itemCardView(for item: ProviderMonitoringItem) -> some View {
-    let isPrimary = item.id == effectivePrimarySessionId
+  private func itemCardView(
+    for item: ProviderMonitoringItem,
+    effectivePrimaryItemID: String? = nil
+  ) -> some View {
+    let isPrimary = item.id == (effectivePrimaryItemID ?? effectivePrimarySessionId)
       switch item {
       case .pending(_, let viewModel, let pending):
         MonitoringCardView(
@@ -1004,9 +1016,9 @@ public struct MultiProviderMonitoringPanelView: View {
   // MARK: - Grouped Content by Module
 
   @ViewBuilder
-  private var listModeGroupedContent: some View {
+  private func listModeGroupedContent(snapshot: MonitoringItemsSnapshot<ProviderMonitoringItem>) -> some View {
     VStack(alignment: .leading, spacing: 18) {
-      ForEach(groupedMonitoredSessions, id: \.modulePath) { group in
+      ForEach(snapshot.groupedItems, id: \.modulePath) { group in
         VStack(alignment: .leading, spacing: 12) {
           ModuleSectionHeader(
             name: URL(fileURLWithPath: group.modulePath).lastPathComponent,
@@ -1014,7 +1026,7 @@ public struct MultiProviderMonitoringPanelView: View {
           )
 
           ForEach(group.items) { item in
-            listModeCard(for: item)
+            listModeCard(for: item, effectivePrimaryItemID: snapshot.effectivePrimaryItemID)
           }
         }
       }
@@ -1022,40 +1034,46 @@ public struct MultiProviderMonitoringPanelView: View {
   }
 
   @ViewBuilder
-  private var monitoredSessionsGroupedContent: some View {
-    ForEach(groupedMonitoredSessions, id: \.modulePath) { group in
+  private func monitoredSessionsGroupedContent(snapshot: MonitoringItemsSnapshot<ProviderMonitoringItem>) -> some View {
+    ForEach(snapshot.groupedItems, id: \.modulePath) { group in
       Section(header: ModuleSectionHeader(
         name: URL(fileURLWithPath: group.modulePath).lastPathComponent,
         sessionCount: group.items.count
       )) {
         ForEach(group.items) { item in
-          itemCardView(for: item)
+          itemCardView(for: item, effectivePrimaryItemID: snapshot.effectivePrimaryItemID)
         }
       }
     }
   }
 
   private var effectivePrimarySessionId: String? {
-    if let current = primarySessionId, allItems.contains(where: { $0.id == current }) {
-      return current
-    }
-    return allItems.sorted { $0.timestamp > $1.timestamp }.first?.id
+    makeItemSnapshot().effectivePrimaryItemID
   }
 
   private var visibleItems: [ProviderMonitoringItem] {
-    if layoutMode == .single {
-      guard let selectedId = effectivePrimarySessionId else { return [] }
-      return allItems.filter { $0.id == selectedId }
-    }
-    return allItems
+    makeItemSnapshot().visibleItems
+  }
+
+  private func makeItemSnapshot() -> MonitoringItemsSnapshot<ProviderMonitoringItem> {
+    MonitoringItemsSnapshot(
+      items: allItems,
+      primaryItemID: primarySessionId,
+      layoutMode: layoutMode,
+      modulePath: { findModulePath(for: $0) },
+      timestamp: { $0.timestamp }
+    )
   }
 
   // MARK: - Helpers
 
   @ViewBuilder
-  private func maximizedCardContent(for itemId: String) -> some View {
-    if let item = allItems.first(where: { $0.id == itemId }) {
-      let isPrimary = item.id == effectivePrimarySessionId
+  private func maximizedCardContent(
+    for itemId: String,
+    snapshot: MonitoringItemsSnapshot<ProviderMonitoringItem>
+  ) -> some View {
+    if let item = snapshot.allItems.first(where: { $0.id == itemId }) {
+      let isPrimary = item.id == snapshot.effectivePrimaryItemID
       switch item {
       case .pending(_, let viewModel, let pending):
         MonitoringCardView(
@@ -1246,22 +1264,23 @@ public struct MultiProviderMonitoringPanelView: View {
   }
 
   private var groupedMonitoredSessions: [(modulePath: String, items: [ProviderMonitoringItem])] {
-    let grouped = Dictionary(grouping: visibleItems) { findModulePath(for: $0) }
-    return grouped.sorted { $0.key < $1.key }
-      .map { (modulePath: $0.key, items: $0.value.sorted { $0.timestamp > $1.timestamp }) }
+    makeItemSnapshot().groupedItems
   }
 
   private var flatSortedItems: [ProviderMonitoringItem] {
-    groupedMonitoredSessions.flatMap { $0.items }
+    makeItemSnapshot().flatSortedItems
   }
 
   private var effectivePrimaryItem: ProviderMonitoringItem? {
-    guard let selectedId = effectivePrimarySessionId else { return nil }
-    return allItems.first(where: { $0.id == selectedId })
+    makeItemSnapshot().effectivePrimaryItem
   }
 
   private var auxiliaryShellTarget: HubAuxiliaryShellTarget? {
-    guard let item = effectivePrimaryItem else { return nil }
+    auxiliaryShellTarget(snapshot: makeItemSnapshot())
+  }
+
+  private func auxiliaryShellTarget(snapshot: MonitoringItemsSnapshot<ProviderMonitoringItem>) -> HubAuxiliaryShellTarget? {
+    guard let item = snapshot.effectivePrimaryItem else { return nil }
 
     switch item {
     case .pending(let provider, let viewModel, let pending):
@@ -1372,17 +1391,18 @@ public struct MultiProviderMonitoringPanelView: View {
     print("[AH-OPEN][AgentHub] \(message())")
   }
 
-  private func ensurePrimarySelection() {
-    guard !allItems.isEmpty else {
+  private func ensurePrimarySelection(snapshot: MonitoringItemsSnapshot<ProviderMonitoringItem>? = nil) {
+    let snapshot = snapshot ?? makeItemSnapshot()
+    guard !snapshot.allItems.isEmpty else {
       primarySessionId = nil
       return
     }
 
-    if let current = primarySessionId, allItems.contains(where: { $0.id == current }) {
+    if let current = primarySessionId, snapshot.allItems.contains(where: { $0.id == current }) {
       return
     }
 
-    primarySessionId = effectivePrimarySessionId
+    primarySessionId = snapshot.effectivePrimaryItemID
   }
 
   private func setPrimarySessionIfNeeded(_ sessionId: String) {
@@ -1397,9 +1417,9 @@ public struct MultiProviderMonitoringPanelView: View {
     }
   }
 
-  private func syncAuxiliaryShellDockState() {
+  private func syncAuxiliaryShellDockState(target: HubAuxiliaryShellTarget? = nil) {
     guard isAuxiliaryShellVisible else { return }
-    guard let target = auxiliaryShellTarget else {
+    guard let target = target ?? auxiliaryShellTarget else {
       withAnimation(auxiliaryShellToggleAnimation) {
         isAuxiliaryShellVisible = false
       }
@@ -1449,12 +1469,15 @@ public struct MultiProviderMonitoringPanelView: View {
   }
 
   @ViewBuilder
-  private func listModeCard(for item: ProviderMonitoringItem) -> some View {
+  private func listModeCard(
+    for item: ProviderMonitoringItem,
+    effectivePrimaryItemID: String? = nil
+  ) -> some View {
     ResizableCardContainer(
       height: cardHeightBinding(for: item.id),
       metrics: listCardMetrics(for: item)
     ) {
-      itemCardView(for: item)
+      itemCardView(for: item, effectivePrimaryItemID: effectivePrimaryItemID)
     }
   }
 
@@ -1497,10 +1520,11 @@ public struct MultiProviderMonitoringPanelView: View {
     )
   }
 
-  private func syncEditorStates() {
+  private func syncEditorStates(snapshot: MonitoringItemsSnapshot<ProviderMonitoringItem>? = nil) {
+    let snapshot = snapshot ?? makeItemSnapshot()
     editorStates = MonitoringEditorStateStore.prune(
       editorStates,
-      validItemIDs: Set(allItems.map(\.id))
+      validItemIDs: Set(snapshot.itemIDs)
     )
   }
 

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/AuxiliaryShellTerminalHostViewTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/AuxiliaryShellTerminalHostViewTests.swift
@@ -39,6 +39,20 @@ struct AuxiliaryShellTerminalHostViewTests {
     #expect(hostView.mountedTerminalKey == "session-a")
   }
 
+  @Test("Mounted state matches the terminal instance and key")
+  @MainActor
+  func mountedStateRequiresSameTerminalAndKey() {
+    let hostView = AuxiliaryShellTerminalHostView(frame: NSRect(x: 0, y: 0, width: 800, height: 400))
+    let firstTerminal = TerminalContainerView()
+    let secondTerminal = TerminalContainerView()
+
+    hostView.mount(firstTerminal, key: "session-a")
+
+    #expect(hostView.isMounted(firstTerminal, key: "session-a"))
+    #expect(!hostView.isMounted(firstTerminal, key: "session-b"))
+    #expect(!hostView.isMounted(secondTerminal, key: "session-a"))
+  }
+
   @Test("Unmount removes the currently mounted terminal")
   @MainActor
   func unmountRemovesTerminal() {

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/MonitoringItemsSnapshotTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/MonitoringItemsSnapshotTests.swift
@@ -1,0 +1,95 @@
+import Foundation
+import Testing
+
+@testable import AgentHubCore
+
+private struct SnapshotItem: Identifiable {
+  let id: String
+  let modulePath: String
+  let timestamp: Date
+}
+
+@Suite("MonitoringItemsSnapshot")
+struct MonitoringItemsSnapshotTests {
+  @Test("Single layout exposes only the selected primary item")
+  func singleLayoutUsesPrimaryItem() throws {
+    let older = SnapshotItem(
+      id: "claude-old",
+      modulePath: "/tmp/repo-a",
+      timestamp: Date(timeIntervalSince1970: 100)
+    )
+    let newer = SnapshotItem(
+      id: "codex-new",
+      modulePath: "/tmp/repo-b",
+      timestamp: Date(timeIntervalSince1970: 200)
+    )
+
+    let snapshot = MonitoringItemsSnapshot(
+      items: [older, newer],
+      primaryItemID: older.id,
+      layoutMode: .single,
+      modulePath: { $0.modulePath },
+      timestamp: { $0.timestamp }
+    )
+
+    #expect(snapshot.effectivePrimaryItemID == older.id)
+    #expect(snapshot.visibleItems.map(\.id) == [older.id])
+    #expect(snapshot.flatSortedItems.map(\.id) == [older.id])
+  }
+
+  @Test("Missing primary falls back to the newest item")
+  func missingPrimaryUsesNewestItem() {
+    let older = SnapshotItem(
+      id: "claude-old",
+      modulePath: "/tmp/repo-a",
+      timestamp: Date(timeIntervalSince1970: 100)
+    )
+    let newer = SnapshotItem(
+      id: "codex-new",
+      modulePath: "/tmp/repo-a",
+      timestamp: Date(timeIntervalSince1970: 200)
+    )
+
+    let snapshot = MonitoringItemsSnapshot(
+      items: [older, newer],
+      primaryItemID: "missing",
+      layoutMode: .single,
+      modulePath: { $0.modulePath },
+      timestamp: { $0.timestamp }
+    )
+
+    #expect(snapshot.effectivePrimaryItemID == newer.id)
+    #expect(snapshot.visibleItems.map(\.id) == [newer.id])
+  }
+
+  @Test("Multi-item layouts group by module and sort groups by recent activity")
+  func groupsAndSortsVisibleItems() {
+    let first = SnapshotItem(
+      id: "first",
+      modulePath: "/tmp/repo-b",
+      timestamp: Date(timeIntervalSince1970: 100)
+    )
+    let second = SnapshotItem(
+      id: "second",
+      modulePath: "/tmp/repo-a",
+      timestamp: Date(timeIntervalSince1970: 300)
+    )
+    let third = SnapshotItem(
+      id: "third",
+      modulePath: "/tmp/repo-a",
+      timestamp: Date(timeIntervalSince1970: 200)
+    )
+
+    let snapshot = MonitoringItemsSnapshot(
+      items: [first, second, third],
+      primaryItemID: nil,
+      layoutMode: .list,
+      modulePath: { $0.modulePath },
+      timestamp: { $0.timestamp }
+    )
+
+    #expect(snapshot.groupedItems.map(\.modulePath) == ["/tmp/repo-a", "/tmp/repo-b"])
+    #expect(snapshot.groupedItems.first?.items.map(\.id) == [second.id, third.id])
+    #expect(snapshot.flatSortedItems.map(\.id) == [second.id, third.id, first.id])
+  }
+}


### PR DESCRIPTION
## Summary

- Adds a `MonitoringItemsSnapshot` helper so the monitoring panel computes visible, grouped, and primary items once per render path.
- Avoids redundant embedded terminal remounts by checking the mounted terminal instance/key before calling `mount`.
- Moves Xcode project detection out of the monitoring card header body and extracts smaller card subviews.

## Why

A launch profile showed main-thread hangs around SwiftUI/AppKit layout and terminal mounting. This keeps the first pass low risk by reducing repeated render-time work without changing terminal process lifecycle, persistence, or session behavior.

## Validation

Passed:

- `swift test --filter MonitoringItemsSnapshotTests`
- `swift test --filter AuxiliaryShellTerminalHostViewTests`
- `swift test --filter AuxiliaryShellTerminalManagementTests`
- `swift test --filter MonitoringEditorStateTests`
- `git diff --check`

Profiling follow-up:

- A new 30s attach trace reported no exported hang events and no Time Profiler bottlenecks.

Caveat:

- Full `swift test` is still failing in `SessionJSONLParserURLTests` with URL extraction expectations returning zero results, then the Swift Testing helper exits with signal 5. Those failures are outside this UI/terminal diff.