### PR TITLE
[codex] Improve monitoring card startup performance

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/ProjectCapabilityService.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/ProjectCapabilityService.swift
@@ -1,0 +1,103 @@
+//
+//  ProjectCapabilityService.swift
+//  AgentHub
+//
+
+import Foundation
+
+public struct ProjectCapabilities: Equatable, Sendable {
+  public let hasStorybook: Bool
+  public let isXcodeProject: Bool
+
+  public init(hasStorybook: Bool, isXcodeProject: Bool) {
+    self.hasStorybook = hasStorybook
+    self.isXcodeProject = isXcodeProject
+  }
+}
+
+public protocol ProjectCapabilityServiceProtocol: Sendable {
+  func cachedCapabilities(for projectPath: String) async -> ProjectCapabilities?
+  func capabilities(for projectPath: String) async -> ProjectCapabilities
+  func invalidate(projectPath: String) async
+}
+
+public actor ProjectCapabilityService: ProjectCapabilityServiceProtocol {
+  public static let shared = ProjectCapabilityService()
+
+  public typealias Evaluator = @Sendable (String) async -> ProjectCapabilities
+
+  private struct InFlightEvaluation: Sendable {
+    let id: UUID
+    let generation: Int
+    let task: Task<ProjectCapabilities, Never>
+  }
+
+  private let evaluator: Evaluator
+  private var cache: [String: ProjectCapabilities] = [:]
+  private var cacheGeneration: [String: Int] = [:]
+  private var inFlightTasks: [String: InFlightEvaluation] = [:]
+
+  public init(evaluator: Evaluator? = nil) {
+    self.evaluator = evaluator ?? { projectPath in
+      await Self.defaultEvaluator(projectPath: projectPath)
+    }
+  }
+
+  public func cachedCapabilities(for projectPath: String) async -> ProjectCapabilities? {
+    cache[Self.normalize(projectPath)]
+  }
+
+  public func capabilities(for projectPath: String) async -> ProjectCapabilities {
+    let normalizedProjectPath = Self.normalize(projectPath)
+    if let cached = cache[normalizedProjectPath] {
+      return cached
+    }
+    if let inFlightTask = inFlightTasks[normalizedProjectPath] {
+      return await inFlightTask.task.value
+    }
+
+    let evaluator = evaluator
+    let task = Task(priority: .utility) {
+      await evaluator(normalizedProjectPath)
+    }
+    let inFlightEvaluation = InFlightEvaluation(
+      id: UUID(),
+      generation: cacheGeneration[normalizedProjectPath] ?? 0,
+      task: task
+    )
+    inFlightTasks[normalizedProjectPath] = inFlightEvaluation
+
+    let capabilities = await task.value
+    if inFlightTasks[normalizedProjectPath]?.id == inFlightEvaluation.id {
+      inFlightTasks.removeValue(forKey: normalizedProjectPath)
+      if (cacheGeneration[normalizedProjectPath] ?? 0) == inFlightEvaluation.generation {
+        cache[normalizedProjectPath] = capabilities
+      }
+    }
+    return capabilities
+  }
+
+  public func invalidate(projectPath: String) async {
+    let normalizedProjectPath = Self.normalize(projectPath)
+    cacheGeneration[normalizedProjectPath, default: 0] += 1
+    cache.removeValue(forKey: normalizedProjectPath)
+    inFlightTasks[normalizedProjectPath]?.task.cancel()
+    inFlightTasks.removeValue(forKey: normalizedProjectPath)
+  }
+
+  private nonisolated static func defaultEvaluator(projectPath: String) async -> ProjectCapabilities {
+    await Task.detached(priority: .utility) {
+      ProjectCapabilities(
+        hasStorybook: ProjectFramework.hasStorybook(at: projectPath),
+        isXcodeProject: XcodeProjectDetector.isXcodeProject(at: projectPath)
+      )
+    }.value
+  }
+
+  public nonisolated static func normalize(_ projectPath: String) -> String {
+    URL(fileURLWithPath: projectPath)
+      .standardizedFileURL
+      .resolvingSymlinksInPath()
+      .path
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/ProjectFileService.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/ProjectFileService.swift
@@ -24,9 +24,14 @@ actor ProjectFileService: ProjectFileServiceProtocol {
   private static let maxIndexedFileSize: UInt64 = 1_000_000
 
   private let webPreviewCandidateService: (any WebPreviewCandidateServiceProtocol)?
+  private let projectCapabilityService: (any ProjectCapabilityServiceProtocol)?
 
-  init(webPreviewCandidateService: (any WebPreviewCandidateServiceProtocol)? = WebPreviewCandidateService.shared) {
+  init(
+    webPreviewCandidateService: (any WebPreviewCandidateServiceProtocol)? = WebPreviewCandidateService.shared,
+    projectCapabilityService: (any ProjectCapabilityServiceProtocol)? = ProjectCapabilityService.shared
+  ) {
     self.webPreviewCandidateService = webPreviewCandidateService
+    self.projectCapabilityService = projectCapabilityService
   }
 
   func readFile(at path: String, projectPath: String) async throws -> String {
@@ -36,6 +41,7 @@ actor ProjectFileService: ProjectFileServiceProtocol {
   func writeFile(at path: String, content: String, projectPath: String) async throws {
     try await FileIndexService.shared.writeFile(at: path, content: content, projectPath: projectPath)
     await webPreviewCandidateService?.invalidate(projectPath: projectPath)
+    await projectCapabilityService?.invalidate(projectPath: projectPath)
   }
 
   func listTextFiles(in projectPath: String, extensions allowedExtensions: Set<String>) async -> [String] {

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringCardView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringCardView.swift
@@ -27,11 +27,13 @@ public struct MonitoringCardView: View {
   var dangerouslySkipPermissions: Bool = false
   var permissionModePlan: Bool = false
   let worktreeName: String?
+  let shouldMountTerminal: Bool
   let onStopMonitoring: () -> Void
   let onConnect: () -> Void
   let onCopySessionId: () -> Void
   let onOpenSessionFile: () -> Void
   let onRefreshTerminal: () -> Void
+  let onRequestMountTerminal: () -> Void
   let onInlineRequestSubmit: ((String, CLISession) -> Void)?
   let onShowDiff: ((CLISession, String) -> Void)?
   let onShowPlan: ((CLISession, PlanState) -> Void)?
@@ -57,7 +59,6 @@ public struct MonitoringCardView: View {
   @State private var showingFilePicker = false
   @State private var showingNameSheet = false
   @State private var showingRemixProviderPicker = false
-  @State private var isXcodeProject = false
   @Environment(\.agentHub) private var agentHub
   @Environment(\.colorScheme) private var colorScheme
 
@@ -78,11 +79,13 @@ public struct MonitoringCardView: View {
     dangerouslySkipPermissions: Bool = false,
     permissionModePlan: Bool = false,
     worktreeName: String? = nil,
+    shouldMountTerminal: Bool = true,
     onStopMonitoring: @escaping () -> Void,
     onConnect: @escaping () -> Void,
     onCopySessionId: @escaping () -> Void,
     onOpenSessionFile: @escaping () -> Void,
     onRefreshTerminal: @escaping () -> Void,
+    onRequestMountTerminal: @escaping () -> Void = {},
     onInlineRequestSubmit: ((String, CLISession) -> Void)? = nil,
     onShowDiff: ((CLISession, String) -> Void)? = nil,
     onShowPlan: ((CLISession, PlanState) -> Void)? = nil,
@@ -115,11 +118,13 @@ public struct MonitoringCardView: View {
     self.dangerouslySkipPermissions = dangerouslySkipPermissions
     self.permissionModePlan = permissionModePlan
     self.worktreeName = worktreeName
+    self.shouldMountTerminal = shouldMountTerminal
     self.onStopMonitoring = onStopMonitoring
     self.onConnect = onConnect
     self.onCopySessionId = onCopySessionId
     self.onOpenSessionFile = onOpenSessionFile
     self.onRefreshTerminal = onRefreshTerminal
+    self.onRequestMountTerminal = onRequestMountTerminal
     self.onInlineRequestSubmit = onInlineRequestSubmit
     self.onShowDiff = onShowDiff
     self.onShowPlan = onShowPlan
@@ -150,6 +155,18 @@ public struct MonitoringCardView: View {
 
   private var webPreviewCandidateStatus: WebPreviewCandidateStatus? {
     viewModel?.webPreviewCandidateStatus(for: session.projectPath)
+  }
+
+  private var projectCapabilities: ProjectCapabilities? {
+    viewModel?.projectCapabilities(for: session.projectPath)
+  }
+
+  private var hasStorybook: Bool {
+    projectCapabilities?.hasStorybook == true
+  }
+
+  private var isXcodeProject: Bool {
+    projectCapabilities?.isXcodeProject == true
   }
 
   private var shouldShowWebPreviewButton: Bool {
@@ -231,13 +248,7 @@ public struct MonitoringCardView: View {
       await loadWebPreviewCandidateIfNeeded()
     }
     .task(id: session.projectPath) {
-      let projectPath = session.projectPath
-      isXcodeProject = false
-      let detected = await Task.detached {
-        XcodeProjectDetector.isXcodeProject(at: projectPath)
-      }.value
-      guard !Task.isCancelled else { return }
-      isXcodeProject = detected
+      await viewModel?.ensureProjectCapabilities(for: session.projectPath)
     }
     .task(id: SessionGitHubQuickAccessViewModel.repositoryKey(projectPath: session.projectPath, branchName: session.branchName)) {
       try? await Task.sleep(for: .seconds(2))
@@ -477,7 +488,7 @@ public struct MonitoringCardView: View {
   /// to two different URLs in confusing ways.
   @ViewBuilder
   private var webPreviewControls: some View {
-    if ProjectFramework.hasStorybook(at: session.projectPath) {
+    if hasStorybook {
       Button(action: {
         Task {
           await DevServerManager.shared.startStorybookServer(
@@ -787,7 +798,9 @@ public struct MonitoringCardView: View {
       dangerouslySkipPermissions: dangerouslySkipPermissions,
       permissionModePlan: permissionModePlan,
       worktreeName: worktreeName,
+      shouldMountTerminal: shouldMountTerminal,
       onUserInteraction: onTerminalInteraction,
+      onRequestMount: onRequestMountTerminal,
       onRequestShowEditor: onRequestShowEditor,
       consumeQueuedWebPreviewContextOnSubmit: {
         viewModel?.consumeQueuedWebPreviewContextPrompt(for: session.id)
@@ -884,28 +897,62 @@ private struct MonitoringCardTerminalContent: View {
   let dangerouslySkipPermissions: Bool
   let permissionModePlan: Bool
   let worktreeName: String?
+  let shouldMountTerminal: Bool
   let onUserInteraction: (() -> Void)?
+  let onRequestMount: () -> Void
   let onRequestShowEditor: (() -> Void)?
   let consumeQueuedWebPreviewContextOnSubmit: (() -> String?)?
 
   var body: some View {
-    EmbeddedTerminalView(
-      terminalKey: terminalKey,
-      sessionId: sessionId,
-      projectPath: projectPath,
-      cliConfiguration: cliConfiguration,
-      initialPrompt: initialPrompt,
-      initialInputText: initialInputText,
-      viewModel: viewModel,
-      dangerouslySkipPermissions: dangerouslySkipPermissions,
-      permissionModePlan: permissionModePlan,
-      worktreeName: worktreeName,
-      onUserInteraction: onUserInteraction,
-      onRequestShowEditor: onRequestShowEditor,
-      consumeQueuedWebPreviewContextOnSubmit: consumeQueuedWebPreviewContextOnSubmit
-    )
+    Group {
+      if shouldMountTerminal {
+        EmbeddedTerminalView(
+          terminalKey: terminalKey,
+          sessionId: sessionId,
+          projectPath: projectPath,
+          cliConfiguration: cliConfiguration,
+          initialPrompt: initialPrompt,
+          initialInputText: initialInputText,
+          viewModel: viewModel,
+          dangerouslySkipPermissions: dangerouslySkipPermissions,
+          permissionModePlan: permissionModePlan,
+          worktreeName: worktreeName,
+          onUserInteraction: onUserInteraction,
+          onRequestShowEditor: onRequestShowEditor,
+          consumeQueuedWebPreviewContextOnSubmit: consumeQueuedWebPreviewContextOnSubmit
+        )
+      } else {
+        TerminalMountPlaceholder(
+          projectPath: projectPath,
+          onRequestMount: onRequestMount
+        )
+      }
+    }
     .padding(DesignTokens.Spacing.sm)
     .frame(minHeight: 300)
+  }
+}
+
+private struct TerminalMountPlaceholder: View {
+  let projectPath: String
+  let onRequestMount: () -> Void
+
+  var body: some View {
+    VStack(spacing: 10) {
+      Image(systemName: "terminal")
+        .font(.title3)
+        .foregroundStyle(.secondary)
+
+      Text(URL(fileURLWithPath: projectPath).lastPathComponent)
+        .font(.primaryDefault)
+        .lineLimit(1)
+
+      Button("Load Terminal", action: onRequestMount)
+        .buttonStyle(.agentHubOutlined)
+    }
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+    .background(Color.secondary.opacity(0.06))
+    .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
   }
 }
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderMonitoringPanelView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderMonitoringPanelView.swift
@@ -135,6 +135,13 @@ enum ProviderMonitoringItem: Identifiable {
     }
   }
 
+  var isPending: Bool {
+    if case .pending = self {
+      return true
+    }
+    return false
+  }
+
   var projectPath: String {
     switch self {
     case .pending(_, _, let pending):
@@ -905,29 +912,31 @@ public struct MultiProviderMonitoringPanelView: View {
     effectivePrimaryItemID: String? = nil
   ) -> some View {
     let isPrimary = item.id == (effectivePrimaryItemID ?? effectivePrimarySessionId)
-      switch item {
-      case .pending(_, let viewModel, let pending):
-        MonitoringCardView(
-          session: pending.placeholderSession,
-          state: nil,
-          cliConfiguration: viewModel.cliConfiguration,
-          providerKind: item.providerKind,
-          initialPrompt: pending.initialPrompt,
-          initialInputText: pending.initialInputText,
-          terminalKey: "pending-\(pending.id.uuidString)",
-          viewModel: viewModel,
-          contentMode: editorContentModeBinding(for: item),
-          selectedEditorFilePath: selectedEditorFilePathBinding(for: item),
-          editorProjectPath: editorState(for: item).projectPath,
-          editorNavigationRequest: editorState(for: item).navigationRequest,
-          dangerouslySkipPermissions: pending.dangerouslySkipPermissions,
-          permissionModePlan: pending.permissionModePlan,
-          worktreeName: pending.worktreeName,
+    switch item {
+    case .pending(_, let viewModel, let pending):
+      MonitoringCardView(
+        session: pending.placeholderSession,
+        state: nil,
+        cliConfiguration: viewModel.cliConfiguration,
+        providerKind: item.providerKind,
+        initialPrompt: pending.initialPrompt,
+        initialInputText: pending.initialInputText,
+        terminalKey: "pending-\(pending.id.uuidString)",
+        viewModel: viewModel,
+        contentMode: editorContentModeBinding(for: item),
+        selectedEditorFilePath: selectedEditorFilePathBinding(for: item),
+        editorProjectPath: editorState(for: item).projectPath,
+        editorNavigationRequest: editorState(for: item).navigationRequest,
+        dangerouslySkipPermissions: pending.dangerouslySkipPermissions,
+        permissionModePlan: pending.permissionModePlan,
+        worktreeName: pending.worktreeName,
+        shouldMountTerminal: shouldMountTerminal(for: item, isPrimary: isPrimary),
         onStopMonitoring: { viewModel.cancelPendingSession(pending) },
         onConnect: { },
         onCopySessionId: { },
         onOpenSessionFile: { },
         onRefreshTerminal: { },
+        onRequestMountTerminal: { setPrimarySessionIfNeeded(item.id) },
         onShowDiff: { session, projectPath in
           toggleSidePanel(
             .diff(sessionId: session.id, session: session, projectPath: projectPath),
@@ -978,22 +987,23 @@ public struct MultiProviderMonitoringPanelView: View {
       let planState = state.flatMap { PlanState.from(activities: $0.recentActivities) }
       let initialPrompt = viewModel.pendingPrompt(for: session.id)
 
-        MonitoringCardView(
-          session: session,
-          state: state,
-          planState: planState,
-          cliConfiguration: viewModel.cliConfiguration,
-          providerKind: item.providerKind,
-          initialPrompt: initialPrompt,
-          terminalKey: session.id,
-          viewModel: viewModel,
-          contentMode: editorContentModeBinding(for: item),
-          selectedEditorFilePath: selectedEditorFilePathBinding(for: item),
-          editorProjectPath: editorState(for: item).projectPath,
-          editorNavigationRequest: editorState(for: item).navigationRequest,
-          onStopMonitoring: {
-            viewModel.stopMonitoring(session: session)
-          },
+      MonitoringCardView(
+        session: session,
+        state: state,
+        planState: planState,
+        cliConfiguration: viewModel.cliConfiguration,
+        providerKind: item.providerKind,
+        initialPrompt: initialPrompt,
+        terminalKey: session.id,
+        viewModel: viewModel,
+        contentMode: editorContentModeBinding(for: item),
+        selectedEditorFilePath: selectedEditorFilePathBinding(for: item),
+        editorProjectPath: editorState(for: item).projectPath,
+        editorNavigationRequest: editorState(for: item).navigationRequest,
+        shouldMountTerminal: shouldMountTerminal(for: item, isPrimary: isPrimary),
+        onStopMonitoring: {
+          viewModel.stopMonitoring(session: session)
+        },
         onConnect: {
           _ = viewModel.connectToSession(session)
         },
@@ -1010,6 +1020,7 @@ public struct MultiProviderMonitoringPanelView: View {
             projectPath: session.projectPath
           )
         },
+        onRequestMountTerminal: { setPrimarySessionIfNeeded(item.id) },
         onInlineRequestSubmit: { prompt, sess in
           viewModel.showTerminalWithPrompt(for: sess, prompt: prompt)
         },
@@ -1459,6 +1470,10 @@ public struct MultiProviderMonitoringPanelView: View {
   private func setPrimarySessionIfNeeded(_ sessionId: String) {
     guard primarySessionId != sessionId else { return }
     primarySessionId = sessionId
+  }
+
+  private func shouldMountTerminal(for item: ProviderMonitoringItem, isPrimary: Bool) -> Bool {
+    item.isPending || isPrimary || maximizedSessionId == item.id
   }
 
   private func toggleAuxiliaryShellDock() {

--- a/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/CLISessionsViewModel.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/CLISessionsViewModel.swift
@@ -32,12 +32,15 @@ public final class CLISessionsViewModel {
   private let terminalWorkspaceStore: (any TerminalWorkspaceStoreProtocol)?
   private let fileWatcher: any SessionFileWatcherProtocol
   private let webPreviewCandidateService: any WebPreviewCandidateServiceProtocol
+  private let projectCapabilityService: any ProjectCapabilityServiceProtocol
   private let approvalNotificationService: any ApprovalNotificationServiceProtocol
   private let approvalClaimStore: (any ApprovalClaimStoreProtocol)?
   private let hookInstaller: (any ClaudeHookInstallerProtocol)?
   private let terminalSurfaceFactory: any EmbeddedTerminalSurfaceFactory
   private let terminalBackend: EmbeddedTerminalBackend
   @ObservationIgnored private var terminalWorkspaceSaveTasks: [String: Task<Void, Never>] = [:]
+  @ObservationIgnored private var scheduledTerminalFocusKeys: Set<String> = []
+  @ObservationIgnored private var scheduledAuxiliaryShellFocusKeys: Set<String> = []
   weak var agentHubProvider: AgentHubProvider?
 
   // MARK: - State
@@ -149,6 +152,30 @@ public final class CLISessionsViewModel {
 
   public func webPreviewCandidateStatus(for projectPath: String) -> WebPreviewCandidateStatus? {
     webPreviewCandidates[WebPreviewCandidateService.normalize(projectPath)]
+  }
+
+  public func projectCapabilities(for projectPath: String) -> ProjectCapabilities? {
+    projectCapabilities[ProjectCapabilityService.normalize(projectPath)]
+  }
+
+  public func ensureProjectCapabilities(
+    for projectPath: String,
+    forceRefresh: Bool = false
+  ) async {
+    let normalizedProjectPath = ProjectCapabilityService.normalize(projectPath)
+
+    if !forceRefresh {
+      if projectCapabilities[normalizedProjectPath] != nil {
+        return
+      }
+      if let cachedCapabilities = await projectCapabilityService.cachedCapabilities(for: normalizedProjectPath) {
+        projectCapabilities[normalizedProjectPath] = cachedCapabilities
+        return
+      }
+    }
+
+    let capabilities = await projectCapabilityService.capabilities(for: normalizedProjectPath)
+    projectCapabilities[normalizedProjectPath] = capabilities
   }
 
   public func ensureWebPreviewCandidate(
@@ -741,16 +768,22 @@ public final class CLISessionsViewModel {
   /// Focuses the terminal for a given key so it receives keyboard input.
   /// Uses a short delay to let SwiftUI layout settle before requesting AppKit first responder.
   public func focusTerminal(forKey key: String) {
+    guard activeTerminals[key] != nil else { return }
+    guard scheduledTerminalFocusKeys.insert(key).inserted else { return }
     Task { @MainActor in
       try? await Task.sleep(for: .milliseconds(100))
+      scheduledTerminalFocusKeys.remove(key)
       activeTerminals[key]?.focus()
     }
   }
 
   /// Focuses the auxiliary shell terminal for a given key so it receives keyboard input.
   public func focusAuxiliaryShellTerminal(forKey key: String) {
+    guard auxiliaryShellTerminals[key] != nil else { return }
+    guard scheduledAuxiliaryShellFocusKeys.insert(key).inserted else { return }
     Task { @MainActor in
       try? await Task.sleep(for: .milliseconds(100))
+      scheduledAuxiliaryShellFocusKeys.remove(key)
       auxiliaryShellTerminals[key]?.focus()
     }
   }
@@ -799,6 +832,9 @@ public final class CLISessionsViewModel {
   /// Cached project-level preview eligibility keyed by normalized project path.
   public private(set) var webPreviewCandidates: [String: WebPreviewCandidateStatus] = [:]
 
+  /// Cached project-level UI capabilities keyed by normalized project path.
+  public private(set) var projectCapabilities: [String: ProjectCapabilities] = [:]
+
   /// Combine cancellables for monitoring subscriptions (keyed by session ID)
   private var monitoringCancellables: [String: AnyCancellable] = [:]
 
@@ -837,6 +873,7 @@ public final class CLISessionsViewModel {
     providerKind: SessionProviderKind,
     metadataStore: SessionMetadataStore? = nil,
     webPreviewCandidateService: any WebPreviewCandidateServiceProtocol = WebPreviewCandidateService.shared,
+    projectCapabilityService: any ProjectCapabilityServiceProtocol = ProjectCapabilityService.shared,
     approvalNotificationService: any ApprovalNotificationServiceProtocol = ApprovalNotificationService.shared,
     approvalClaimStore: (any ApprovalClaimStoreProtocol)? = nil,
     hookInstaller: (any ClaudeHookInstallerProtocol)? = nil,
@@ -851,6 +888,7 @@ public final class CLISessionsViewModel {
     self.terminalWorkspaceStore = terminalWorkspaceStore ?? metadataStore
     self.fileWatcher = fileWatcher
     self.webPreviewCandidateService = webPreviewCandidateService
+    self.projectCapabilityService = projectCapabilityService
     self.approvalNotificationService = approvalNotificationService
     self.approvalClaimStore = approvalClaimStore
     self.hookInstaller = hookInstaller

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/AuxiliaryShellTerminalManagementTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/AuxiliaryShellTerminalManagementTests.swift
@@ -68,6 +68,7 @@ private final class TestTerminalSurface: NSView, EmbeddedTerminalSurface {
   var workspaceSnapshotToCapture: TerminalWorkspaceSnapshot?
   private(set) var configureCallCount = 0
   private(set) var terminateCallCount = 0
+  private(set) var focusCallCount = 0
 
   func updateContext(terminalSessionKey: String?, sessionViewModel: CLISessionsViewModel?) {}
 
@@ -110,7 +111,9 @@ private final class TestTerminalSurface: NSView, EmbeddedTerminalSurface {
     initialTypedTexts.append(text)
   }
   func syncAppearance(isDark: Bool, fontSize: CGFloat, fontFamily: String, theme: RuntimeTheme?) {}
-  func focus() {}
+  func focus() {
+    focusCallCount += 1
+  }
   func captureWorkspaceSnapshot() -> TerminalWorkspaceSnapshot? {
     workspaceSnapshotToCapture
   }
@@ -305,6 +308,33 @@ struct AuxiliaryShellTerminalManagementTests {
     #expect(keys.contains("session-123"))
     #expect(keys.contains("shell:session-123"))
     #expect(keys.count == 2)
+  }
+
+  @Test("Duplicate terminal focus requests are coalesced while layout settles")
+  @MainActor
+  func duplicateTerminalFocusRequestsAreCoalesced() async throws {
+    let viewModel = makeAuxiliaryShellViewModel()
+    let terminal = TestTerminalSurface()
+    viewModel.activeTerminals["session-123"] = terminal
+
+    viewModel.focusTerminal(forKey: "session-123")
+    viewModel.focusTerminal(forKey: "session-123")
+
+    try await Task.sleep(for: .milliseconds(150))
+
+    #expect(terminal.focusCallCount == 1)
+  }
+
+  @Test("Missing terminals are not focused")
+  @MainActor
+  func missingTerminalFocusDoesNothing() async throws {
+    let viewModel = makeAuxiliaryShellViewModel()
+
+    viewModel.focusTerminal(forKey: "missing")
+
+    try await Task.sleep(for: .milliseconds(150))
+
+    #expect(viewModel.activeTerminals.isEmpty)
   }
 
   @Test("Stopping monitoring removes and terminates both terminal surfaces for the session")

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/WebPreviewCandidateServiceTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/WebPreviewCandidateServiceTests.swift
@@ -132,6 +132,58 @@ private actor MockWebPreviewCandidateService: WebPreviewCandidateServiceProtocol
   }
 }
 
+private actor ProjectCapabilityEvaluatorSpy {
+  private(set) var evaluationCount = 0
+  private let capabilities: ProjectCapabilities
+  private let delay: Duration?
+
+  init(
+    capabilities: ProjectCapabilities = ProjectCapabilities(hasStorybook: true, isXcodeProject: true),
+    delay: Duration? = nil
+  ) {
+    self.capabilities = capabilities
+    self.delay = delay
+  }
+
+  func evaluate(projectPath _: String) async -> ProjectCapabilities {
+    evaluationCount += 1
+    if let delay {
+      try? await Task.sleep(for: delay)
+    }
+    return capabilities
+  }
+}
+
+private actor MockProjectCapabilityService: ProjectCapabilityServiceProtocol {
+  private let capabilities: ProjectCapabilities
+  private let cachedCapabilities: ProjectCapabilities?
+  private(set) var invalidatedProjectPaths: [String] = []
+
+  init(
+    capabilities: ProjectCapabilities = ProjectCapabilities(hasStorybook: true, isXcodeProject: true),
+    cachedCapabilities: ProjectCapabilities? = nil
+  ) {
+    self.capabilities = capabilities
+    self.cachedCapabilities = cachedCapabilities
+  }
+
+  func cachedCapabilities(for projectPath: String) async -> ProjectCapabilities? {
+    cachedCapabilities
+  }
+
+  func capabilities(for projectPath: String) async -> ProjectCapabilities {
+    capabilities
+  }
+
+  func invalidate(projectPath: String) async {
+    invalidatedProjectPaths.append(projectPath)
+  }
+
+  func recordedInvalidations() -> [String] {
+    invalidatedProjectPaths
+  }
+}
+
 @Suite("WebPreviewCandidateService")
 struct WebPreviewCandidateServiceTests {
 
@@ -375,6 +427,107 @@ struct CLISessionsViewModelWebPreviewCandidateTests {
   }
 }
 
+@Suite("ProjectCapabilityService")
+struct ProjectCapabilityServiceTests {
+
+  @Test("Capabilities are cached by normalized project path")
+  func capabilitiesAreCachedByNormalizedPath() async {
+    let spy = ProjectCapabilityEvaluatorSpy(
+      capabilities: ProjectCapabilities(hasStorybook: true, isXcodeProject: false)
+    )
+    let service = ProjectCapabilityService(evaluator: { projectPath in
+      await spy.evaluate(projectPath: projectPath)
+    })
+
+    let first = await service.capabilities(for: "/tmp/project/../project")
+    let second = await service.capabilities(for: "/tmp/project")
+
+    #expect(first == ProjectCapabilities(hasStorybook: true, isXcodeProject: false))
+    #expect(second == first)
+    #expect(await spy.evaluationCount == 1)
+  }
+
+  @Test("Concurrent capability requests share in-flight evaluation")
+  func concurrentRequestsShareInFlightEvaluation() async {
+    let spy = ProjectCapabilityEvaluatorSpy(delay: .milliseconds(50))
+    let service = ProjectCapabilityService(evaluator: { projectPath in
+      await spy.evaluate(projectPath: projectPath)
+    })
+
+    async let first = service.capabilities(for: "/tmp/project")
+    async let second = service.capabilities(for: "/tmp/project")
+    _ = await (first, second)
+
+    #expect(await spy.evaluationCount == 1)
+  }
+
+  @Test("Invalidation prevents in-flight results from repopulating cache")
+  func invalidationPreventsInFlightResultsFromRepopulatingCache() async throws {
+    let spy = ProjectCapabilityEvaluatorSpy(delay: .milliseconds(50))
+    let service = ProjectCapabilityService(evaluator: { projectPath in
+      await spy.evaluate(projectPath: projectPath)
+    })
+
+    async let capabilities = service.capabilities(for: "/tmp/project")
+    try await Task.sleep(for: .milliseconds(10))
+    await service.invalidate(projectPath: "/tmp/project")
+    _ = await capabilities
+
+    #expect(await service.cachedCapabilities(for: "/tmp/project") == nil)
+  }
+}
+
+@Suite("CLISessionsViewModel Project Capabilities")
+struct CLISessionsViewModelProjectCapabilityTests {
+
+  @Test("ensureProjectCapabilities stores the resolved capabilities")
+  @MainActor
+  func ensureProjectCapabilitiesStoresResolvedCapabilities() async {
+    let capabilityService = MockProjectCapabilityService(
+      capabilities: ProjectCapabilities(hasStorybook: true, isXcodeProject: false)
+    )
+    let viewModel = CLISessionsViewModel(
+      monitorService: StubMonitorService(),
+      fileWatcher: StubFileWatcher(),
+      searchService: nil,
+      cliConfiguration: CLICommandConfiguration(command: "claude", mode: .claude),
+      providerKind: .claude,
+      projectCapabilityService: capabilityService,
+      approvalNotificationService: NoOpApprovalNotificationService()
+    )
+
+    await viewModel.ensureProjectCapabilities(for: "/tmp/project")
+
+    #expect(
+      viewModel.projectCapabilities(for: "/tmp/project")
+        == ProjectCapabilities(hasStorybook: true, isXcodeProject: false)
+    )
+  }
+
+  @Test("ensureProjectCapabilities uses fresh cached capabilities")
+  @MainActor
+  func ensureProjectCapabilitiesUsesFreshCachedCapabilities() async {
+    let cached = ProjectCapabilities(hasStorybook: false, isXcodeProject: true)
+    let capabilityService = MockProjectCapabilityService(
+      capabilities: ProjectCapabilities(hasStorybook: true, isXcodeProject: false),
+      cachedCapabilities: cached
+    )
+    let viewModel = CLISessionsViewModel(
+      monitorService: StubMonitorService(),
+      fileWatcher: StubFileWatcher(),
+      searchService: nil,
+      cliConfiguration: CLICommandConfiguration(command: "claude", mode: .claude),
+      providerKind: .claude,
+      projectCapabilityService: capabilityService,
+      approvalNotificationService: NoOpApprovalNotificationService()
+    )
+
+    await viewModel.ensureProjectCapabilities(for: "/tmp/project")
+
+    #expect(viewModel.projectCapabilities(for: "/tmp/project") == cached)
+  }
+}
+
 @Suite("ProjectFileService web preview invalidation")
 struct ProjectFileServiceWebPreviewInvalidationTests {
 
@@ -397,6 +550,29 @@ struct ProjectFileServiceWebPreviewInvalidationTests {
     )
 
     let invalidatedPaths = await candidateService.recordedInvalidations()
+    #expect(invalidatedPaths == [fixture.root.path])
+  }
+
+  @Test("Writes invalidate cached project capabilities")
+  func writesInvalidateProjectCapabilityCache() async throws {
+    let fixture = try WebPreviewCandidateFixture.create()
+    defer { fixture.cleanup() }
+
+    try fixture.write("package.json", content: "{}")
+    let capabilityService = MockProjectCapabilityService()
+    let projectFileService = ProjectFileService(
+      webPreviewCandidateService: nil,
+      projectCapabilityService: capabilityService
+    )
+    let filePath = fixture.root.appendingPathComponent("package.json").path
+
+    try await projectFileService.writeFile(
+      at: filePath,
+      content: "{\"scripts\":{\"storybook\":\"storybook dev\"}}",
+      projectPath: fixture.root.path
+    )
+
+    let invalidatedPaths = await capabilityService.recordedInvalidations()
     #expect(invalidatedPaths == [fixture.root.path])
   }
 }


### PR DESCRIPTION
## Summary

This PR is the first performance pass for monitoring cards and startup rendering. It moves project capability detection out of SwiftUI body work, avoids mounting non-primary terminals in multi-session layouts until needed, and coalesces delayed terminal focus requests.

## Changes

- Added `ProjectCapabilityService`, an actor-backed cache for Storybook/Xcode project capability detection.
- Injected cached project capabilities into `CLISessionsViewModel` and `MonitoringCardView`.
- Replaced synchronous Storybook/Xcode checks in card rendering with async cached capability loading.
- Lazy-mounted non-primary terminals in multi-provider layouts behind a lightweight `Load Terminal` placeholder.
- Kept pending, primary, and maximized cards mounted so launch/resume behavior remains intact.
- Coalesced duplicate terminal focus calls while SwiftUI layout settles.
- Invalidated project capability cache after project file writes.

## Regression Coverage

Added tests for:

- Project capability cache normalization.
- Concurrent capability requests sharing one in-flight evaluation.
- Invalidating an in-flight capability lookup without repopulating stale cache.
- ViewModel capability loading from resolved and cached service values.
- Project file writes invalidating cached capabilities.
- Duplicate terminal focus requests coalescing.
- Missing terminal focus requests doing nothing.

## Validation

- `git diff --check`
- `xcodebuild -project app/AgentHub.xcodeproj -scheme AgentHub -destination 'platform=macOS' test -only-testing:AgentHubTests/ProjectCapabilityServiceTests -only-testing:AgentHubTests/CLISessionsViewModelProjectCapabilityTests -only-testing:AgentHubTests/ProjectFileServiceWebPreviewInvalidationTests -only-testing:AgentHubTests/AuxiliaryShellTerminalManagementTests`

The targeted Xcode test run completed with `** TEST SUCCEEDED **`. Xcode still prints the existing SwiftLint plugin footer for `CodeEditTextView` and `CodeEditSourceEditor`, but the command exits successfully.

## Profiling Notes

A non-interactive 60s follow-up profile after this change showed no exported hang events and no Time Profiler CPU bottlenecks. An interactive profile still showed AppKit/SwiftUI layout churn during mouse/drag/card interaction; that should be handled in a separate PR so this startup/session-card change remains reviewable.