### PR TITLE
[codex] Redesign terminal tab chrome

### DIFF
--- a/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyPendingTerminalPaneView.swift
+++ b/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyPendingTerminalPaneView.swift
@@ -11,36 +11,27 @@ struct AgentHubGhosttyPendingTerminalPaneView: View {
 
   var body: some View {
     VStack(spacing: 0) {
-      HStack(spacing: 0) {
-        Text("Shell")
-          .font(.caption2.weight(.medium))
-          .lineLimit(1)
-          .frame(minWidth: 76, maxWidth: 150, alignment: .leading)
-          .frame(height: 28)
-          .padding(.leading, 10)
-          .padding(.trailing, 10)
-          .foregroundStyle(Color.primary)
-          .background(Color.primary.opacity(0.12))
-          .overlay(alignment: .trailing) {
-            Rectangle()
-              .fill(Color.primary.opacity(0.14))
-              .frame(width: 1)
-          }
-          .overlay(alignment: .bottom) {
-            Rectangle()
-              .fill(Color.accentColor.opacity(0.75))
-              .frame(height: 2)
-          }
+      ZStack(alignment: .bottom) {
+        AgentHubGhosttyTerminalTabChrome.stripBackground
 
-        Spacer(minLength: 0)
-      }
-      .frame(height: 28)
-      .background(Color(nsColor: .windowBackgroundColor).opacity(0.72))
-      .overlay(alignment: .bottom) {
         Rectangle()
-          .fill(Color.secondary.opacity(0.18))
+          .fill(AgentHubGhosttyTerminalTabChrome.divider)
           .frame(height: 1)
+
+        HStack(spacing: 0) {
+          AgentHubGhosttyTerminalTabItem(
+            title: "Shell",
+            isActive: true,
+            isFirst: true,
+            canClose: false,
+            onSelect: {},
+            onClose: {}
+          )
+
+          Spacer(minLength: 0)
+        }
       }
+      .frame(height: AgentHubGhosttyTerminalTabChrome.stripHeight)
 
       AgentHubGhosttyTerminalPaneActivityOverlay(activity: activity)
         .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalPaneActivity.swift
+++ b/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalPaneActivity.swift
@@ -50,3 +50,9 @@ final class AgentHubGhosttyPaneActivityRegistry {
     activities[panelID]
   }
 }
+
+enum AgentHubGhosttyTerminalPaneActivityPolicy {
+  static func activityForClosingTab(tabCount: Int) -> AgentHubGhosttyTerminalPaneActivity? {
+    tabCount == 1 ? .closingTerminal : nil
+  }
+}

--- a/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalPaneHeader.swift
+++ b/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalPaneHeader.swift
@@ -20,127 +20,75 @@ struct AgentHubGhosttyTerminalPaneHeader: View {
   let onClosePanel: () -> Void
 
   var body: some View {
-    HStack(spacing: 6) {
-      ScrollView(.horizontal, showsIndicators: false) {
-        HStack(spacing: 0) {
-          ForEach(Array(panel.tabs.enumerated()), id: \.element.id) { index, tab in
-            tabButton(tab: tab, index: index)
+    ZStack(alignment: .bottom) {
+      AgentHubGhosttyTerminalTabChrome.stripBackground
+
+      Rectangle()
+        .fill(AgentHubGhosttyTerminalTabChrome.divider)
+        .frame(height: 1)
+
+      HStack(spacing: 0) {
+        ScrollView(.horizontal, showsIndicators: false) {
+          HStack(spacing: 0) {
+            ForEach(Array(panel.tabs.enumerated()), id: \.element.id) { index, tab in
+              tabButton(tab: tab, index: index)
+            }
           }
         }
-      }
 
-      Spacer(minLength: 4)
+        Spacer(minLength: 0)
 
-      HStack(spacing: 4) {
-        headerIconButton(
-          title: "New Tab",
-          systemImage: "plus",
-          help: "New terminal tab",
-          action: onOpenTab
-        )
-
-        headerIconButton(
-          title: "Split Right",
-          systemImage: "rectangle.split.2x1",
-          help: "Split terminal to the right",
-          isDisabled: !canSplit,
-          action: onSplitRight
-        )
-
-        headerIconButton(
-          title: "Split Below",
-          systemImage: "rectangle.split.1x2",
-          help: "Split terminal below",
-          isDisabled: !canSplit,
-          action: onSplitBelow
-        )
-
-        if canClosePanel {
-          headerIconButton(
-            title: "Close Pane",
-            systemImage: "xmark",
-            help: "Close terminal pane",
-            action: onClosePanel
+        HStack(spacing: 2) {
+          AgentHubGhosttyTerminalToolbarButton(
+            title: "New Tab",
+            systemImage: "plus",
+            help: "New terminal tab",
+            action: onOpenTab
           )
-        }
-      }
-      .font(.system(size: 12, weight: .medium))
-      .foregroundStyle(.secondary)
-      .padding(.trailing, 6)
-    }
-    .frame(height: 28)
-    .background(Color(nsColor: .windowBackgroundColor).opacity(0.72))
-    .overlay(alignment: .bottom) {
-      Rectangle()
-        .fill(Color.secondary.opacity(0.18))
-        .frame(height: 1)
-    }
-  }
 
-  private func headerIconButton(
-    title: String,
-    systemImage: String,
-    help: String,
-    isDisabled: Bool = false,
-    action: @escaping () -> Void
-  ) -> some View {
-    Button(title, systemImage: systemImage, action: action)
-      .labelStyle(.iconOnly)
-      .buttonStyle(.plain)
-      .frame(width: 32, height: 28)
-      .contentShape(Rectangle())
-      .disabled(isDisabled)
-      .help(help)
+          AgentHubGhosttyTerminalToolbarButton(
+            title: "Split Right",
+            systemImage: "rectangle.split.2x1",
+            help: "Split terminal to the right",
+            isDisabled: !canSplit,
+            action: onSplitRight
+          )
+
+          AgentHubGhosttyTerminalToolbarButton(
+            title: "Split Below",
+            systemImage: "rectangle.split.1x2",
+            help: "Split terminal below",
+            isDisabled: !canSplit,
+            action: onSplitBelow
+          )
+
+          if canClosePanel {
+            AgentHubGhosttyTerminalToolbarButton(
+              title: "Close Pane",
+              systemImage: "xmark",
+              help: "Close terminal pane",
+              action: onClosePanel
+            )
+          }
+        }
+        .padding(.horizontal, 8)
+      }
+      .frame(height: AgentHubGhosttyTerminalTabChrome.stripHeight)
+    }
+    .frame(height: AgentHubGhosttyTerminalTabChrome.stripHeight)
   }
 
   private func tabButton(tab: TerminalTab, index: Int) -> some View {
     let isActive = tab.id == panel.activeTabID
     let title = tab.displayName(index: index)
 
-    return HStack(spacing: 5) {
-      Button(action: { onSelectTab(tab) }) {
-        Text(title)
-          .font(.caption2.weight(isActive ? .medium : .regular))
-          .lineLimit(1)
-          .frame(minWidth: 76, maxWidth: 150, alignment: .leading)
-          .contentShape(Rectangle())
-      }
-      .buttonStyle(.plain)
-
-      if canCloseTab(tab) {
-        Button(action: { onCloseTab(tab) }) {
-          Label("Close Tab", systemImage: "xmark")
-            .labelStyle(.iconOnly)
-            .font(.system(size: 9, weight: .medium))
-            .frame(width: 14, height: 14)
-            .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
-        .help("Close Tab")
-      }
-    }
-    .frame(height: 28)
-    .padding(.leading, 10)
-    .padding(.trailing, canCloseTab(tab) ? 7 : 10)
-    .foregroundStyle(isActive ? Color.primary : Color.secondary)
-    .background {
-      Rectangle()
-        .fill(isActive ? Color.primary.opacity(0.12) : Color.clear)
-    }
-    .overlay(alignment: .trailing) {
-      Rectangle()
-        .fill(Color.primary.opacity(0.14))
-        .frame(width: 1)
-    }
-    .overlay(alignment: .bottom) {
-      if isActive {
-        Rectangle()
-          .fill(Color.accentColor.opacity(0.75))
-          .frame(height: 2)
-      }
-    }
-    .contentShape(Rectangle())
-    .help(title)
-    .zIndex(isActive ? 1 : 0)
+    return AgentHubGhosttyTerminalTabItem(
+      title: title,
+      isActive: isActive,
+      isFirst: index == 0,
+      canClose: canCloseTab(tab),
+      onSelect: { onSelectTab(tab) },
+      onClose: { onCloseTab(tab) }
+    )
   }
 }

--- a/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalPaneView.swift
+++ b/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalPaneView.swift
@@ -83,7 +83,9 @@ struct AgentHubGhosttyTerminalPaneView: View {
 
   private func closeTab(_ tab: TerminalTab) {
     guard immediateActivity == nil else { return }
-    immediateActivity = .closingTerminal
+    immediateActivity = AgentHubGhosttyTerminalPaneActivityPolicy.activityForClosingTab(
+      tabCount: panel.tabs.count
+    )
     Task { @MainActor in
       await Task.yield()
       onCloseTab(panel, tab)

--- a/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalSurface.swift
+++ b/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalSurface.swift
@@ -43,7 +43,7 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
   private var configuredProcessProvider: SessionProviderKind?
   private var configuredExpectedExecutable: String?
   private static let terminalPaneDividerSize: CGFloat = 1
-  private static let terminalTabStripHeight: CGFloat = 28
+  private static let terminalTabStripHeight = AgentHubGhosttyTerminalTabChrome.stripHeight
   private static let shellStartupFallbackDelay: Duration = .milliseconds(900)
   private static let pendingPaneRenderDelay: Duration = .milliseconds(16)
 
@@ -385,6 +385,11 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
     terminalSession?.activeTab?.controller
   }
 
+  private var protectedAgentTabName: String {
+    let providerKind = sessionViewModel?.providerKind ?? configuredProcessProvider
+    return providerKind?.rawValue ?? "CLI"
+  }
+
   private var protectedAgentController: GhosttyTerminalController? {
     guard
       let terminalSession,
@@ -405,7 +410,7 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
       let session = try TerminalSession(
         configPath: GhosttyConfigPathResolver.configuredPath(),
         primaryConfiguration: primaryConfiguration,
-        primaryName: protectsPrimaryTab ? "Agent" : "Shell"
+        primaryName: protectsPrimaryTab ? protectedAgentTabName : "Shell"
       )
       if protectsPrimaryTab, let primaryTab = session.primaryPanel.activeTab {
         protectedAgentPanelID = session.primaryPanelID
@@ -751,7 +756,10 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
   }
 
   private func restoredTabName(for tab: TerminalWorkspaceTabSnapshot) -> String? {
-    Self.nonEmpty(tab.name) ?? Self.nonEmpty(tab.title) ?? "Shell"
+    if tab.role == .agent {
+      return protectedAgentTabName
+    }
+    return Self.nonEmpty(tab.name) ?? Self.nonEmpty(tab.title) ?? "Shell"
   }
 
   private func resolvedFontSize() -> Float {

--- a/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalSurface.swift
+++ b/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalSurface.swift
@@ -1063,7 +1063,9 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
   private func closeGhosttyTab(_ tab: TerminalTab, in panel: TerminalPanel) {
     guard terminalSession != nil, canCloseGhosttyTab(tab, in: panel) else { return }
     guard pendingTabCloseTasks[tab.id] == nil else { return }
-    markPaneClosingTerminal(panel.id)
+    if AgentHubGhosttyTerminalPaneActivityPolicy.activityForClosingTab(tabCount: panel.tabs.count) != nil {
+      markPaneClosingTerminal(panel.id)
+    }
     pendingTabCloseTasks[tab.id] = Task { @MainActor [weak self] in
       await Task.yield()
       guard !Task.isCancelled else { return }

--- a/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalTabChrome.swift
+++ b/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalTabChrome.swift
@@ -1,0 +1,21 @@
+//
+//  AgentHubGhosttyTerminalTabChrome.swift
+//  AgentHub
+//
+
+import SwiftUI
+
+enum AgentHubGhosttyTerminalTabChrome {
+  static let stripHeight: CGFloat = 32
+  static let tabMinWidth: CGFloat = 118
+  static let tabMaxWidth: CGFloat = 192
+  static let firstTabCornerRadius: CGFloat = 10
+  static let accent = Color.primary
+  static let stripBackground = Color(nsColor: .windowBackgroundColor).opacity(0.78)
+  static let activeBackground = Color(nsColor: .textBackgroundColor).opacity(0.94)
+  static let hoverBackground = Color.primary.opacity(0.07)
+  static let closeHoverBackground = Color.primary.opacity(0.12)
+  static let divider = Color.secondary.opacity(0.18)
+
+  static let tabEdge = Color.secondary.opacity(0.13)
+}

--- a/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalTabItem.swift
+++ b/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalTabItem.swift
@@ -1,0 +1,117 @@
+//
+//  AgentHubGhosttyTerminalTabItem.swift
+//  AgentHub
+//
+
+import SwiftUI
+
+@MainActor
+struct AgentHubGhosttyTerminalTabItem: View {
+  let title: String
+  let isActive: Bool
+  let isFirst: Bool
+  let canClose: Bool
+  let onSelect: () -> Void
+  let onClose: () -> Void
+
+  @State private var isHovered = false
+  @State private var isCloseHovered = false
+
+  var body: some View {
+    HStack(spacing: 0) {
+      Button(action: onSelect) {
+        Text(title)
+          .font(.system(size: 12, weight: isActive ? .medium : .regular))
+          .lineLimit(1)
+          .truncationMode(.tail)
+          .frame(maxWidth: .infinity, alignment: .leading)
+          .padding(.leading, isFirst ? 20 : 18)
+          .padding(.trailing, canClose ? 8 : 12)
+          .contentShape(Rectangle())
+      }
+      .buttonStyle(.plain)
+
+      if canClose {
+        Button(action: onClose) {
+          Label("Close Tab", systemImage: "xmark")
+            .labelStyle(.iconOnly)
+            .font(.system(size: 10, weight: .semibold))
+            .frame(width: 20, height: 20)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .disabled(!showsCloseButton)
+        .foregroundStyle(Color.secondary)
+        .background {
+          RoundedRectangle(cornerRadius: 3, style: .continuous)
+            .fill(isCloseHovered ? AgentHubGhosttyTerminalTabChrome.closeHoverBackground : Color.clear)
+        }
+        .opacity(closeButtonOpacity)
+        .accessibilityHidden(!showsCloseButton)
+        .accessibilityLabel("Close \(title) tab")
+        .help("Close Tab")
+        .onHover { hovering in
+          isCloseHovered = hovering
+        }
+        .padding(.trailing, 6)
+      }
+    }
+    .frame(
+      minWidth: AgentHubGhosttyTerminalTabChrome.tabMinWidth,
+      maxWidth: AgentHubGhosttyTerminalTabChrome.tabMaxWidth
+    )
+    .frame(height: AgentHubGhosttyTerminalTabChrome.stripHeight)
+    .foregroundStyle(isActive ? Color.primary : Color.secondary)
+    .background {
+      tabShape.fill(tabBackground)
+    }
+    .overlay(alignment: .top) {
+      if isActive {
+        Rectangle()
+          .fill(AgentHubGhosttyTerminalTabChrome.accent)
+          .frame(height: 2)
+          .clipShape(tabShape)
+      }
+    }
+    .overlay(alignment: .leading) {
+      if isActive {
+        Rectangle()
+          .fill(AgentHubGhosttyTerminalTabChrome.tabEdge)
+          .frame(width: 1)
+      }
+    }
+    .overlay(alignment: .trailing) {
+      Rectangle()
+        .fill(isActive ? AgentHubGhosttyTerminalTabChrome.tabEdge : AgentHubGhosttyTerminalTabChrome.divider)
+        .frame(width: 1)
+    }
+    .clipShape(tabShape)
+    .contentShape(Rectangle())
+    .help(title)
+    .onHover { hovering in
+      isHovered = hovering
+    }
+    .animation(.easeOut(duration: 0.10), value: isHovered)
+    .animation(.easeOut(duration: 0.10), value: isCloseHovered)
+    .zIndex(isActive ? 1 : 0)
+  }
+
+  private var tabBackground: Color {
+    if isActive {
+      return AgentHubGhosttyTerminalTabChrome.activeBackground
+    }
+    return isHovered ? AgentHubGhosttyTerminalTabChrome.hoverBackground : Color.clear
+  }
+
+  private var closeButtonOpacity: Double {
+    showsCloseButton ? 1 : 0
+  }
+
+  private var showsCloseButton: Bool {
+    isActive || isHovered || isCloseHovered
+  }
+
+  private var tabShape: AgentHubGhosttyTerminalTabShape {
+    AgentHubGhosttyTerminalTabShape(roundsTopLeading: isFirst)
+  }
+}

--- a/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalTabShape.swift
+++ b/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalTabShape.swift
@@ -1,0 +1,34 @@
+//
+//  AgentHubGhosttyTerminalTabShape.swift
+//  AgentHub
+//
+
+import SwiftUI
+
+struct AgentHubGhosttyTerminalTabShape: Shape {
+  let roundsTopLeading: Bool
+
+  func path(in rect: CGRect) -> Path {
+    guard roundsTopLeading else {
+      return Path(rect)
+    }
+
+    let radius = min(
+      AgentHubGhosttyTerminalTabChrome.firstTabCornerRadius,
+      rect.width,
+      rect.height
+    )
+
+    var path = Path()
+    path.move(to: CGPoint(x: rect.minX, y: rect.maxY))
+    path.addLine(to: CGPoint(x: rect.minX, y: rect.minY + radius))
+    path.addQuadCurve(
+      to: CGPoint(x: rect.minX + radius, y: rect.minY),
+      control: CGPoint(x: rect.minX, y: rect.minY)
+    )
+    path.addLine(to: CGPoint(x: rect.maxX, y: rect.minY))
+    path.addLine(to: CGPoint(x: rect.maxX, y: rect.maxY))
+    path.closeSubpath()
+    return path
+  }
+}

--- a/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalToolbarButton.swift
+++ b/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalToolbarButton.swift
@@ -1,0 +1,52 @@
+//
+//  AgentHubGhosttyTerminalToolbarButton.swift
+//  AgentHub
+//
+
+import SwiftUI
+
+@MainActor
+struct AgentHubGhosttyTerminalToolbarButton: View {
+  let title: String
+  let systemImage: String
+  let help: String
+  let isDisabled: Bool
+  let action: () -> Void
+
+  @State private var isHovered = false
+
+  init(
+    title: String,
+    systemImage: String,
+    help: String,
+    isDisabled: Bool = false,
+    action: @escaping () -> Void
+  ) {
+    self.title = title
+    self.systemImage = systemImage
+    self.help = help
+    self.isDisabled = isDisabled
+    self.action = action
+  }
+
+  var body: some View {
+    Button(title, systemImage: systemImage, action: action)
+      .labelStyle(.iconOnly)
+      .buttonStyle(.plain)
+      .font(.system(size: 13, weight: .medium))
+      .foregroundStyle(isDisabled ? Color.secondary.opacity(0.45) : Color.secondary)
+      .frame(width: 28, height: 28)
+      .background {
+        RoundedRectangle(cornerRadius: 4, style: .continuous)
+          .fill(isHovered && !isDisabled ? AgentHubGhosttyTerminalTabChrome.hoverBackground : Color.clear)
+      }
+      .contentShape(Rectangle())
+      .disabled(isDisabled)
+      .accessibilityLabel(title)
+      .help(help)
+      .onHover { hovering in
+        isHovered = hovering
+      }
+      .animation(.easeOut(duration: 0.10), value: isHovered)
+  }
+}

--- a/app/modules/Ghostty/Tests/GhosttyTests/AgentHubGhosttyPaneActivityRegistryTests.swift
+++ b/app/modules/Ghostty/Tests/GhosttyTests/AgentHubGhosttyPaneActivityRegistryTests.swift
@@ -75,4 +75,18 @@ struct AgentHubGhosttyPaneActivityRegistryTests {
     #expect(registry.activity(for: firstPanelID) == nil)
     #expect(registry.activity(for: secondPanelID) == nil)
   }
+
+  @Test("Closing the last tab exposes terminal closing activity")
+  func closingLastTabExposesTerminalClosingActivity() {
+    let activity = AgentHubGhosttyTerminalPaneActivityPolicy.activityForClosingTab(tabCount: 1)
+
+    #expect(activity == .closingTerminal)
+  }
+
+  @Test("Closing one tab in a multi-tab pane does not expose pane activity")
+  func closingTabInMultiTabPaneDoesNotExposePaneActivity() {
+    let activity = AgentHubGhosttyTerminalPaneActivityPolicy.activityForClosingTab(tabCount: 2)
+
+    #expect(activity == nil)
+  }
 }


### PR DESCRIPTION
## Summary

Redesigns the embedded Ghostty terminal tab strip to feel closer to VS Code tabs.

- Replaces the rounded pill tab treatment with a flush, connected tab strip.
- Adds shared tab chrome components for the strip, tab item, first-tab shape, and toolbar buttons.
- Removes the leading tab-strip inset, rounds the first tab's top-leading corner, and uses system primary color for the active accent so it renders white in dark mode and black in light mode.
- Removes per-tab SF Symbols so tab labels carry the layout cleanly.
- Keeps pending terminal panes aligned with the same tab chrome and ties terminal content sizing to the shared strip height.
- Fixes multi-tab close behavior so the pane-level “Closing terminal…” overlay only appears when closing the last tab, not when closing one tab from a multi-tab pane.

## Validation

- `xcodebuild -quiet -project app/AgentHub.xcodeproj -scheme AgentHub -destination 'platform=macOS' build`
- Attempted `xcodebuild -quiet -project app/AgentHub.xcodeproj -scheme Ghostty -destination 'platform=macOS' test`, but the Ghostty scheme is not configured for the test action.
- Attempted `xcodebuild -quiet -project app/AgentHub.xcodeproj -scheme AgentHub -destination 'platform=macOS' test -only-testing:GhosttyTests/AgentHubGhosttyPaneActivityRegistryTests`, but `GhosttyTests` is not a member of the AgentHub scheme/test plan.