### PR TITLE
[codex] Avoid Ghostty config loading on app launch

### DIFF
--- a/app/AgentHub.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/app/AgentHub.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "62cbf0414f4ca61f2f3966fb9c15798279a026c4d7c36944699cc6dbd0321562",
+  "originHash" : "5a43a0a027ff402ac9f13b384378e85dea913837eebe5a20954105491bb2c8cc",
   "pins" : [
     {
       "identity" : "beautiful-mermaid-swift",
@@ -69,8 +69,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/jamesrochabrun/GhosttySwift",
       "state" : {
-        "revision" : "09013e66d2ee1854519367824bdf0197a81e4e2e",
-        "version" : "1.0.3"
+        "branch" : "codex/async-runtime-config",
+        "revision" : "d1e6298c6fdbf0abd4fcce56c41cfbe32fe64b4f"
       }
     },
     {

--- a/app/AgentHub.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/app/AgentHub.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -69,8 +69,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/jamesrochabrun/GhosttySwift",
       "state" : {
-        "branch" : "codex/async-runtime-config",
-        "revision" : "d1e6298c6fdbf0abd4fcce56c41cfbe32fe64b4f"
+        "revision" : "f7286937278044fcfa0d6385b1264fe9cc8195b3",
+        "version" : "1.0.4"
       }
     },
     {

--- a/app/AgentHub/AgentHubApp.swift
+++ b/app/AgentHub/AgentHubApp.swift
@@ -36,12 +36,6 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
     // session begins monitoring.
     provider.reconcileClaudeHooksOnLaunch()
     provider.cleanupOrphanedProcesses()
-    // Build the shared Ghostty runtime off the critical launch path so the
-    // first session's terminal mount only pays the per-tab cost, not the
-    // full app-wide font/config/Metal cold-start.
-    Task { @MainActor in
-      AgentHubSharedGhosttyRuntime.prewarm()
-    }
   }
 
   /// Register all bundled fonts (Geist, GeistMono, JetBrains Mono)

--- a/app/modules/Ghostty/Package.swift
+++ b/app/modules/Ghostty/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
   ],
   dependencies: [
     .package(path: "../AgentHubCore"),
-    .package(url: "https://github.com/jamesrochabrun/GhosttySwift", branch: "codex/async-runtime-config"),
+    .package(url: "https://github.com/jamesrochabrun/GhosttySwift", exact: "1.0.4"),
   ],
   targets: [
     .target(

--- a/app/modules/Ghostty/Package.swift
+++ b/app/modules/Ghostty/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
   ],
   dependencies: [
     .package(path: "../AgentHubCore"),
-    .package(url: "https://github.com/jamesrochabrun/GhosttySwift", exact: "1.0.3"),
+    .package(url: "https://github.com/jamesrochabrun/GhosttySwift", branch: "codex/async-runtime-config"),
   ],
   targets: [
     .target(

--- a/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalSurface.swift
+++ b/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalSurface.swift
@@ -409,14 +409,15 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
   private func mountGhosttySession(
     primaryConfiguration: GhosttySurfaceConfiguration,
     protectsPrimaryTab: Bool
-  ) {
+  ) async {
     do {
       AgentHubGhosttyRuntimeLogging.applyQuietDefault()
       // Share a single `GhosttyRuntime` across every embedded session in the
       // app. Without this, each TerminalSession.init runs `ghostty_app_new`
       // afresh — loading fonts, config, and Metal pipelines per surface —
       // which is the bulk of the per-mount cold-start cost.
-      let runtime = try AgentHubSharedGhosttyRuntime.acquire()
+      let runtime = try await AgentHubSharedGhosttyRuntime.acquire()
+      guard !Task.isCancelled else { return }
       let session = try TerminalSession(
         runtime: runtime,
         primaryConfiguration: primaryConfiguration,
@@ -479,7 +480,7 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
       guard !Task.isCancelled else { return }
       self.pendingMountTask = nil
       guard self.canMountGhosttySession, self.terminalSession == nil else { return }
-      self.mountGhosttySession(
+      await self.mountGhosttySession(
         primaryConfiguration: configuration,
         protectsPrimaryTab: protectsPrimaryTab
       )

--- a/app/modules/Ghostty/Sources/Ghostty/AgentHubSharedGhosttyRuntime.swift
+++ b/app/modules/Ghostty/Sources/Ghostty/AgentHubSharedGhosttyRuntime.swift
@@ -15,27 +15,50 @@ import GhosttySwift
 /// (observed in xctrace traces).
 ///
 /// Sharing one runtime app-wide means every session past the first reuses the
-/// same `ghostty_app_t`, font cache, and config — and the runtime can be
-/// pre-warmed in the background once at launch so the first user-facing mount
-/// is cheap too.
+/// same `ghostty_app_t`, font cache, and config. Runtime creation remains
+/// lazy; GhosttySwift's async factory keeps config loading off the main actor
+/// before returning to the main actor for AppKit-facing runtime setup.
 @MainActor
 public enum AgentHubSharedGhosttyRuntime {
   private static var runtime: GhosttyRuntime?
+  private static var loadingTask: Task<GhosttyRuntime, Error>?
 
   /// Returns the shared runtime, lazily constructing it the first time.
-  /// Throws whatever `GhosttyRuntime.init` throws.
-  public static func acquire() throws -> GhosttyRuntime {
+  /// Throws whatever GhosttySwift's runtime factory throws.
+  public static func acquire() async throws -> GhosttyRuntime {
     if let runtime { return runtime }
+    if let loadingTask {
+      return try await loadingTask.value
+    }
+
     AgentHubGhosttyRuntimeLogging.applyQuietDefault()
-    let new = try GhosttyRuntime(configPath: GhosttyConfigPathResolver.configuredPath())
-    runtime = new
-    return new
+    let configPath = GhosttyConfigPathResolver.configuredPath()
+    let task = Task { @MainActor in
+      try await GhosttyRuntime.make(configPath: configPath)
+    }
+    loadingTask = task
+
+    do {
+      let new = try await task.value
+      runtime = new
+      loadingTask = nil
+      return new
+    } catch {
+      loadingTask = nil
+      throw error
+    }
   }
 
-  /// Warms the runtime off the critical path. Safe to call multiple times.
+  /// Warms the runtime. Safe to call multiple times.
+  ///
+  /// Config loading happens off the main actor, but the final Ghostty app
+  /// creation remains main-actor work. Do not call it from launch or other
+  /// latency-sensitive paths.
   /// Errors are swallowed — if pre-warm fails, the next `acquire()` call will
   /// surface the real error to the caller that needs it.
   public static func prewarm() {
-    _ = try? acquire()
+    Task { @MainActor in
+      _ = try? await acquire()
+    }
   }
 }

--- a/app/modules/Ghostty/Sources/Ghostty/GhosttyConfigPathResolver.swift
+++ b/app/modules/Ghostty/Sources/Ghostty/GhosttyConfigPathResolver.swift
@@ -21,10 +21,21 @@ public enum GhosttyConfigPathResolver {
     let expandedPath = (path as NSString).expandingTildeInPath
     var isDirectory: ObjCBool = false
     guard fileManager.fileExists(atPath: expandedPath, isDirectory: &isDirectory),
-          !isDirectory.boolValue else {
+          !isDirectory.boolValue,
+          fileManager.isReadableFile(atPath: expandedPath),
+          isRegularFile(atPath: expandedPath) else {
       return nil
     }
 
     return expandedPath
+  }
+
+  private static func isRegularFile(atPath path: String) -> Bool {
+    do {
+      let values = try URL(fileURLWithPath: path).resourceValues(forKeys: [.isRegularFileKey])
+      return values.isRegularFile == true
+    } catch {
+      return false
+    }
   }
 }

--- a/app/modules/Ghostty/Tests/GhosttyTests/GhosttyConfigPathResolverTests.swift
+++ b/app/modules/Ghostty/Tests/GhosttyTests/GhosttyConfigPathResolverTests.swift
@@ -1,6 +1,9 @@
 import AgentHubCore
 import Foundation
 import Testing
+#if canImport(Darwin)
+import Darwin
+#endif
 
 @testable import Ghostty
 
@@ -41,6 +44,22 @@ struct GhosttyConfigPathResolverTests {
     defaults.set(directoryURL.appendingPathComponent("missing").path, forKey: AgentHubDefaults.terminalGhosttyConfigPath)
     #expect(GhosttyConfigPathResolver.configuredPath(defaults: defaults) == nil)
   }
+
+  #if canImport(Darwin)
+  @Test("Ignores non-regular files")
+  func ignoresNonRegularFiles() throws {
+    let defaults = makeDefaults()
+    let fifoURL = FileManager.default.temporaryDirectory
+      .appendingPathComponent("ghostty-config-\(UUID().uuidString).fifo")
+    let created = fifoURL.path.withCString { mkfifo($0, mode_t(0o600)) }
+    try #require(created == 0)
+    defer { unlink(fifoURL.path) }
+
+    defaults.set(fifoURL.path, forKey: AgentHubDefaults.terminalGhosttyConfigPath)
+
+    #expect(GhosttyConfigPathResolver.configuredPath(defaults: defaults) == nil)
+  }
+  #endif
 }
 
 private func makeDefaults() -> UserDefaults {


### PR DESCRIPTION
## Summary

- Removes launch-time Ghostty runtime prewarming.
- Awaits the shared Ghostty runtime during terminal mount using the async factory released in `GhosttySwift` `1.0.4`.
- Rejects unreadable or non-regular custom Ghostty config paths before passing them to Ghostty's loader.

## Root Cause

`applicationDidFinishLaunching` scheduled `AgentHubSharedGhosttyRuntime.prewarm()` on the main actor. `GhosttyRuntime` is main-actor isolated and its config loader can block in file I/O, which showed up as `pread` on the main thread during launch.

## Impact

App launch no longer initializes Ghostty or reads Ghostty config files. The first terminal mount still creates the runtime lazily, but config loading happens off the main actor through the `GhosttySwift` `1.0.4` async runtime factory.

## Dependency

Uses `GhosttySwift` `1.0.4`: https://github.com/jamesrochabrun/GhosttySwift/releases/tag/1.0.4

## Validation

- `gh release view 1.0.4 --repo jamesrochabrun/GhosttySwift --json tagName,targetCommitish,url,isDraft,isPrerelease,assets`
- `swift package resolve --scratch-path /tmp/AgentHubGhostty-resolve-104`
- `git diff --check`

Note: earlier, a clean `swift test --scratch-path /tmp/AgentHubGhostty-scratch --filter GhosttyConfigPathResolverTests` reached unrelated dependency compilation and failed in `CodeEditSymbols` because `Bundle.module` was unavailable there.
