### PR TITLE
Diff/plan comments panel: header Send button, stay-open, inline editor focus fix

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/DiffCommentsPanelView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/DiffCommentsPanelView.swift
@@ -48,7 +48,7 @@ struct DiffCommentsPanelView: View {
             }
           }
         }
-        .frame(maxHeight: 200)
+        .frame(maxHeight: 150)
 
         toolbarView
           .transition(.move(edge: .bottom).combined(with: .opacity))
@@ -79,30 +79,60 @@ struct DiffCommentsPanelView: View {
   // MARK: - Header
 
   private var headerView: some View {
-    Button {
-      isExpanded.toggle()
-    } label: {
-      HStack(spacing: 8) {
-        Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
-          .font(.caption2.weight(.semibold))
-          .foregroundColor(.secondary)
-          .frame(width: 10)
+    HStack(spacing: 8) {
+      Button {
+        isExpanded.toggle()
+      } label: {
+        HStack(spacing: 8) {
+          Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
+            .font(.caption2.weight(.semibold))
+            .foregroundColor(.secondary)
+            .frame(width: 10)
 
-        Image(systemName: "text.bubble.fill")
-          .font(.caption)
-          .foregroundColor(.secondary)
+          Image(systemName: "text.bubble.fill")
+            .font(.caption)
+            .foregroundColor(.secondary)
 
-        Text("\(commentsState.commentCount) Comment\(commentsState.commentCount == 1 ? "" : "s")")
-          .font(.caption.bold())
-          .foregroundColor(.primary)
+          Text("\(commentsState.commentCount) Comment\(commentsState.commentCount == 1 ? "" : "s")")
+            .font(.caption.bold())
+            .foregroundColor(.primary)
 
-        Spacer()
+          Spacer(minLength: 0)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .contentShape(Rectangle())
       }
-      .padding(.horizontal, 12)
-      .padding(.vertical, 8)
+      .buttonStyle(.plain)
+
+      // Only shown while collapsed — when expanded, the bottom toolbar
+      // already exposes the same action.
+      if !isExpanded {
+        headerSendButton
+      }
+    }
+    .padding(.horizontal, 12)
+    .padding(.vertical, 8)
+  }
+
+  private var headerSendButton: some View {
+    Button(action: onSendToCloud) {
+      HStack(spacing: 4) {
+        Image(systemName: "paperplane")
+          .font(.caption)
+        Text("Send \(commentsState.commentCount) to \(providerKind.rawValue)")
+          .font(.caption.bold())
+      }
+      .foregroundColor(.primary)
+      .padding(.horizontal, 10)
+      .padding(.vertical, 4)
+      .background(
+        RoundedRectangle(cornerRadius: 6)
+          .stroke(Color.primary.opacity(0.3), lineWidth: 1)
+      )
       .contentShape(Rectangle())
     }
     .buttonStyle(.plain)
+    .help("Send all comments to \(providerKind.rawValue) (⌘⇧↵)")
   }
 
   // MARK: - Toolbar

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/GitDiffView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/GitDiffView.swift
@@ -593,7 +593,6 @@ public struct GitDiffView: View {
     if let callback = onInlineRequestSubmit {
       callback(prompt, session)
       commentsState.clearAll()
-      onDismiss()
     } else if let config = cliConfiguration {
       // Fallback to external Terminal with cliConfiguration
       if let error = TerminalLauncher.launchTerminalWithSession(
@@ -605,7 +604,6 @@ public struct GitDiffView: View {
         inlineEditorState.errorMessage = error.localizedDescription
       } else {
         commentsState.clearAll()
-        onDismiss()
       }
     }
   }

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/InlineEditorView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/InlineEditorView.swift
@@ -116,6 +116,24 @@ struct InlineEditorView: View {
     .onAppear {
       isFocused = true
     }
+    // When the editor is reused for a different line (the overlay keeps the
+    // same view alive and only swaps init params), clicking the new line
+    // hands first-responder back to the diff view. @FocusState is still
+    // `true` locally, so re-asserting `true` would be a no-op — toggle
+    // through `false` on the next runloop tick to force SwiftUI to push
+    // focus back into the TextEditor's NSTextView.
+    .onChange(of: focusReassertKey) { _, _ in
+      isFocused = false
+      DispatchQueue.main.async {
+        isFocused = true
+      }
+    }
+  }
+
+  /// Identity used to detect when the editor is repositioned to a new line
+  /// while still on screen, so we can reapply focus.
+  private var focusReassertKey: String {
+    "\(fileName)|\(side)|\(lineNumber)|\(endLineNumber ?? -1)"
   }
 
   // MARK: - Input View

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/PlanView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/PlanView.swift
@@ -364,7 +364,6 @@ public struct PlanView: View {
 
     onSendFeedback?("\u{1B}[B\u{1B}[B\u{1B}[B\r\(feedback)", session)
     commentsState.clearAll()
-    onDismiss()
   }
 
   // MARK: - Load Content


### PR DESCRIPTION
## Summary
- **Inline editor focus** — when the user clicks a different diff line while the inline editor is already showing, the overlay reuses the same `InlineEditorView` (only init params change). `.onAppear` only fired once, and the click handed first-responder back to the diff view, so subsequent line clicks left the editor unfocused. Now `InlineEditorView` reapplies focus via `.onChange(of: focusReassertKey)`, toggling `isFocused` through `false → true` across runloop ticks to force SwiftUI to push the change into the underlying `NSTextView`.
- **Send button in collapsed header** — `DiffCommentsPanelView` now exposes the Send button in the collapsed header so it's reachable without expanding. It is hidden when expanded since the existing bottom toolbar already has it. Applies to both `GitDiffView` and `PlanView` (shared component).
- **Trimmed expanded panel** — comment list `maxHeight` reduced from 200 to 150.
- **Keep side panel open after Send** — `GitDiffView.sendAllCommentsToCloud()` and `PlanView.sendFeedbackToTerminal()` no longer call `onDismiss()` (which was `closeEmbeddedSidePanel`). `clearAll()` still empties the list.

## Test plan
- [ ] Open a diff with multiple files; click a line, type a comment, then click another line without dismissing — the new inline editor input should be focused immediately.
- [ ] Add a comment, collapse the comments panel — the "Send N to Claude/Codex" button should be visible in the header and dispatch the send action without expanding.
- [ ] Expand the comments panel — the header Send button should disappear (bottom toolbar one stays); list scroll area should feel ~50px shorter.
- [ ] Send comments from a diff and from a plan view — comments list should clear but the side panel should stay open.