### PR TITLE
Update Ghostty default theme background to #252627

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/Design/Theme/BundledThemes/ghostty.yaml
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Design/Theme/BundledThemes/ghostty.yaml
@@ -1,5 +1,5 @@
 name: "Ghostty"
-version: "1.2"
+version: "1.3"
 author: "AgentHub"
 description: "Ghostty-only theme with Singularity highlights and soft app backgrounds"
 
@@ -10,11 +10,11 @@ colors:
     tertiary: "#CBD5E0"
 
   backgrounds:
-    dark: "#040F16"
+    dark: "#252627"
     light: "#FBFBFF"
 
   terminal:
-    background: "#040F16"
+    background: "#252627"
     foreground: "#E2E8F0"
     cursor: "#A0AEC0"
     ansi:


### PR DESCRIPTION
## Summary
- Bumps bundled `ghostty.yaml` theme to v1.3
- Replaces the dark/terminal background (`#040F16` → `#252627`) for a softer default

## Test plan
- [ ] Launch app, switch to the Ghostty theme, confirm new background applies in app and embedded terminal