### PR TITLE
[codex] Add module landing page

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/Models/ModuleLandingSelection.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Models/ModuleLandingSelection.swift
@@ -1,0 +1,36 @@
+//
+//  ModuleLandingSelection.swift
+//  AgentHub
+//
+enum ModuleLandingSelection {
+  static func activeModulePath(
+    selectedPath: String?,
+    repositories: [SelectedRepository],
+    itemProjectPaths: [String]
+  ) -> String? {
+    guard let selectedPath else { return nil }
+    guard repositories.contains(where: { $0.path == selectedPath }) else { return nil }
+
+    let hasItems = itemProjectPaths.contains { itemPath in
+      parentModulePath(for: itemPath, repositories: repositories) == selectedPath
+    }
+    return hasItems ? nil : selectedPath
+  }
+
+  private static func parentModulePath(
+    for itemPath: String,
+    repositories: [SelectedRepository]
+  ) -> String {
+    for repository in repositories {
+      if repository.path == itemPath {
+        return repository.path
+      }
+
+      if repository.worktrees.contains(where: { $0.path == itemPath }) {
+        return repository.path
+      }
+    }
+
+    return itemPath
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderMonitoringPanelView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderMonitoringPanelView.swift
@@ -196,6 +196,7 @@ public struct MultiProviderMonitoringPanelView: View {
   @State private var editorStates: [String: MonitoringEditorState] = [:]
   @State private var availableDetailWidth: CGFloat = 0
   @Binding var primarySessionId: String?
+  @Binding var selectedModuleLandingPath: String?
   @AppStorage(AgentHubDefaults.hubLayoutMode)
   private var layoutModeRawValue: Int = LayoutMode.single.rawValue
   @AppStorage(AgentHubDefaults.hubPreviousLayoutMode)
@@ -232,6 +233,7 @@ public struct MultiProviderMonitoringPanelView: View {
   private func wantsEmbeddedSidePanelPresentation(snapshot: MonitoringItemsSnapshot<ProviderMonitoringItem>) -> Bool {
     layoutMode == .single
       && maximizedSessionId == nil
+      && activeModuleLandingPath(snapshot: snapshot) == nil
       && sidePanelPresentation.shellPayload != nil
       && !snapshot.visibleItems.isEmpty
   }
@@ -244,12 +246,14 @@ public struct MultiProviderMonitoringPanelView: View {
     claudeViewModel: CLISessionsViewModel,
     codexViewModel: CLISessionsViewModel,
     primarySessionId: Binding<String?>,
+    selectedModuleLandingPath: Binding<String?> = .constant(nil),
     onEmbeddedSidePanelVisibilityChange: @escaping (Bool) -> Void = { _ in },
     onRequestStartSession: @escaping (String?) -> Void
   ) {
     self.claudeViewModel = claudeViewModel
     self.codexViewModel = codexViewModel
     self._primarySessionId = primarySessionId
+    self._selectedModuleLandingPath = selectedModuleLandingPath
     self.onEmbeddedSidePanelVisibilityChange = onEmbeddedSidePanelVisibilityChange
     self.onRequestStartSession = onRequestStartSession
   }
@@ -291,6 +295,11 @@ public struct MultiProviderMonitoringPanelView: View {
     }
     .onChange(of: snapshot.effectivePrimaryItemID) { _, _ in
       syncAuxiliaryShellDockState()
+    }
+    .onChange(of: activeModuleLandingPath(snapshot: snapshot)) { _, activePath in
+      guard activePath != nil else { return }
+      maximizedSessionId = nil
+      closeEmbeddedSidePanel()
     }
     .onChange(of: isAuxiliaryShellVisible) { _, _ in
       syncAuxiliaryShellDockState()
@@ -457,7 +466,12 @@ public struct MultiProviderMonitoringPanelView: View {
 
   @ViewBuilder
   private func mainContentBody(snapshot: MonitoringItemsSnapshot<ProviderMonitoringItem>) -> some View {
-    if !snapshot.allItems.isEmpty {
+    if let modulePath = activeModuleLandingPath(snapshot: snapshot) {
+      ModuleLandingView(
+        modulePath: modulePath,
+        onStartSession: { onRequestStartSession(modulePath) }
+      )
+    } else if !snapshot.allItems.isEmpty {
       monitoredSessionsList(snapshot: snapshot)
     } else if isLoading {
       loadingState
@@ -1352,6 +1366,7 @@ public struct MultiProviderMonitoringPanelView: View {
   }
 
   private func auxiliaryShellTarget(snapshot: MonitoringItemsSnapshot<ProviderMonitoringItem>) -> HubAuxiliaryShellTarget? {
+    guard activeModuleLandingPath(snapshot: snapshot) == nil else { return nil }
     guard let item = snapshot.effectivePrimaryItem else { return nil }
 
     switch item {
@@ -1464,6 +1479,11 @@ public struct MultiProviderMonitoringPanelView: View {
   }
 
   private func ensurePrimarySelection(snapshot: MonitoringItemsSnapshot<ProviderMonitoringItem>? = nil) {
+    guard selectedModuleLandingPath == nil else {
+      primarySessionId = nil
+      return
+    }
+
     let snapshot = snapshot ?? makeItemSnapshot()
     guard !snapshot.allItems.isEmpty else {
       primarySessionId = nil
@@ -1619,6 +1639,7 @@ public struct MultiProviderMonitoringPanelView: View {
   }
 
   private func togglePrimarySessionContentMode() {
+    guard activeModuleLandingPath(snapshot: makeItemSnapshot()) == nil else { return }
     guard let item = effectivePrimaryItem else { return }
     let nextMode: MonitoringCardContentMode =
       editorState(for: item).contentMode == .terminal ? .editor : .terminal
@@ -1660,6 +1681,60 @@ public struct MultiProviderMonitoringPanelView: View {
         state: state
       )
     }
+  }
+
+  private func activeModuleLandingPath(snapshot: MonitoringItemsSnapshot<ProviderMonitoringItem>) -> String? {
+    ModuleLandingSelection.activeModulePath(
+      selectedPath: selectedModuleLandingPath,
+      repositories: allSelectedRepositories,
+      itemProjectPaths: snapshot.allItems.map(\.projectPath)
+    )
+  }
+}
+
+// MARK: - ModuleLandingView
+
+private struct ModuleLandingView: View {
+  let modulePath: String
+  let onStartSession: () -> Void
+
+  @Environment(\.colorScheme) private var colorScheme
+
+  private var moduleName: String {
+    URL(fileURLWithPath: modulePath).lastPathComponent
+  }
+
+  var body: some View {
+    VStack(spacing: 20) {
+      Text("What should we build in \(moduleName)?")
+        .font(.system(size: 31, weight: .regular))
+        .foregroundStyle(.primary)
+        .multilineTextAlignment(.center)
+        .lineLimit(nil)
+        .minimumScaleFactor(0.65)
+        .fixedSize(horizontal: false, vertical: true)
+
+      Button(action: onStartSession) {
+        HStack(spacing: 8) {
+          Image(systemName: "plus.circle.fill")
+            .font(.system(size: 13))
+          Text("Start Session")
+            .font(.system(size: 13, weight: .semibold))
+        }
+        .foregroundStyle(colorScheme == .dark ? .black : .white)
+        .frame(height: 36)
+        .padding(.horizontal, 18)
+        .background(
+          RoundedRectangle(cornerRadius: 10, style: .continuous)
+            .fill(Color.primary)
+        )
+      }
+      .buttonStyle(.plain)
+      .help("Start a session in \(moduleName)")
+    }
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+    .padding(.horizontal, 48)
+    .padding(.vertical, 32)
   }
 }
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
@@ -165,6 +165,9 @@ public struct MultiProviderSessionsListView: View {
   @State private var gitHubSheetItem: GitHubSheetItem?
   @State private var archiveConfirmation: ArchiveConfirmation?
   @State private var removeConfirmation: RemoveConfirmation?
+  @State private var selectedModuleLandingPath: String?
+  @State private var pendingAddedModulePaths: [String] = []
+  @State private var isStartSessionSheetPresented = false
 
   // TODO: Remove along with MultiSessionLaunchView once the new Threads-based
   // session-start flow is fully implemented. Flip to `true` to restore the
@@ -227,6 +230,7 @@ public struct MultiProviderSessionsListView: View {
           claudeViewModel: claudeViewModel,
           codexViewModel: codexViewModel,
           primarySessionId: $primarySessionId,
+          selectedModuleLandingPath: $selectedModuleLandingPath,
           onEmbeddedSidePanelVisibilityChange: handleEmbeddedSidePanelVisibilityChange,
           onRequestStartSession: { preferredRepositoryPath in
             triggerNewSessionFlow(preferredRepositoryPath: preferredRepositoryPath)
@@ -281,10 +285,21 @@ public struct MultiProviderSessionsListView: View {
       codexViewModel.lastCreatedPendingId = nil
     }
     .onChange(of: selectedSessionItems.map(\.id)) { _, _ in
+      syncModuleLandingSelection()
       ensurePrimarySelection()
       if selectedSessionItems.isEmpty {
         setAuxiliaryShellVisible(false)
       }
+    }
+    .onChange(of: orderedTrackedRepos.map(\.path)) { _, _ in
+      syncPendingModuleRows()
+      syncModuleLandingSelection()
+      ensurePrimarySelection()
+    }
+    .onChange(of: sidebarGroupMode) { _, newMode in
+      guard newMode != .repo else { return }
+      selectedModuleLandingPath = nil
+      ensurePrimarySelection()
     }
     .sheet(item: $sessionFileSheetItem) { item in
       SessionFileSheetView(
@@ -403,6 +418,15 @@ public struct MultiProviderSessionsListView: View {
           }
         }
       )
+    }
+    .sheet(isPresented: $isStartSessionSheetPresented) {
+      if let multiLaunchViewModel {
+        StartSessionSheet(
+          launchViewModel: multiLaunchViewModel,
+          intelligenceViewModel: intelligenceViewModel,
+          onDismiss: { isStartSessionSheetPresented = false }
+        )
+      }
     }
     .modifier(ArchiveConfirmationAlert(confirmation: $archiveConfirmation))
     .modifier(RemoveConfirmationAlert(confirmation: $removeConfirmation))
@@ -930,6 +954,17 @@ public struct MultiProviderSessionsListView: View {
         onAddFolder: { showAddRepositoryPicker() }
       )
 
+      let pendingModules = pendingModulePaths
+      if !pendingModules.isEmpty {
+        ForEach(pendingModules, id: \.self) { path in
+          PendingModuleRow(
+            name: moduleDisplayName(for: path),
+            isSelected: selectedModuleLandingPath == path
+          )
+          .transition(.opacity.combined(with: .move(edge: .top)))
+        }
+      }
+
       // Pinned sessions section
       let pinned = pinnedSessionItems
       if !pinned.isEmpty {
@@ -960,6 +995,7 @@ public struct MultiProviderSessionsListView: View {
               name: group.displayName,
               isExpanded: isExpanded,
               canToggle: !group.items.isEmpty,
+              isSelected: selectedModuleLandingPath == group.id && group.items.isEmpty,
               onToggle: {
                 withAnimation(.easeInOut(duration: 0.25)) {
                   if isExpanded {
@@ -969,9 +1005,13 @@ public struct MultiProviderSessionsListView: View {
                   }
                 }
               },
+              onSelectEmptyModule: {
+                selectEmptyModule(group.id)
+              },
               repoPath: group.id,
-              launchViewModel: multiLaunchViewModel,
-              intelligenceViewModel: intelligenceViewModel,
+              onStartSession: {
+                triggerNewSessionFlow(preferredRepositoryPath: group.id)
+              },
               onOpenInFinder: {
                 NSWorkspace.shared.selectFile(nil, inFileViewerRootedAtPath: group.id)
               },
@@ -999,6 +1039,9 @@ public struct MultiProviderSessionsListView: View {
                   repoName: group.displayName,
                   sessionCount: group.items.count
                 ) {
+                  if selectedModuleLandingPath == group.id {
+                    selectedModuleLandingPath = nil
+                  }
                   if let repo = claudeViewModel.selectedRepositories.first(where: { $0.path == group.id }) {
                     claudeViewModel.removeRepository(repo)
                   }
@@ -1090,6 +1133,7 @@ public struct MultiProviderSessionsListView: View {
             }
           }(),
           onSelect: {
+            selectedModuleLandingPath = nil
             primarySessionId = item.id
           }
         )
@@ -1354,8 +1398,11 @@ public struct MultiProviderSessionsListView: View {
   }
 
   private func addRepository(at path: String) {
+    sidebarGroupMode = .repo
+    trackPendingModule(path)
     claudeViewModel.addRepository(at: path)
     codexViewModel.addRepository(at: path)
+    selectEmptyModule(path)
   }
 
   private func openSessionFile(for session: CLISession, viewModel: CLISessionsViewModel) {
@@ -1423,6 +1470,11 @@ public struct MultiProviderSessionsListView: View {
   }
 
   private func ensurePrimarySelection() {
+    guard selectedModuleLandingPath == nil else {
+      primarySessionId = nil
+      return
+    }
+
     let items = selectedSessionItems
     guard !items.isEmpty else {
       primarySessionId = nil
@@ -1432,6 +1484,54 @@ public struct MultiProviderSessionsListView: View {
       return
     }
     primarySessionId = items.first?.id
+  }
+
+  private func selectEmptyModule(_ path: String) {
+    selectedModuleLandingPath = path
+    primarySessionId = nil
+    setAuxiliaryShellVisible(false)
+  }
+
+  private func syncModuleLandingSelection() {
+    if let selectedModuleLandingPath,
+       pendingModulePaths.contains(selectedModuleLandingPath) {
+      return
+    }
+
+    let activePath = ModuleLandingSelection.activeModulePath(
+      selectedPath: selectedModuleLandingPath,
+      repositories: orderedTrackedRepos,
+      itemProjectPaths: selectedSessionItems.map { $0.session.projectPath }
+    )
+
+    if activePath == nil {
+      selectedModuleLandingPath = nil
+    }
+  }
+
+  private func trackPendingModule(_ path: String) {
+    guard !orderedTrackedRepos.contains(where: { $0.path == path }),
+          !pendingAddedModulePaths.contains(path) else {
+      return
+    }
+    pendingAddedModulePaths.insert(path, at: 0)
+  }
+
+  private func syncPendingModuleRows() {
+    let trackedPaths = Set(orderedTrackedRepos.map(\.path))
+    pendingAddedModulePaths.removeAll { trackedPaths.contains($0) }
+  }
+
+  private var pendingModulePaths: [String] {
+    let trackedPaths = Set(orderedTrackedRepos.map(\.path))
+    var seen: Set<String> = []
+    return pendingAddedModulePaths.filter { path in
+      !trackedPaths.contains(path) && seen.insert(path).inserted
+    }
+  }
+
+  private func moduleDisplayName(for path: String) -> String {
+    URL(fileURLWithPath: path).lastPathComponent
   }
 
   // MARK: - Computed
@@ -1488,6 +1588,7 @@ public struct MultiProviderSessionsListView: View {
 
     case .switchToSession(let id, _, _, _):
       if let item = selectedSessionItems.first(where: { $0.id == id }) {
+        selectedModuleLandingPath = nil
         primarySessionId = item.id
         scrollToSessionId = item.id
       }
@@ -1533,25 +1634,21 @@ public struct MultiProviderSessionsListView: View {
   }
 
   private func triggerNewSessionFlow(preferredRepositoryPath: String? = nil) {
-    withAnimation(browseAnimation) {
-      isBrowseExpanded = true
-    }
-    claudeViewModel.ensureBrowseSessionsLoaded()
-    codexViewModel.ensureBrowseSessionsLoaded()
-    launchExpandRequestID += 1
-
     guard let multiLaunchViewModel else { return }
-
     multiLaunchViewModel.reset()
 
     guard let preferredRepositoryPath else {
+      isStartSessionSheetPresented = true
       multiLaunchViewModel.selectRepository()
       return
     }
 
     Task { @MainActor in
       let didPreselect = await multiLaunchViewModel.preselectRepository(path: preferredRepositoryPath)
-      if !didPreselect {
+      if didPreselect {
+        isStartSessionSheetPresented = true
+      } else {
+        isStartSessionSheetPresented = true
         multiLaunchViewModel.selectRepository()
       }
     }
@@ -1609,12 +1706,51 @@ public struct MultiProviderSessionsListView: View {
       case .backward:
         newIndex = max(currentIndex - 1, 0)
       }
+      selectedModuleLandingPath = nil
       primarySessionId = items[newIndex].id
       scrollToSessionId = items[newIndex].id
     } else {
+      selectedModuleLandingPath = nil
       primarySessionId = items.first?.id
       scrollToSessionId = items.first?.id
     }
+  }
+}
+
+// MARK: - PendingModuleRow
+
+private struct PendingModuleRow: View {
+  let name: String
+  let isSelected: Bool
+
+  @Environment(\.colorScheme) private var colorScheme
+
+  var body: some View {
+    HStack(spacing: 8) {
+      ProgressView()
+        .controlSize(.small)
+        .scaleEffect(0.65)
+        .frame(width: 13, height: 13)
+
+      Text(name)
+        .font(Font.geist(size: 13, weight: .semibold))
+        .foregroundStyle(.secondary)
+        .lineLimit(1)
+        .truncationMode(.tail)
+
+      Spacer(minLength: 0)
+    }
+    .padding(.vertical, 6)
+    .padding(.horizontal, 4)
+    .background(
+      RoundedRectangle(cornerRadius: 6, style: .continuous)
+        .fill(isSelected
+              ? Color.brandPrimary.opacity(colorScheme == .dark ? 0.12 : 0.1)
+              : Color.clear)
+    )
+    .padding(.top, 2)
+    .accessibilityElement(children: .combine)
+    .accessibilityLabel("Adding \(name)")
   }
 }
 
@@ -1624,24 +1760,24 @@ private struct ProjectGroupHeader: View {
   let name: String
   let isExpanded: Bool
   let canToggle: Bool
+  let isSelected: Bool
   let onToggle: () -> Void
+  let onSelectEmptyModule: () -> Void
   let repoPath: String
-  let launchViewModel: MultiSessionLaunchViewModel?
-  let intelligenceViewModel: IntelligenceViewModel?
+  let onStartSession: () -> Void
   let onOpenInFinder: () -> Void
   let onOpenGitHub: () -> Void
   let onArchiveSessions: (() -> Void)?
   let onRemove: () -> Void
 
   @State private var isHovered: Bool = false
-  @State private var showStartSheet: Bool = false
   @Environment(\.colorScheme) private var colorScheme
 
   var body: some View {
     HStack(spacing: 4) {
-      Button(action: { if canToggle { onToggle() } }) {
+      Button(action: { canToggle ? onToggle() : onSelectEmptyModule() }) {
         HStack(spacing: 8) {
-          Image(systemName: canToggle && isExpanded ? "folder.fill" : "folder")
+          Image(systemName: isSelected || (canToggle && isExpanded) ? "folder.fill" : "folder")
             .font(.system(size: 13))
             .foregroundColor(.primary)
             .contentTransition(.symbolEffect(.replace))
@@ -1661,6 +1797,7 @@ private struct ProjectGroupHeader: View {
         .contentShape(Rectangle())
       }
       .buttonStyle(.plain)
+      .help(canToggle ? "Expand or collapse sessions" : "Show module landing page")
 
       HeaderIconMenu(systemName: "ellipsis", size: 14, help: "More actions") {
         Button(action: onOpenInFinder) {
@@ -1679,35 +1816,20 @@ private struct ProjectGroupHeader: View {
           Label("Remove", systemImage: "xmark")
         }
       }
-      .opacity(isHovered || showStartSheet ? 1 : 0)
+      .opacity(isHovered ? 1 : 0)
 
       HeaderIconButton(
         systemName: "square.and.pencil",
         size: 14,
         help: "Start a new session"
-      ) {
-        guard let vm = launchViewModel else { return }
-        Task { @MainActor in
-          _ = await vm.preselectRepository(path: repoPath)
-          showStartSheet = true
-        }
-      }
-      .opacity(isHovered || showStartSheet ? 1 : 0)
-      .sheet(isPresented: $showStartSheet) {
-        if let vm = launchViewModel {
-          StartSessionSheet(
-            launchViewModel: vm,
-            intelligenceViewModel: intelligenceViewModel,
-            onDismiss: { showStartSheet = false }
-          )
-        }
-      }
+      ) { onStartSession() }
+      .opacity(isHovered ? 1 : 0)
     }
     .padding(.vertical, 6)
     .padding(.horizontal, 4)
     .background(
       RoundedRectangle(cornerRadius: 6, style: .continuous)
-        .fill(isHovered
+        .fill(isSelected || isHovered
               ? Color.brandPrimary.opacity(colorScheme == .dark ? 0.12 : 0.1)
               : Color.clear)
     )

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/ModuleLandingSelectionTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/ModuleLandingSelectionTests.swift
@@ -1,0 +1,71 @@
+import Testing
+
+@testable import AgentHubCore
+
+@Suite("ModuleLandingSelection")
+struct ModuleLandingSelectionTests {
+  @Test("Returns selected module when it has no items")
+  func returnsSelectedEmptyModule() {
+    let repository = SelectedRepository(path: "/tmp/AgentHub")
+
+    let activePath = ModuleLandingSelection.activeModulePath(
+      selectedPath: repository.path,
+      repositories: [repository],
+      itemProjectPaths: []
+    )
+
+    #expect(activePath == repository.path)
+  }
+
+  @Test("Clears selected module when a worktree item belongs to it")
+  func clearsModuleWithWorktreeItem() {
+    let repository = SelectedRepository(
+      path: "/tmp/AgentHub",
+      worktrees: [
+        WorktreeBranch(
+          name: "feature",
+          path: "/tmp/AgentHub-feature",
+          isWorktree: true
+        )
+      ]
+    )
+
+    let activePath = ModuleLandingSelection.activeModulePath(
+      selectedPath: repository.path,
+      repositories: [repository],
+      itemProjectPaths: ["/tmp/AgentHub-feature"]
+    )
+
+    #expect(activePath == nil)
+  }
+
+  @Test("Clears missing or unselected module")
+  func clearsMissingOrUnselectedModule() {
+    let repository = SelectedRepository(path: "/tmp/AgentHub")
+
+    let noSelection = ModuleLandingSelection.activeModulePath(
+      selectedPath: nil,
+      repositories: [repository],
+      itemProjectPaths: []
+    )
+    let removedSelection = ModuleLandingSelection.activeModulePath(
+      selectedPath: "/tmp/Removed",
+      repositories: [repository],
+      itemProjectPaths: []
+    )
+
+    #expect(noSelection == nil)
+    #expect(removedSelection == nil)
+  }
+
+  @Test("Does not activate before the module is tracked")
+  func doesNotActivateBeforeRepositoryRowExists() {
+    let activePath = ModuleLandingSelection.activeModulePath(
+      selectedPath: "/tmp/NewModule",
+      repositories: [],
+      itemProjectPaths: []
+    )
+
+    #expect(activePath == nil)
+  }
+}


### PR DESCRIPTION
## Summary

Adds a module landing state for empty module rows in the sessions sidebar. Selecting an empty module now deselects any active session and shows a landing page in the detail panel with a Start Session CTA.

The Start Session CTA and module pencil action now route through the Start Session sheet instead of expanding the deprecated Browse All Sessions flow.

Newly added modules now show a pending sidebar row with a spinner while repository registration catches up. The detail landing page is gated on the real module row existing, so the right panel no longer gets ahead of the sidebar.

## Impact

This makes empty modules feel selectable and gives users a clear next action without changing expand/collapse behavior for modules that already have sessions.

## Validation

- `xcodebuild build -project app/AgentHub.xcodeproj -scheme AgentHubCore -destination 'platform=macOS'`
