### PR TITLE
[codex] Fix Codex pending session discovery

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubProvider.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubProvider.swift
@@ -331,6 +331,7 @@ public final class AgentHubProvider {
       webPreviewCandidateService: webPreviewCandidateService,
       approvalClaimStore: claimStore,
       hookInstaller: installer,
+      codexDataPath: providerKind == .codex ? configuration.codexDataPath : nil,
       terminalSurfaceFactory: terminalSurfaceFactory,
       terminalBackend: terminalBackend,
       terminalWorkspaceStore: metadataStore

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/CodexSessionFileScanner.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/CodexSessionFileScanner.swift
@@ -30,6 +30,8 @@ public struct CodexSessionMeta: Sendable {
 }
 
 public enum CodexSessionFileScanner {
+  private static let firstLineChunkSize = 16_384
+  private static let maxFirstLineBytes = 262_144
 
   public static func listSessionFiles(codexDataPath: String) -> [String] {
     let sessionsRoot = (codexDataPath as NSString).expandingTildeInPath + "/sessions"
@@ -57,38 +59,30 @@ public enum CodexSessionFileScanner {
     guard let handle = FileHandle(forReadingAtPath: path) else { return nil }
     defer { try? handle.close() }
 
-    guard let data = try? handle.read(upToCount: 16_384),
-          let content = String(data: data, encoding: .utf8) else {
+    guard let firstLine = readFirstLine(from: handle),
+          let jsonData = firstLine.data(using: .utf8),
+          let json = try? JSONSerialization.jsonObject(with: jsonData) as? [String: Any] else {
       return nil
     }
 
-    for line in content.components(separatedBy: .newlines) where !line.isEmpty {
-      guard let jsonData = line.data(using: .utf8),
-            let json = try? JSONSerialization.jsonObject(with: jsonData) as? [String: Any] else {
-        continue
-      }
-
-      guard let type = json["type"] as? String, type == "session_meta" else { continue }
-      guard let payload = json["payload"] as? [String: Any] else { continue }
-      guard let sessionId = payload["id"] as? String,
-            let cwd = payload["cwd"] as? String else {
-        continue
-      }
-
-      let startedAt = parseTimestamp(payload["timestamp"] as? String) ?? parseTimestamp(json["timestamp"] as? String)
-      let git = payload["git"] as? [String: Any]
-      let branch = git?["branch"] as? String
-
-      return CodexSessionMeta(
-        sessionId: sessionId,
-        projectPath: cwd,
-        branch: branch,
-        startedAt: startedAt,
-        sessionFilePath: path
-      )
+    guard let type = json["type"] as? String, type == "session_meta" else { return nil }
+    guard let payload = json["payload"] as? [String: Any] else { return nil }
+    guard let sessionId = payload["id"] as? String,
+          let cwd = payload["cwd"] as? String else {
+      return nil
     }
 
-    return nil
+    let startedAt = parseTimestamp(payload["timestamp"] as? String) ?? parseTimestamp(json["timestamp"] as? String)
+    let git = payload["git"] as? [String: Any]
+    let branch = git?["branch"] as? String
+
+    return CodexSessionMeta(
+      sessionId: sessionId,
+      projectPath: cwd,
+      branch: branch,
+      startedAt: startedAt,
+      sessionFilePath: path
+    )
   }
 
   private static func parseTimestamp(_ string: String?) -> Date? {
@@ -101,5 +95,37 @@ public enum CodexSessionFileScanner {
     formatter.formatOptions = [.withInternetDateTime]
     return formatter.date(from: string)
   }
-}
 
+  private static func readFirstLine(from handle: FileHandle) -> String? {
+    var data = Data()
+
+    while data.count < maxFirstLineBytes {
+      let remaining = min(firstLineChunkSize, maxFirstLineBytes - data.count)
+      guard remaining > 0 else { break }
+
+      guard let chunk = try? handle.read(upToCount: remaining),
+            !chunk.isEmpty else {
+        break
+      }
+
+      if let newlineIndex = chunk.firstIndex(of: 0x0A) {
+        data.append(chunk.prefix(upTo: newlineIndex))
+        return String(data: data, encoding: .utf8)?
+          .trimmingCharacters(in: CharacterSet(charactersIn: "\r"))
+      }
+
+      data.append(chunk)
+
+      if chunk.count < remaining {
+        break
+      }
+    }
+
+    guard !data.isEmpty, data.count < maxFirstLineBytes else {
+      return nil
+    }
+
+    return String(data: data, encoding: .utf8)?
+      .trimmingCharacters(in: CharacterSet(charactersIn: "\r"))
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/CLISessionsViewModel.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/CLISessionsViewModel.swift
@@ -27,6 +27,7 @@ public final class CLISessionsViewModel {
   private let searchService: (any SessionSearchServiceProtocol)?
   public let cliConfiguration: CLICommandConfiguration
   public let providerKind: SessionProviderKind
+  private let codexDataPath: String
   private let worktreeService = GitWorktreeService()
   private let metadataStore: SessionMetadataStore?
   private let terminalWorkspaceStore: (any TerminalWorkspaceStoreProtocol)?
@@ -877,6 +878,7 @@ public final class CLISessionsViewModel {
     approvalNotificationService: any ApprovalNotificationServiceProtocol = ApprovalNotificationService.shared,
     approvalClaimStore: (any ApprovalClaimStoreProtocol)? = nil,
     hookInstaller: (any ClaudeHookInstallerProtocol)? = nil,
+    codexDataPath: String? = nil,
     terminalSurfaceFactory: any EmbeddedTerminalSurfaceFactory = DefaultEmbeddedTerminalSurfaceFactory(),
     terminalBackend: EmbeddedTerminalBackend = .storedPreference,
     terminalWorkspaceStore: (any TerminalWorkspaceStoreProtocol)? = nil
@@ -896,6 +898,7 @@ public final class CLISessionsViewModel {
     self.terminalBackend = terminalBackend
     self.cliConfiguration = cliConfiguration
     self.providerKind = providerKind
+    self.codexDataPath = NSString(string: codexDataPath ?? "~/.codex").expandingTildeInPath
     self.showLastMessage = UserDefaults.standard.bool(forKey: "CLISessionsShowLastMessage")
 
     // Load approval timeout with default of 5 seconds
@@ -2445,8 +2448,7 @@ public final class CLISessionsViewModel {
   /// Watches the Codex sessions directory for a new session file.
   @MainActor
   private func watchForNewCodexSession(pending: PendingHubSession, worktree: WorktreeBranch) async {
-    let codexPath = FileManager.default.homeDirectoryForCurrentUser.path + "/.codex"
-    var knownFiles = Set(CodexSessionFileScanner.listSessionFiles(codexDataPath: codexPath))
+    var knownFiles = Set(CodexSessionFileScanner.listSessionFiles(codexDataPath: codexDataPath))
 
     if let meta = findRecentCodexSession(
       in: knownFiles,
@@ -2465,7 +2467,7 @@ public final class CLISessionsViewModel {
     await pollForNewCodexSession(
       pending: pending,
       worktree: worktree,
-      codexPath: codexPath,
+      codexPath: codexDataPath,
       knownFiles: &knownFiles
     )
   }

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/CodexSessionFileScannerTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/CodexSessionFileScannerTests.swift
@@ -1,0 +1,84 @@
+import Foundation
+import Testing
+
+@testable import AgentHubCore
+
+@Suite("CodexSessionFileScanner")
+struct CodexSessionFileScannerTests {
+  @Test("Reads session metadata when the first JSONL line exceeds sixteen kilobytes")
+  func readsOversizedSessionMetaLine() throws {
+    let root = try temporaryDirectory()
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    let sessionID = "55555555-5555-5555-5555-555555555555"
+    let projectPath = "/tmp/oversized-project"
+    let sessionFile = root.appending(path: "session.jsonl")
+
+    try oversizedCodexSessionFileContents(
+      sessionID: sessionID,
+      cwd: projectPath,
+      branch: "feature/oversized-meta",
+      baseInstructionsLength: 24_000
+    )
+    .write(to: sessionFile, atomically: true, encoding: .utf8)
+
+    let meta = try #require(CodexSessionFileScanner.readSessionMeta(from: sessionFile.path))
+
+    #expect(meta.sessionId == sessionID)
+    #expect(meta.projectPath == projectPath)
+    #expect(meta.branch == "feature/oversized-meta")
+    #expect(meta.sessionFilePath == sessionFile.path)
+
+    let expectedDate = ISO8601DateFormatter().date(from: "2026-05-05T12:00:00.000Z")
+    #expect(meta.startedAt == expectedDate)
+  }
+}
+
+private func oversizedCodexSessionFileContents(
+  sessionID: String,
+  cwd: String,
+  branch: String,
+  baseInstructionsLength: Int
+) -> String {
+  let sessionMeta: [String: Any] = [
+    "timestamp": "2026-05-05T12:00:00.000Z",
+    "type": "session_meta",
+    "payload": [
+      "id": sessionID,
+      "timestamp": "2026-05-05T12:00:00.000Z",
+      "cwd": cwd,
+      "git": [
+        "branch": branch
+      ],
+      "base_instructions": [
+        "text": String(repeating: "x", count: baseInstructionsLength)
+      ]
+    ]
+  ]
+  let userMessage: [String: Any] = [
+    "timestamp": "2026-05-05T12:00:01.000Z",
+    "type": "event_msg",
+    "payload": [
+      "type": "user_message",
+      "message": "hello"
+    ]
+  ]
+
+  return """
+  \(jsonLine(sessionMeta))
+  \(jsonLine(userMessage))
+
+  """
+}
+
+private func jsonLine(_ object: [String: Any]) -> String {
+  let data = try! JSONSerialization.data(withJSONObject: object)
+  return String(decoding: data, as: UTF8.self)
+}
+
+private func temporaryDirectory() throws -> URL {
+  let url = FileManager.default.temporaryDirectory
+    .appending(path: "codex_session_file_scanner_\(UUID().uuidString)", directoryHint: .isDirectory)
+  try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+  return url
+}

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/LazyBrowseSessionsLoadingTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/LazyBrowseSessionsLoadingTests.swift
@@ -426,7 +426,12 @@ struct LazyBrowseSessionsLoadingTests {
 
     let requestedId = "22222222-2222-2222-2222-222222222222"
     let otherId = "33333333-3333-3333-3333-333333333333"
-    try codexLines(sessionId: requestedId, cwd: "/tmp/project", message: "requested")
+    try codexLines(
+      sessionId: requestedId,
+      cwd: "/tmp/project",
+      message: "requested",
+      baseInstructionsLength: 24_000
+    )
       .write(
         to: sessionsDir.appending(path: "rollout-2026-05-05T12-00-00-\(requestedId).jsonl"),
         atomically: true,
@@ -445,6 +450,73 @@ struct LazyBrowseSessionsLoadingTests {
     #expect(sessions.map(\.id) == [requestedId])
     #expect(sessions.first?.firstMessage == "requested")
     #expect(sessions.first?.projectPath == "/tmp/project")
+  }
+
+  @Test("Codex pending session resolves from configured data path with oversized session metadata")
+  func codexPendingSessionResolvesFromConfiguredDataPath() async throws {
+    let root = try temporaryDirectory()
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    let projectURL = root.appending(path: "project", directoryHint: .isDirectory)
+    try FileManager.default.createDirectory(at: projectURL, withIntermediateDirectories: true)
+
+    let watcher = RecordingFileWatcher()
+    let monitorService = CodexSessionMonitorService(codexDataPath: root.path)
+    let viewModel = CLISessionsViewModel(
+      monitorService: monitorService,
+      fileWatcher: watcher,
+      searchService: nil,
+      cliConfiguration: CLICommandConfiguration(command: "codex", mode: .codex),
+      providerKind: .codex,
+      approvalNotificationService: NoOpApprovalNotificationService(),
+      codexDataPath: root.path
+    )
+
+    viewModel.addRepository(at: projectURL.path)
+
+    await waitUntil(timeout: .seconds(6)) {
+      viewModel.loadingState == .idle && viewModel.selectedRepositories.count == 1
+    }
+
+    let worktree = try #require(
+      viewModel.selectedRepositories.first?.worktrees.first(where: { $0.path == projectURL.path })
+    )
+
+    viewModel.startNewSessionInHub(worktree, initialPrompt: "pending codex")
+
+    await waitUntil {
+      viewModel.pendingHubSessions.count == 1
+    }
+
+    let pending = try #require(viewModel.pendingHubSessions.first)
+    let sessionId = "44444444-4444-4444-4444-444444444444"
+    let sessionsDir = root
+      .appending(path: "sessions")
+      .appending(path: "2026")
+      .appending(path: "05")
+      .appending(path: "05")
+    try FileManager.default.createDirectory(at: sessionsDir, withIntermediateDirectories: true)
+
+    try codexLines(
+      sessionId: sessionId,
+      cwd: projectURL.path,
+      message: "pending codex",
+      baseInstructionsLength: 24_000
+    )
+    .write(
+      to: sessionsDir.appending(path: "rollout-2026-05-05T12-02-00-\(sessionId).jsonl"),
+      atomically: true,
+      encoding: .utf8
+    )
+
+    await waitUntil(timeout: .seconds(8)) {
+      viewModel.resolvedPendingSessions[pending.id] == sessionId
+        && !viewModel.pendingHubSessions.contains(where: { $0.id == pending.id })
+        && viewModel.monitoredSessions.contains(where: { $0.session.id == sessionId })
+    }
+
+    #expect(viewModel.findSession(byId: sessionId)?.projectPath == projectURL.path)
+    #expect((await watcher.startedSessionIds()).contains(sessionId))
   }
 }
 
@@ -665,10 +737,49 @@ private func claudeLine(
   """
 }
 
-private func codexLines(sessionId: String, cwd: String, message: String) -> String {
-  """
-  {"timestamp":"2026-05-05T12:00:00.000Z","type":"session_meta","payload":{"id":"\(sessionId)","timestamp":"2026-05-05T12:00:00.000Z","cwd":"\(cwd)","git":{"branch":"main"}}}
-  {"timestamp":"2026-05-05T12:00:01.000Z","type":"event_msg","payload":{"type":"user_message","message":"\(message)"}}
+private func codexLines(
+  sessionId: String,
+  cwd: String,
+  message: String,
+  baseInstructionsLength: Int = 0
+) -> String {
+  var sessionMetaPayload: [String: Any] = [
+    "id": sessionId,
+    "timestamp": "2026-05-05T12:00:00.000Z",
+    "cwd": cwd,
+    "git": [
+      "branch": "main"
+    ]
+  ]
+
+  if baseInstructionsLength > 0 {
+    sessionMetaPayload["base_instructions"] = [
+      "text": String(repeating: "x", count: baseInstructionsLength)
+    ]
+  }
+
+  let sessionMeta: [String: Any] = [
+    "timestamp": "2026-05-05T12:00:00.000Z",
+    "type": "session_meta",
+    "payload": sessionMetaPayload
+  ]
+  let userMessage: [String: Any] = [
+    "timestamp": "2026-05-05T12:00:01.000Z",
+    "type": "event_msg",
+    "payload": [
+      "type": "user_message",
+      "message": message
+    ]
+  ]
+
+  return """
+  \(jsonLine(sessionMeta))
+  \(jsonLine(userMessage))
 
   """
+}
+
+private func jsonLine(_ object: [String: Any]) -> String {
+  let data = try! JSONSerialization.data(withJSONObject: object)
+  return String(decoding: data, as: UTF8.self)
 }


### PR DESCRIPTION
## Summary

- Thread the configured Codex data path into pending-session detection instead of assuming `~/.codex`.
- Read oversized Codex `session_meta` first lines in chunks so pending-session matching still sees metadata when base instructions are large.
- Add coverage for oversized metadata scanning and configured-data-path pending-session resolution.

## Validation

- `xcodebuild build -project app/AgentHub.xcodeproj -scheme AgentHubCore -destination 'platform=macOS'` completed with `** BUILD SUCCEEDED **`.
- `swift test --package-path app/modules/AgentHubCore --filter CodexSessionFileScannerTests` did not reach tests because the package build fails in dependency `CodeEditSymbols` with `Bundle.module` errors.
- `xcodebuild test` could not run the focused tests because the `AgentHubCore`, `AgentHub`, and `agenthub` schemes are not configured for the test action.