### PR TITLE
Render large diff files using changed hunks only

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/Models/GitDiffState.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Models/GitDiffState.swift
@@ -68,6 +68,39 @@ public struct GitDiffState: Equatable, Sendable {
   }
 }
 
+// MARK: - GitDiffRenderPolicy
+
+public struct GitDiffRenderPolicy: Equatable, Sendable {
+  public static let `default` = GitDiffRenderPolicy(maxFullContentBytes: 2 * 1024 * 1024)
+
+  public let maxFullContentBytes: UInt64
+
+  public init(maxFullContentBytes: UInt64) {
+    self.maxFullContentBytes = maxFullContentBytes
+  }
+}
+
+// MARK: - GitDiffRenderPayload
+
+public struct GitDiffRenderPayload: Equatable, Sendable {
+  public let oldContent: String
+  public let newContent: String
+  public let isLimitedContext: Bool
+  public let limitedContextReason: String?
+
+  public init(
+    oldContent: String,
+    newContent: String,
+    isLimitedContext: Bool = false,
+    limitedContextReason: String? = nil
+  ) {
+    self.oldContent = oldContent
+    self.newContent = newContent
+    self.isLimitedContext = isLimitedContext
+    self.limitedContextReason = limitedContextReason
+  }
+}
+
 // MARK: - GitDiffFileEntry
 
 /// Individual file with unstaged changes, including path and line statistics

--- a/app/modules/AgentHubCore/Sources/AgentHub/Models/GitDiffTree.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Models/GitDiffTree.swift
@@ -1,0 +1,137 @@
+import Foundation
+
+public struct GitDiffTreeResult: Equatable, Sendable {
+  public let nodes: [GitDiffTreeNode]
+  public let commonPrefix: String
+  public let allFolderPaths: Set<String>
+
+  public init(nodes: [GitDiffTreeNode], commonPrefix: String, allFolderPaths: Set<String>) {
+    self.nodes = nodes
+    self.commonPrefix = commonPrefix
+    self.allFolderPaths = allFolderPaths
+  }
+}
+
+public struct GitDiffTreeNode: Identifiable, Equatable, Sendable {
+  public let id: String
+  public let name: String
+  public let fullPath: String
+  public let file: GitDiffFileEntry?
+  public let children: [GitDiffTreeNode]
+
+  public var isFolder: Bool { file == nil }
+
+  public init(name: String, fullPath: String, file: GitDiffFileEntry?, children: [GitDiffTreeNode] = []) {
+    self.name = name
+    self.fullPath = fullPath
+    self.file = file
+    self.children = children
+    self.id = "\(file == nil ? "folder" : "file"):\(fullPath)"
+  }
+}
+
+public enum GitDiffTreeBuilder {
+  public static func build(from files: [GitDiffFileEntry]) -> GitDiffTreeResult {
+    guard !files.isEmpty else {
+      return GitDiffTreeResult(nodes: [], commonPrefix: "", allFolderPaths: [])
+    }
+
+    let commonComponents = findCommonPrefix(from: files)
+    let commonPrefix = commonComponents.joined(separator: "/")
+    let stripCount = commonComponents.count
+
+    let root = MutableGitDiffTreeNode(name: "", fullPath: "", file: nil)
+    var allFolderPaths: Set<String> = []
+
+    for file in files {
+      let allComponents = file.relativePath.components(separatedBy: "/")
+      let pathComponents = Array(allComponents.dropFirst(stripCount))
+
+      var currentNode = root
+      var currentPath = ""
+
+      for (index, component) in pathComponents.enumerated() {
+        let isLastComponent = index == pathComponents.count - 1
+        currentPath = currentPath.isEmpty ? component : "\(currentPath)/\(component)"
+
+        if isLastComponent {
+          currentNode.childrenDict[component] = MutableGitDiffTreeNode(
+            name: component,
+            fullPath: currentPath,
+            file: file
+          )
+        } else {
+          if currentNode.childrenDict[component] == nil {
+            currentNode.childrenDict[component] = MutableGitDiffTreeNode(
+              name: component,
+              fullPath: currentPath,
+              file: nil
+            )
+          }
+          allFolderPaths.insert(currentPath)
+          if let nextNode = currentNode.childrenDict[component] {
+            currentNode = nextNode
+          }
+        }
+      }
+    }
+
+    return GitDiffTreeResult(
+      nodes: sortNodes(from: root.childrenDict),
+      commonPrefix: commonPrefix,
+      allFolderPaths: allFolderPaths
+    )
+  }
+
+  private static func findCommonPrefix(from files: [GitDiffFileEntry]) -> [String] {
+    guard let first = files.first else { return [] }
+
+    var commonComponents = Array(first.relativePath.components(separatedBy: "/").dropLast())
+
+    for file in files.dropFirst() {
+      let components = Array(file.relativePath.components(separatedBy: "/").dropLast())
+      var matchCount = 0
+
+      for (lhs, rhs) in zip(commonComponents, components) {
+        guard lhs == rhs else { break }
+        matchCount += 1
+      }
+
+      commonComponents = Array(commonComponents.prefix(matchCount))
+      if commonComponents.isEmpty { break }
+    }
+
+    return commonComponents
+  }
+
+  private static func sortNodes(from dict: [String: MutableGitDiffTreeNode]) -> [GitDiffTreeNode] {
+    dict.values
+      .map { node in
+        GitDiffTreeNode(
+          name: node.name,
+          fullPath: node.fullPath,
+          file: node.file,
+          children: sortNodes(from: node.childrenDict)
+        )
+      }
+      .sorted { lhs, rhs in
+        if lhs.isFolder != rhs.isFolder {
+          return lhs.isFolder
+        }
+        return lhs.name.localizedStandardCompare(rhs.name) == .orderedAscending
+      }
+  }
+}
+
+private final class MutableGitDiffTreeNode {
+  let name: String
+  let fullPath: String
+  let file: GitDiffFileEntry?
+  var childrenDict: [String: MutableGitDiffTreeNode] = [:]
+
+  init(name: String, fullPath: String, file: GitDiffFileEntry?) {
+    self.name = name
+    self.fullPath = fullPath
+    self.file = file
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/GitDiffPatchRenderAdapter.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/GitDiffPatchRenderAdapter.swift
@@ -1,0 +1,63 @@
+import Foundation
+
+public enum GitDiffPatchRenderAdapter {
+  private static let omittedSectionMarker = "..."
+
+  public static func renderedPayload(
+    from patch: String,
+    limitedContextReason: String
+  ) -> GitDiffRenderPayload? {
+    guard let renderedDiff = renderedDiff(from: patch) else { return nil }
+
+    return GitDiffRenderPayload(
+      oldContent: renderedDiff.oldContent,
+      newContent: renderedDiff.newContent,
+      isLimitedContext: true,
+      limitedContextReason: limitedContextReason
+    )
+  }
+
+  public static func renderedDiff(from patch: String) -> (oldContent: String, newContent: String)? {
+    guard !patch.isEmpty else { return nil }
+
+    let lines = patch.components(separatedBy: "\n")
+    var oldLines: [String] = []
+    var newLines: [String] = []
+    var didParseHunk = false
+    var hunkCount = 0
+
+    for line in lines {
+      if line.hasPrefix("@@") {
+        if hunkCount > 0 && (!oldLines.isEmpty || !newLines.isEmpty) {
+          oldLines.append(omittedSectionMarker)
+          newLines.append(omittedSectionMarker)
+        }
+        hunkCount += 1
+        didParseHunk = true
+        continue
+      }
+
+      guard didParseHunk else { continue }
+
+      if line.hasPrefix("\\ No newline at end of file") {
+        continue
+      }
+
+      if line.hasPrefix("+") && !line.hasPrefix("+++") {
+        newLines.append(String(line.dropFirst()))
+      } else if line.hasPrefix("-") && !line.hasPrefix("---") {
+        oldLines.append(String(line.dropFirst()))
+      } else if line.hasPrefix(" ") {
+        let content = String(line.dropFirst())
+        oldLines.append(content)
+        newLines.append(content)
+      }
+    }
+
+    guard didParseHunk else { return nil }
+    return (
+      oldContent: oldLines.joined(separator: "\n"),
+      newContent: newLines.joined(separator: "\n")
+    )
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/GitDiffService.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/GitDiffService.swift
@@ -33,12 +33,30 @@ public enum GitDiffError: LocalizedError, Sendable {
 }
 
 /// Service for git diff operations
-public actor GitDiffService {
+public protocol GitDiffServiceProtocol: Sendable {
+  func changedFiles(at repoPath: String, mode: DiffMode, baseBranch: String?) async throws -> GitDiffState
+  func renderPayload(
+    for file: GitDiffFileEntry,
+    at repoPath: String,
+    mode: DiffMode,
+    baseBranch: String?
+  ) async throws -> GitDiffRenderPayload
+  func detectBaseBranch(at repoPath: String) async throws -> String
+  func findGitRoot(at path: String) async throws -> String
+}
+
+public actor GitDiffService: GitDiffServiceProtocol {
 
   /// Maximum time to wait for git commands (in seconds)
   private static let gitCommandTimeout: TimeInterval = 30.0
+  private static let limitedContextReason = "Large file rendered with changed hunks only."
 
-  public init() { }
+  private let renderPolicy: GitDiffRenderPolicy
+  private var gitRootCache: [String: String] = [:]
+
+  public init(renderPolicy: GitDiffRenderPolicy = .default) {
+    self.renderPolicy = renderPolicy
+  }
 
   // MARK: - Public API
 
@@ -51,6 +69,14 @@ public actor GitDiffService {
   ///   - baseBranch: Base branch for branch mode (auto-detected if nil)
   /// - Returns: GitDiffState containing all files with changes
   public func getChanges(
+    at repoPath: String,
+    mode: DiffMode,
+    baseBranch: String? = nil
+  ) async throws -> GitDiffState {
+    try await changedFiles(at: repoPath, mode: mode, baseBranch: baseBranch)
+  }
+
+  public func changedFiles(
     at repoPath: String,
     mode: DiffMode,
     baseBranch: String? = nil
@@ -306,6 +332,137 @@ public actor GitDiffService {
     }
   }
 
+  public func renderPayload(
+    for file: GitDiffFileEntry,
+    at repoPath: String,
+    mode: DiffMode,
+    baseBranch: String? = nil
+  ) async throws -> GitDiffRenderPayload {
+    if Task.isCancelled {
+      throw CancellationError()
+    }
+
+    if try await shouldUseLimitedContext(for: file, at: repoPath, mode: mode, baseBranch: baseBranch) {
+      return try await limitedContextPayload(for: file, at: repoPath, mode: mode, baseBranch: baseBranch)
+    }
+
+    do {
+      let contents = try await getFileDiff(
+        filePath: file.filePath,
+        at: repoPath,
+        mode: mode,
+        baseBranch: baseBranch
+      )
+      return GitDiffRenderPayload(oldContent: contents.oldContent, newContent: contents.newContent)
+    } catch {
+      if let fallback = try? await limitedContextPayload(for: file, at: repoPath, mode: mode, baseBranch: baseBranch) {
+        return fallback
+      }
+      throw error
+    }
+  }
+
+  private func shouldUseLimitedContext(
+    for file: GitDiffFileEntry,
+    at repoPath: String,
+    mode: DiffMode,
+    baseBranch: String?
+  ) async throws -> Bool {
+    let gitRoot = try await findGitRoot(at: repoPath)
+    let relativePath = relativePath(for: file.filePath, gitRoot: gitRoot)
+    let sizes = try await estimatedSideSizes(
+      filePath: file.filePath,
+      relativePath: relativePath,
+      gitRoot: gitRoot,
+      repoPath: repoPath,
+      mode: mode,
+      baseBranch: baseBranch
+    )
+
+    return max(sizes.old, sizes.new) > renderPolicy.maxFullContentBytes
+  }
+
+  private func estimatedSideSizes(
+    filePath: String,
+    relativePath: String,
+    gitRoot: String,
+    repoPath: String,
+    mode: DiffMode,
+    baseBranch: String?
+  ) async throws -> (old: UInt64, new: UInt64) {
+    switch mode {
+    case .unstaged:
+      async let oldSize = gitObjectSize("HEAD:\(relativePath)", at: gitRoot)
+      let newSize = localFileSize(filePath)
+      return await (oldSize ?? 0, newSize ?? 0)
+
+    case .staged:
+      async let oldSize = gitObjectSize("HEAD:\(relativePath)", at: gitRoot)
+      async let newSize = gitObjectSize(":\(relativePath)", at: gitRoot)
+      return await (oldSize ?? 0, newSize ?? 0)
+
+    case .branch:
+      let branch: String
+      if let baseBranch {
+        branch = baseBranch
+      } else {
+        branch = try await detectBaseBranch(at: repoPath)
+      }
+      let base = try await mergeBase(for: branch, gitRoot: gitRoot)
+      async let oldSize = gitObjectSize("\(base):\(relativePath)", at: gitRoot)
+      async let newSize = gitObjectSize("HEAD:\(relativePath)", at: gitRoot)
+      return await (oldSize ?? 0, newSize ?? 0)
+    }
+  }
+
+  private func limitedContextPayload(
+    for file: GitDiffFileEntry,
+    at repoPath: String,
+    mode: DiffMode,
+    baseBranch: String?
+  ) async throws -> GitDiffRenderPayload {
+    let patch = try await unifiedPatch(for: file, at: repoPath, mode: mode, baseBranch: baseBranch)
+    guard let payload = GitDiffPatchRenderAdapter.renderedPayload(
+      from: patch,
+      limitedContextReason: Self.limitedContextReason
+    ) else {
+      throw GitDiffError.binaryFile(file.relativePath)
+    }
+    return payload
+  }
+
+  private func unifiedPatch(
+    for file: GitDiffFileEntry,
+    at repoPath: String,
+    mode: DiffMode,
+    baseBranch: String?
+  ) async throws -> String {
+    let gitRoot = try await findGitRoot(at: repoPath)
+    let relativePath = relativePath(for: file.filePath, gitRoot: gitRoot)
+
+    let shouldUseNoIndexDiff: Bool
+    if mode == .unstaged {
+      shouldUseNoIndexDiff = !(try await isTracked(relativePath: relativePath, gitRoot: gitRoot))
+    } else {
+      shouldUseNoIndexDiff = false
+    }
+
+    if shouldUseNoIndexDiff {
+      return try await runGitCommand(
+        ["diff", "--no-index", "--", "/dev/null", relativePath],
+        at: gitRoot,
+        allowedExitCodes: [0, 1]
+      )
+    }
+
+    return try await getUnifiedFileDiff(
+      filePath: file.filePath,
+      at: repoPath,
+      mode: mode,
+      baseBranch: baseBranch
+    )
+  }
+
   /// Gets the diff content for an unstaged file (old content from HEAD, new content from disk)
   private func getUnstagedFileDiff(filePath: String, at repoPath: String) async throws -> (oldContent: String, newContent: String) {
     let gitRoot = try await findGitRoot(at: repoPath)
@@ -373,9 +530,7 @@ public actor GitDiffService {
       relativePath = filePath
     }
 
-    // Find the merge-base between current branch and base branch
-    let mergeBaseOutput = try await runGitCommand(["merge-base", baseBranch, "HEAD"], at: gitRoot)
-    let mergeBase = mergeBaseOutput.trimmingCharacters(in: .whitespacesAndNewlines)
+    let mergeBase = try await mergeBase(for: baseBranch, gitRoot: gitRoot)
 
     // Get old content from merge-base and new content from HEAD in parallel
     async let oldTask = fetchGitFileContent(ref: mergeBase, relativePath: relativePath, gitRoot: gitRoot)
@@ -397,6 +552,48 @@ public actor GitDiffService {
     } catch {
       // File might be new or deleted
       return ""
+    }
+  }
+
+  private func relativePath(for filePath: String, gitRoot: String) -> String {
+    if filePath == gitRoot {
+      return ""
+    }
+
+    let prefix = gitRoot.hasSuffix("/") ? gitRoot : "\(gitRoot)/"
+    if filePath.hasPrefix(prefix) {
+      return String(filePath.dropFirst(prefix.count))
+    }
+    return filePath
+  }
+
+  private func gitObjectSize(_ spec: String, at gitRoot: String) async -> UInt64? {
+    guard let output = try? await runGitCommand(["cat-file", "-s", spec], at: gitRoot) else {
+      return nil
+    }
+
+    return UInt64(output.trimmingCharacters(in: .whitespacesAndNewlines))
+  }
+
+  private func localFileSize(_ filePath: String) -> UInt64? {
+    guard let attributes = try? FileManager.default.attributesOfItem(atPath: filePath),
+          let size = attributes[.size] as? NSNumber else {
+      return nil
+    }
+    return size.uint64Value
+  }
+
+  private func mergeBase(for baseBranch: String, gitRoot: String) async throws -> String {
+    let output = try await runGitCommand(["merge-base", baseBranch, "HEAD"], at: gitRoot)
+    return output.trimmingCharacters(in: .whitespacesAndNewlines)
+  }
+
+  private func isTracked(relativePath: String, gitRoot: String) async throws -> Bool {
+    do {
+      _ = try await runGitCommand(["ls-files", "--error-unmatch", "--", relativePath], at: gitRoot)
+      return true
+    } catch {
+      return false
     }
   }
 
@@ -443,8 +640,14 @@ public actor GitDiffService {
 
   /// Finds the git root directory from any path within a repository
   public func findGitRoot(at path: String) async throws -> String {
+    if let cached = gitRootCache[path] {
+      return cached
+    }
+
     let output = try await runGitCommand(["rev-parse", "--show-toplevel"], at: path)
-    return output.trimmingCharacters(in: .whitespacesAndNewlines)
+    let root = output.trimmingCharacters(in: .whitespacesAndNewlines)
+    gitRootCache[path] = root
+    return root
   }
 
   // MARK: - Helper Methods
@@ -453,7 +656,8 @@ public actor GitDiffService {
   private func runGitCommand(
     _ arguments: [String],
     at path: String,
-    timeout: TimeInterval = gitCommandTimeout
+    timeout: TimeInterval = gitCommandTimeout,
+    allowedExitCodes: Set<Int32> = [0]
   ) async throws -> String {
 
     let process = Process()
@@ -542,7 +746,7 @@ public actor GitDiffService {
       throw GitDiffError.timeout
     }
 
-    if process.terminationStatus != 0 {
+    if !allowedExitCodes.contains(process.terminationStatus) {
       throw GitDiffError.gitCommandFailed(errorOutput.trimmingCharacters(in: .whitespacesAndNewlines))
     }
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/GitDiffView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/GitDiffView.swift
@@ -187,13 +187,21 @@ public struct GitDiffView: View {
         Text(session.shortId)
           .font(.system(.caption, design: .monospaced))
           .foregroundColor(.secondary)
+          .lineLimit(1)
+          .minimumScaleFactor(0.7)
+          .allowsTightening(true)
 
         if let branch = session.branchName {
           Text("[\(branch)]")
             .font(.caption)
             .foregroundColor(.secondary)
+            .lineLimit(1)
+            .minimumScaleFactor(0.7)
+            .allowsTightening(true)
+            .truncationMode(.middle)
         }
       }
+      .frame(minWidth: 0, alignment: .leading)
 
       Spacer()
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/GitDiffView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/GitDiffView.swift
@@ -39,7 +39,7 @@ public struct GitDiffView: View {
   @State private var isLoading = true
   @State private var errorMessage: String?
   @State private var selectedFileId: UUID?
-  @State private var diffContents: [UUID: (old: String, new: String)] = [:]
+  @State private var diffContents: [UUID: GitDiffRenderPayload] = [:]
   @State private var loadingStates: [UUID: Bool] = [:]
   @State private var fileErrorMessages: [UUID: String] = [:]
   @State private var diffStyle: DiffStyle = .unified
@@ -51,7 +51,10 @@ public struct GitDiffView: View {
   @State private var showDiscardCommentsAlert = false
   @State private var expandedPaths: Set<String> = []
   @State private var showSidebar: Bool = true
+  @State private var fileTree: [GitDiffTreeNode] = []
   @State private var treeCommonPrefix: String = ""
+  @State private var fileLoadTask: Task<Void, Never>?
+  @State private var loadGeneration = UUID()
 
   @Environment(\.colorScheme) private var colorScheme
   @Environment(\.runtimeTheme) private var runtimeTheme
@@ -60,7 +63,7 @@ public struct GitDiffView: View {
     Color.adaptiveExpandedContentBackground(for: colorScheme, theme: runtimeTheme)
   }
 
-  private let gitDiffService = GitDiffService()
+  private let gitDiffService: any GitDiffServiceProtocol
 
   public init(
     session: CLISession,
@@ -69,7 +72,8 @@ public struct GitDiffView: View {
     cliConfiguration: CLICommandConfiguration? = nil,
     providerKind: SessionProviderKind = .claude,
     onInlineRequestSubmit: ((String, CLISession) -> Void)? = nil,
-    isEmbedded: Bool = false
+    isEmbedded: Bool = false,
+    gitDiffService: any GitDiffServiceProtocol = GitDiffService()
   ) {
     self.session = session
     self.projectPath = projectPath
@@ -78,6 +82,7 @@ public struct GitDiffView: View {
     self.providerKind = providerKind
     self.onInlineRequestSubmit = onInlineRequestSubmit
     self.isEmbedded = isEmbedded
+    self.gitDiffService = gitDiffService
   }
 
   public var body: some View {
@@ -143,6 +148,11 @@ public struct GitDiffView: View {
     }
     .task {
       await loadChanges(for: diffMode)
+    }
+    .onDisappear {
+      fileLoadTask?.cancel()
+      fileLoadTask = nil
+      loadGeneration = UUID()
     }
     .confirmationDialog(
       "Discard Unsent Comments?",
@@ -294,117 +304,6 @@ public struct GitDiffView: View {
 
   // MARK: - File List Sidebar
 
-  /// Builds a hierarchical tree from flat file entries
-  private var fileTree: [GitDiffTreeNode] {
-    buildFileTree(from: diffState.files).nodes
-  }
-
-  /// Finds the longest common directory prefix among all file paths
-  private func findCommonPrefix(from files: [GitDiffFileEntry]) -> [String] {
-    guard let first = files.first else { return [] }
-
-    // Get directory components (exclude filename)
-    var commonComponents = Array(first.relativePath.components(separatedBy: "/").dropLast())
-
-    for file in files.dropFirst() {
-      let components = Array(file.relativePath.components(separatedBy: "/").dropLast())
-      // Keep only matching prefix components
-      var matchCount = 0
-      for (a, b) in zip(commonComponents, components) {
-        if a == b {
-          matchCount += 1
-        } else {
-          break
-        }
-      }
-      commonComponents = Array(commonComponents.prefix(matchCount))
-      if commonComponents.isEmpty { break }
-    }
-
-    return commonComponents
-  }
-
-  /// Result of building the file tree
-  private struct FileTreeResult {
-    let nodes: [GitDiffTreeNode]
-    let commonPrefix: String
-    let allFolderPaths: Set<String>
-  }
-
-  private func buildFileTree(from files: [GitDiffFileEntry]) -> FileTreeResult {
-    guard !files.isEmpty else {
-      return FileTreeResult(nodes: [], commonPrefix: "", allFolderPaths: [])
-    }
-
-    // Find common prefix to strip
-    let commonComponents = findCommonPrefix(from: files)
-    let commonPrefix = commonComponents.joined(separator: "/")
-    let stripCount = commonComponents.count
-
-    // Root node to hold top-level children
-    let root = GitDiffTreeNode(name: "", fullPath: "", file: nil)
-    var allFolderPaths: Set<String> = []
-
-    for file in files {
-      // Strip common prefix from path components
-      let allComponents = file.relativePath.components(separatedBy: "/")
-      let pathComponents = Array(allComponents.dropFirst(stripCount))
-
-      var currentNode = root
-      var currentPath = ""
-
-      for (index, component) in pathComponents.enumerated() {
-        let isLastComponent = index == pathComponents.count - 1
-        currentPath = currentPath.isEmpty ? component : "\(currentPath)/\(component)"
-
-        if isLastComponent {
-          // This is a file node
-          let fileNode = GitDiffTreeNode(
-            name: component,
-            fullPath: currentPath,
-            file: file
-          )
-          currentNode.childrenDict[component] = fileNode
-        } else {
-          // This is a folder node
-          if currentNode.childrenDict[component] == nil {
-            let folderNode = GitDiffTreeNode(
-              name: component,
-              fullPath: currentPath,
-              file: nil
-            )
-            currentNode.childrenDict[component] = folderNode
-          }
-          allFolderPaths.insert(currentPath)
-          // Move into this folder
-          currentNode = currentNode.childrenDict[component]!
-        }
-      }
-    }
-
-    // Convert dictionary to sorted array starting from root's children
-    let nodes = sortNodes(from: root.childrenDict)
-    return FileTreeResult(nodes: nodes, commonPrefix: commonPrefix, allFolderPaths: allFolderPaths)
-  }
-
-  private func sortNodes(from dict: [String: GitDiffTreeNode]) -> [GitDiffTreeNode] {
-    dict.values
-      .map { node in
-        // Recursively sort children
-        if !node.childrenDict.isEmpty {
-          node.children = sortNodes(from: node.childrenDict)
-        }
-        return node
-      }
-      .sorted { lhs, rhs in
-        // Folders first, then alphabetically
-        if lhs.isFolder != rhs.isFolder {
-          return lhs.isFolder
-        }
-        return lhs.name.localizedStandardCompare(rhs.name) == .orderedAscending
-      }
-  }
-
   /// Computes the ideal sidebar width based on the deepest/widest node in the tree
   private var computedSidebarWidth: CGFloat {
     let (maxDepth, longestName) = measureTree(nodes: fileTree, depth: 0)
@@ -509,16 +408,18 @@ public struct GitDiffView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .padding()
-      } else if let contents = diffContents[selectedId] {
+      } else if let payload = diffContents[selectedId] {
         // Find the file entry for the name
         if let file = diffState.files.first(where: { $0.id == selectedId }) {
           GitDiffContentView(
-            oldContent: contents.old,
-            newContent: contents.new,
+            oldContent: payload.oldContent,
+            newContent: payload.newContent,
             fileName: file.fileName,
             filePath: file.filePath,
             projectPath: projectPath,
             isWebRenderable: file.isWebRenderable,
+            isLimitedContext: payload.isLimitedContext,
+            limitedContextReason: payload.limitedContextReason,
             showSidebar: $showSidebar,
             diffStyle: $diffStyle,
             overflowMode: $overflowMode,
@@ -549,9 +450,13 @@ public struct GitDiffView: View {
   private func loadChanges(for mode: DiffMode) async {
     let clock = ContinuousClock()
     let totalStart = clock.now
+    let generation = UUID()
 
     // Clear existing state when switching modes
     await MainActor.run {
+      loadGeneration = generation
+      fileLoadTask?.cancel()
+      fileLoadTask = nil
       isLoading = true
       errorMessage = nil
       diffState = .empty
@@ -559,64 +464,55 @@ public struct GitDiffView: View {
       selectedFileId = nil
       loadingStates = [:]
       fileErrorMessages = [:]
+      fileTree = []
       treeCommonPrefix = ""
       expandedPaths = []
     }
 
     do {
       // Detect base branch for branch mode (cache it for later use)
+      let baseBranch: String?
       if mode == .branch && detectedBaseBranch == nil {
         let branchStart = clock.now
-        detectedBaseBranch = try await gitDiffService.detectBaseBranch(at: projectPath)
+        let detectedBranch = try await gitDiffService.detectBaseBranch(at: projectPath)
         AppLogger.git.info("[perf] detectBaseBranch: \(clock.now - branchStart)")
+        baseBranch = detectedBranch
+        await MainActor.run {
+          guard loadGeneration == generation else { return }
+          detectedBaseBranch = detectedBranch
+        }
+      } else {
+        baseBranch = mode == .branch ? detectedBaseBranch : nil
       }
 
       let gitRootStart = clock.now
-      let gitRoot = try await gitDiffService.findGitRoot(at: projectPath)
-      AppLogger.git.info("[perf] findGitRoot: \(clock.now - gitRootStart)")
+      _ = try await gitDiffService.findGitRoot(at: projectPath)
+      AppLogger.git.info("[perf] findGitRoot/cache: \(clock.now - gitRootStart)")
 
-      // Get unified diff in ONE command (fast path)
-      let diffStart = clock.now
-      let unifiedDiff = try await gitDiffService.getUnifiedDiffOutput(
+      let changedFilesStart = clock.now
+      let state = try await gitDiffService.changedFiles(
         at: projectPath,
         mode: mode,
-        baseBranch: detectedBaseBranch
+        baseBranch: baseBranch
       )
-      AppLogger.git.info("[perf] getUnifiedDiffOutput: \(clock.now - diffStart)")
-
-      // Parse all tracked file diffs upfront
-      let parseStart = clock.now
-      let parsed = DiffParserUtils.parse(diffOutput: unifiedDiff)
-      var entries = DiffParserUtils.toGitDiffFileEntries(parsed, gitRoot: gitRoot)
-      AppLogger.git.info("[perf] parse+toEntries: \(clock.now - parseStart)")
-
-      // Add untracked files in unstaged mode (not present in `git diff` output).
-      if mode == .unstaged {
-        let untrackedStart = clock.now
-        let untrackedEntries = try await gitDiffService.getUntrackedChanges(atGitRoot: gitRoot)
-        AppLogger.git.info("[perf] getUntrackedChanges: \(clock.now - untrackedStart)")
-
-        if !untrackedEntries.isEmpty {
-          var seenPaths = Set(entries.map(\.relativePath))
-          for entry in untrackedEntries where seenPaths.insert(entry.relativePath).inserted {
-            entries.append(entry)
-          }
-        }
-      }
+      AppLogger.git.info("[perf] changedFiles: \(clock.now - changedFilesStart)")
 
       await MainActor.run {
-        diffState = GitDiffState(files: entries)
+        guard loadGeneration == generation else { return }
+
+        diffState = state
         isLoading = false
 
         // Build tree and auto-expand all folders
-        let treeResult = buildFileTree(from: entries)
+        let treeResult = GitDiffTreeBuilder.build(from: state.files)
+        fileTree = treeResult.nodes
         treeCommonPrefix = treeResult.commonPrefix
         expandedPaths = treeResult.allFolderPaths
 
         // Auto-select first file
-        if let first = entries.first {
+        if let first = state.files.first {
           selectedFileId = first.id
-          loadFileDiff(for: first, mode: mode)
+          loadFileDiff(for: first, mode: mode, generation: generation)
         }
       }
 
@@ -624,35 +520,60 @@ public struct GitDiffView: View {
 
     } catch {
       await MainActor.run {
+        guard loadGeneration == generation else { return }
         errorMessage = error.localizedDescription
         isLoading = false
       }
     }
   }
 
-  private func loadFileDiff(for file: GitDiffFileEntry, mode: DiffMode? = nil) {
+  private func loadFileDiff(
+    for file: GitDiffFileEntry,
+    mode: DiffMode? = nil,
+    generation: UUID? = nil
+  ) {
+    let loadingIds = loadingStates.filter(\.value).map(\.key)
+    fileLoadTask?.cancel()
+    fileLoadTask = nil
+    for id in loadingIds {
+      loadingStates[id] = false
+    }
+
     // Skip if already loaded
     if diffContents[file.id] != nil { return }
 
-    // Fetch full file contents via git (preserves real line numbers)
+    // Fetch render payload lazily for the selected file.
     loadingStates[file.id] = true
+    fileErrorMessages[file.id] = nil
 
     let currentMode = mode ?? diffMode
+    let currentGeneration = generation ?? loadGeneration
+    let currentBaseBranch = currentMode == .branch ? detectedBaseBranch : nil
 
-    Task {
+    fileLoadTask = Task {
       do {
-        let (oldContent, newContent) = try await gitDiffService.getFileDiff(
-          filePath: file.filePath,
+        let payload = try await gitDiffService.renderPayload(
+          for: file,
           at: projectPath,
           mode: currentMode,
-          baseBranch: detectedBaseBranch
+          baseBranch: currentBaseBranch
         )
+        guard !Task.isCancelled else { return }
         await MainActor.run {
-          diffContents[file.id] = (old: oldContent, new: newContent)
+          guard loadGeneration == currentGeneration,
+                selectedFileId == file.id else { return }
+          diffContents[file.id] = payload
+          loadingStates[file.id] = false
+        }
+      } catch is CancellationError {
+        await MainActor.run {
+          guard loadGeneration == currentGeneration else { return }
           loadingStates[file.id] = false
         }
       } catch {
         await MainActor.run {
+          guard loadGeneration == currentGeneration,
+                selectedFileId == file.id else { return }
           fileErrorMessages[file.id] = error.localizedDescription
           loadingStates[file.id] = false
         }
@@ -689,26 +610,6 @@ public struct GitDiffView: View {
     }
   }
 
-}
-
-// MARK: - GitDiffTreeNode
-
-/// Represents a node in the hierarchical file tree (folder or file)
-private class GitDiffTreeNode: Identifiable {
-  let id = UUID()
-  let name: String                        // Folder or file name
-  let fullPath: String                    // Full relative path
-  var children: [GitDiffTreeNode] = []       // Child nodes (populated after tree build)
-  var childrenDict: [String: GitDiffTreeNode] = [:] // Used during tree construction
-  let file: GitDiffFileEntry?             // Non-nil for leaf file nodes
-
-  var isFolder: Bool { file == nil }
-
-  init(name: String, fullPath: String, file: GitDiffFileEntry?) {
-    self.name = name
-    self.fullPath = fullPath
-    self.file = file
-  }
 }
 
 // MARK: - GitDiffTreeNodeRow
@@ -894,6 +795,8 @@ private struct GitDiffContentView: View {
   let filePath: String
   let projectPath: String
   let isWebRenderable: Bool
+  let isLimitedContext: Bool
+  let limitedContextReason: String?
 
   @Binding var showSidebar: Bool
   @Binding var diffStyle: DiffStyle
@@ -920,7 +823,7 @@ private struct GitDiffContentView: View {
 
   /// Inline editor is enabled when cliConfiguration is available
   private var isInlineEditorEnabled: Bool {
-    cliConfiguration != nil
+    cliConfiguration != nil && !isLimitedContext
   }
 
   var body: some View {
@@ -1103,6 +1006,17 @@ private struct GitDiffContentView: View {
             .foregroundStyle(.blue)
           Text(fileName)
             .font(.headline)
+            .lineLimit(1)
+            .truncationMode(.middle)
+        }
+        .frame(minWidth: 0, alignment: .leading)
+
+        if isLimitedContext {
+          Label("Limited context", systemImage: "speedometer")
+            .font(.caption)
+            .foregroundStyle(.secondary)
+            .lineLimit(1)
+            .help(limitedContextReason ?? "Only changed hunks are rendered for this file.")
         }
 
         // TODO: Revisit Code/Preview toggle for web-renderable files

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/GitDiffPatchRenderAdapterTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/GitDiffPatchRenderAdapterTests.swift
@@ -1,0 +1,83 @@
+import Testing
+
+@testable import AgentHubCore
+
+@Suite("GitDiffPatchRenderAdapter")
+struct GitDiffPatchRenderAdapterTests {
+
+  @Test("renders modified hunks into old and new buffers")
+  func rendersModifiedHunk() {
+    let patch = """
+    @@ -1,3 +1,3 @@
+     alpha
+    -beta
+    +beta updated
+     gamma
+    """
+
+    let rendered = GitDiffPatchRenderAdapter.renderedDiff(from: patch)
+
+    #expect(rendered?.oldContent == "alpha\nbeta\ngamma")
+    #expect(rendered?.newContent == "alpha\nbeta updated\ngamma")
+  }
+
+  @Test("renders added files with empty old content")
+  func rendersAddedFile() {
+    let patch = """
+    @@ -0,0 +1,2 @@
+    +alpha
+    +beta
+    """
+
+    let rendered = GitDiffPatchRenderAdapter.renderedDiff(from: patch)
+
+    #expect(rendered?.oldContent == "")
+    #expect(rendered?.newContent == "alpha\nbeta")
+  }
+
+  @Test("renders deleted files with empty new content")
+  func rendersDeletedFile() {
+    let patch = """
+    @@ -1,2 +0,0 @@
+    -alpha
+    -beta
+    """
+
+    let rendered = GitDiffPatchRenderAdapter.renderedDiff(from: patch)
+
+    #expect(rendered?.oldContent == "alpha\nbeta")
+    #expect(rendered?.newContent == "")
+  }
+
+  @Test("adds separators between hunks")
+  func rendersMultipleHunks() {
+    let patch = """
+    diff --git a/File.swift b/File.swift
+    index 1111111..2222222 100644
+    --- a/File.swift
+    +++ b/File.swift
+    @@ -1,2 +1,2 @@
+    -old one
+    +new one
+     keep one
+    @@ -10,2 +10,2 @@
+     keep two
+    -old two
+    +new two
+    """
+
+    let rendered = GitDiffPatchRenderAdapter.renderedDiff(from: patch)
+
+    #expect(rendered?.oldContent == "old one\nkeep one\n...\nkeep two\nold two")
+    #expect(rendered?.newContent == "new one\nkeep one\n...\nkeep two\nnew two")
+  }
+
+  @Test("returns nil when no hunks are present")
+  func returnsNilWithoutHunks() {
+    let patch = "Binary files a/File.swift and b/File.swift differ"
+
+    let rendered = GitDiffPatchRenderAdapter.renderedDiff(from: patch)
+
+    #expect(rendered == nil)
+  }
+}

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/GitDiffServiceTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/GitDiffServiceTests.swift
@@ -1,0 +1,136 @@
+import Foundation
+import Testing
+
+@testable import AgentHubCore
+
+@Suite("GitDiffService")
+struct GitDiffServiceTests {
+
+  @Test("lists and renders unstaged changes")
+  func listsAndRendersUnstagedChanges() async throws {
+    let fixture = try GitRepoFixture.create()
+    defer { fixture.cleanup() }
+
+    try "changed".write(toFile: fixture.repoPath + "/README.md", atomically: true, encoding: .utf8)
+
+    let service = GitDiffService()
+    let state = try await service.changedFiles(at: fixture.repoPath, mode: .unstaged, baseBranch: nil)
+    let file = try #require(state.files.first(where: { $0.relativePath == "README.md" }))
+    let payload = try await service.renderPayload(for: file, at: fixture.repoPath, mode: .unstaged, baseBranch: nil)
+
+    #expect(file.additions == 1)
+    #expect(file.deletions == 1)
+    #expect(payload.oldContent == "initial")
+    #expect(payload.newContent == "changed")
+    #expect(!payload.isLimitedContext)
+  }
+
+  @Test("lists and renders staged changes")
+  func listsAndRendersStagedChanges() async throws {
+    let fixture = try GitRepoFixture.create()
+    defer { fixture.cleanup() }
+
+    try "staged".write(toFile: fixture.repoPath + "/README.md", atomically: true, encoding: .utf8)
+    try fixture.runGit("add", "README.md")
+
+    let service = GitDiffService()
+    let state = try await service.changedFiles(at: fixture.repoPath, mode: .staged, baseBranch: nil)
+    let file = try #require(state.files.first(where: { $0.relativePath == "README.md" }))
+    let payload = try await service.renderPayload(for: file, at: fixture.repoPath, mode: .staged, baseBranch: nil)
+
+    #expect(payload.oldContent == "initial")
+    #expect(payload.newContent == "staged")
+    #expect(!payload.isLimitedContext)
+  }
+
+  @Test("lists and renders branch changes")
+  func listsAndRendersBranchChanges() async throws {
+    let fixture = try GitRepoFixture.create()
+    defer { fixture.cleanup() }
+
+    try fixture.runGit("checkout", "-b", "feature/diff")
+    try "branch".write(toFile: fixture.repoPath + "/README.md", atomically: true, encoding: .utf8)
+    try fixture.runGit("add", "README.md")
+    try fixture.runGit("commit", "-m", "branch change")
+
+    let service = GitDiffService()
+    let state = try await service.changedFiles(at: fixture.repoPath, mode: .branch, baseBranch: "main")
+    let file = try #require(state.files.first(where: { $0.relativePath == "README.md" }))
+    let payload = try await service.renderPayload(for: file, at: fixture.repoPath, mode: .branch, baseBranch: "main")
+
+    #expect(payload.oldContent == "initial")
+    #expect(payload.newContent == "branch")
+    #expect(!payload.isLimitedContext)
+  }
+
+  @Test("renders deleted unstaged files")
+  func rendersDeletedUnstagedFiles() async throws {
+    let fixture = try GitRepoFixture.create()
+    defer { fixture.cleanup() }
+
+    try FileManager.default.removeItem(atPath: fixture.repoPath + "/README.md")
+
+    let service = GitDiffService()
+    let state = try await service.changedFiles(at: fixture.repoPath, mode: .unstaged, baseBranch: nil)
+    let file = try #require(state.files.first(where: { $0.relativePath == "README.md" }))
+    let payload = try await service.renderPayload(for: file, at: fixture.repoPath, mode: .unstaged, baseBranch: nil)
+
+    #expect(payload.oldContent == "initial")
+    #expect(payload.newContent == "")
+  }
+
+  @Test("lists and renders untracked files")
+  func listsAndRendersUntrackedFiles() async throws {
+    let fixture = try GitRepoFixture.create()
+    defer { fixture.cleanup() }
+
+    try "new file".write(toFile: fixture.repoPath + "/NewFile.txt", atomically: true, encoding: .utf8)
+
+    let service = GitDiffService()
+    let state = try await service.changedFiles(at: fixture.repoPath, mode: .unstaged, baseBranch: nil)
+    let file = try #require(state.files.first(where: { $0.relativePath == "NewFile.txt" }))
+    let payload = try await service.renderPayload(for: file, at: fixture.repoPath, mode: .unstaged, baseBranch: nil)
+
+    #expect(payload.oldContent == "")
+    #expect(payload.newContent == "new file")
+    #expect(!payload.isLimitedContext)
+  }
+
+  @Test("uses hunk fallback for large tracked files")
+  func usesHunkFallbackForLargeTrackedFiles() async throws {
+    let fixture = try GitRepoFixture.create()
+    defer { fixture.cleanup() }
+
+    try "changed line\nsecond line\n".write(
+      toFile: fixture.repoPath + "/README.md",
+      atomically: true,
+      encoding: .utf8
+    )
+
+    let service = GitDiffService(renderPolicy: GitDiffRenderPolicy(maxFullContentBytes: 8))
+    let state = try await service.changedFiles(at: fixture.repoPath, mode: .unstaged, baseBranch: nil)
+    let file = try #require(state.files.first(where: { $0.relativePath == "README.md" }))
+    let payload = try await service.renderPayload(for: file, at: fixture.repoPath, mode: .unstaged, baseBranch: nil)
+
+    #expect(payload.isLimitedContext)
+    #expect(payload.oldContent == "initial")
+    #expect(payload.newContent == "changed line\nsecond line")
+  }
+
+  @Test("uses no-index hunk fallback for large untracked files")
+  func usesNoIndexHunkFallbackForLargeUntrackedFiles() async throws {
+    let fixture = try GitRepoFixture.create()
+    defer { fixture.cleanup() }
+
+    try "alpha\nbeta\n".write(toFile: fixture.repoPath + "/LargeNew.txt", atomically: true, encoding: .utf8)
+
+    let service = GitDiffService(renderPolicy: GitDiffRenderPolicy(maxFullContentBytes: 4))
+    let state = try await service.changedFiles(at: fixture.repoPath, mode: .unstaged, baseBranch: nil)
+    let file = try #require(state.files.first(where: { $0.relativePath == "LargeNew.txt" }))
+    let payload = try await service.renderPayload(for: file, at: fixture.repoPath, mode: .unstaged, baseBranch: nil)
+
+    #expect(payload.isLimitedContext)
+    #expect(payload.oldContent == "")
+    #expect(payload.newContent == "alpha\nbeta")
+  }
+}

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/GitDiffTreeBuilderTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/GitDiffTreeBuilderTests.swift
@@ -1,0 +1,59 @@
+import Testing
+
+@testable import AgentHubCore
+
+@Suite("GitDiffTreeBuilder")
+struct GitDiffTreeBuilderTests {
+
+  @Test("builds stable ids across rebuilds")
+  func buildsStableIdsAcrossRebuilds() {
+    let files = [
+      entry("Sources/App/View.swift"),
+      entry("Sources/App/Model.swift"),
+      entry("Tests/AppTests/ViewTests.swift"),
+    ]
+
+    let first = GitDiffTreeBuilder.build(from: files)
+    let second = GitDiffTreeBuilder.build(from: files)
+
+    #expect(flattenIds(first.nodes) == flattenIds(second.nodes))
+  }
+
+  @Test("strips common directory prefix")
+  func stripsCommonPrefix() throws {
+    let result = GitDiffTreeBuilder.build(from: [
+      entry("Sources/App/View.swift"),
+      entry("Sources/App/Model.swift"),
+    ])
+
+    #expect(result.commonPrefix == "Sources/App")
+    #expect(result.nodes.map(\.name) == ["Model.swift", "View.swift"])
+  }
+
+  @Test("sorts folders before files deterministically")
+  func sortsFoldersBeforeFiles() {
+    let result = GitDiffTreeBuilder.build(from: [
+      entry("z-file.swift"),
+      entry("A/child.swift"),
+      entry("b-file.swift"),
+    ])
+
+    #expect(result.nodes.map(\.name) == ["A", "b-file.swift", "z-file.swift"])
+    #expect(result.nodes.first?.children.map(\.name) == ["child.swift"])
+  }
+
+  private func entry(_ relativePath: String) -> GitDiffFileEntry {
+    GitDiffFileEntry(
+      filePath: "/tmp/repo/\(relativePath)",
+      relativePath: relativePath,
+      additions: 1,
+      deletions: 0
+    )
+  }
+
+  private func flattenIds(_ nodes: [GitDiffTreeNode]) -> [String] {
+    nodes.flatMap { node in
+      [node.id] + flattenIds(node.children)
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Introduce `GitDiffServiceProtocol` with a render-payload API; `GitDiffView` now takes it via init for testability and mocking.
- Files exceeding the render policy limit (default 2 MB per side) fall back to a patch-derived limited-context render — only the changed hunks are shown — so opening huge files no longer hangs the diff view.
- Extract `GitDiffTreeBuilder` and `GitDiffTreeNode` out of `GitDiffView` into the Models layer and cover them with unit tests.
- Add generation-tracked cancellation in `GitDiffView` (`fileLoadTask` + `loadGeneration`) so rapid mode switches and selection changes can't drop stale results into state.

## Test plan
- [ ] `xcodebuild -workspace app/AgentHub.xcodeproj/project.xcworkspace -scheme AgentHub test`
- [ ] Open the diff view on a repo with a >2 MB changed file — verify the limited-context banner shows and only changed hunks render.
- [ ] Toggle between Unstaged / Staged / Branch modes rapidly — no stale content from a prior mode flashes in.
- [ ] Switch selected files quickly in a large changeset — only the latest selection's content lands.