### PR TITLE
[codex] Handle Ghostty clipboard confirmations

### DIFF
--- a/app/AgentHub.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/app/AgentHub.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -69,8 +69,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/jamesrochabrun/GhosttySwift",
       "state" : {
-        "revision" : "f7286937278044fcfa0d6385b1264fe9cc8195b3",
-        "version" : "1.0.4"
+        "revision" : "6bdbd756b4b0e111ff94dc2cfa6420d82f134e78",
+        "version" : "1.0.5"
       }
     },
     {

--- a/app/modules/Ghostty/Package.swift
+++ b/app/modules/Ghostty/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
   ],
   dependencies: [
     .package(path: "../AgentHubCore"),
-    .package(url: "https://github.com/jamesrochabrun/GhosttySwift", exact: "1.0.4"),
+    .package(url: "https://github.com/jamesrochabrun/GhosttySwift", exact: "1.0.5"),
   ],
   targets: [
     .target(

--- a/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyClipboardConfirmationCopy.swift
+++ b/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyClipboardConfirmationCopy.swift
@@ -1,0 +1,35 @@
+//
+//  AgentHubGhosttyClipboardConfirmationCopy.swift
+//  AgentHub
+//
+
+import GhosttySwift
+
+struct AgentHubGhosttyClipboardConfirmationCopy: Equatable {
+  let title: String
+  let message: String
+  let allowButtonTitle: String
+
+  static func copy(for request: GhosttyClipboardRequest) -> AgentHubGhosttyClipboardConfirmationCopy {
+    switch request {
+    case .paste:
+      AgentHubGhosttyClipboardConfirmationCopy(
+        title: "Paste potentially unsafe text?",
+        message: "The pasted text may contain commands or terminal control sequences. Review it before allowing the paste.",
+        allowButtonTitle: "Paste"
+      )
+    case .osc52Read:
+      AgentHubGhosttyClipboardConfirmationCopy(
+        title: "Allow terminal to read the clipboard?",
+        message: "A program running in this terminal wants to read your clipboard contents.",
+        allowButtonTitle: "Allow Read"
+      )
+    case .osc52Write:
+      AgentHubGhosttyClipboardConfirmationCopy(
+        title: "Allow terminal to write the clipboard?",
+        message: "A program running in this terminal wants to replace your clipboard contents.",
+        allowButtonTitle: "Allow Write"
+      )
+    }
+  }
+}

--- a/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalSurface.swift
+++ b/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalSurface.swift
@@ -36,6 +36,7 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
   private var pendingPaneOpenTasks: [TerminalPanelID: Task<Void, Never>] = [:]
   private var pendingPaneCloseTasks: [TerminalPanelID: Task<Void, Never>] = [:]
   private var pendingTabCloseTasks: [TerminalTabID: Task<Void, Never>] = [:]
+  private var clipboardConfirmationInFlight = false
   private var localEventMonitor: Any?
   private var projectPath: String = ""
   private var isRestoringWorkspace = false
@@ -1289,7 +1290,84 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
     controller.onOpenURL = { [weak self] url in
       self?.handleOpenURL(url) ?? false
     }
+    controller.onClipboardConfirmation = { [weak self] confirmation in
+      guard let self else { return .deny }
+      return await self.presentClipboardConfirmation(confirmation)
+    }
     registerPIDWhenAvailable(for: controller)
+  }
+
+  private func presentClipboardConfirmation(
+    _ confirmation: GhosttyClipboardConfirmation
+  ) async -> GhosttyClipboardDecision {
+    guard !clipboardConfirmationInFlight else {
+      return .deny
+    }
+
+    guard let window else {
+      return .deny
+    }
+
+    clipboardConfirmationInFlight = true
+    let copy = AgentHubGhosttyClipboardConfirmationCopy.copy(for: confirmation.request)
+
+    return await withCheckedContinuation { continuation in
+      let alert = NSAlert()
+      alert.alertStyle = .warning
+      alert.messageText = copy.title
+      alert.informativeText = copy.message
+      alert.addButton(withTitle: copy.allowButtonTitle)
+      alert.addButton(withTitle: "Deny")
+      alert.buttons.first?.keyEquivalent = "\r"
+      if alert.buttons.count > 1 {
+        alert.buttons[1].keyEquivalent = "\u{1b}"
+      }
+      alert.accessoryView = makeClipboardConfirmationAccessoryView(
+        contents: confirmation.contents
+      )
+
+      alert.beginSheetModal(for: window) { [weak self] response in
+        Task { @MainActor in
+          self?.clipboardConfirmationInFlight = false
+          continuation.resume(
+            returning: response == .alertFirstButtonReturn ? .allow : .deny
+          )
+        }
+      }
+    }
+  }
+
+  private func makeClipboardConfirmationAccessoryView(contents: String) -> NSView {
+    let textView = NSTextView(frame: NSRect(x: 0, y: 0, width: 460, height: 180))
+    textView.string = contents
+    textView.isEditable = false
+    textView.isSelectable = true
+    textView.drawsBackground = true
+    textView.backgroundColor = .textBackgroundColor
+    textView.textColor = .textColor
+    textView.font = .monospacedSystemFont(ofSize: NSFont.smallSystemFontSize, weight: .regular)
+    textView.textContainerInset = NSSize(width: 8, height: 8)
+    textView.minSize = NSSize(width: 0, height: 0)
+    textView.maxSize = NSSize(
+      width: CGFloat.greatestFiniteMagnitude,
+      height: CGFloat.greatestFiniteMagnitude
+    )
+    textView.isVerticallyResizable = true
+    textView.isHorizontallyResizable = false
+    textView.textContainer?.containerSize = NSSize(
+      width: 460,
+      height: CGFloat.greatestFiniteMagnitude
+    )
+    textView.textContainer?.widthTracksTextView = true
+    textView.autoresizingMask = [.width]
+
+    let scrollView = NSScrollView(frame: NSRect(x: 0, y: 0, width: 460, height: 180))
+    scrollView.borderType = .bezelBorder
+    scrollView.hasVerticalScroller = true
+    scrollView.hasHorizontalScroller = false
+    scrollView.autohidesScrollers = true
+    scrollView.documentView = textView
+    return scrollView
   }
 
   private func closeControllerIfAllowed(_ controller: GhosttyTerminalController) {

--- a/app/modules/Ghostty/Tests/GhosttyTests/AgentHubGhosttyClipboardConfirmationCopyTests.swift
+++ b/app/modules/Ghostty/Tests/GhosttyTests/AgentHubGhosttyClipboardConfirmationCopyTests.swift
@@ -1,0 +1,31 @@
+import GhosttySwift
+import Testing
+
+@testable import Ghostty
+
+struct AgentHubGhosttyClipboardConfirmationCopyTests {
+  @Test
+  func pasteCopyDescribesUnsafePaste() {
+    let copy = AgentHubGhosttyClipboardConfirmationCopy.copy(for: .paste)
+
+    #expect(copy.title == "Paste potentially unsafe text?")
+    #expect(copy.allowButtonTitle == "Paste")
+    #expect(copy.message.contains("terminal control sequences"))
+  }
+
+  @Test
+  func osc52ReadCopyDescribesClipboardRead() {
+    let copy = AgentHubGhosttyClipboardConfirmationCopy.copy(for: .osc52Read)
+
+    #expect(copy.title == "Allow terminal to read the clipboard?")
+    #expect(copy.allowButtonTitle == "Allow Read")
+  }
+
+  @Test
+  func osc52WriteCopyDescribesClipboardWrite() {
+    let copy = AgentHubGhosttyClipboardConfirmationCopy.copy(for: .osc52Write)
+
+    #expect(copy.title == "Allow terminal to write the clipboard?")
+    #expect(copy.allowButtonTitle == "Allow Write")
+  }
+}


### PR DESCRIPTION
## Summary

Wires AgentHub to GhosttySwift 1.0.5 and handles the new host-mediated clipboard confirmation API.

## Why

GhosttySwift now defaults sensitive clipboard operations to deny unless the embedding host explicitly confirms them. AgentHub needs to provide that confirmation UX so unsafe paste, OSC 52 clipboard read, and OSC 52 clipboard write requests are visible to the user instead of silently denied.

## Changes

- Bump GhosttySwift from 1.0.4 to 1.0.5 and update the Xcode workspace package pin.
- Add copy for the three Ghostty clipboard confirmation request types.
- Present an AppKit sheet with the exact clipboard/request text and explicit allow/deny actions.
- Default-deny overlapping confirmation requests and missing-window cases.
- Add focused tests for the confirmation copy.

## Validation

- `jq empty app/AgentHub.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved`
- `git diff --cached --check`
- `swift package --skip-update resolve` from `app/modules/Ghostty` resolved GhosttySwift at `1.0.5` (`6bdbd756b4b0e111ff94dc2cfa6420d82f134e78`).
- Attempted `swift test --package-path app/modules/Ghostty --filter AgentHubGhosttyClipboardConfirmationCopyTests`; build progressed through GhosttySwift 1.0.5 but failed in unrelated dependency `CodeEditSymbols` because `Bundle.module` was unavailable for its asset resource setup.