### PR TITLE
[codex] Fix monitoring panel loading state

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderMonitoringPanelView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderMonitoringPanelView.swift
@@ -457,12 +457,12 @@ public struct MultiProviderMonitoringPanelView: View {
 
   @ViewBuilder
   private func mainContentBody(snapshot: MonitoringItemsSnapshot<ProviderMonitoringItem>) -> some View {
-    if isLoading {
-      loadingState
-    } else if snapshot.allItems.isEmpty {
-      emptyState
-    } else {
+    if !snapshot.allItems.isEmpty {
       monitoredSessionsList(snapshot: snapshot)
+    } else if isLoading {
+      loadingState
+    } else {
+      emptyState
     }
   }
 
@@ -476,11 +476,21 @@ public struct MultiProviderMonitoringPanelView: View {
     VStack(spacing: 12) {
       ProgressView()
         .scaleEffect(0.8)
-      Text("Restoring sessions...")
+      Text(loadingMessage)
         .font(.primaryDefault)
         .foregroundColor(.secondary)
     }
     .frame(maxWidth: .infinity, maxHeight: .infinity)
+  }
+
+  private var loadingMessage: String {
+    if claudeViewModel.isLoading {
+      return claudeViewModel.loadingState.message
+    }
+    if codexViewModel.isLoading {
+      return codexViewModel.loadingState.message
+    }
+    return "Loading sessions..."
   }
 
   // MARK: - Empty State


### PR DESCRIPTION
## Summary

- Render pending or monitored session cards before considering the monitoring panel loading placeholder.
- Replace the hard-coded `Restoring sessions...` label with the active provider ViewModel's contextual loading message.

## Root Cause

The combined monitoring panel treated any provider `isLoading` state as a full-panel restore state. New-session launch paths call repository add/refresh operations, so the panel could show `Restoring sessions...` even while a pending session card was available.

## Impact

Starting a new session now keeps the pending session/terminal card visible. The full-panel loader only appears when there are no renderable session cards, and its copy matches the actual loading operation.

## Validation

- `git diff --check -- app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderMonitoringPanelView.swift`
- `xcodebuild -project app/AgentHub.xcodeproj -scheme AgentHubCore -destination platform=macOS build`