### PR TITLE
[codex] Add inline diff display preference

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubDefaults.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubDefaults.swift
@@ -105,6 +105,10 @@ public enum AgentHubDefaults {
   /// Type: Bool (default: true)
   public static let sourceEditorWrapLinesEnabled = "\(keyPrefix)editor.wrapLinesEnabled"
 
+  /// Preferred presentation for git diffs from session cards
+  /// Type: String (default: "inline")
+  public static let diffDisplayMode = "\(keyPrefix)ui.diffDisplayMode"
+
   /// Preferred newline shortcut in the embedded terminal
   /// Type: Int (default: 0 = system/default)
   /// See: NewlineShortcut enum in EmbeddedTerminalView.swift

--- a/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubProvider.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubProvider.swift
@@ -128,6 +128,11 @@ public final class AgentHubProvider {
     WebPreviewCandidateService.shared
   }()
 
+  /// Cached project-level detector for inline diff tab visibility.
+  lazy var diffAvailabilityService: any DiffAvailabilityServiceProtocol = {
+    DiffAvailabilityService.shared
+  }()
+
   /// Session metadata store for user-provided session names
   public private(set) lazy var metadataStore: SessionMetadataStore? = {
     if let metadataStoreOverride {
@@ -329,6 +334,7 @@ public final class AgentHubProvider {
       providerKind: providerKind,
       metadataStore: metadataStore,
       webPreviewCandidateService: webPreviewCandidateService,
+      diffAvailabilityService: diffAvailabilityService,
       approvalClaimStore: claimStore,
       hookInstaller: installer,
       terminalSurfaceFactory: terminalSurfaceFactory,

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/DiffAvailabilityService.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/DiffAvailabilityService.swift
@@ -1,0 +1,228 @@
+//
+//  DiffAvailabilityService.swift
+//  AgentHub
+//
+
+import Foundation
+
+public enum DiffAvailabilityStatus: Equatable, Sendable {
+  case checking
+  case available
+  case unavailable
+
+  public var isAvailable: Bool {
+    self == .available
+  }
+
+  public var isChecking: Bool {
+    self == .checking
+  }
+}
+
+public protocol DiffAvailabilityServiceProtocol: Sendable {
+  func cachedAvailability(for projectPath: String) async -> DiffAvailabilityStatus?
+  func availability(for projectPath: String) async -> DiffAvailabilityStatus
+  func invalidate(projectPath: String) async
+}
+
+public actor DiffAvailabilityService: DiffAvailabilityServiceProtocol {
+  public static let shared = DiffAvailabilityService()
+
+  typealias Evaluator = @Sendable (String) async -> DiffAvailabilityStatus
+
+  private struct InFlightEvaluation: Sendable {
+    let id: UUID
+    let generation: Int
+    let task: Task<DiffAvailabilityStatus, Never>
+  }
+
+  private let evaluator: Evaluator
+  private var cache: [String: DiffAvailabilityStatus] = [:]
+  private var cacheGeneration: [String: Int] = [:]
+  private var inFlightTasks: [String: InFlightEvaluation] = [:]
+
+  init(evaluator: Evaluator? = nil) {
+    self.evaluator = evaluator ?? { projectPath in
+      await Self.defaultEvaluator(projectPath: projectPath)
+    }
+  }
+
+  public func cachedAvailability(for projectPath: String) async -> DiffAvailabilityStatus? {
+    cache[Self.normalize(projectPath)]
+  }
+
+  public func availability(for projectPath: String) async -> DiffAvailabilityStatus {
+    let normalizedProjectPath = Self.normalize(projectPath)
+
+    if let cached = cache[normalizedProjectPath] {
+      return cached
+    }
+    if let inFlightTask = inFlightTasks[normalizedProjectPath] {
+      return await inFlightTask.task.value
+    }
+
+    let evaluator = evaluator
+    let task = Task(priority: .utility) {
+      await evaluator(normalizedProjectPath)
+    }
+    let inFlightEvaluation = InFlightEvaluation(
+      id: UUID(),
+      generation: cacheGeneration[normalizedProjectPath] ?? 0,
+      task: task
+    )
+    inFlightTasks[normalizedProjectPath] = inFlightEvaluation
+
+    let status = await task.value
+    if inFlightTasks[normalizedProjectPath]?.id == inFlightEvaluation.id {
+      inFlightTasks.removeValue(forKey: normalizedProjectPath)
+      if (cacheGeneration[normalizedProjectPath] ?? 0) == inFlightEvaluation.generation {
+        cache[normalizedProjectPath] = status
+      }
+    }
+    return status
+  }
+
+  public func invalidate(projectPath: String) async {
+    let normalizedProjectPath = Self.normalize(projectPath)
+    cacheGeneration[normalizedProjectPath, default: 0] += 1
+    cache.removeValue(forKey: normalizedProjectPath)
+    inFlightTasks[normalizedProjectPath]?.task.cancel()
+    inFlightTasks.removeValue(forKey: normalizedProjectPath)
+  }
+
+  public nonisolated static func normalize(_ projectPath: String) -> String {
+    URL(fileURLWithPath: projectPath)
+      .standardizedFileURL
+      .resolvingSymlinksInPath()
+      .path
+  }
+
+  private nonisolated static func defaultEvaluator(projectPath: String) async -> DiffAvailabilityStatus {
+    await Task.detached(priority: .utility) {
+      evaluateGitDiffAvailability(projectPath: projectPath)
+    }.value
+  }
+
+  private nonisolated static func evaluateGitDiffAvailability(projectPath: String) -> DiffAvailabilityStatus {
+    let gitRootResult = runGit(["rev-parse", "--show-toplevel"], at: projectPath)
+    guard gitRootResult.exitCode == 0 else {
+      return .unavailable
+    }
+
+    let gitRoot = gitRootResult.output.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !gitRoot.isEmpty else {
+      return .unavailable
+    }
+
+    let unstagedDiff = runGit(["diff", "--quiet"], at: gitRoot)
+    if unstagedDiff.exitCode == 1 {
+      return .available
+    }
+
+    let stagedDiff = runGit(["diff", "--cached", "--quiet"], at: gitRoot)
+    if stagedDiff.exitCode == 1 {
+      return .available
+    }
+
+    let untrackedFiles = runGit(["ls-files", "--others", "--exclude-standard", "--directory"], at: gitRoot)
+    if untrackedFiles.exitCode == 0, !untrackedFiles.output.isEmpty {
+      return .available
+    }
+
+    guard let baseBranch = detectBaseBranch(at: gitRoot) else {
+      return .unavailable
+    }
+
+    let branchDiff = runGit(["diff", "--quiet", "\(baseBranch)...HEAD"], at: gitRoot)
+    switch branchDiff.exitCode {
+    case 0:
+      return .unavailable
+    case 1:
+      return .available
+    default:
+      return .unavailable
+    }
+  }
+
+  private nonisolated static func detectBaseBranch(at gitRoot: String) -> String? {
+    let candidates = [
+      "refs/heads/main",
+      "refs/heads/master",
+      "refs/remotes/origin/main",
+      "refs/remotes/origin/master",
+    ]
+
+    for candidate in candidates {
+      let result = runGit(["rev-parse", "--verify", candidate], at: gitRoot)
+      if result.exitCode == 0 {
+        return candidate
+      }
+    }
+
+    return nil
+  }
+
+  private struct GitCommandResult: Sendable {
+    let output: String
+    let errorOutput: String
+    let exitCode: Int32
+  }
+
+  private nonisolated static func runGit(
+    _ arguments: [String],
+    at path: String
+  ) -> GitCommandResult {
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "/usr/bin/git")
+    process.arguments = arguments
+    process.currentDirectoryURL = URL(fileURLWithPath: path)
+
+    var environment = ProcessInfo.processInfo.environment
+    environment["GIT_TERMINAL_PROMPT"] = "0"
+    environment["GIT_SSH_COMMAND"] = "ssh -o BatchMode=yes"
+    process.environment = environment
+
+    let inputPipe = Pipe()
+    let outputPipe = Pipe()
+    let errorPipe = Pipe()
+    process.standardInput = inputPipe
+    process.standardOutput = outputPipe
+    process.standardError = errorPipe
+
+    do {
+      try process.run()
+      try inputPipe.fileHandleForWriting.close()
+    } catch {
+      return GitCommandResult(
+        output: "",
+        errorOutput: error.localizedDescription,
+        exitCode: 127
+      )
+    }
+
+    var outputData: Data?
+    var errorData: Data?
+    let readGroup = DispatchGroup()
+
+    readGroup.enter()
+    DispatchQueue.global(qos: .utility).async {
+      outputData = try? outputPipe.fileHandleForReading.readToEnd()
+      readGroup.leave()
+    }
+
+    readGroup.enter()
+    DispatchQueue.global(qos: .utility).async {
+      errorData = try? errorPipe.fileHandleForReading.readToEnd()
+      readGroup.leave()
+    }
+
+    process.waitUntilExit()
+    readGroup.wait()
+
+    return GitCommandResult(
+      output: String(data: outputData ?? Data(), encoding: .utf8) ?? "",
+      errorOutput: String(data: errorData ?? Data(), encoding: .utf8) ?? "",
+      exitCode: process.terminationStatus
+    )
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/CommandPaletteView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/CommandPaletteView.swift
@@ -38,7 +38,7 @@ public enum CommandPaletteAction: Identifiable {
     case .openSettings: return "Open Settings"
     case .toggleSidebar: return "Toggle Sidebar"
     case .toggleFocusMode: return "Toggle Focus Mode"
-    case .toggleTerminalEditor: return "Swap Terminal and Code"
+    case .toggleTerminalEditor: return "Swap Terminal and Files"
     }
   }
 
@@ -57,7 +57,7 @@ public enum CommandPaletteAction: Identifiable {
     case .openSettings: return "Open application settings"
     case .toggleSidebar: return "Show or hide the sidebar"
     case .toggleFocusMode: return "Expand focused session or restore previous layout"
-    case .toggleTerminalEditor: return "Switch the focused session between terminal and code"
+    case .toggleTerminalEditor: return "Switch the focused session between terminal and files"
     }
   }
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringCardView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringCardView.swift
@@ -59,6 +59,8 @@ public struct MonitoringCardView: View {
   @State private var showingFilePicker = false
   @State private var showingNameSheet = false
   @State private var showingRemixProviderPicker = false
+  @AppStorage(AgentHubDefaults.diffDisplayMode)
+  private var diffDisplayModeRawValue: String = DiffDisplayMode.inline.rawValue
   @Environment(\.agentHub) private var agentHub
   @Environment(\.colorScheme) private var colorScheme
 
@@ -161,6 +163,28 @@ public struct MonitoringCardView: View {
     viewModel?.projectCapabilities(for: session.projectPath)
   }
 
+  private var diffDisplayMode: DiffDisplayMode {
+    DiffDisplayMode(rawValue: diffDisplayModeRawValue) ?? .inline
+  }
+
+  private var diffAvailabilityStatus: DiffAvailabilityStatus? {
+    viewModel?.diffAvailabilityStatus(for: session.projectPath)
+  }
+
+  private var availableContentModes: [MonitoringCardContentMode] {
+    MonitoringEditorStateStore.availableContentModes(
+      diffDisplayMode: diffDisplayMode,
+      diffAvailabilityStatus: diffAvailabilityStatus
+    )
+  }
+
+  private var effectiveContentMode: MonitoringCardContentMode {
+    MonitoringEditorStateStore.coercedContentMode(
+      contentMode,
+      availableModes: availableContentModes
+    )
+  }
+
   private var hasStorybook: Bool {
     projectCapabilities?.hasStorybook == true
   }
@@ -250,6 +274,9 @@ public struct MonitoringCardView: View {
     .task(id: session.projectPath) {
       await viewModel?.ensureProjectCapabilities(for: session.projectPath)
     }
+    .task(id: session.projectPath) {
+      await viewModel?.ensureDiffAvailability(for: session.projectPath, forceRefresh: true)
+    }
     .task(id: SessionGitHubQuickAccessViewModel.repositoryKey(projectPath: session.projectPath, branchName: session.branchName)) {
       try? await Task.sleep(for: .seconds(2))
       guard !Task.isCancelled else { return }
@@ -270,6 +297,7 @@ public struct MonitoringCardView: View {
       Task {
         await sessionGitHubQuickAccessViewModel.notifySessionActivity(at: newValue)
         await loadWebPreviewCandidateIfNeeded()
+        await viewModel?.ensureDiffAvailability(for: session.projectPath, forceRefresh: true)
       }
     }
     .onChange(of: state?.detectedLocalhostURL) { _, newValue in
@@ -612,18 +640,20 @@ public struct MonitoringCardView: View {
           .help("View session plan")
         }
 
-        // Diff button
-        Button(action: {
-          onShowDiff?(session, session.projectPath)
-        }) {
-          HStack(spacing: 4) {
-            Image(systemName: "arrow.left.arrow.right")
-              .font(.caption2)
-            Text("Diff")
+        if diffDisplayMode == .sidePanel {
+          // Diff button
+          Button(action: {
+            onShowDiff?(session, session.projectPath)
+          }) {
+            HStack(spacing: 4) {
+              Image(systemName: "arrow.left.arrow.right")
+                .font(.caption2)
+              Text("Diff")
+            }
           }
+          .buttonStyle(.agentHubOutlined)
+          .help("View git changes")
         }
-        .buttonStyle(.agentHubOutlined)
-        .help("View git unstaged changes")
 
         // Web preview controls — segmented App | Storybook when Storybook is
         // detected, otherwise a single Preview button.
@@ -770,7 +800,8 @@ public struct MonitoringCardView: View {
     MonitoringCardPathRow(
       session: session,
       providerKind: providerKind,
-      contentMode: $contentMode
+      contentMode: $contentMode,
+      availableContentModes: availableContentModes
     )
   }
 
@@ -778,11 +809,13 @@ public struct MonitoringCardView: View {
 
   @ViewBuilder
   private var monitorContent: some View {
-    switch contentMode {
+    switch effectiveContentMode {
     case .terminal:
       terminalContent
     case .editor:
       editorContent
+    case .diffs:
+      diffContent
     }
   }
 
@@ -821,6 +854,27 @@ public struct MonitoringCardView: View {
     .id("editor-\(session.id)")
   }
 
+  private var diffContent: some View {
+    GitDiffView(
+      session: session,
+      projectPath: session.projectPath,
+      onDismiss: { contentMode = .terminal },
+      cliConfiguration: viewModel?.cliConfiguration,
+      providerKind: providerKind,
+      onInlineRequestSubmit: { prompt, sess in
+        contentMode = .terminal
+        if let onInlineRequestSubmit {
+          onInlineRequestSubmit(prompt, sess)
+        } else {
+          viewModel?.showTerminalWithPrompt(for: sess, prompt: prompt)
+        }
+      },
+      isEmbedded: false
+    )
+    .frame(maxWidth: .infinity, minHeight: 300, maxHeight: .infinity)
+    .id("diffs-\(session.id)")
+  }
+
   private var previewContextBadge: some View {
     Text("\(queuedPreviewContextCount)")
       .font(.system(.caption2, design: .monospaced))
@@ -834,13 +888,21 @@ public struct MonitoringCardView: View {
   }
 }
 
-private enum MonitoringCardContentModeItems {
-  static let items = MonitoringCardContentMode.allCases.map { mode in
-    BracketedSegmentedControlItem(
-      value: mode,
-      title: mode.label.lowercased(),
-      helpText: mode.label
-    )
+enum MonitoringCardContentModeItems {
+  static func items(
+    diffDisplayMode: DiffDisplayMode,
+    diffAvailabilityStatus: DiffAvailabilityStatus?
+  ) -> [BracketedSegmentedControlItem<MonitoringCardContentMode>] {
+    MonitoringEditorStateStore.availableContentModes(
+      diffDisplayMode: diffDisplayMode,
+      diffAvailabilityStatus: diffAvailabilityStatus
+    ).map { mode in
+      BracketedSegmentedControlItem(
+        value: mode,
+        title: mode.label.lowercased(),
+        helpText: mode.label
+      )
+    }
   }
 }
 
@@ -848,6 +910,29 @@ private struct MonitoringCardPathRow: View {
   let session: CLISession
   let providerKind: SessionProviderKind
   @Binding var contentMode: MonitoringCardContentMode
+  let availableContentModes: [MonitoringCardContentMode]
+
+  private var selection: Binding<MonitoringCardContentMode> {
+    Binding(
+      get: {
+        MonitoringEditorStateStore.coercedContentMode(
+          contentMode,
+          availableModes: availableContentModes
+        )
+      },
+      set: { contentMode = $0 }
+    )
+  }
+
+  private var items: [BracketedSegmentedControlItem<MonitoringCardContentMode>] {
+    availableContentModes.map { mode in
+      BracketedSegmentedControlItem(
+        value: mode,
+        title: mode.label.lowercased(),
+        helpText: mode.label
+      )
+    }
+  }
 
   var body: some View {
     HStack(spacing: 8) {
@@ -875,12 +960,12 @@ private struct MonitoringCardPathRow: View {
       Spacer(minLength: 8)
 
       BracketedSegmentedControl(
-        selection: $contentMode,
-        items: MonitoringCardContentModeItems.items,
+        selection: selection,
+        items: items,
         selectedColor: Color.brandPrimary(for: providerKind)
       )
       .layoutPriority(2)
-      .help("Switch between terminal and code")
+      .help("Switch session content")
     }
     .frame(minHeight: 24)
   }

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringEditorState.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringEditorState.swift
@@ -6,20 +6,36 @@
 import Foundation
 
 extension Notification.Name {
-  /// Request the focused monitoring card to swap between Terminal and Code content modes.
+  /// Request the focused monitoring card to swap between Terminal and Files content modes.
   static let toggleMonitoringContentMode = Notification.Name("com.agenthub.toggleMonitoringContentMode")
+}
+
+public enum DiffDisplayMode: String, CaseIterable, Identifiable, Sendable {
+  case inline
+  case sidePanel
+
+  public var id: String { rawValue }
+
+  var label: String {
+    switch self {
+    case .inline: "Inline"
+    case .sidePanel: "Side Panel"
+    }
+  }
 }
 
 public enum MonitoringCardContentMode: String, CaseIterable, Identifiable {
   case terminal
   case editor
+  case diffs
 
   public var id: String { rawValue }
 
   var label: String {
     switch self {
     case .terminal: "Terminal"
-    case .editor: "Code"
+    case .editor: "Files"
+    case .diffs: "Diffs"
     }
   }
 
@@ -27,6 +43,7 @@ public enum MonitoringCardContentMode: String, CaseIterable, Identifiable {
     switch self {
     case .terminal: "terminal"
     case .editor: "doc.text"
+    case .diffs: "arrow.left.arrow.right"
     }
   }
 }
@@ -60,6 +77,31 @@ struct MonitoringEditorRouteResult {
 }
 
 enum MonitoringEditorStateStore {
+  static func availableContentModes(
+    diffDisplayMode: DiffDisplayMode,
+    diffAvailabilityStatus: DiffAvailabilityStatus?
+  ) -> [MonitoringCardContentMode] {
+    var modes: [MonitoringCardContentMode] = [.terminal, .editor]
+    if diffDisplayMode == .inline,
+       diffAvailabilityStatus?.isAvailable == true {
+      modes.append(.diffs)
+    }
+    return modes
+  }
+
+  static func coercedContentMode(
+    _ contentMode: MonitoringCardContentMode,
+    availableModes: [MonitoringCardContentMode]
+  ) -> MonitoringCardContentMode {
+    availableModes.contains(contentMode) ? contentMode : .terminal
+  }
+
+  static func toggledTerminalFilesMode(
+    from contentMode: MonitoringCardContentMode
+  ) -> MonitoringCardContentMode {
+    contentMode == .terminal ? .editor : .terminal
+  }
+
   static func state(
     for itemID: String,
     defaultProjectPath: String,

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringPanelView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringPanelView.swift
@@ -73,6 +73,7 @@ public struct MonitoringPanelView: View {
   @Bindable var viewModel: CLISessionsViewModel
   @State private var sessionFileSheetItem: SessionFileSheetItem?
   @State private var maximizedSessionId: String?
+  @State private var editorStates: [String: MonitoringEditorState] = [:]
   /// Primary session shown in Single mode and highlighted in All mode
   @Binding var primarySessionId: String?
   @AppStorage(AgentHubDefaults.hubLayoutMode)
@@ -205,9 +206,11 @@ public struct MonitoringPanelView: View {
     }
     .onAppear {
       ensurePrimarySelection()
+      syncEditorStates()
     }
     .onChange(of: allItems.map(\.id)) { _, _ in
       ensurePrimarySelection()
+      syncEditorStates()
     }
   }
 
@@ -255,6 +258,7 @@ public struct MonitoringPanelView: View {
     let isPrimary = sessionId == effectivePrimarySessionId
     // Find the session to maximize (check both pending and monitored)
     if let pending = viewModel.pendingHubSessions.first(where: { "pending-\($0.id.uuidString)" == sessionId }) {
+      let monitoringItem = MonitoringItem.pending(pending)
       MonitoringCardView(
         session: pending.placeholderSession,
         state: nil,
@@ -264,6 +268,10 @@ public struct MonitoringPanelView: View {
         initialInputText: pending.initialInputText,
         terminalKey: "pending-\(pending.id.uuidString)",
         viewModel: viewModel,
+        contentMode: editorContentModeBinding(for: monitoringItem),
+        selectedEditorFilePath: selectedEditorFilePathBinding(for: monitoringItem),
+        editorProjectPath: editorState(for: monitoringItem).projectPath,
+        editorNavigationRequest: editorState(for: monitoringItem).navigationRequest,
         dangerouslySkipPermissions: pending.dangerouslySkipPermissions,
         permissionModePlan: pending.permissionModePlan,
         worktreeName: pending.worktreeName,
@@ -278,6 +286,7 @@ public struct MonitoringPanelView: View {
         onOpenSessionFile: { },
         onRefreshTerminal: { },
         onTerminalInteraction: { setPrimarySessionIfNeeded(sessionId) },
+        onRequestShowEditor: { setContentMode(.editor, for: monitoringItem) },
         isMaximized: true,
         onToggleMaximize: {
           withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) {
@@ -288,6 +297,7 @@ public struct MonitoringPanelView: View {
         showPrimaryIndicator: layoutMode != .single
       )
     } else if let item = viewModel.monitoredSessions.first(where: { $0.session.id == sessionId }) {
+      let monitoringItem = MonitoringItem.monitored(session: item.session, state: item.state)
       let planState = item.state.flatMap {
         PlanState.from(activities: $0.recentActivities)
       }
@@ -302,6 +312,10 @@ public struct MonitoringPanelView: View {
         initialPrompt: initialPrompt,
         terminalKey: item.session.id,
         viewModel: viewModel,
+        contentMode: editorContentModeBinding(for: monitoringItem),
+        selectedEditorFilePath: selectedEditorFilePathBinding(for: monitoringItem),
+        editorProjectPath: editorState(for: monitoringItem).projectPath,
+        editorNavigationRequest: editorState(for: monitoringItem).navigationRequest,
         onStopMonitoring: {
           viewModel.stopMonitoring(session: item.session)
           withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) {
@@ -331,6 +345,7 @@ public struct MonitoringPanelView: View {
           viewModel.clearPendingPrompt(for: item.session.id)
         },
         onTerminalInteraction: { setPrimarySessionIfNeeded(item.session.id) },
+        onRequestShowEditor: { setContentMode(.editor, for: monitoringItem) },
         isMaximized: true,
         onToggleMaximize: {
           withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) {
@@ -400,6 +415,7 @@ public struct MonitoringPanelView: View {
       switch item {
       case .pending(let pending):
         let pendingId = "pending-\(pending.id.uuidString)"
+        let monitoringItem = MonitoringItem.pending(pending)
         MonitoringCardView(
           session: pending.placeholderSession,
           state: nil,
@@ -409,6 +425,10 @@ public struct MonitoringPanelView: View {
           initialInputText: pending.initialInputText,
           terminalKey: pendingId,
           viewModel: viewModel,
+          contentMode: editorContentModeBinding(for: monitoringItem),
+          selectedEditorFilePath: selectedEditorFilePathBinding(for: monitoringItem),
+          editorProjectPath: editorState(for: monitoringItem).projectPath,
+          editorNavigationRequest: editorState(for: monitoringItem).navigationRequest,
           dangerouslySkipPermissions: pending.dangerouslySkipPermissions,
           permissionModePlan: pending.permissionModePlan,
           worktreeName: pending.worktreeName,
@@ -420,6 +440,7 @@ public struct MonitoringPanelView: View {
           onOpenSessionFile: { },
           onRefreshTerminal: { },
           onTerminalInteraction: { setPrimarySessionIfNeeded(pendingId) },
+          onRequestShowEditor: { setContentMode(.editor, for: monitoringItem) },
           isMaximized: false,
           onToggleMaximize: { },
           isPrimarySession: true,
@@ -429,6 +450,7 @@ public struct MonitoringPanelView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
 
       case .monitored(let session, let state):
+        let monitoringItem = MonitoringItem.monitored(session: session, state: state)
         let planState = state.flatMap { PlanState.from(activities: $0.recentActivities) }
         let initialPrompt = viewModel.pendingPrompt(for: session.id)
 
@@ -441,6 +463,10 @@ public struct MonitoringPanelView: View {
           initialPrompt: initialPrompt,
           terminalKey: session.id,
           viewModel: viewModel,
+          contentMode: editorContentModeBinding(for: monitoringItem),
+          selectedEditorFilePath: selectedEditorFilePathBinding(for: monitoringItem),
+          editorProjectPath: editorState(for: monitoringItem).projectPath,
+          editorNavigationRequest: editorState(for: monitoringItem).navigationRequest,
           onStopMonitoring: {
             viewModel.stopMonitoring(session: session)
           },
@@ -467,6 +493,7 @@ public struct MonitoringPanelView: View {
             viewModel.clearPendingPrompt(for: session.id)
           },
           onTerminalInteraction: { setPrimarySessionIfNeeded(session.id) },
+          onRequestShowEditor: { setContentMode(.editor, for: monitoringItem) },
           isMaximized: false,
           onToggleMaximize: { },
           isPrimarySession: true,
@@ -495,6 +522,10 @@ public struct MonitoringPanelView: View {
         initialInputText: pending.initialInputText,
         terminalKey: pendingId,
         viewModel: viewModel,
+        contentMode: editorContentModeBinding(for: item),
+        selectedEditorFilePath: selectedEditorFilePathBinding(for: item),
+        editorProjectPath: editorState(for: item).projectPath,
+        editorNavigationRequest: editorState(for: item).navigationRequest,
         dangerouslySkipPermissions: pending.dangerouslySkipPermissions,
         permissionModePlan: pending.permissionModePlan,
         worktreeName: pending.worktreeName,
@@ -506,6 +537,7 @@ public struct MonitoringPanelView: View {
         onOpenSessionFile: { },
         onRefreshTerminal: { },
         onTerminalInteraction: { setPrimarySessionIfNeeded(pendingId) },
+        onRequestShowEditor: { setContentMode(.editor, for: item) },
         isMaximized: maximizedSessionId == pendingId,
         onToggleMaximize: {
           withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) {
@@ -533,6 +565,10 @@ public struct MonitoringPanelView: View {
         initialPrompt: initialPrompt,
         terminalKey: session.id,
         viewModel: viewModel,
+        contentMode: editorContentModeBinding(for: item),
+        selectedEditorFilePath: selectedEditorFilePathBinding(for: item),
+        editorProjectPath: editorState(for: item).projectPath,
+        editorNavigationRequest: editorState(for: item).navigationRequest,
         onStopMonitoring: {
           viewModel.stopMonitoring(session: session)
         },
@@ -559,6 +595,7 @@ public struct MonitoringPanelView: View {
           viewModel.clearPendingPrompt(for: session.id)
         },
         onTerminalInteraction: { setPrimarySessionIfNeeded(session.id) },
+        onRequestShowEditor: { setContentMode(.editor, for: item) },
         isMaximized: maximizedSessionId == session.id,
         onToggleMaximize: {
           withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) {
@@ -641,6 +678,59 @@ public struct MonitoringPanelView: View {
   private func setPrimarySessionIfNeeded(_ sessionId: String) {
     guard primarySessionId != sessionId else { return }
     primarySessionId = sessionId
+  }
+
+  private func editorState(for item: MonitoringItem) -> MonitoringEditorState {
+    MonitoringEditorStateStore.state(
+      for: item.id,
+      defaultProjectPath: item.projectPath,
+      in: editorStates
+    )
+  }
+
+  private func editorContentModeBinding(for item: MonitoringItem) -> Binding<MonitoringCardContentMode> {
+    Binding(
+      get: { editorState(for: item).contentMode },
+      set: { newValue in
+        setContentMode(newValue, for: item)
+      }
+    )
+  }
+
+  private func selectedEditorFilePathBinding(for item: MonitoringItem) -> Binding<String?> {
+    Binding(
+      get: { editorState(for: item).selectedFilePath },
+      set: { newValue in
+        setPrimarySessionIfNeeded(item.id)
+        editorStates = MonitoringEditorStateStore.setSelectedFilePath(
+          newValue,
+          for: item.id,
+          defaultProjectPath: editorState(for: item).projectPath,
+          in: editorStates
+        )
+      }
+    )
+  }
+
+  private func syncEditorStates() {
+    editorStates = MonitoringEditorStateStore.prune(
+      editorStates,
+      validItemIDs: Set(allItems.map(\.id))
+    )
+  }
+
+  private func setContentMode(_ contentMode: MonitoringCardContentMode, for item: MonitoringItem) {
+    setPrimarySessionIfNeeded(item.id)
+    editorStates = MonitoringEditorStateStore.setContentMode(
+      contentMode,
+      for: item.id,
+      defaultProjectPath: editorState(for: item).projectPath,
+      in: editorStates
+    )
+
+    if contentMode == .terminal {
+      viewModel.focusTerminal(forKey: item.id)
+    }
   }
 
   @ViewBuilder

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderMonitoringPanelView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderMonitoringPanelView.swift
@@ -833,7 +833,15 @@ public struct MultiProviderMonitoringPanelView: View {
         onDismiss: closeEmbeddedSidePanel,
         cliConfiguration: viewModel.cliConfiguration,
         providerKind: payload.providerKind,
-        onInlineRequestSubmit: { prompt, sess in viewModel.showTerminalWithPrompt(for: sess, prompt: prompt) },
+        onInlineRequestSubmit: { prompt, sess in
+          closeEmbeddedSidePanel()
+          showTerminalWithPrompt(
+            prompt,
+            for: sess,
+            itemID: payload.itemID,
+            viewModel: viewModel
+          )
+        },
         isEmbedded: true
       )
     case .plan(_, let session, let planState):
@@ -844,7 +852,13 @@ public struct MultiProviderMonitoringPanelView: View {
         isEmbedded: true,
         providerKind: payload.providerKind,
         onSendFeedback: { feedback, sess in
-          viewModel.showTerminalWithPrompt(for: sess, prompt: feedback)
+          closeEmbeddedSidePanel()
+          showTerminalWithPrompt(
+            feedback,
+            for: sess,
+            itemID: payload.itemID,
+            viewModel: viewModel
+          )
         }
       )
     case .webPreview(let sessionId, let session, let projectPath, let mode):
@@ -1610,9 +1624,24 @@ public struct MultiProviderMonitoringPanelView: View {
 
   private func togglePrimarySessionContentMode() {
     guard let item = effectivePrimaryItem else { return }
-    let nextMode: MonitoringCardContentMode =
-      editorState(for: item).contentMode == .terminal ? .editor : .terminal
+    let nextMode = MonitoringEditorStateStore.toggledTerminalFilesMode(
+      from: editorState(for: item).contentMode
+    )
     setContentMode(nextMode, for: item)
+  }
+
+  private func showTerminalWithPrompt(
+    _ prompt: String,
+    for session: CLISession,
+    itemID: String,
+    viewModel: CLISessionsViewModel
+  ) {
+    if let item = allItems.first(where: { $0.id == itemID }) {
+      setContentMode(.terminal, for: item)
+    } else {
+      viewModel.focusTerminal(forKey: session.id)
+    }
+    viewModel.showTerminalWithPrompt(for: session, prompt: prompt)
   }
 
   private func openFileInEditor(

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/SettingsView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/SettingsView.swift
@@ -44,6 +44,9 @@ public struct SettingsView: View {
   @AppStorage(AgentHubDefaults.sourceEditorWrapLinesEnabled)
   private var sourceEditorWrapLinesEnabled: Bool = true
 
+  @AppStorage(AgentHubDefaults.diffDisplayMode)
+  private var diffDisplayModeRawValue: String = DiffDisplayMode.inline.rawValue
+
   @AppStorage(AgentHubDefaults.terminalNewlineShortcut)
   private var newlineShortcutRawValue: Int = NewlineShortcut.system.rawValue
 
@@ -260,6 +263,12 @@ public struct SettingsView: View {
           description: "Show all sessions without per-repository sections",
           isOn: $flatSessionLayout
         )
+
+        Picker("Diff display", selection: $diffDisplayModeRawValue) {
+          ForEach(DiffDisplayMode.allCases) { mode in
+            Text(mode.label).tag(mode.rawValue)
+          }
+        }
       }
 
       Section("Terminal") {

--- a/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/CLISessionsViewModel.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/CLISessionsViewModel.swift
@@ -33,6 +33,7 @@ public final class CLISessionsViewModel {
   private let fileWatcher: any SessionFileWatcherProtocol
   private let webPreviewCandidateService: any WebPreviewCandidateServiceProtocol
   private let projectCapabilityService: any ProjectCapabilityServiceProtocol
+  private let diffAvailabilityService: any DiffAvailabilityServiceProtocol
   private let approvalNotificationService: any ApprovalNotificationServiceProtocol
   private let approvalClaimStore: (any ApprovalClaimStoreProtocol)?
   private let hookInstaller: (any ClaudeHookInstallerProtocol)?
@@ -158,6 +159,10 @@ public final class CLISessionsViewModel {
     projectCapabilities[ProjectCapabilityService.normalize(projectPath)]
   }
 
+  public func diffAvailabilityStatus(for projectPath: String) -> DiffAvailabilityStatus? {
+    diffAvailability[DiffAvailabilityService.normalize(projectPath)]
+  }
+
   public func ensureProjectCapabilities(
     for projectPath: String,
     forceRefresh: Bool = false
@@ -202,6 +207,31 @@ public final class CLISessionsViewModel {
     }
     let status = await webPreviewCandidateService.candidateStatus(for: normalizedProjectPath)
     webPreviewCandidates[normalizedProjectPath] = status
+  }
+
+  public func ensureDiffAvailability(
+    for projectPath: String,
+    forceRefresh: Bool = false
+  ) async {
+    let normalizedProjectPath = DiffAvailabilityService.normalize(projectPath)
+
+    if forceRefresh {
+      await diffAvailabilityService.invalidate(projectPath: normalizedProjectPath)
+    } else {
+      if let currentStatus = diffAvailability[normalizedProjectPath],
+         currentStatus.isAvailable || currentStatus.isChecking {
+        return
+      }
+
+      if let cachedStatus = await diffAvailabilityService.cachedAvailability(for: normalizedProjectPath) {
+        diffAvailability[normalizedProjectPath] = cachedStatus
+        return
+      }
+    }
+
+    diffAvailability[normalizedProjectPath] = .checking
+    let status = await diffAvailabilityService.availability(for: normalizedProjectPath)
+    diffAvailability[normalizedProjectPath] = status
   }
 
   /// Start polling for a session
@@ -835,6 +865,9 @@ public final class CLISessionsViewModel {
   /// Cached project-level UI capabilities keyed by normalized project path.
   public private(set) var projectCapabilities: [String: ProjectCapabilities] = [:]
 
+  /// Cached project-level git diff availability keyed by normalized project path.
+  public private(set) var diffAvailability: [String: DiffAvailabilityStatus] = [:]
+
   /// Combine cancellables for monitoring subscriptions (keyed by session ID)
   private var monitoringCancellables: [String: AnyCancellable] = [:]
 
@@ -874,6 +907,7 @@ public final class CLISessionsViewModel {
     metadataStore: SessionMetadataStore? = nil,
     webPreviewCandidateService: any WebPreviewCandidateServiceProtocol = WebPreviewCandidateService.shared,
     projectCapabilityService: any ProjectCapabilityServiceProtocol = ProjectCapabilityService.shared,
+    diffAvailabilityService: any DiffAvailabilityServiceProtocol = DiffAvailabilityService.shared,
     approvalNotificationService: any ApprovalNotificationServiceProtocol = ApprovalNotificationService.shared,
     approvalClaimStore: (any ApprovalClaimStoreProtocol)? = nil,
     hookInstaller: (any ClaudeHookInstallerProtocol)? = nil,
@@ -889,6 +923,7 @@ public final class CLISessionsViewModel {
     self.fileWatcher = fileWatcher
     self.webPreviewCandidateService = webPreviewCandidateService
     self.projectCapabilityService = projectCapabilityService
+    self.diffAvailabilityService = diffAvailabilityService
     self.approvalNotificationService = approvalNotificationService
     self.approvalClaimStore = approvalClaimStore
     self.hookInstaller = hookInstaller

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/DiffAvailabilityServiceTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/DiffAvailabilityServiceTests.swift
@@ -1,0 +1,253 @@
+import Combine
+import Foundation
+import Testing
+
+@testable import AgentHubCore
+
+private actor DiffAvailabilityEvaluatorSpy {
+  private var queuedStatuses: [DiffAvailabilityStatus]
+  private(set) var evaluationCount = 0
+  private let delay: Duration?
+
+  init(
+    queuedStatuses: [DiffAvailabilityStatus],
+    delay: Duration? = nil
+  ) {
+    self.queuedStatuses = queuedStatuses
+    self.delay = delay
+  }
+
+  func evaluate(projectPath _: String) async -> DiffAvailabilityStatus {
+    evaluationCount += 1
+    if let delay {
+      try? await Task.sleep(for: delay)
+    }
+
+    guard !queuedStatuses.isEmpty else {
+      return .unavailable
+    }
+
+    return queuedStatuses.removeFirst()
+  }
+}
+
+private actor MockDiffAvailabilityService: DiffAvailabilityServiceProtocol {
+  private let status: DiffAvailabilityStatus
+  private let cachedStatus: DiffAvailabilityStatus?
+  private(set) var invalidatedProjectPaths: [String] = []
+
+  init(
+    status: DiffAvailabilityStatus = .unavailable,
+    cachedStatus: DiffAvailabilityStatus? = nil
+  ) {
+    self.status = status
+    self.cachedStatus = cachedStatus
+  }
+
+  func cachedAvailability(for projectPath: String) async -> DiffAvailabilityStatus? {
+    cachedStatus
+  }
+
+  func availability(for projectPath: String) async -> DiffAvailabilityStatus {
+    status
+  }
+
+  func invalidate(projectPath: String) async {
+    invalidatedProjectPaths.append(projectPath)
+  }
+
+  func recordedInvalidations() -> [String] {
+    invalidatedProjectPaths
+  }
+}
+
+private actor DiffStubMonitorService: SessionMonitorServiceProtocol {
+  nonisolated var repositoriesPublisher: AnyPublisher<[SelectedRepository], Never> {
+    Empty<[SelectedRepository], Never>().eraseToAnyPublisher()
+  }
+
+  func addRepository(_ path: String) async -> SelectedRepository? { nil }
+  func removeRepository(_ path: String) async {}
+  func getSelectedRepositories() async -> [SelectedRepository] { [] }
+  func setSelectedRepositories(_ repositories: [SelectedRepository]) async {}
+  func refreshSessions(skipWorktreeRedetection: Bool) async {}
+}
+
+private actor DiffStubFileWatcher: SessionFileWatcherProtocol {
+  private nonisolated let subject = PassthroughSubject<SessionFileWatcher.StateUpdate, Never>()
+
+  nonisolated var statePublisher: AnyPublisher<SessionFileWatcher.StateUpdate, Never> {
+    subject.eraseToAnyPublisher()
+  }
+
+  func startMonitoring(sessionId: String, projectPath: String, sessionFilePath: String?) async {}
+  func stopMonitoring(sessionId: String) async {}
+  func getState(sessionId: String) async -> SessionMonitorState? { nil }
+  func refreshState(sessionId: String) async {}
+  func setApprovalTimeout(_ seconds: Int) async {}
+}
+
+@Suite("DiffAvailabilityService")
+struct DiffAvailabilityServiceTests {
+  @Test("Clean repository is unavailable")
+  func cleanRepositoryIsUnavailable() async throws {
+    let fixture = try GitRepoFixture.create()
+    defer { fixture.cleanup() }
+
+    let status = await DiffAvailabilityService().availability(for: fixture.repoPath)
+
+    #expect(status == .unavailable)
+  }
+
+  @Test("Unstaged changes are available")
+  func unstagedChangesAreAvailable() async throws {
+    let fixture = try GitRepoFixture.create()
+    defer { fixture.cleanup() }
+    try "changed".write(toFile: fixture.repoPath + "/README.md", atomically: true, encoding: .utf8)
+
+    let status = await DiffAvailabilityService().availability(for: fixture.repoPath)
+
+    #expect(status == .available)
+  }
+
+  @Test("Staged changes are available")
+  func stagedChangesAreAvailable() async throws {
+    let fixture = try GitRepoFixture.create()
+    defer { fixture.cleanup() }
+    try "changed".write(toFile: fixture.repoPath + "/README.md", atomically: true, encoding: .utf8)
+    try fixture.runGit("add", "README.md")
+
+    let status = await DiffAvailabilityService().availability(for: fixture.repoPath)
+
+    #expect(status == .available)
+  }
+
+  @Test("Untracked changes are available")
+  func untrackedChangesAreAvailable() async throws {
+    let fixture = try GitRepoFixture.create()
+    defer { fixture.cleanup() }
+    try "new".write(toFile: fixture.repoPath + "/NewFile.swift", atomically: true, encoding: .utf8)
+
+    let status = await DiffAvailabilityService().availability(for: fixture.repoPath)
+
+    #expect(status == .available)
+  }
+
+  @Test("Branch-only changes are available")
+  func branchOnlyChangesAreAvailable() async throws {
+    let fixture = try GitRepoFixture.create()
+    defer { fixture.cleanup() }
+    try fixture.runGit("switch", "-c", "feature/diff-availability")
+    try "branch".write(toFile: fixture.repoPath + "/BranchFile.swift", atomically: true, encoding: .utf8)
+    try fixture.runGit("add", "BranchFile.swift")
+    try fixture.runGit("commit", "-m", "branch change")
+
+    let status = await DiffAvailabilityService().availability(for: fixture.repoPath)
+
+    #expect(status == .available)
+  }
+
+  @Test("Non-git path is unavailable")
+  func nonGitPathIsUnavailable() async throws {
+    let path = FileManager.default.temporaryDirectory
+      .appendingPathComponent("DiffAvailabilityNonGit-\(UUID().uuidString)", isDirectory: true)
+      .path
+    try FileManager.default.createDirectory(atPath: path, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(atPath: path) }
+
+    let status = await DiffAvailabilityService().availability(for: path)
+
+    #expect(status == .unavailable)
+  }
+
+  @Test("In-flight and cached calls reuse one evaluation")
+  func inFlightAndCachedCallsReuseOneEvaluation() async {
+    let evaluator = DiffAvailabilityEvaluatorSpy(
+      queuedStatuses: [.available],
+      delay: .milliseconds(100)
+    )
+    let service = DiffAvailabilityService(evaluator: { projectPath in
+      await evaluator.evaluate(projectPath: projectPath)
+    })
+
+    async let first = service.availability(for: "/tmp/project")
+    async let second = service.availability(for: "/tmp/project")
+
+    let statuses = await [first, second]
+    let cached = await service.availability(for: "/tmp/project")
+    let evaluationCount = await evaluator.evaluationCount
+
+    #expect(statuses == [.available, .available])
+    #expect(cached == .available)
+    #expect(evaluationCount == 1)
+  }
+}
+
+@Suite("CLISessionsViewModel Diff Availability")
+struct CLISessionsViewModelDiffAvailabilityTests {
+  @Test("ensureDiffAvailability stores the resolved status")
+  @MainActor
+  func ensureDiffAvailabilityStoresResolvedStatus() async {
+    let diffService = MockDiffAvailabilityService(status: .available)
+    let viewModel = CLISessionsViewModel(
+      monitorService: DiffStubMonitorService(),
+      fileWatcher: DiffStubFileWatcher(),
+      searchService: nil,
+      cliConfiguration: CLICommandConfiguration(command: "claude", mode: .claude),
+      providerKind: .claude,
+      diffAvailabilityService: diffService,
+      approvalNotificationService: NoOpApprovalNotificationService()
+    )
+
+    await viewModel.ensureDiffAvailability(for: "/tmp/project")
+
+    #expect(viewModel.diffAvailabilityStatus(for: "/tmp/project") == .available)
+  }
+
+  @Test("ensureDiffAvailability uses the fresh cached status without rechecking")
+  @MainActor
+  func ensureDiffAvailabilityUsesFreshCachedStatus() async {
+    let diffService = MockDiffAvailabilityService(
+      status: .available,
+      cachedStatus: .unavailable
+    )
+    let viewModel = CLISessionsViewModel(
+      monitorService: DiffStubMonitorService(),
+      fileWatcher: DiffStubFileWatcher(),
+      searchService: nil,
+      cliConfiguration: CLICommandConfiguration(command: "claude", mode: .claude),
+      providerKind: .claude,
+      diffAvailabilityService: diffService,
+      approvalNotificationService: NoOpApprovalNotificationService()
+    )
+
+    await viewModel.ensureDiffAvailability(for: "/tmp/project")
+
+    #expect(viewModel.diffAvailabilityStatus(for: "/tmp/project") == .unavailable)
+  }
+
+  @Test("force refresh invalidates stale availability")
+  @MainActor
+  func forceRefreshInvalidatesStaleAvailability() async {
+    let diffService = MockDiffAvailabilityService(
+      status: .available,
+      cachedStatus: .unavailable
+    )
+    let viewModel = CLISessionsViewModel(
+      monitorService: DiffStubMonitorService(),
+      fileWatcher: DiffStubFileWatcher(),
+      searchService: nil,
+      cliConfiguration: CLICommandConfiguration(command: "claude", mode: .claude),
+      providerKind: .claude,
+      diffAvailabilityService: diffService,
+      approvalNotificationService: NoOpApprovalNotificationService()
+    )
+
+    await viewModel.ensureDiffAvailability(for: "/tmp/project")
+    await viewModel.ensureDiffAvailability(for: "/tmp/project", forceRefresh: true)
+
+    let invalidations = await diffService.recordedInvalidations()
+    #expect(viewModel.diffAvailabilityStatus(for: "/tmp/project") == .available)
+    #expect(invalidations.count == 1)
+  }
+}

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/MonitoringEditorStateTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/MonitoringEditorStateTests.swift
@@ -100,4 +100,54 @@ struct MonitoringEditorStateTests {
     #expect(prunedStates["claude-session-1"] == nil)
     #expect(prunedStates["codex-session-2"]?.projectPath == "/tmp/repo-b")
   }
+
+  @Test("Diff mode can be stored")
+  func diffModeCanBeStored() throws {
+    let states = MonitoringEditorStateStore.setContentMode(
+      .diffs,
+      for: "claude-session-1",
+      defaultProjectPath: "/tmp/repo",
+      in: [:]
+    )
+
+    let state = try #require(states["claude-session-1"])
+    #expect(state.contentMode == .diffs)
+  }
+
+  @Test("Unavailable diff mode falls back to terminal")
+  func unavailableDiffModeFallsBackToTerminal() {
+    let mode = MonitoringEditorStateStore.coercedContentMode(
+      .diffs,
+      availableModes: [.terminal, .editor]
+    )
+
+    #expect(mode == .terminal)
+  }
+
+  @Test("Terminal files shortcut ignores diffs")
+  func terminalFilesShortcutIgnoresDiffs() {
+    #expect(MonitoringEditorStateStore.toggledTerminalFilesMode(from: .terminal) == .editor)
+    #expect(MonitoringEditorStateStore.toggledTerminalFilesMode(from: .editor) == .terminal)
+    #expect(MonitoringEditorStateStore.toggledTerminalFilesMode(from: .diffs) == .terminal)
+  }
+
+  @Test("Inline available modes include diffs only when available")
+  func inlineAvailableModesIncludeDiffsOnlyWhenAvailable() {
+    let availableItems = MonitoringCardContentModeItems.items(
+      diffDisplayMode: .inline,
+      diffAvailabilityStatus: .available
+    )
+    let unavailableItems = MonitoringCardContentModeItems.items(
+      diffDisplayMode: .inline,
+      diffAvailabilityStatus: .unavailable
+    )
+    let sidePanelItems = MonitoringCardContentModeItems.items(
+      diffDisplayMode: .sidePanel,
+      diffAvailabilityStatus: .available
+    )
+
+    #expect(availableItems.map(\.value) == [.terminal, .editor, .diffs])
+    #expect(unavailableItems.map(\.value) == [.terminal, .editor])
+    #expect(sidePanelItems.map(\.value) == [.terminal, .editor])
+  }
 }


### PR DESCRIPTION
## Summary

Adds an Inline diff display preference as the new default while preserving the legacy Side Panel option. In Inline mode, monitored session cards dynamically show `Terminal / Files / Diffs` once async git detection confirms diffs exist.

## Changes

- Added a namespaced `Diff display` appearance preference with `Inline` and `Side Panel` values.
- Added `.diffs` to monitoring card content modes and relabeled the editor tab as `Files`.
- Added an actor-backed `DiffAvailabilityServiceProtocol` implementation with cached and in-flight git checks for unstaged, staged, untracked, and branch-vs-base changes.
- Wired diff availability into `CLISessionsViewModel` and monitored cards.
- Embedded the existing `GitDiffView` as inline card content.
- Updated diff and plan feedback flows to switch the source card back to Terminal before sending prompts to Claude/Codex.
- Added focused service, view model, and editor state tests.

## Validation

- `xcodebuild test -project app/AgentHub.xcodeproj -scheme AgentHub -destination 'platform=macOS' -skipPackagePluginValidation -only-testing:AgentHubTests/DiffAvailabilityServiceTests -only-testing:AgentHubTests/CLISessionsViewModelDiffAvailabilityTests -only-testing:AgentHubTests/MonitoringEditorStateTests -quiet`
- `xcodebuild -project app/AgentHub.xcodeproj -scheme AgentHub -destination 'platform=macOS' -skipPackagePluginValidation build -quiet`
- `git diff --check`

`swift test` remains blocked by the existing `CodeEditSymbols` SwiftPM checkout issue where `Bundle.module` is unavailable.