### PR TITLE
[codex] Smooth embedded side panel transitions

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/EmbeddedSidePanelPresentationState.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/EmbeddedSidePanelPresentationState.swift
@@ -1,0 +1,81 @@
+//
+//  EmbeddedSidePanelPresentationState.swift
+//  AgentHub
+//
+
+import SwiftUI
+
+@MainActor
+@Observable
+final class EmbeddedSidePanelPresentationState<Payload: Equatable> {
+  private enum DeferredTransition {
+    case mount(id: UInt64, payload: Payload)
+    case removeShell(id: UInt64)
+
+    var id: UInt64 {
+      switch self {
+      case .mount(let id, _), .removeShell(let id):
+        return id
+      }
+    }
+  }
+
+  private(set) var shellPayload: Payload?
+  private(set) var mountedPayload: Payload?
+
+  private var transitionID: UInt64 = 0
+  private var deferredTransition: DeferredTransition?
+
+  var currentPayload: Payload? {
+    mountedPayload ?? shellPayload
+  }
+
+  @discardableResult
+  func open(_ payload: Payload) -> UInt64 {
+    transitionID += 1
+    let id = transitionID
+
+    withAnimationsDisabled {
+      shellPayload = payload
+      mountedPayload = nil
+    }
+    deferredTransition = .mount(id: id, payload: payload)
+
+    return id
+  }
+
+  @discardableResult
+  func close() -> UInt64 {
+    transitionID += 1
+    let id = transitionID
+
+    mountedPayload = nil
+    deferredTransition = .removeShell(id: id)
+
+    return id
+  }
+
+  func completeDeferredTransition(id: UInt64) {
+    guard let deferredTransition, deferredTransition.id == id else { return }
+
+    switch deferredTransition {
+    case .mount(_, let payload):
+      guard shellPayload == payload else { return }
+      mountedPayload = payload
+
+    case .removeShell:
+      guard mountedPayload == nil else { return }
+      withAnimationsDisabled {
+        shellPayload = nil
+      }
+    }
+
+    self.deferredTransition = nil
+  }
+
+  private func withAnimationsDisabled(_ updates: () -> Void) {
+    var transaction = Transaction()
+    transaction.disablesAnimations = true
+    withTransaction(transaction, updates)
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderMonitoringPanelView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderMonitoringPanelView.swift
@@ -39,6 +39,12 @@ private enum SidePanelContent: Equatable {
   }
 }
 
+private struct SidePanelPayload: Equatable {
+  let itemID: String
+  let providerKind: SessionProviderKind
+  let content: SidePanelContent
+}
+
 // MARK: - GitHubPopOutItem
 
 private struct GitHubPopOutItem: Identifiable {
@@ -179,7 +185,7 @@ public struct MultiProviderMonitoringPanelView: View {
 
   @State private var sessionFileSheetItem: SessionFileSheetItem?
   @State private var maximizedSessionId: String?
-  @State private var sidePanelContent: SidePanelContent?
+  @State private var sidePanelPresentation = EmbeddedSidePanelPresentationState<SidePanelPayload>()
   @State private var editorStates: [String: MonitoringEditorState] = [:]
   @State private var availableDetailWidth: CGFloat = 0
   @Binding var primarySessionId: String?
@@ -219,23 +225,12 @@ public struct MultiProviderMonitoringPanelView: View {
   private func wantsEmbeddedSidePanelPresentation(snapshot: MonitoringItemsSnapshot<ProviderMonitoringItem>) -> Bool {
     layoutMode == .single
       && maximizedSessionId == nil
-      && sidePanelContent != nil
+      && sidePanelPresentation.shellPayload != nil
       && !snapshot.visibleItems.isEmpty
   }
 
   private var wantsEmbeddedSidePanelPresentation: Bool {
     wantsEmbeddedSidePanelPresentation(snapshot: makeItemSnapshot())
-  }
-
-  private var embeddedSidePanelTransition: AnyTransition {
-    .asymmetric(
-      insertion: .move(edge: .trailing).combined(with: .opacity),
-      removal: .move(edge: .trailing).combined(with: .opacity)
-    )
-  }
-
-  private var isEmbeddedSidePanelVisible: Bool {
-    wantsEmbeddedSidePanelPresentation
   }
 
   public init(
@@ -367,22 +362,28 @@ public struct MultiProviderMonitoringPanelView: View {
       ensurePrimarySelection()
     }
     .onChange(of: snapshot.effectivePrimaryItemID) { _, newId in
-      guard let currentSidePanelContent = sidePanelContent else { return }
+      guard let currentSidePanelPayload = sidePanelPresentation.currentPayload else { return }
       let currentSnapshot = makeItemSnapshot()
-      if case .webPreview(let sessionId, _, let projectPath, let mode) = currentSidePanelContent,
+      if case .webPreview(let sessionId, _, let projectPath, let mode) = currentSidePanelPayload.content,
          sessionId.hasPrefix("pending-"),
          let newId,
          let item = currentSnapshot.allItems.first(where: { $0.id == newId }),
          case .monitored(_, _, let session, _) = item,
          session.projectPath == projectPath {
-        sidePanelContent = .webPreview(
-          sessionId: session.id,
-          session: session,
-          projectPath: session.projectPath,
-          mode: mode
+        openEmbeddedSidePanel(
+          SidePanelPayload(
+            itemID: item.id,
+            providerKind: item.providerKind,
+            content: .webPreview(
+              sessionId: session.id,
+              session: session,
+              projectPath: session.projectPath,
+              mode: mode
+            )
+          )
         )
       } else {
-        sidePanelContent = nil
+        closeEmbeddedSidePanel()
       }
     }
     .onChange(of: primarySessionId) { _, newId in
@@ -407,6 +408,24 @@ public struct MultiProviderMonitoringPanelView: View {
       return Color.adaptiveBackground(for: colorScheme, theme: runtimeTheme)
     }
     return defaultBackground
+  }
+
+  private var embeddedSidePanelContentAnimation: Animation {
+    accessibilityReduceMotion ? .easeOut(duration: 0.08) : .timingCurve(0.22, 1, 0.36, 1, duration: 0.26)
+  }
+
+  private var embeddedSidePanelCloseShellDelay: Duration {
+    accessibilityReduceMotion ? .milliseconds(50) : .milliseconds(120)
+  }
+
+  private var embeddedSidePanelContentTransition: AnyTransition {
+    if accessibilityReduceMotion {
+      return .opacity
+    }
+    return .asymmetric(
+      insertion: .move(edge: .trailing).combined(with: .opacity),
+      removal: .move(edge: .trailing).combined(with: .opacity)
+    )
   }
 
   private var auxiliaryShellToggleAnimation: Animation {
@@ -600,8 +619,7 @@ public struct MultiProviderMonitoringPanelView: View {
             isMaximized: false,
             onToggleMaximize: { },
             isPrimarySession: true,
-            showPrimaryIndicator: false,
-            isSidePanelOpen: sidePanelContent != nil
+            showPrimaryIndicator: false
           )
           .id(pendingId)
           .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -688,8 +706,7 @@ public struct MultiProviderMonitoringPanelView: View {
             isMaximized: false,
             onToggleMaximize: { },
             isPrimarySession: true,
-            showPrimaryIndicator: false,
-            isSidePanelOpen: sidePanelContent != nil
+            showPrimaryIndicator: false
           )
           .id(session.id)
           .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -708,7 +725,7 @@ public struct MultiProviderMonitoringPanelView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
         .blursWhileResizing()
 
-      if let panelContent = sidePanelContent {
+      if let shellPayload = sidePanelPresentation.shellPayload {
         ResizablePanelContainer(
           side: .trailing,
           minWidth: embeddedSidePanelMinWidth,
@@ -716,13 +733,21 @@ public struct MultiProviderMonitoringPanelView: View {
           defaultWidth: min(embeddedSidePanelDefaultWidth, allowedEmbeddedSidePanelWidth),
           userDefaultsKey: AgentHubDefaults.sidePanelWidth
         ) {
-          sidePanelView(for: panelContent, viewModel: viewModel)
+          ZStack {
+            if let mountedPayload = sidePanelPresentation.mountedPayload,
+               mountedPayload == shellPayload {
+              sidePanelView(for: mountedPayload, viewModel: viewModel)
+                .transition(embeddedSidePanelContentTransition)
+            } else {
+              Color.clear
+            }
+          }
+          .frame(maxWidth: .infinity, maxHeight: .infinity)
+          .clipped()
         }
-        .transition(embeddedSidePanelTransition)
+        .animation(embeddedSidePanelContentAnimation, value: sidePanelPresentation.mountedPayload)
       }
     }
-    .animation(.easeInOut(duration: 0.25), value: sidePanelContent)
-    .animation(.easeInOut(duration: 0.25), value: isEmbeddedSidePanelVisible)
   }
 
   private func presentWebPreviewInSidePanel(forItemID itemID: String, session: CLISession, projectPath: String, mode: WebPreviewMode) {
@@ -735,7 +760,13 @@ public struct MultiProviderMonitoringPanelView: View {
   /// Ensures the single-mode inline layout is active for `itemID`, then toggles the requested
   /// side panel content (open if not already presenting it; close if re-selected).
   private func toggleSidePanel(_ content: SidePanelContent, forItemID itemID: String) {
-    withAnimation(.easeInOut(duration: 0.25)) {
+    let payload = SidePanelPayload(
+      itemID: itemID,
+      providerKind: providerKind(forItemID: itemID),
+      content: content
+    )
+
+    performWithoutAnimation {
       if primarySessionId != itemID {
         primarySessionId = itemID
       }
@@ -746,35 +777,55 @@ public struct MultiProviderMonitoringPanelView: View {
         maximizedSessionId = nil
       }
     }
-    if sidePanelContent == content {
+
+    if sidePanelPresentation.currentPayload == payload {
       closeEmbeddedSidePanel()
     } else {
-      openEmbeddedSidePanel(content)
+      openEmbeddedSidePanel(payload)
     }
   }
 
-  private func openEmbeddedSidePanel(_ content: SidePanelContent) {
-    withAnimation(.easeInOut(duration: 0.25)) {
-      sidePanelContent = content
-    }
+  private func openEmbeddedSidePanel(_ payload: SidePanelPayload) {
+    let transitionID = sidePanelPresentation.open(payload)
+    completeDeferredSidePanelTransition(transitionID)
   }
 
   private func closeEmbeddedSidePanel() {
-    withAnimation(.easeInOut(duration: 0.25)) {
-      sidePanelContent = nil
+    let transitionID = sidePanelPresentation.close()
+    completeDeferredSidePanelTransition(transitionID, delay: embeddedSidePanelCloseShellDelay)
+  }
+
+  private func completeDeferredSidePanelTransition(_ transitionID: UInt64, delay: Duration? = nil) {
+    Task { @MainActor [sidePanelPresentation] in
+      if let delay {
+        try? await Task.sleep(for: delay)
+      } else {
+        await Task.yield()
+      }
+      sidePanelPresentation.completeDeferredTransition(id: transitionID)
     }
   }
 
+  private func providerKind(forItemID itemID: String) -> SessionProviderKind {
+    allItems.first(where: { $0.id == itemID })?.providerKind ?? .claude
+  }
+
+  private func performWithoutAnimation(_ updates: () -> Void) {
+    var transaction = Transaction()
+    transaction.disablesAnimations = true
+    withTransaction(transaction, updates)
+  }
+
   @ViewBuilder
-  private func sidePanelView(for content: SidePanelContent, viewModel: CLISessionsViewModel) -> some View {
-    switch content {
+  private func sidePanelView(for payload: SidePanelPayload, viewModel: CLISessionsViewModel) -> some View {
+    switch payload.content {
     case .diff(_, let session, let projectPath):
       GitDiffView(
         session: session,
         projectPath: projectPath,
-        onDismiss: { withAnimation(.easeInOut(duration: 0.25)) { sidePanelContent = nil } },
+        onDismiss: closeEmbeddedSidePanel,
         cliConfiguration: viewModel.cliConfiguration,
-        providerKind: visibleItems.first?.providerKind ?? .claude,
+        providerKind: payload.providerKind,
         onInlineRequestSubmit: { prompt, sess in viewModel.showTerminalWithPrompt(for: sess, prompt: prompt) },
         isEmbedded: true
       )
@@ -782,9 +833,9 @@ public struct MultiProviderMonitoringPanelView: View {
       PlanView(
         session: session,
         planState: planState,
-        onDismiss: { withAnimation(.easeInOut(duration: 0.25)) { sidePanelContent = nil } },
+        onDismiss: closeEmbeddedSidePanel,
         isEmbedded: true,
-        providerKind: visibleItems.first?.providerKind ?? .claude,
+        providerKind: payload.providerKind,
         onSendFeedback: { feedback, sess in
           viewModel.showTerminalWithPrompt(for: sess, prompt: feedback)
         }
@@ -793,7 +844,7 @@ public struct MultiProviderMonitoringPanelView: View {
       WebPreviewView(
         session: session,
         projectPath: projectPath,
-        onDismiss: { withAnimation(.easeInOut(duration: 0.25)) { sidePanelContent = nil } },
+        onDismiss: closeEmbeddedSidePanel,
         isEmbedded: true,
         onInspectSubmit: { prompt, sess in
           if !viewModel.sendPromptToActiveTerminal(forKey: sess.id, prompt: prompt) {
@@ -811,18 +862,18 @@ public struct MultiProviderMonitoringPanelView: View {
     case .mermaid(_, let session):
       MermaidDiagramView(
         session: session,
-        onDismiss: { withAnimation(.easeInOut(duration: 0.25)) { sidePanelContent = nil } },
+        onDismiss: closeEmbeddedSidePanel,
         isEmbedded: true
       )
     case .gitHub(_, let session, let projectPath):
       GitHubPanelView(
         projectPath: projectPath,
-        onDismiss: { withAnimation(.easeInOut(duration: 0.25)) { sidePanelContent = nil } },
+        onDismiss: closeEmbeddedSidePanel,
         isEmbedded: true,
         session: session,
         onSendToSession: { prompt, sess in viewModel.showTerminalWithPrompt(for: sess, prompt: prompt) },
         onPopOut: {
-          withAnimation(.easeInOut(duration: 0.25)) { sidePanelContent = nil }
+          closeEmbeddedSidePanel()
           gitHubPopOutItem = GitHubPopOutItem(session: session, projectPath: projectPath)
         }
       )
@@ -831,7 +882,7 @@ public struct MultiProviderMonitoringPanelView: View {
         PendingChangesView(
           session: session,
           pendingToolUse: pendingToolUse,
-          onDismiss: { withAnimation(.easeInOut(duration: 0.25)) { sidePanelContent = nil } },
+          onDismiss: closeEmbeddedSidePanel,
           isEmbedded: true,
           onApprovalResponse: { response, sess in
             viewModel.showTerminalWithPrompt(for: sess, prompt: response)
@@ -840,7 +891,7 @@ public struct MultiProviderMonitoringPanelView: View {
       } else {
         PendingChangesWaitingView(
           session: session,
-          onDismiss: { withAnimation(.easeInOut(duration: 0.25)) { sidePanelContent = nil } }
+          onDismiss: closeEmbeddedSidePanel
         )
       }
     }

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
@@ -237,6 +237,11 @@ public struct MultiProviderSessionsListView: View {
         .frame(minWidth: 300)
         .padding(.vertical, 8)
         .padding(.horizontal, 8)
+        .background {
+          NSSplitViewAutosaveDisabler()
+            .frame(width: 0, height: 0)
+            .allowsHitTesting(false)
+        }
       }
       .navigationSplitViewStyle(.balanced)
       .background(appBackground.ignoresSafeArea())
@@ -1516,9 +1521,7 @@ public struct MultiProviderSessionsListView: View {
       }
 
       sidebarVisibilityBeforeAutoHide = columnVisibility
-      withAnimation(.easeInOut(duration: 0.2)) {
-        columnVisibility = .detailOnly
-      }
+      columnVisibility = .detailOnly
       return
     }
 
@@ -1526,9 +1529,7 @@ public struct MultiProviderSessionsListView: View {
     sidebarVisibilityBeforeAutoHide = nil
 
     guard columnVisibility == .detailOnly else { return }
-    withAnimation(.easeInOut(duration: 0.2)) {
-      columnVisibility = previousVisibility
-    }
+    columnVisibility = previousVisibility
   }
 
   private func triggerNewSessionFlow(preferredRepositoryPath: String? = nil) {

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/NSSplitViewAutosaveDisabler.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/NSSplitViewAutosaveDisabler.swift
@@ -1,0 +1,55 @@
+//
+//  NSSplitViewAutosaveDisabler.swift
+//  AgentHub
+//
+
+import AppKit
+import SwiftUI
+
+struct NSSplitViewAutosaveDisabler: NSViewRepresentable {
+  func makeNSView(context: Context) -> ProbeView {
+    ProbeView()
+  }
+
+  func updateNSView(_ nsView: ProbeView, context: Context) {
+    nsView.disableAutosaveSoon()
+  }
+
+  @discardableResult
+  static func disableNearestSplitViewAutosave(from view: NSView) -> NSSplitView? {
+    guard let splitView = nearestSplitView(from: view) else { return nil }
+    splitView.autosaveName = nil
+    return splitView
+  }
+
+  static func nearestSplitView(from view: NSView) -> NSSplitView? {
+    var candidate: NSView? = view
+    while let current = candidate {
+      if let splitView = current as? NSSplitView {
+        return splitView
+      }
+      candidate = current.superview
+    }
+    return nil
+  }
+
+  final class ProbeView: NSView {
+    override func viewDidMoveToSuperview() {
+      super.viewDidMoveToSuperview()
+      disableAutosaveSoon()
+    }
+
+    override func viewDidMoveToWindow() {
+      super.viewDidMoveToWindow()
+      disableAutosaveSoon()
+    }
+
+    func disableAutosaveSoon() {
+      NSSplitViewAutosaveDisabler.disableNearestSplitViewAutosave(from: self)
+      Task { @MainActor [weak self] in
+        guard let self else { return }
+        NSSplitViewAutosaveDisabler.disableNearestSplitViewAutosave(from: self)
+      }
+    }
+  }
+}

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/EmbeddedSidePanelPresentationStateTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/EmbeddedSidePanelPresentationStateTests.swift
@@ -1,0 +1,60 @@
+import Testing
+
+@testable import AgentHubCore
+
+@MainActor
+@Suite("EmbeddedSidePanelPresentationState")
+struct EmbeddedSidePanelPresentationStateTests {
+  @Test("Open presents shell before mounting content")
+  func openPresentsShellBeforeMountingContent() {
+    let state = EmbeddedSidePanelPresentationState<String>()
+
+    let id = state.open("github")
+
+    #expect(state.shellPayload == "github")
+    #expect(state.mountedPayload == nil)
+    #expect(state.currentPayload == "github")
+
+    state.completeDeferredTransition(id: id)
+
+    #expect(state.shellPayload == "github")
+    #expect(state.mountedPayload == "github")
+  }
+
+  @Test("Close unmounts content before removing shell")
+  func closeUnmountsContentBeforeRemovingShell() {
+    let state = EmbeddedSidePanelPresentationState<String>()
+    let openID = state.open("diff")
+    state.completeDeferredTransition(id: openID)
+
+    let closeID = state.close()
+
+    #expect(state.shellPayload == "diff")
+    #expect(state.mountedPayload == nil)
+
+    state.completeDeferredTransition(id: closeID)
+
+    #expect(state.shellPayload == nil)
+    #expect(state.mountedPayload == nil)
+  }
+
+  @Test("Stale deferred transitions are ignored")
+  func staleDeferredTransitionsAreIgnored() {
+    let state = EmbeddedSidePanelPresentationState<String>()
+
+    let firstOpenID = state.open("web")
+    let closeID = state.close()
+    let secondOpenID = state.open("github")
+
+    state.completeDeferredTransition(id: firstOpenID)
+    state.completeDeferredTransition(id: closeID)
+
+    #expect(state.shellPayload == "github")
+    #expect(state.mountedPayload == nil)
+
+    state.completeDeferredTransition(id: secondOpenID)
+
+    #expect(state.shellPayload == "github")
+    #expect(state.mountedPayload == "github")
+  }
+}

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/NSSplitViewAutosaveDisablerTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/NSSplitViewAutosaveDisablerTests.swift
@@ -1,0 +1,38 @@
+import AppKit
+import Testing
+
+@testable import AgentHubCore
+
+@MainActor
+@Suite("NSSplitViewAutosaveDisabler")
+struct NSSplitViewAutosaveDisablerTests {
+  @Test("Clears nearest ancestor split view autosave name")
+  func clearsNearestAncestorAutosaveName() {
+    let splitView = NSSplitView()
+    splitView.autosaveName = NSSplitView.AutosaveName("com.agenthub.test.split")
+
+    let sidebar = NSView()
+    let detail = NSView()
+    let probe = NSView()
+
+    splitView.addArrangedSubview(sidebar)
+    splitView.addArrangedSubview(detail)
+    detail.addSubview(probe)
+
+    let disabledSplitView = NSSplitViewAutosaveDisabler.disableNearestSplitViewAutosave(from: probe)
+
+    #expect(disabledSplitView === splitView)
+    #expect(splitView.autosaveName == nil)
+  }
+
+  @Test("Does nothing when there is no ancestor split view")
+  func doesNothingWithoutAncestorSplitView() {
+    let root = NSView()
+    let probe = NSView()
+    root.addSubview(probe)
+
+    let disabledSplitView = NSSplitViewAutosaveDisabler.disableNearestSplitViewAutosave(from: probe)
+
+    #expect(disabledSplitView == nil)
+  }
+}


### PR DESCRIPTION
## Summary

- Split embedded side-panel presentation into a stable shell and separately mounted content so opening/closing the panel does not animate the split width.
- Added a content-only trailing slide transition with Reduce Motion handling and a short close-shell delay so dismissal feels smooth without lingering.
- Disabled NSSplitView autosave for the session detail split and removed sidebar visibility animations that were contributing to the panel open/close hang path.
- Added focused tests for the presentation state machine and NSSplitView autosave disabler.

## Validation

- `swift test --package-path app/modules/AgentHubCore --filter EmbeddedSidePanelPresentationState`
- `swift test --package-path app/modules/AgentHubCore --filter NSSplitViewAutosaveDisabler`
- `swift build --package-path app/modules/AgentHubCore`
- `git diff --check`
- `xcodebuild -project app/AgentHub.xcodeproj -scheme AgentHub -configuration Debug build` completed with `BUILD SUCCEEDED`

Note: Xcode still prints the existing CodeEdit SwiftLint plugin footer after the successful build.