### PR TITLE
[codex] Add regular terminal multi-panel support

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/EmbeddedTerminalSurface.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/EmbeddedTerminalSurface.swift
@@ -95,7 +95,6 @@ extension TerminalContainerView: EmbeddedTerminalSurface {
   }
 
   public func focus() {
-    guard let terminalView, let window = terminalView.window else { return }
-    window.makeFirstResponder(terminalView)
+    focusActiveTerminal()
   }
 }

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/EmbeddedTerminalView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/EmbeddedTerminalView.swift
@@ -219,17 +219,30 @@ public struct EmbeddedTerminalView: NSViewRepresentable {
 /// Container view that manages the terminal lifecycle
 public class TerminalContainerView: NSView, ManagedLocalProcessTerminalViewDelegate {
   var terminalView: SafeLocalProcessTerminalView?
+  private var terminalPanelSession: TerminalPanelKit.Session<SafeLocalProcessTerminalView>?
+  private var protectedAgentPanelID: RegularTerminalPanelID?
+  private var protectedAgentTabID: RegularTerminalTabID?
+  private var workspaceHostingView: NSHostingView<RegularTerminalWorkspaceView>?
   private var isConfigured = false
   private var hasDeliveredInitialPrompt = false
   private var hasPrefilledInitialInputText = false
   private var lastAppliedFontSize: CGFloat?
   private var lastAppliedFontFamily: String?
   private var lastAppliedIsDark: Bool?
+  private var currentIsDark = true
+  private var currentFontSize: CGFloat = 12
+  private var currentFontFamily = "SF Mono"
+  private var currentTheme: RuntimeTheme?
   private var terminalPidMap: [ObjectIdentifier: pid_t] = [:]
   private var localEventMonitor: Any?
+  private var projectPath: String = ""
+  private var configuredProcessProvider: SessionProviderKind?
+  private var isRestoringWorkspace = false
+  private var lastWorkspaceSnapshot: TerminalWorkspaceSnapshot?
   public var onUserInteraction: (() -> Void)?
   public var onRequestShowEditor: (() -> Void)?
   public var consumeQueuedWebPreviewContextOnSubmit: (() -> String?)?
+  public var onWorkspaceChanged: ((TerminalWorkspaceSnapshot) -> Void)?
   var terminalSessionKey: String?
   weak var sessionViewModel: CLISessionsViewModel?
   var metadataStore: SessionMetadataStore?
@@ -237,7 +250,7 @@ public class TerminalContainerView: NSView, ManagedLocalProcessTerminalViewDeleg
 
   /// The PID of the current terminal process, if running
   public var currentProcessPID: Int32? {
-    terminalView?.currentProcessId
+    protectedAgentTab?.terminalView.currentProcessId ?? activeTab?.terminalView.currentProcessId
   }
 
   // MARK: - Lifecycle
@@ -255,9 +268,9 @@ public class TerminalContainerView: NSView, ManagedLocalProcessTerminalViewDeleg
   /// Safe to call multiple times - subsequent calls are no-ops.
   public func terminateProcess() {
     terminateProcessCallCount += 1
-    // Stop data reception FIRST to prevent DispatchIO race condition crash
-    terminalView?.stopReceivingData()
-    terminalView?.terminateProcessTree()
+    for terminal in allTerminalViews {
+      terminateAndUnregister(terminal)
+    }
   }
 
   // MARK: - Configuration
@@ -270,8 +283,8 @@ public class TerminalContainerView: NSView, ManagedLocalProcessTerminalViewDeleg
     cliConfiguration: CLICommandConfiguration
   ) {
     terminateProcess()
-    terminalView?.removeFromSuperview()
-    terminalView = nil
+    removeMountedContent()
+    resetWorkspaceState()
     isConfigured = false
     hasDeliveredInitialPrompt = false  // Reset for fresh start
     hasPrefilledInitialInputText = false
@@ -295,6 +308,9 @@ public class TerminalContainerView: NSView, ManagedLocalProcessTerminalViewDeleg
     }
     guard !isConfigured else { return }
     isConfigured = true
+    self.projectPath = projectPath
+    currentIsDark = isDark
+    configuredProcessProvider = SessionProviderKind(cliMode: cliConfiguration.mode)
 
     let terminal = prepareTerminalView(isDark: isDark)
     terminal.projectPath = projectPath
@@ -319,10 +335,17 @@ public class TerminalContainerView: NSView, ManagedLocalProcessTerminalViewDeleg
     registerProcessIfNeeded(
       for: terminal,
       kind: .agentTerminal,
-      provider: SessionProviderKind(cliMode: cliConfiguration.mode),
+      provider: configuredProcessProvider,
       sessionId: sessionId,
       projectPath: projectPath,
       expectedExecutable: cliConfiguration.executableName
+    )
+    mountInitialWorkspace(
+      terminal: terminal,
+      role: .agent,
+      panelRole: .primary,
+      name: providerDisplayName,
+      workingDirectory: resolvedProjectPath
     )
 
     if let initialInputText, !initialInputText.isEmpty {
@@ -339,8 +362,17 @@ public class TerminalContainerView: NSView, ManagedLocalProcessTerminalViewDeleg
   ) {
     guard !isConfigured else { return }
     isConfigured = true
+    self.projectPath = projectPath
+    currentIsDark = isDark
+    configuredProcessProvider = sessionViewModel?.providerKind
 
     let terminal = prepareTerminalView(isDark: isDark)
+    terminal.projectPath = projectPath
+    terminal.onOpenFile = { [weak self] path, line in
+      if let self, let vm = self.sessionViewModel, let key = self.terminalSessionKey {
+        vm.pendingFileOpen = (sessionId: key, filePath: path, lineNumber: line)
+      }
+    }
     installInteractionMonitorIfNeeded()
 
     startShellProcess(
@@ -356,6 +388,13 @@ public class TerminalContainerView: NSView, ManagedLocalProcessTerminalViewDeleg
       projectPath: projectPath,
       expectedExecutable: nil
     )
+    mountInitialWorkspace(
+      terminal: terminal,
+      role: .shell,
+      panelRole: .primary,
+      name: "Shell",
+      workingDirectory: resolvedProjectPath
+    )
   }
 
   /// Resets the prompt delivery flag so a new prompt can be sent.
@@ -366,9 +405,10 @@ public class TerminalContainerView: NSView, ManagedLocalProcessTerminalViewDeleg
 
   /// Sends a prompt to the terminal (only once per terminal instance unless reset)
   public func sendPromptIfNeeded(_ prompt: String) {
-    guard let terminal = terminalView else { return }
+    guard let terminal = protectedAgentTab?.terminalView else { return }
     guard !hasDeliveredInitialPrompt else { return }
     hasDeliveredInitialPrompt = true
+    focusProtectedAgentTab()
 
     // Detect plan-feedback prefix: 3 down-arrows + Enter marks step-by-step delivery
     let planFeedbackPrefix = "\u{1B}[B\u{1B}[B\u{1B}[B\r"
@@ -405,7 +445,8 @@ public class TerminalContainerView: NSView, ManagedLocalProcessTerminalViewDeleg
   /// This path is for explicit user actions and must not be gated by initial
   /// prompt delivery state.
   public func submitPromptImmediately(_ prompt: String) -> Bool {
-    guard let terminal = terminalView else { return false }
+    guard let terminal = protectedAgentTab?.terminalView else { return false }
+    focusProtectedAgentTab()
     terminal.send(TerminalPromptSubmissionPayload.textBytes(
       prompt: prompt,
       bracketedPasteMode: terminal.terminal?.bracketedPasteMode ?? false
@@ -431,7 +472,7 @@ public class TerminalContainerView: NSView, ManagedLocalProcessTerminalViewDeleg
   /// Types text into the terminal WITHOUT pressing Enter.
   /// Used for drag-and-drop file paths where user adds context before submitting.
   public func typeText(_ text: String) {
-    guard let terminal = terminalView else { return }
+    guard let terminal = activeTab?.terminalView ?? protectedAgentTab?.terminalView else { return }
     terminal.send(txt: text)
   }
 
@@ -440,24 +481,29 @@ public class TerminalContainerView: NSView, ManagedLocalProcessTerminalViewDeleg
     guard !text.isEmpty else { return }
     guard !hasPrefilledInitialInputText else { return }
     hasPrefilledInitialInputText = true
-    typeText(text)
+    focusProtectedAgentTab()
+    protectedAgentTab?.terminalView.send(txt: text)
   }
 
   public func syncAppearance(isDark: Bool, fontSize: CGFloat, fontFamily: String = "SF Mono", theme: RuntimeTheme? = nil) {
+    currentIsDark = isDark
+    currentFontSize = max(fontSize, 8)
+    currentFontFamily = fontFamily
+    currentTheme = theme
     updateColors(isDark: isDark, theme: theme)
     updateFont(size: fontSize, family: fontFamily)
   }
 
   /// Updates terminal font size and family.
   public func updateFont(size: CGFloat, family: String = "SF Mono") {
-    guard let terminal = terminalView else { return }
     let resolvedSize = max(size, 8)
-    guard lastAppliedFontSize != resolvedSize || lastAppliedFontFamily != family else { return }
 
     let font = NSFont(name: family, size: resolvedSize)
       ?? NSFont(name: "SF Mono", size: resolvedSize)
       ?? NSFont.monospacedSystemFont(ofSize: resolvedSize, weight: .regular)
-    terminal.font = font
+    for terminal in allTerminalViews {
+      terminal.font = font
+    }
     lastAppliedFontSize = resolvedSize
     lastAppliedFontFamily = family
   }
@@ -468,37 +514,36 @@ public class TerminalContainerView: NSView, ManagedLocalProcessTerminalViewDeleg
   /// Only background and cursor are themed — foreground and ANSI colors are left
   /// untouched to preserve Claude Code / Codex syntax highlighting.
   public func updateColors(isDark: Bool, theme: RuntimeTheme? = nil) {
-    guard let terminal = terminalView else { return }
-
     let themeId = theme?.id
-    let needsUpdate = lastAppliedIsDark != isDark || lastAppliedThemeId != themeId
-    guard needsUpdate else { return }
 
-    // Theme terminal colors only apply in dark mode
-    if isDark, let bg = theme?.terminalBackground {
-      terminal.nativeBackgroundColor = bg
-    } else if isDark {
-      terminal.nativeBackgroundColor = NSColor(red: 0.1, green: 0.1, blue: 0.12, alpha: 1.0)
-    } else {
-      // Match app light background
-      terminal.nativeBackgroundColor = NSColor(Color.backgroundLight)
-    }
+    for terminal in allTerminalViews {
+      // Theme terminal colors only apply in dark mode
+      if isDark, let bg = theme?.terminalBackground {
+        terminal.nativeBackgroundColor = bg
+      } else if isDark {
+        terminal.nativeBackgroundColor = NSColor(red: 0.1, green: 0.1, blue: 0.12, alpha: 1.0)
+      } else {
+        // Match app light background
+        terminal.nativeBackgroundColor = NSColor(Color.backgroundLight)
+      }
 
-    if isDark {
-      terminal.nativeForegroundColor = NSColor(red: 0.9, green: 0.9, blue: 0.88, alpha: 1.0)
-    } else {
-      terminal.nativeForegroundColor = NSColor(red: 0.1, green: 0.1, blue: 0.1, alpha: 1.0)
-    }
+      if isDark {
+        terminal.nativeForegroundColor = NSColor(red: 0.9, green: 0.9, blue: 0.88, alpha: 1.0)
+      } else {
+        terminal.nativeForegroundColor = NSColor(red: 0.1, green: 0.1, blue: 0.1, alpha: 1.0)
+      }
 
-    if isDark, let cursor = theme?.terminalCursor {
-      terminal.caretColor = cursor
-    } else {
-      terminal.caretColor = NSColor(red: 204/255, green: 120/255, blue: 92/255, alpha: 1.0)
+      if isDark, let cursor = theme?.terminalCursor {
+        terminal.caretColor = cursor
+      } else {
+        terminal.caretColor = NSColor(red: 204/255, green: 120/255, blue: 92/255, alpha: 1.0)
+      }
+
+      terminal.needsDisplay = true
     }
 
     lastAppliedIsDark = isDark
     lastAppliedThemeId = themeId
-    terminal.needsDisplay = true
   }
 
   private func applyInitialAppearance(to terminal: TerminalView, isDark: Bool) {
@@ -522,15 +567,24 @@ public class TerminalContainerView: NSView, ManagedLocalProcessTerminalViewDeleg
   private func installInteractionMonitorIfNeeded() {
     guard localEventMonitor == nil else { return }
     localEventMonitor = NSEvent.addLocalMonitorForEvents(matching: [.keyDown, .leftMouseUp]) { [weak self] event in
-      guard let self, let terminal = self.terminalView else { return event }
+      guard let self else { return event }
 
       switch event.type {
       case .keyDown:
-        guard let window = terminal.window,
-              event.window === window else { break }
+        guard let window = event.window ?? self.window,
+              window === self.window else { break }
+        guard let focusedTab = self.focusedTab(in: window) else { break }
+        let terminal = focusedTab.terminalView
+        self.syncSelection(to: focusedTab)
 
         let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
         let isTerminalVisible = terminal.superview != nil && !terminal.isHidden && terminal.alphaValue > 0
+
+        if let shortcut = RegularTerminalShortcut.action(for: event) {
+          self.handleShortcut(shortcut, focusedTerminal: terminal)
+          self.onUserInteraction?()
+          return nil
+        }
 
         if isTerminalVisible,
            self.isTerminalResponderActive(window: window, terminal: terminal),
@@ -542,21 +596,12 @@ public class TerminalContainerView: NSView, ManagedLocalProcessTerminalViewDeleg
           return nil
         }
 
-        // Cmd+F: only when terminal has focus (let file editor handle it otherwise)
-        if isTerminalVisible, self.isTerminalResponderActive(window: window, terminal: terminal) {
-          if flags == .command, event.charactersIgnoringModifiers == "f" {
-            window.makeFirstResponder(terminal)
-            // performFindPanelAction requires an NSMenuItem with the correct tag
-            let menuItem = NSMenuItem()
-            menuItem.tag = Int(NSFindPanelAction.showFindPanel.rawValue)
-            terminal.performFindPanelAction(menuItem)
-            return nil
-          }
-
-          }
-
         // Typing shortcuts (require terminal to be first responder)
         guard isTerminalResponderActive(window: window, terminal: terminal) else { break }
+        guard isProtectedAgentTab(focusedTab) else {
+          self.onUserInteraction?()
+          break
+        }
 
         let shortcut = NewlineShortcut(
           rawValue: UserDefaults.standard.integer(forKey: AgentHubDefaults.terminalNewlineShortcut)
@@ -606,9 +651,9 @@ public class TerminalContainerView: NSView, ManagedLocalProcessTerminalViewDeleg
         guard !ResizeInteractionSuppression.shared.shouldSuppressSelection else {
           return event
         }
-        guard let window = terminal.window, event.window === window else { return event }
-        let locationInTerminal = terminal.convert(event.locationInWindow, from: nil)
-        if terminal.bounds.contains(locationInTerminal) {
+        guard let window = event.window, window === self.window else { return event }
+        if let tab = self.tab(containingMouseEvent: event) {
+          self.syncSelection(to: tab)
           // Defer selection updates until after mouse handling completes.
           DispatchQueue.main.async { [weak self] in
             self?.onUserInteraction?()
@@ -649,16 +694,10 @@ public class TerminalContainerView: NSView, ManagedLocalProcessTerminalViewDeleg
     terminal.processDelegate = self
 
     configureTerminalAppearance(terminal, isDark: isDark)
+    terminal.font = NSFont(name: currentFontFamily, size: currentFontSize)
+      ?? NSFont(name: "SF Mono", size: currentFontSize)
+      ?? NSFont.monospacedSystemFont(ofSize: currentFontSize, weight: .regular)
 
-    addSubview(terminal)
-    NSLayoutConstraint.activate([
-      terminal.leadingAnchor.constraint(equalTo: leadingAnchor),
-      terminal.trailingAnchor.constraint(equalTo: trailingAnchor),
-      terminal.topAnchor.constraint(equalTo: topAnchor),
-      terminal.bottomAnchor.constraint(equalTo: bottomAnchor)
-    ])
-
-    self.terminalView = terminal
     return terminal
   }
 
@@ -748,13 +787,704 @@ public class TerminalContainerView: NSView, ManagedLocalProcessTerminalViewDeleg
     }
   }
 
+  private var resolvedProjectPath: String {
+    projectPath.isEmpty ? NSHomeDirectory() : projectPath
+  }
+
+  private var providerDisplayName: String {
+    (sessionViewModel?.providerKind ?? configuredProcessProvider)?.rawValue ?? "CLI"
+  }
+
+  private var panels: [RegularTerminalPanel] {
+    terminalPanelSession?.panels ?? []
+  }
+
+  private var primaryPanelID: RegularTerminalPanelID? {
+    terminalPanelSession?.primaryPanelID
+  }
+
+  private var activePanelID: RegularTerminalPanelID? {
+    terminalPanelSession?.activePanelID
+  }
+
+  private var splitRoot: RegularTerminalSplitNode? {
+    terminalPanelSession?.splitRoot
+  }
+
+  private var activePanel: RegularTerminalPanel? {
+    terminalPanelSession?.activePanel
+  }
+
+  private var activeTab: RegularTerminalTab? {
+    activePanel?.activeTab
+  }
+
+  private var protectedAgentTab: RegularTerminalTab? {
+    guard let protectedAgentPanelID, let protectedAgentTabID else { return nil }
+    return panels
+      .first { $0.id == protectedAgentPanelID }?
+      .tabs
+      .first { $0.id == protectedAgentTabID }
+  }
+
+  private var allTabs: [RegularTerminalTab] {
+    panels.flatMap(\.tabs)
+  }
+
+  private var allTerminalViews: [SafeLocalProcessTerminalView] {
+    allTabs.map(\.terminalView)
+  }
+
+  private func mountInitialWorkspace(
+    terminal: SafeLocalProcessTerminalView,
+    role: TerminalWorkspaceTabRole,
+    panelRole: TerminalWorkspacePanelRole,
+    name: String?,
+    workingDirectory: String?
+  ) {
+    let tab = RegularTerminalTab(
+      role: role,
+      name: name,
+      workingDirectory: workingDirectory,
+      terminalView: terminal
+    )
+    let panel = RegularTerminalPanel(
+      role: panelRole,
+      tabs: [tab],
+      activeTabID: tab.id
+    )
+
+    terminalView = terminal
+    terminalPanelSession = TerminalPanelKit.Session(primaryPanel: panel)
+
+    if role == .agent {
+      protectedAgentPanelID = panel.id
+      protectedAgentTabID = tab.id
+    }
+
+    refreshWorkspaceRootView()
+    syncAppearance(
+      isDark: currentIsDark,
+      fontSize: currentFontSize,
+      fontFamily: currentFontFamily,
+      theme: currentTheme
+    )
+    lastWorkspaceSnapshot = captureWorkspaceSnapshot()
+  }
+
+  private func resetWorkspaceState() {
+    terminalPanelSession = nil
+    protectedAgentPanelID = nil
+    protectedAgentTabID = nil
+    terminalView = nil
+    lastWorkspaceSnapshot = nil
+  }
+
+  private func removeMountedContent() {
+    workspaceHostingView?.removeFromSuperview()
+    workspaceHostingView = nil
+    for subview in subviews {
+      subview.removeFromSuperview()
+    }
+  }
+
+  private func refreshWorkspaceRootView() {
+    guard !panels.isEmpty else {
+      removeMountedContent()
+      return
+    }
+
+    if let workspaceHostingView {
+      workspaceHostingView.rootView = makeWorkspaceRootView()
+      return
+    }
+
+    let host = NSHostingView(rootView: makeWorkspaceRootView())
+    host.translatesAutoresizingMaskIntoConstraints = false
+    host.wantsLayer = true
+    host.layer?.backgroundColor = NSColor.clear.cgColor
+    addSubview(host)
+    NSLayoutConstraint.activate([
+      host.leadingAnchor.constraint(equalTo: leadingAnchor),
+      host.trailingAnchor.constraint(equalTo: trailingAnchor),
+      host.topAnchor.constraint(equalTo: topAnchor),
+      host.bottomAnchor.constraint(equalTo: bottomAnchor)
+    ])
+    workspaceHostingView = host
+  }
+
+  private func makeWorkspaceRootView() -> RegularTerminalWorkspaceView {
+    RegularTerminalWorkspaceView(
+      panels: panels,
+      splitRoot: splitRoot,
+      activePanelID: activePanelID,
+      canClosePanel: { [weak self] panel in
+        self?.canCloseRegularPanel(panel) ?? false
+      },
+      canCloseTab: { [weak self] panel, tab in
+        self?.canCloseRegularTab(tab, in: panel) ?? false
+      },
+      onActivatePanel: { [weak self] panel in
+        self?.activateRegularPanel(panel)
+      },
+      onSelectTab: { [weak self] panel, tab in
+        self?.selectRegularTab(tab, in: panel)
+      },
+      onClosePanel: { [weak self] panel in
+        self?.closeRegularPanel(panel)
+      },
+      onCloseTab: { [weak self] panel, tab in
+        self?.closeRegularTab(tab, in: panel)
+      },
+      onOpenTab: { [weak self] panel in
+        self?.openShellTab(in: panel.id)
+      },
+      onSplitPanel: { [weak self] panel, axis in
+        self?.openShellPane(axis: axis, anchorPanelID: panel.id)
+      }
+    )
+  }
+
+  private func makeShellTab(
+    name: String? = "Shell",
+    workingDirectory: String? = nil
+  ) -> RegularTerminalTab {
+    let shellProjectPath = resolvedExistingDirectory(workingDirectory)
+    let terminal = prepareTerminalView(isDark: currentIsDark)
+    terminal.projectPath = shellProjectPath
+    terminal.onOpenFile = { [weak self] path, line in
+      if let self, let vm = self.sessionViewModel, let key = self.terminalSessionKey {
+        vm.pendingFileOpen = (sessionId: key, filePath: path, lineNumber: line)
+      }
+    }
+
+    let tab = RegularTerminalTab(
+      role: .shell,
+      name: name,
+      workingDirectory: shellProjectPath,
+      terminalView: terminal
+    )
+    scheduleShellStart(for: tab, projectPath: shellProjectPath)
+    return tab
+  }
+
+  private func scheduleShellStart(for tab: RegularTerminalTab, projectPath: String) {
+    Task { @MainActor [weak self, weak tab] in
+      await Task.yield()
+      guard let self, let tab else { return }
+      guard self.allTabs.contains(where: { $0.id == tab.id }) else { return }
+      guard !tab.terminalView.isStopped else { return }
+
+      self.startShellProcess(
+        terminal: tab.terminalView,
+        projectPath: projectPath,
+        shellPath: nil
+      )
+      self.registerProcessIfNeeded(
+        for: tab.terminalView,
+        kind: .auxiliaryShell,
+        provider: self.sessionViewModel?.providerKind ?? self.configuredProcessProvider,
+        sessionId: self.terminalSessionKey,
+        projectPath: projectPath,
+        expectedExecutable: nil
+      )
+    }
+  }
+
+  private func openShellTab(in panelID: RegularTerminalPanelID? = nil) {
+    guard RegularTerminalLaunchFeatures.tabsEnabled else { return }
+    guard let session = terminalPanelSession else { return }
+    guard let panel = panel(for: panelID ?? activePanelID ?? primaryPanelID) else { return }
+    let tab = makeShellTab(workingDirectory: panel.activeTab?.workingDirectory)
+    guard session.appendTab(tab, in: panel.id) else { return }
+    refreshWorkspaceRootView()
+    syncAppearance(
+      isDark: currentIsDark,
+      fontSize: currentFontSize,
+      fontFamily: currentFontFamily,
+      theme: currentTheme
+    )
+    notifyWorkspaceChanged()
+    focus(tab)
+  }
+
+  private func openShellPane(
+    axis: RegularTerminalSplitAxis = .horizontal,
+    anchorPanelID: RegularTerminalPanelID? = nil
+  ) {
+    guard let session = terminalPanelSession, session.canOpenPanel else { return }
+    guard let anchorPanel = panel(for: anchorPanelID ?? activePanelID ?? primaryPanelID) else { return }
+    let tab = makeShellTab(workingDirectory: anchorPanel.activeTab?.workingDirectory)
+    guard session.openPanel(with: tab, beside: anchorPanel.id, axis: axis) != nil else { return }
+    refreshWorkspaceRootView()
+    syncAppearance(
+      isDark: currentIsDark,
+      fontSize: currentFontSize,
+      fontFamily: currentFontFamily,
+      theme: currentTheme
+    )
+    notifyWorkspaceChanged()
+    focus(tab)
+  }
+
+  private func canCloseRegularPanel(_ panel: RegularTerminalPanel) -> Bool {
+    terminalPanelSession?.canClosePanel(panel.id) ?? false
+  }
+
+  private func canCloseRegularTab(_ tab: RegularTerminalTab, in panel: RegularTerminalPanel) -> Bool {
+    guard RegularTerminalLaunchFeatures.tabsEnabled else { return false }
+    return terminalPanelSession?.canCloseTab(
+      tab.id,
+      in: panel.id,
+      isProtected: isProtectedAgentTab(tab, in: panel.id)
+    ) ?? false
+  }
+
+  private func activateRegularPanel(_ panel: RegularTerminalPanel) {
+    guard terminalPanelSession?.focusPanel(panel.id) == true else { return }
+    notifyWorkspaceChanged()
+  }
+
+  private func selectRegularTab(_ tab: RegularTerminalTab, in panel: RegularTerminalPanel) {
+    guard RegularTerminalLaunchFeatures.tabsEnabled || panel.activeTabID == tab.id else { return }
+    guard terminalPanelSession?.selectTab(tab.id, in: panel.id) == true else { return }
+    refreshWorkspaceRootView()
+    notifyWorkspaceChanged()
+    focus(tab)
+  }
+
+  private func closeRegularPanel(_ panel: RegularTerminalPanel) {
+    guard canCloseRegularPanel(panel) else { return }
+    let wasActivePanel = activePanelID == panel.id
+    let closeResult = terminalPanelSession?.closePanel(panel.id) ?? .empty
+    refreshWorkspaceRootView()
+    notifyWorkspaceChanged()
+    if wasActivePanel, let activeTab {
+      focus(activeTab)
+    }
+    terminateAfterWorkspaceUpdate(closeResult.payloads)
+  }
+
+  private func closeRegularTab(_ tab: RegularTerminalTab, in panel: RegularTerminalPanel) {
+    guard canCloseRegularTab(tab, in: panel) else { return }
+    let wasActiveTab = panel.activeTabID == tab.id
+    let closeResult = terminalPanelSession?.closeTab(tab.id, in: panel.id) ?? .empty
+    refreshWorkspaceRootView()
+    notifyWorkspaceChanged()
+    if wasActiveTab, let replacementTab = activePanel?.activeTab {
+      focus(replacementTab)
+    }
+    terminateAfterWorkspaceUpdate(closeResult.payloads)
+  }
+
+  private func closeActiveOrLastAuxiliaryPanel() {
+    guard let activePanel else { return }
+    if canCloseRegularPanel(activePanel) {
+      closeRegularPanel(activePanel)
+      return
+    }
+    if let auxiliary = panels.reversed().first(where: canCloseRegularPanel) {
+      closeRegularPanel(auxiliary)
+    }
+  }
+
+  private func focus(_ tab: RegularTerminalTab) {
+    focusTerminalView(tab.terminalView)
+  }
+
+  func focusActiveTerminal() {
+    focusTerminalView(activeTab?.terminalView ?? protectedAgentTab?.terminalView ?? terminalView)
+  }
+
+  private func focusTerminalView(_ terminal: SafeLocalProcessTerminalView?) {
+    guard let terminal else { return }
+    Task { @MainActor [weak terminal] in
+      await Task.yield()
+      guard let terminal, let window = terminal.window else { return }
+      window.makeFirstResponder(terminal)
+    }
+  }
+
+  private func terminateAfterWorkspaceUpdate(_ terminals: [SafeLocalProcessTerminalView]) {
+    guard !terminals.isEmpty else { return }
+    Task { @MainActor [weak self, terminals] in
+      await Task.yield()
+      guard let self else {
+        for terminal in terminals {
+          terminal.stopReceivingData()
+          terminal.terminateProcessTree()
+        }
+        return
+      }
+      for terminal in terminals {
+        self.terminateAndUnregister(terminal)
+      }
+    }
+  }
+
+  private func focusProtectedAgentTab() {
+    guard let tab = protectedAgentTab,
+          let protectedAgentPanelID,
+          terminalPanelSession?.selectTab(tab.id, in: protectedAgentPanelID) == true else {
+      return
+    }
+    refreshWorkspaceRootView()
+    focus(tab)
+  }
+
+  private func handleShortcut(
+    _ shortcut: RegularTerminalShortcut,
+    focusedTerminal: SafeLocalProcessTerminalView
+  ) {
+    switch shortcut {
+    case .startSearch:
+      showFindPanel(in: focusedTerminal)
+    case .openTab:
+      guard RegularTerminalLaunchFeatures.tabsEnabled else { return }
+      openShellTab()
+    case .openPane(let axis):
+      openShellPane(axis: axis)
+    case .closePanel:
+      closeActiveOrLastAuxiliaryPanel()
+    case .focusPanel(let direction):
+      if focusPanel(direction: direction) {
+        notifyWorkspaceChanged()
+      }
+    case .selectTab(let direction):
+      guard RegularTerminalLaunchFeatures.tabsEnabled else { return }
+      if selectTab(direction: direction) {
+        notifyWorkspaceChanged()
+      }
+    }
+  }
+
+  private func showFindPanel(in terminal: SafeLocalProcessTerminalView) {
+    guard let window = terminal.window else { return }
+    window.makeFirstResponder(terminal)
+    let menuItem = NSMenuItem()
+    menuItem.tag = Int(NSFindPanelAction.showFindPanel.rawValue)
+    terminal.performFindPanelAction(menuItem)
+  }
+
+  private func focusPanel(direction: RegularTerminalPanelNavigationDirection) -> Bool {
+    guard terminalPanelSession?.focusPanel(direction: direction, viewportSize: bounds.size) == true else {
+      return false
+    }
+    refreshWorkspaceRootView()
+    if let activeTab {
+      focus(activeTab)
+    }
+    return true
+  }
+
+  private func selectTab(direction: RegularTerminalTabNavigationDirection) -> Bool {
+    guard RegularTerminalLaunchFeatures.tabsEnabled else { return false }
+    guard terminalPanelSession?.selectTab(direction: direction) == true else { return false }
+    refreshWorkspaceRootView()
+    if let activeTab {
+      focus(activeTab)
+    }
+    return true
+  }
+
+  public func captureWorkspaceSnapshot() -> TerminalWorkspaceSnapshot? {
+    guard !panels.isEmpty else { return nil }
+
+    let panelSnapshots = panels.map { panel in
+      let snapshot = tabsForWorkspaceSnapshot(in: panel)
+      let tabs = snapshot.tabs.map { tab in
+        TerminalWorkspaceTabSnapshot(
+          role: tab.role,
+          name: Self.nonEmpty(tab.name),
+          title: Self.nonEmpty(tab.title),
+          workingDirectory: Self.nonEmpty(tab.workingDirectory ?? resolvedProjectPath)
+        )
+      }
+      return TerminalWorkspacePanelSnapshot(
+        role: panel.id == primaryPanelID ? .primary : .auxiliary,
+        tabs: tabs,
+        activeTabIndex: snapshot.activeTabIndex
+      )
+    }
+
+    return TerminalWorkspaceSnapshot(
+      panels: panelSnapshots,
+      activePanelIndex: panels.firstIndex { $0.id == activePanelID } ?? 0
+    )
+  }
+
+  public func restoreWorkspaceSnapshot(_ snapshot: TerminalWorkspaceSnapshot) {
+    guard !panels.isEmpty, !snapshot.panels.isEmpty else { return }
+    isRestoringWorkspace = true
+    defer {
+      isRestoringWorkspace = false
+      lastWorkspaceSnapshot = captureWorkspaceSnapshot()
+    }
+
+    resetToPrimaryTerminal()
+    let panelSnapshots = normalizedPanelSnapshots(snapshot.panels)
+    var restoredPanelIDs: [RegularTerminalPanelID] = []
+    var restoredTabIDs: [[RegularTerminalTabID]] = []
+
+    if let primary = panel(for: primaryPanelID) {
+      restoredPanelIDs.append(primary.id)
+      var primaryTabIDs = primary.tabs.map(\.id)
+      if let primarySnapshot = panelSnapshots.first {
+        primaryTabIDs = restoreShellTabs(
+          from: primarySnapshot,
+          in: primary,
+          existingTabIDs: primaryTabIDs
+        )
+      }
+      restoredTabIDs.append(primaryTabIDs)
+    }
+
+    for panelSnapshot in panelSnapshots.dropFirst() {
+      guard let session = terminalPanelSession, session.canOpenPanel else { break }
+      guard let firstShellTab = panelSnapshot.tabs.first(where: { $0.role == .shell }) else { continue }
+      let tab = makeShellTab(
+        name: restoredTabName(for: firstShellTab),
+        workingDirectory: firstShellTab.workingDirectory
+      )
+      let anchorPanelID = primaryPanelID ?? panels[0].id
+      guard let panel = session.openPanel(
+        with: tab,
+        beside: anchorPanelID,
+        axis: .horizontal
+      ) else {
+        continue
+      }
+
+      var tabIDs = [tab.id]
+      if RegularTerminalLaunchFeatures.tabsEnabled {
+        tabIDs = restoreShellTabs(
+          from: panelSnapshot,
+          in: panel,
+          existingTabIDs: tabIDs,
+          skippingFirstShellTab: true
+        )
+      }
+      restoredPanelIDs.append(panel.id)
+      restoredTabIDs.append(tabIDs)
+    }
+
+    restoreActiveSelection(
+      from: snapshot,
+      panelIDs: restoredPanelIDs,
+      tabIDs: restoredTabIDs
+    )
+    refreshWorkspaceRootView()
+    syncAppearance(
+      isDark: currentIsDark,
+      fontSize: currentFontSize,
+      fontFamily: currentFontFamily,
+      theme: currentTheme
+    )
+  }
+
+  private func resetToPrimaryTerminal() {
+    guard let session = terminalPanelSession,
+          let primary = panel(for: primaryPanelID) ?? panels.first else { return }
+    let keepTabID = protectedAgentTabID ?? primary.tabs.first?.id
+    let closeResult = session.resetToPrimary(keeping: keepTabID)
+    for terminal in closeResult.payloads {
+      terminateAndUnregister(terminal)
+    }
+  }
+
+  private func restoreShellTabs(
+    from panelSnapshot: TerminalWorkspacePanelSnapshot,
+    in panel: RegularTerminalPanel,
+    existingTabIDs: [RegularTerminalTabID],
+    skippingFirstShellTab: Bool = false
+  ) -> [RegularTerminalTabID] {
+    guard RegularTerminalLaunchFeatures.tabsEnabled else { return existingTabIDs }
+    var restoredTabIDs = existingTabIDs
+    var hasSkippedFirstShellTab = false
+
+    for tabSnapshot in panelSnapshot.tabs where tabSnapshot.role == .shell {
+      if skippingFirstShellTab && !hasSkippedFirstShellTab {
+        hasSkippedFirstShellTab = true
+        continue
+      }
+
+      let tab = makeShellTab(
+        name: restoredTabName(for: tabSnapshot),
+        workingDirectory: tabSnapshot.workingDirectory
+      )
+      panel.appendTab(tab)
+      restoredTabIDs.append(tab.id)
+    }
+
+    return restoredTabIDs
+  }
+
+  private func tabsForWorkspaceSnapshot(
+    in panel: RegularTerminalPanel
+  ) -> (tabs: [RegularTerminalTab], activeTabIndex: Int) {
+    if RegularTerminalLaunchFeatures.tabsEnabled {
+      let activeTabIndex = panel.tabs.firstIndex { $0.id == panel.activeTabID } ?? 0
+      return (panel.tabs, activeTabIndex)
+    }
+
+    if let activeTab = panel.activeTab {
+      return ([activeTab], 0)
+    }
+
+    if let firstTab = panel.tabs.first {
+      return ([firstTab], 0)
+    }
+
+    return ([], 0)
+  }
+
+  private func restoreActiveSelection(
+    from snapshot: TerminalWorkspaceSnapshot,
+    panelIDs: [RegularTerminalPanelID],
+    tabIDs: [[RegularTerminalTabID]]
+  ) {
+    guard !panelIDs.isEmpty else { return }
+    let panelIndex = min(max(snapshot.activePanelIndex, 0), panelIDs.count - 1)
+    let panelID = panelIDs[panelIndex]
+
+    guard let panel = panel(for: panelID) else { return }
+    let savedPanel = snapshot.panels.indices.contains(panelIndex) ? snapshot.panels[panelIndex] : nil
+    let savedActiveTabIndex = savedPanel?.activeTabIndex ?? 0
+    let panelTabIDs = tabIDs.indices.contains(panelIndex) ? tabIDs[panelIndex] : []
+    guard !panelTabIDs.isEmpty else { return }
+
+    let tabIndex = min(max(savedActiveTabIndex, 0), panelTabIDs.count - 1)
+    _ = terminalPanelSession?.selectTab(panelTabIDs[tabIndex], in: panel.id)
+  }
+
+  private func normalizedPanelSnapshots(
+    _ panels: [TerminalWorkspacePanelSnapshot]
+  ) -> [TerminalWorkspacePanelSnapshot] {
+    let primary = panels.first { $0.role == .primary } ?? panels.first
+    let auxiliaries = panels.filter { $0.role == .auxiliary }
+    return ([primary].compactMap { $0 } + auxiliaries).prefix(4).map { $0 }
+  }
+
+  private func restoredTabName(for tab: TerminalWorkspaceTabSnapshot) -> String? {
+    if tab.role == .agent {
+      return providerDisplayName
+    }
+    return Self.nonEmpty(tab.name) ?? Self.nonEmpty(tab.title) ?? "Shell"
+  }
+
+  private func resolvedExistingDirectory(_ path: String?) -> String {
+    guard let path = Self.nonEmpty(path) else { return resolvedProjectPath }
+    let expandedPath = (path as NSString).expandingTildeInPath
+    var isDirectory: ObjCBool = false
+    guard FileManager.default.fileExists(atPath: expandedPath, isDirectory: &isDirectory),
+          isDirectory.boolValue else {
+      return resolvedProjectPath
+    }
+    return expandedPath
+  }
+
+  private func panel(for id: RegularTerminalPanelID?) -> RegularTerminalPanel? {
+    terminalPanelSession?.panel(for: id)
+  }
+
+  private func isProtectedAgentTab(_ tab: RegularTerminalTab) -> Bool {
+    guard let located = locate(tab) else { return false }
+    return isProtectedAgentTab(tab, in: located.panel.id)
+  }
+
+  private func isProtectedAgentTab(_ tab: RegularTerminalTab, in panelID: RegularTerminalPanelID) -> Bool {
+    panelID == protectedAgentPanelID && tab.id == protectedAgentTabID
+  }
+
+  private func locate(_ tab: RegularTerminalTab) -> (panel: RegularTerminalPanel, tab: RegularTerminalTab)? {
+    for panel in panels {
+      if let matchedTab = panel.tabs.first(where: { $0.id == tab.id }) {
+        return (panel, matchedTab)
+      }
+    }
+    return nil
+  }
+
+  private func locate(terminal: TerminalView) -> (panel: RegularTerminalPanel, tab: RegularTerminalTab)? {
+    for panel in panels {
+      if let matchedTab = panel.tabs.first(where: { $0.terminalView === terminal }) {
+        return (panel, matchedTab)
+      }
+    }
+    return nil
+  }
+
+  private func focusedTab(in window: NSWindow) -> RegularTerminalTab? {
+    guard let responder = window.firstResponder else { return nil }
+    guard let responderView = responder as? NSView else { return nil }
+    if let focusedTab = allTabs.first(where: { tab in
+      responderView === tab.terminalView || responderView.isDescendant(of: tab.terminalView)
+    }) {
+      return focusedTab
+    }
+    if responderView === self || responderView.isDescendant(of: self) {
+      return activeTab
+    }
+    return nil
+  }
+
+  private func tab(containingMouseEvent event: NSEvent) -> RegularTerminalTab? {
+    allTabs.first { tab in
+      guard event.window === tab.terminalView.window else { return false }
+      let location = tab.terminalView.convert(event.locationInWindow, from: nil)
+      return tab.terminalView.bounds.contains(location)
+    }
+  }
+
+  private func syncSelection(to tab: RegularTerminalTab) {
+    guard let located = locate(tab) else { return }
+    if activePanelID != located.panel.id || located.panel.activeTabID != located.tab.id {
+      _ = terminalPanelSession?.selectTab(located.tab.id, in: located.panel.id)
+      refreshWorkspaceRootView()
+      notifyWorkspaceChanged()
+    }
+  }
+
+  private func terminateAndUnregister(_ terminal: SafeLocalProcessTerminalView) {
+    let key = ObjectIdentifier(terminal)
+    if let pid = terminalPidMap.removeValue(forKey: key) {
+      Task {
+        await TerminalProcessRegistry.shared.unregister(pid: pid)
+      }
+    }
+    terminal.stopReceivingData()
+    terminal.terminateProcessTree()
+  }
+
+  private func notifyWorkspaceChanged() {
+    guard !isRestoringWorkspace else { return }
+    guard let snapshot = captureWorkspaceSnapshot() else { return }
+    guard snapshot != lastWorkspaceSnapshot else { return }
+    lastWorkspaceSnapshot = snapshot
+    onWorkspaceChanged?(snapshot)
+  }
+
+  private static func nonEmpty(_ value: String?) -> String? {
+    let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines)
+    return trimmed?.isEmpty == false ? trimmed : nil
+  }
+
   // MARK: - ManagedLocalProcessTerminalViewDelegate
 
   public func sizeChanged(source: ManagedLocalProcessTerminalView, newCols: Int, newRows: Int) {}
 
-  public func setTerminalTitle(source: ManagedLocalProcessTerminalView, title: String) {}
+  public func setTerminalTitle(source: ManagedLocalProcessTerminalView, title: String) {
+    guard let located = locate(terminal: source) else { return }
+    located.tab.title = title
+    refreshWorkspaceRootView()
+    notifyWorkspaceChanged()
+  }
 
-  public func hostCurrentDirectoryUpdate(source: TerminalView, directory: String?) {}
+  public func hostCurrentDirectoryUpdate(source: TerminalView, directory: String?) {
+    guard let located = locate(terminal: source) else { return }
+    located.tab.workingDirectory = directory
+    notifyWorkspaceChanged()
+  }
 
   public func processTerminated(source: TerminalView, exitCode: Int32?) {
     let key = ObjectIdentifier(source)

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/RegularTerminalWorkspaceView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/RegularTerminalWorkspaceView.swift
@@ -1,0 +1,538 @@
+//
+//  RegularTerminalWorkspaceView.swift
+//  AgentHub
+//
+
+import AppKit
+import SwiftUI
+
+typealias RegularTerminalPanelID = TerminalPanelKit.PanelID
+typealias RegularTerminalTabID = TerminalPanelKit.TabID
+typealias RegularTerminalSplitAxis = TerminalPanelKit.SplitAxis
+typealias RegularTerminalPanelNavigationDirection = TerminalPanelKit.PanelNavigationDirection
+typealias RegularTerminalTabNavigationDirection = TerminalPanelKit.TabNavigationDirection
+typealias RegularTerminalSplitNode = TerminalPanelKit.SplitNode
+typealias RegularTerminalShortcut = TerminalPanelKit.Shortcut
+typealias RegularTerminalTab = TerminalPanelKit.Tab<SafeLocalProcessTerminalView>
+typealias RegularTerminalPanel = TerminalPanelKit.Panel<SafeLocalProcessTerminalView>
+typealias RegularTerminalSplitLayoutBuilder = TerminalPanelKit.SplitLayoutBuilder
+
+enum RegularTerminalLaunchFeatures {
+  // TODO: Re-enable regular terminal tabs after launch once SwiftTerm tab creation latency is solved.
+  static let tabsEnabled = false
+}
+
+@MainActor
+extension TerminalPanelKit.Tab where Payload == SafeLocalProcessTerminalView {
+  var terminalView: SafeLocalProcessTerminalView {
+    payload
+  }
+
+  convenience init(
+    id: RegularTerminalTabID = RegularTerminalTabID(),
+    role: TerminalWorkspaceTabRole,
+    name: String? = nil,
+    title: String? = nil,
+    workingDirectory: String? = nil,
+    terminalView: SafeLocalProcessTerminalView
+  ) {
+    self.init(
+      id: id,
+      role: role,
+      name: name,
+      title: title,
+      workingDirectory: workingDirectory,
+      payload: terminalView
+    )
+  }
+}
+
+@MainActor
+struct RegularTerminalWorkspaceView: View {
+  let panels: [RegularTerminalPanel]
+  let splitRoot: RegularTerminalSplitNode?
+  let activePanelID: RegularTerminalPanelID?
+  let canClosePanel: (RegularTerminalPanel) -> Bool
+  let canCloseTab: (RegularTerminalPanel, RegularTerminalTab) -> Bool
+  let onActivatePanel: (RegularTerminalPanel) -> Void
+  let onSelectTab: (RegularTerminalPanel, RegularTerminalTab) -> Void
+  let onClosePanel: (RegularTerminalPanel) -> Void
+  let onCloseTab: (RegularTerminalPanel, RegularTerminalTab) -> Void
+  let onOpenTab: (RegularTerminalPanel) -> Void
+  let onSplitPanel: (RegularTerminalPanel, RegularTerminalSplitAxis) -> Void
+
+  var body: some View {
+    if panels.isEmpty {
+      Text("No terminal available")
+        .foregroundStyle(.secondary)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    } else {
+      RegularTerminalSplitView(
+        node: resolvedSplitRoot,
+        panels: panels,
+        activePanelID: activePanelID,
+        canClosePanel: canClosePanel,
+        canCloseTab: canCloseTab,
+        onActivatePanel: onActivatePanel,
+        onSelectTab: onSelectTab,
+        onClosePanel: onClosePanel,
+        onCloseTab: onCloseTab,
+        onOpenTab: onOpenTab,
+        onSplitPanel: onSplitPanel
+      )
+    }
+  }
+
+  private var resolvedSplitRoot: RegularTerminalSplitNode {
+    splitRoot ?? panels.first.map { .panel($0.id) } ?? .panel(RegularTerminalPanelID())
+  }
+}
+
+@MainActor
+private struct RegularTerminalSplitView: View {
+  let node: RegularTerminalSplitNode
+  let panels: [RegularTerminalPanel]
+  let activePanelID: RegularTerminalPanelID?
+  let canClosePanel: (RegularTerminalPanel) -> Bool
+  let canCloseTab: (RegularTerminalPanel, RegularTerminalTab) -> Bool
+  let onActivatePanel: (RegularTerminalPanel) -> Void
+  let onSelectTab: (RegularTerminalPanel, RegularTerminalTab) -> Void
+  let onClosePanel: (RegularTerminalPanel) -> Void
+  let onCloseTab: (RegularTerminalPanel, RegularTerminalTab) -> Void
+  let onOpenTab: (RegularTerminalPanel) -> Void
+  let onSplitPanel: (RegularTerminalPanel, RegularTerminalSplitAxis) -> Void
+
+  var body: some View {
+    content(for: node)
+  }
+
+  @ViewBuilder
+  private func content(for node: RegularTerminalSplitNode) -> some View {
+    switch node {
+    case .panel(let panelID):
+      if let panel = panels.first(where: { $0.id == panelID }) {
+        RegularTerminalPaneView(
+          panel: panel,
+          isActive: panel.id == activePanelID,
+          showsSelectionBorder: panels.count > 1,
+          canSplit: panels.count < 4,
+          canClosePanel: canClosePanel(panel),
+          canCloseTab: { tab in canCloseTab(panel, tab) },
+          onActivatePanel: { onActivatePanel(panel) },
+          onSelectTab: { tab in onSelectTab(panel, tab) },
+          onClosePanel: { onClosePanel(panel) },
+          onCloseTab: { tab in onCloseTab(panel, tab) },
+          onOpenTab: { onOpenTab(panel) },
+          onSplitRight: { onSplitPanel(panel, .horizontal) },
+          onSplitBelow: { onSplitPanel(panel, .vertical) }
+        )
+      } else {
+        EmptyView()
+      }
+
+    case .split(let axis, let children):
+      split(axis: axis, children: children)
+    }
+  }
+
+  @ViewBuilder
+  private func split(
+    axis: RegularTerminalSplitAxis,
+    children: [RegularTerminalSplitNode]
+  ) -> some View {
+    GeometryReader { proxy in
+      switch axis {
+      case .horizontal:
+        horizontalSplit(children: children, size: proxy.size)
+      case .vertical:
+        verticalSplit(children: children, size: proxy.size)
+      }
+    }
+  }
+
+  private func horizontalSplit(
+    children: [RegularTerminalSplitNode],
+    size: CGSize
+  ) -> some View {
+    let dividerSize: CGFloat = 1
+    let childCount = CGFloat(max(children.count, 1))
+    let totalDividerWidth = dividerSize * CGFloat(max(children.count - 1, 0))
+    let childWidth = max(0, size.width - totalDividerWidth) / childCount
+
+    return HStack(spacing: 0) {
+      ForEach(Array(children.enumerated()), id: \.offset) { offset, child in
+        if offset > 0 {
+          divider(axis: .horizontal)
+        }
+        RegularTerminalSplitView(
+          node: child,
+          panels: panels,
+          activePanelID: activePanelID,
+          canClosePanel: canClosePanel,
+          canCloseTab: canCloseTab,
+          onActivatePanel: onActivatePanel,
+          onSelectTab: onSelectTab,
+          onClosePanel: onClosePanel,
+          onCloseTab: onCloseTab,
+          onOpenTab: onOpenTab,
+          onSplitPanel: onSplitPanel
+        )
+        .frame(width: childWidth, height: size.height)
+      }
+    }
+  }
+
+  private func verticalSplit(
+    children: [RegularTerminalSplitNode],
+    size: CGSize
+  ) -> some View {
+    let dividerSize: CGFloat = 1
+    let childCount = CGFloat(max(children.count, 1))
+    let totalDividerHeight = dividerSize * CGFloat(max(children.count - 1, 0))
+    let childHeight = max(0, size.height - totalDividerHeight) / childCount
+
+    return VStack(spacing: 0) {
+      ForEach(Array(children.enumerated()), id: \.offset) { offset, child in
+        if offset > 0 {
+          divider(axis: .vertical)
+        }
+        RegularTerminalSplitView(
+          node: child,
+          panels: panels,
+          activePanelID: activePanelID,
+          canClosePanel: canClosePanel,
+          canCloseTab: canCloseTab,
+          onActivatePanel: onActivatePanel,
+          onSelectTab: onSelectTab,
+          onClosePanel: onClosePanel,
+          onCloseTab: onCloseTab,
+          onOpenTab: onOpenTab,
+          onSplitPanel: onSplitPanel
+        )
+        .frame(width: size.width, height: childHeight)
+      }
+    }
+  }
+
+  @ViewBuilder
+  private func divider(axis: RegularTerminalSplitAxis) -> some View {
+    switch axis {
+    case .horizontal:
+      Color.primary.opacity(0.25)
+        .frame(width: 1)
+    case .vertical:
+      Color.primary.opacity(0.25)
+        .frame(height: 1)
+    }
+  }
+}
+
+@MainActor
+private struct RegularTerminalPaneView: View {
+  let panel: RegularTerminalPanel
+  let isActive: Bool
+  let showsSelectionBorder: Bool
+  let canSplit: Bool
+  let canClosePanel: Bool
+  let canCloseTab: (RegularTerminalTab) -> Bool
+  let onActivatePanel: () -> Void
+  let onSelectTab: (RegularTerminalTab) -> Void
+  let onClosePanel: () -> Void
+  let onCloseTab: (RegularTerminalTab) -> Void
+  let onOpenTab: () -> Void
+  let onSplitRight: () -> Void
+  let onSplitBelow: () -> Void
+
+  var body: some View {
+    VStack(spacing: 0) {
+      RegularTerminalPaneHeader(
+        panel: panel,
+        canSplit: canSplit,
+        canClosePanel: canClosePanel,
+        canCloseTab: canCloseTab,
+        onSelectTab: onSelectTab,
+        onCloseTab: onCloseTab,
+        onOpenTab: onOpenTab,
+        onSplitRight: onSplitRight,
+        onSplitBelow: onSplitBelow,
+        onClosePanel: onClosePanel
+      )
+
+      if let activeTab = panel.activeTab {
+        RegularTerminalTabRepresentable(tab: activeTab)
+          .id(activeTab.id)
+          .frame(maxWidth: .infinity, maxHeight: .infinity)
+      } else {
+        Text("No tab available")
+          .foregroundStyle(.secondary)
+          .frame(maxWidth: .infinity, maxHeight: .infinity)
+      }
+    }
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+    .background(Color.clear)
+    .contentShape(Rectangle())
+    .onTapGesture(perform: onActivatePanel)
+    .overlay {
+      if isActive && showsSelectionBorder {
+        Rectangle()
+          .stroke(Color.accentColor.opacity(0.55), lineWidth: 1)
+      }
+    }
+  }
+}
+
+@MainActor
+private struct RegularTerminalPaneHeader: View {
+  let panel: RegularTerminalPanel
+  let canSplit: Bool
+  let canClosePanel: Bool
+  let canCloseTab: (RegularTerminalTab) -> Bool
+  let onSelectTab: (RegularTerminalTab) -> Void
+  let onCloseTab: (RegularTerminalTab) -> Void
+  let onOpenTab: () -> Void
+  let onSplitRight: () -> Void
+  let onSplitBelow: () -> Void
+  let onClosePanel: () -> Void
+
+  var body: some View {
+    ZStack(alignment: .bottom) {
+      Color(nsColor: .controlBackgroundColor)
+        .opacity(0.85)
+
+      Rectangle()
+        .fill(Color.primary.opacity(0.16))
+        .frame(height: 1)
+
+      HStack(spacing: 0) {
+        if RegularTerminalLaunchFeatures.tabsEnabled {
+          ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 0) {
+              ForEach(Array(panel.tabs.enumerated()), id: \.element.id) { index, tab in
+                RegularTerminalTabItem(
+                  title: tab.displayName(index: index),
+                  isActive: tab.id == panel.activeTabID,
+                  isFirst: index == 0,
+                  canClose: canCloseTab(tab),
+                  onSelect: { onSelectTab(tab) },
+                  onClose: { onCloseTab(tab) }
+                )
+              }
+            }
+          }
+        } else {
+          Text(activeTabTitle)
+            .lineLimit(1)
+            .truncationMode(.tail)
+            .font(.system(size: 12, weight: .semibold))
+            .foregroundStyle(Color.primary)
+            .padding(.leading, 12)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+
+        Spacer(minLength: 0)
+
+        HStack(spacing: 2) {
+          if RegularTerminalLaunchFeatures.tabsEnabled {
+            RegularTerminalToolbarButton(
+              title: "New Tab",
+              systemImage: "plus",
+              help: "New terminal tab",
+              action: onOpenTab
+            )
+          }
+
+          RegularTerminalToolbarButton(
+            title: "Split Right",
+            systemImage: "rectangle.split.2x1",
+            help: "Split terminal to the right",
+            isDisabled: !canSplit,
+            action: onSplitRight
+          )
+
+          RegularTerminalToolbarButton(
+            title: "Split Below",
+            systemImage: "rectangle.split.1x2",
+            help: "Split terminal below",
+            isDisabled: !canSplit,
+            action: onSplitBelow
+          )
+
+          if canClosePanel {
+            RegularTerminalToolbarButton(
+              title: "Close Pane",
+              systemImage: "xmark",
+              help: "Close terminal pane",
+              action: onClosePanel
+            )
+          }
+        }
+        .padding(.horizontal, 8)
+      }
+      .frame(height: 32)
+    }
+    .frame(height: 32)
+  }
+
+  private var activeTabTitle: String {
+    panel.activeTab?.displayName(index: 0) ?? panel.name ?? "Terminal"
+  }
+}
+
+@MainActor
+private struct RegularTerminalTabItem: View {
+  let title: String
+  let isActive: Bool
+  let isFirst: Bool
+  let canClose: Bool
+  let onSelect: () -> Void
+  let onClose: () -> Void
+
+  @State private var isHovered = false
+  @State private var isCloseHovered = false
+
+  var body: some View {
+    HStack(spacing: 0) {
+      Button(action: onSelect) {
+        Text(title)
+          .lineLimit(1)
+          .truncationMode(.tail)
+          .font(.system(size: 12, weight: isActive ? .semibold : .regular))
+          .frame(maxWidth: .infinity, alignment: .leading)
+          .padding(.leading, isFirst ? 12 : 10)
+          .padding(.trailing, canClose ? 6 : 10)
+          .contentShape(Rectangle())
+      }
+      .buttonStyle(.plain)
+
+      if canClose {
+        Button("Close Tab", systemImage: "xmark", action: onClose)
+          .labelStyle(.iconOnly)
+          .buttonStyle(.plain)
+          .font(.system(size: 10, weight: .bold))
+          .foregroundStyle(Color.secondary)
+          .frame(width: 16, height: 16)
+          .background {
+            RoundedRectangle(cornerRadius: 4, style: .continuous)
+              .fill(isCloseHovered ? Color.primary.opacity(0.10) : Color.clear)
+          }
+          .help("Close terminal tab")
+          .padding(.trailing, 6)
+          .onHover { hovering in
+            isCloseHovered = hovering
+          }
+      }
+    }
+    .frame(height: 32)
+    .frame(minWidth: 96, maxWidth: 180, alignment: .leading)
+    .foregroundStyle(isActive ? Color.primary : Color.secondary)
+    .background {
+      Rectangle()
+        .fill(backgroundColor)
+    }
+    .overlay(alignment: .bottom) {
+      if isActive {
+        Rectangle()
+          .fill(Color.accentColor)
+          .frame(height: 2)
+      }
+    }
+    .contentShape(Rectangle())
+    .help(title)
+    .onHover { hovering in
+      isHovered = hovering
+    }
+  }
+
+  private var backgroundColor: Color {
+    if isActive {
+      return Color.primary.opacity(0.08)
+    }
+    if isHovered {
+      return Color.primary.opacity(0.05)
+    }
+    return .clear
+  }
+}
+
+@MainActor
+private struct RegularTerminalToolbarButton: View {
+  let title: String
+  let systemImage: String
+  let help: String
+  let isDisabled: Bool
+  let action: () -> Void
+
+  @State private var isHovered = false
+
+  init(
+    title: String,
+    systemImage: String,
+    help: String,
+    isDisabled: Bool = false,
+    action: @escaping () -> Void
+  ) {
+    self.title = title
+    self.systemImage = systemImage
+    self.help = help
+    self.isDisabled = isDisabled
+    self.action = action
+  }
+
+  var body: some View {
+    Button(title, systemImage: systemImage, action: action)
+      .labelStyle(.iconOnly)
+      .buttonStyle(.plain)
+      .font(.system(size: 13, weight: .medium))
+      .foregroundStyle(isDisabled ? Color.secondary.opacity(0.45) : Color.secondary)
+      .frame(width: 28, height: 28)
+      .background {
+        RoundedRectangle(cornerRadius: 4, style: .continuous)
+          .fill(isHovered && !isDisabled ? Color.primary.opacity(0.08) : Color.clear)
+      }
+      .contentShape(Rectangle())
+      .disabled(isDisabled)
+      .accessibilityLabel(title)
+      .help(help)
+      .onHover { hovering in
+        isHovered = hovering
+      }
+  }
+}
+
+@MainActor
+private struct RegularTerminalTabRepresentable: NSViewRepresentable {
+  let tab: RegularTerminalTab
+
+  func makeNSView(context: Context) -> RegularTerminalTabHostView {
+    let hostView = RegularTerminalTabHostView()
+    hostView.mount(tab.terminalView, key: tab.id.rawValue.uuidString)
+    return hostView
+  }
+
+  func updateNSView(_ nsView: RegularTerminalTabHostView, context: Context) {
+    nsView.mount(tab.terminalView, key: tab.id.rawValue.uuidString)
+  }
+}
+
+@MainActor
+private final class RegularTerminalTabHostView: NSView {
+  private var mountedKey: String?
+  private weak var mountedView: NSView?
+
+  func mount(_ terminalView: NSView, key: String) {
+    guard mountedKey != key || mountedView !== terminalView else { return }
+
+    mountedView?.removeFromSuperview()
+    terminalView.removeFromSuperview()
+    terminalView.translatesAutoresizingMaskIntoConstraints = false
+    addSubview(terminalView)
+    NSLayoutConstraint.activate([
+      terminalView.leadingAnchor.constraint(equalTo: leadingAnchor),
+      terminalView.trailingAnchor.constraint(equalTo: trailingAnchor),
+      terminalView.topAnchor.constraint(equalTo: topAnchor),
+      terminalView.bottomAnchor.constraint(equalTo: bottomAnchor)
+    ])
+    mountedKey = key
+    mountedView = terminalView
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/TerminalPanelKit.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/TerminalPanelKit.swift
@@ -1,0 +1,727 @@
+//
+//  TerminalPanelKit.swift
+//  AgentHub
+//
+
+import AppKit
+import Foundation
+
+public enum TerminalPanelKit {
+  public struct PanelID: Codable, Hashable, Identifiable, Sendable {
+    public let id: UUID
+
+    public var rawValue: UUID {
+      id
+    }
+
+    public init(_ id: UUID = UUID()) {
+      self.id = id
+    }
+  }
+
+  public struct TabID: Codable, Hashable, Identifiable, Sendable {
+    public let id: UUID
+
+    public var rawValue: UUID {
+      id
+    }
+
+    public init(_ id: UUID = UUID()) {
+      self.id = id
+    }
+  }
+
+  public enum SplitAxis: Codable, Equatable, Sendable {
+    case horizontal
+    case vertical
+  }
+
+  public enum PanelNavigationDirection: Equatable, Sendable {
+    case left
+    case right
+    case up
+    case down
+  }
+
+  public enum TabNavigationDirection: Equatable, Sendable {
+    case previous
+    case next
+  }
+
+  public indirect enum SplitNode: Codable, Equatable, Sendable {
+    case panel(PanelID)
+    case split(axis: SplitAxis, children: [SplitNode])
+
+    public var panelIDs: [PanelID] {
+      switch self {
+      case .panel(let panelID):
+        return [panelID]
+      case .split(_, let children):
+        return children.flatMap(\.panelIDs)
+      }
+    }
+
+    public func containsPanel(_ panelID: PanelID) -> Bool {
+      switch self {
+      case .panel(let currentPanelID):
+        return currentPanelID == panelID
+      case .split(_, let children):
+        return children.contains { $0.containsPanel(panelID) }
+      }
+    }
+  }
+
+  public enum Shortcut: Equatable {
+    case startSearch
+    case openTab
+    case openPane(axis: SplitAxis)
+    case closePanel
+    case focusPanel(PanelNavigationDirection)
+    case selectTab(TabNavigationDirection)
+
+    public static func action(for event: NSEvent) -> Shortcut? {
+      action(
+        keyCode: event.keyCode,
+        charactersIgnoringModifiers: event.charactersIgnoringModifiers,
+        modifierFlags: event.modifierFlags
+      )
+    }
+
+    public static func action(
+      keyCode: UInt16,
+      charactersIgnoringModifiers: String?,
+      modifierFlags: NSEvent.ModifierFlags
+    ) -> Shortcut? {
+      let flags = normalizedModifierFlags(modifierFlags)
+      let key = charactersIgnoringModifiers?.lowercased()
+
+      if flags == [.command] {
+        switch keyCode {
+        case 123: return .focusPanel(.left)
+        case 124: return .focusPanel(.right)
+        case 125: return .focusPanel(.down)
+        case 126: return .focusPanel(.up)
+        default:
+          break
+        }
+
+        switch key {
+        case "f": return .startSearch
+        case "t": return .openTab
+        case "d": return .openPane(axis: .horizontal)
+        default: return nil
+        }
+      }
+
+      if flags == [.command, .shift] {
+        switch keyCode {
+        case 123: return .selectTab(.previous)
+        case 124: return .selectTab(.next)
+        default:
+          break
+        }
+
+        switch key {
+        case "d": return .openPane(axis: .vertical)
+        case "w": return .closePanel
+        default: return nil
+        }
+      }
+
+      return nil
+    }
+
+    private static func normalizedModifierFlags(
+      _ flags: NSEvent.ModifierFlags
+    ) -> NSEvent.ModifierFlags {
+      flags
+        .intersection(.deviceIndependentFlagsMask)
+        .subtracting([.numericPad, .function, .capsLock])
+    }
+  }
+
+  public enum PaneActivity: Equatable {
+    case starting
+    case closingPanel
+    case closingTerminal
+
+    public var message: String {
+      switch self {
+      case .starting:
+        return "Starting terminal..."
+      case .closingPanel:
+        return "Closing panel..."
+      case .closingTerminal:
+        return "Closing terminal..."
+      }
+    }
+  }
+
+  public struct ClosedTab<Payload> {
+    public let panelID: PanelID
+    public let tabID: TabID
+    public let payload: Payload
+  }
+
+  public struct CloseResult<Payload> {
+    public let closedPanelID: PanelID?
+    public let closedTabs: [ClosedTab<Payload>]
+
+    public static var empty: CloseResult<Payload> {
+      CloseResult(closedPanelID: nil, closedTabs: [])
+    }
+
+    public var payloads: [Payload] {
+      closedTabs.map(\.payload)
+    }
+  }
+
+  @MainActor
+  public final class Tab<Payload>: Identifiable {
+    public let id: TabID
+    public let role: TerminalWorkspaceTabRole
+    public var name: String?
+    public var title: String?
+    public var workingDirectory: String?
+    public let payload: Payload
+
+    public init(
+      id: TabID = TabID(),
+      role: TerminalWorkspaceTabRole,
+      name: String? = nil,
+      title: String? = nil,
+      workingDirectory: String? = nil,
+      payload: Payload
+    ) {
+      self.id = id
+      self.role = role
+      self.name = name
+      self.title = title
+      self.workingDirectory = workingDirectory
+      self.payload = payload
+    }
+
+    public func displayName(index: Int) -> String {
+      if let name = Self.nonEmpty(name) {
+        return name
+      }
+      if let title = Self.nonEmpty(title) {
+        return title
+      }
+      if let workingDirectory = Self.nonEmpty(workingDirectory),
+         let directoryName = Self.directoryDisplayName(from: workingDirectory) {
+        return directoryName
+      }
+      switch role {
+      case .agent:
+        return "Agent"
+      case .shell:
+        return index == 0 ? "Shell" : "Shell \(index + 1)"
+      }
+    }
+
+    private static func nonEmpty(_ value: String?) -> String? {
+      let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines)
+      return trimmed?.isEmpty == false ? trimmed : nil
+    }
+
+    private static func directoryDisplayName(from workingDirectory: String) -> String? {
+      let lastPathComponent = URL(fileURLWithPath: workingDirectory).lastPathComponent
+      guard !lastPathComponent.isEmpty, lastPathComponent != "/" else {
+        return workingDirectory
+      }
+      return lastPathComponent
+    }
+  }
+
+  @MainActor
+  public final class Panel<Payload>: Identifiable {
+    public let id: PanelID
+    public let role: TerminalWorkspacePanelRole
+    public var name: String?
+    public private(set) var tabs: [Tab<Payload>]
+    public private(set) var activeTabID: TabID
+
+    public init(
+      id: PanelID = PanelID(),
+      role: TerminalWorkspacePanelRole,
+      name: String? = nil,
+      tabs: [Tab<Payload>],
+      activeTabID: TabID? = nil
+    ) {
+      self.id = id
+      self.role = role
+      self.name = name
+      self.tabs = tabs
+      self.activeTabID = activeTabID ?? tabs.first?.id ?? TabID()
+    }
+
+    public var activeTab: Tab<Payload>? {
+      tab(for: activeTabID) ?? tabs.first
+    }
+
+    public func tab(for id: TabID) -> Tab<Payload>? {
+      tabs.first { $0.id == id }
+    }
+
+    public func appendTab(_ tab: Tab<Payload>) {
+      tabs.append(tab)
+      activeTabID = tab.id
+    }
+
+    @discardableResult
+    public func selectTab(_ id: TabID) -> Bool {
+      guard tab(for: id) != nil else { return false }
+      activeTabID = id
+      return true
+    }
+
+    @discardableResult
+    public func removeTab(_ id: TabID) -> ClosedTab<Payload>? {
+      let tabIDs = tabs.map(\.id)
+      guard tabIDs.contains(id),
+            let nextActiveTabID = Self.activeTabIDAfterClosing(
+              id,
+              tabIDs: tabIDs,
+              activeTabID: activeTabID
+            ),
+            let index = tabs.firstIndex(where: { $0.id == id }) else {
+        return nil
+      }
+
+      let tab = tabs.remove(at: index)
+      activeTabID = nextActiveTabID
+      return ClosedTab(panelID: self.id, tabID: tab.id, payload: tab.payload)
+    }
+
+    @discardableResult
+    public func keepOnlyTab(_ id: TabID) -> [ClosedTab<Payload>] {
+      guard tab(for: id) != nil else { return [] }
+      let closedTabs = tabs
+        .filter { $0.id != id }
+        .map { ClosedTab(panelID: self.id, tabID: $0.id, payload: $0.payload) }
+      tabs.removeAll { $0.id != id }
+      activeTabID = id
+      return closedTabs
+    }
+
+    nonisolated public static func activeTabIDAfterClosing(
+      _ closingID: TabID,
+      tabIDs: [TabID],
+      activeTabID: TabID
+    ) -> TabID? {
+      guard let closingIndex = tabIDs.firstIndex(of: closingID) else {
+        return activeTabID
+      }
+
+      var remainingIDs = tabIDs
+      remainingIDs.remove(at: closingIndex)
+
+      guard activeTabID == closingID else {
+        return remainingIDs.contains(activeTabID) ? activeTabID : remainingIDs.first
+      }
+
+      if closingIndex < remainingIDs.count {
+        return remainingIDs[closingIndex]
+      }
+
+      return remainingIDs.last
+    }
+  }
+
+  @MainActor
+  public final class Session<Payload> {
+    public private(set) var panels: [Panel<Payload>]
+    public private(set) var primaryPanelID: PanelID
+    public private(set) var activePanelID: PanelID
+    public private(set) var splitRoot: SplitNode?
+
+    public init(primaryPanel: Panel<Payload>) {
+      self.panels = [primaryPanel]
+      self.primaryPanelID = primaryPanel.id
+      self.activePanelID = primaryPanel.id
+      self.splitRoot = .panel(primaryPanel.id)
+    }
+
+    public convenience init(
+      primaryTab: Tab<Payload>,
+      primaryName: String? = nil
+    ) {
+      self.init(primaryPanel: Panel(
+        role: .primary,
+        name: primaryName,
+        tabs: [primaryTab],
+        activeTabID: primaryTab.id
+      ))
+    }
+
+    public var primaryPanel: Panel<Payload>? {
+      panel(for: primaryPanelID)
+    }
+
+    public var activePanel: Panel<Payload>? {
+      panel(for: activePanelID) ?? primaryPanel ?? panels.first
+    }
+
+    public var activeTab: Tab<Payload>? {
+      activePanel?.activeTab
+    }
+
+    public var allTabs: [Tab<Payload>] {
+      panels.flatMap(\.tabs)
+    }
+
+    public var canOpenPanel: Bool {
+      panels.count < 4
+    }
+
+    public func panel(for id: PanelID?) -> Panel<Payload>? {
+      guard let id else { return nil }
+      return panels.first { $0.id == id }
+    }
+
+    public func tab(
+      for tabID: TabID,
+      in panelID: PanelID
+    ) -> Tab<Payload>? {
+      panel(for: panelID)?.tab(for: tabID)
+    }
+
+    @discardableResult
+    public func appendTab(
+      _ tab: Tab<Payload>,
+      in panelID: PanelID? = nil
+    ) -> Bool {
+      guard let panel = panel(for: panelID ?? activePanelID) else { return false }
+      panel.appendTab(tab)
+      activePanelID = panel.id
+      return true
+    }
+
+    @discardableResult
+    public func openPanel(
+      with tab: Tab<Payload>,
+      beside anchorPanelID: PanelID,
+      axis: SplitAxis,
+      name: String? = nil
+    ) -> Panel<Payload>? {
+      guard canOpenPanel, panel(for: anchorPanelID) != nil else { return nil }
+      let panel = Panel(
+        role: .auxiliary,
+        name: name,
+        tabs: [tab],
+        activeTabID: tab.id
+      )
+      panels.append(panel)
+      activePanelID = panel.id
+      splitRoot = SplitLayoutBuilder.addingPanel(
+        panel.id,
+        to: currentSplitRoot(),
+        beside: anchorPanelID,
+        axis: axis
+      )
+      return panel
+    }
+
+    public func canClosePanel(_ panelID: PanelID) -> Bool {
+      panelID != primaryPanelID && panels.count > 1
+    }
+
+    public func canCloseTab(
+      _ tabID: TabID,
+      in panelID: PanelID,
+      isProtected: Bool = false
+    ) -> Bool {
+      guard !isProtected, let panel = panel(for: panelID), panel.tab(for: tabID) != nil else {
+        return false
+      }
+      return panel.tabs.count > 1 || canClosePanel(panel.id)
+    }
+
+    @discardableResult
+    public func closePanel(_ panelID: PanelID) -> CloseResult<Payload> {
+      guard canClosePanel(panelID),
+            let panelIndex = panels.firstIndex(where: { $0.id == panelID }) else {
+        return .empty
+      }
+
+      let panel = panels.remove(at: panelIndex)
+      let closedTabs = panel.tabs.map {
+        ClosedTab(panelID: panel.id, tabID: $0.id, payload: $0.payload)
+      }
+      splitRoot = SplitLayoutBuilder.removingPanel(panel.id, from: currentSplitRoot())
+
+      if activePanelID == panelID {
+        activePanelID = primaryPanelID
+      }
+
+      return CloseResult(closedPanelID: panel.id, closedTabs: closedTabs)
+    }
+
+    @discardableResult
+    public func closeTab(_ tabID: TabID, in panelID: PanelID) -> CloseResult<Payload> {
+      guard let panel = panel(for: panelID), panel.tab(for: tabID) != nil else {
+        return .empty
+      }
+
+      if panel.tabs.count == 1 {
+        return closePanel(panelID)
+      }
+
+      guard let closedTab = panel.removeTab(tabID) else {
+        return .empty
+      }
+      activePanelID = panel.id
+      return CloseResult(closedPanelID: nil, closedTabs: [closedTab])
+    }
+
+    @discardableResult
+    public func focusPanel(_ panelID: PanelID) -> Bool {
+      guard panel(for: panelID) != nil else { return false }
+      activePanelID = panelID
+      return true
+    }
+
+    @discardableResult
+    public func focusPanel(
+      direction: PanelNavigationDirection,
+      viewportSize: CGSize
+    ) -> Bool {
+      guard panels.count > 1 else { return false }
+      let frames = Self.panelFrames(
+        for: currentSplitRoot(),
+        in: CGRect(origin: .zero, size: viewportSize)
+      )
+      guard let activeFrame = frames[activePanelID] else { return false }
+      let activeCenter = Self.center(of: activeFrame)
+
+      let candidates = frames.filter { panelID, frame in
+        guard panelID != activePanelID else { return false }
+        let center = Self.center(of: frame)
+        switch direction {
+        case .left:
+          return center.x < activeCenter.x
+        case .right:
+          return center.x > activeCenter.x
+        case .up:
+          return center.y < activeCenter.y
+        case .down:
+          return center.y > activeCenter.y
+        }
+      }
+
+      guard let target = candidates.min(by: { lhs, rhs in
+        Self.scorePanelFrame(lhs.value, from: activeFrame, direction: direction)
+          < Self.scorePanelFrame(rhs.value, from: activeFrame, direction: direction)
+      }) else {
+        return false
+      }
+
+      activePanelID = target.key
+      return true
+    }
+
+    @discardableResult
+    public func selectTab(_ tabID: TabID, in panelID: PanelID) -> Bool {
+      guard let panel = panel(for: panelID), panel.selectTab(tabID) else {
+        return false
+      }
+      activePanelID = panel.id
+      return true
+    }
+
+    @discardableResult
+    public func selectTab(direction: TabNavigationDirection) -> Bool {
+      guard let panel = activePanel, panel.tabs.count > 1 else { return false }
+      let currentIndex = panel.tabs.firstIndex { $0.id == panel.activeTabID } ?? 0
+      let nextIndex: Int
+      switch direction {
+      case .previous:
+        nextIndex = (currentIndex - 1 + panel.tabs.count) % panel.tabs.count
+      case .next:
+        nextIndex = (currentIndex + 1) % panel.tabs.count
+      }
+      return selectTab(panel.tabs[nextIndex].id, in: panel.id)
+    }
+
+    @discardableResult
+    public func resetToPrimary(keeping keepTabID: TabID?) -> CloseResult<Payload> {
+      guard let primary = primaryPanel ?? panels.first else { return .empty }
+      var closedTabs: [ClosedTab<Payload>] = []
+
+      for panel in panels where panel.id != primary.id {
+        closedTabs.append(contentsOf: panel.tabs.map {
+          ClosedTab(panelID: panel.id, tabID: $0.id, payload: $0.payload)
+        })
+      }
+
+      panels = [primary]
+      primaryPanelID = primary.id
+      activePanelID = primary.id
+      splitRoot = .panel(primary.id)
+
+      if let keepTabID {
+        closedTabs.append(contentsOf: primary.keepOnlyTab(keepTabID))
+      }
+
+      return CloseResult(closedPanelID: nil, closedTabs: closedTabs)
+    }
+
+    public func currentSplitRoot() -> SplitNode {
+      splitRoot ?? panels.first.map { .panel($0.id) } ?? .panel(PanelID())
+    }
+
+    public func containsTab(_ tabID: TabID) -> Bool {
+      allTabs.contains { $0.id == tabID }
+    }
+
+    private static func center(of rect: CGRect) -> CGPoint {
+      CGPoint(x: rect.midX, y: rect.midY)
+    }
+
+    private static func scorePanelFrame(
+      _ frame: CGRect,
+      from activeFrame: CGRect,
+      direction: PanelNavigationDirection
+    ) -> CGFloat {
+      let activeCenter = center(of: activeFrame)
+      let center = center(of: frame)
+      let primaryDistance: CGFloat
+      let crossDistance: CGFloat
+      let overlaps: Bool
+
+      switch direction {
+      case .left, .right:
+        primaryDistance = abs(center.x - activeCenter.x)
+        crossDistance = abs(center.y - activeCenter.y)
+        overlaps = frame.maxY > activeFrame.minY && frame.minY < activeFrame.maxY
+      case .up, .down:
+        primaryDistance = abs(center.y - activeCenter.y)
+        crossDistance = abs(center.x - activeCenter.x)
+        overlaps = frame.maxX > activeFrame.minX && frame.minX < activeFrame.maxX
+      }
+
+      return primaryDistance + crossDistance * 0.25 + (overlaps ? 0 : 10_000)
+    }
+
+    public static func panelFrames(
+      for node: SplitNode,
+      in rect: CGRect
+    ) -> [PanelID: CGRect] {
+      switch node {
+      case .panel(let panelID):
+        return [panelID: rect]
+      case .split(let axis, let children):
+        return splitPanelFrames(axis: axis, children: children, in: rect)
+      }
+    }
+
+    private static func splitPanelFrames(
+      axis: SplitAxis,
+      children: [SplitNode],
+      in rect: CGRect
+    ) -> [PanelID: CGRect] {
+      guard !children.isEmpty else { return [:] }
+
+      var result: [PanelID: CGRect] = [:]
+      let dividerSize: CGFloat = 1
+      let childCount = CGFloat(children.count)
+
+      switch axis {
+      case .horizontal:
+        let totalDividerWidth = dividerSize * CGFloat(max(children.count - 1, 0))
+        let childWidth = max(0, rect.width - totalDividerWidth) / childCount
+        var nextX = rect.minX
+
+        for (index, child) in children.enumerated() {
+          if index > 0 {
+            nextX += dividerSize
+          }
+          let childRect = CGRect(x: nextX, y: rect.minY, width: childWidth, height: rect.height)
+          result.merge(panelFrames(for: child, in: childRect), uniquingKeysWith: { current, _ in current })
+          nextX += childWidth
+        }
+
+      case .vertical:
+        let totalDividerHeight = dividerSize * CGFloat(max(children.count - 1, 0))
+        let childHeight = max(0, rect.height - totalDividerHeight) / childCount
+        var nextY = rect.minY
+
+        for (index, child) in children.enumerated() {
+          if index > 0 {
+            nextY += dividerSize
+          }
+          let childRect = CGRect(x: rect.minX, y: nextY, width: rect.width, height: childHeight)
+          result.merge(panelFrames(for: child, in: childRect), uniquingKeysWith: { current, _ in current })
+          nextY += childHeight
+        }
+      }
+
+      return result
+    }
+  }
+
+  public enum SplitLayoutBuilder {
+    public static func addingPanel(
+      _ newPanelID: PanelID,
+      to root: SplitNode,
+      beside anchorPanelID: PanelID,
+      axis: SplitAxis
+    ) -> SplitNode {
+      switch root {
+      case .panel(let panelID):
+        guard panelID == anchorPanelID else { return root }
+        return .split(axis: axis, children: [.panel(panelID), .panel(newPanelID)])
+
+      case .split(let splitAxis, let children):
+        return .split(
+          axis: splitAxis,
+          children: children.map { child in
+            guard child.containsPanel(anchorPanelID) else { return child }
+            return addingPanel(newPanelID, to: child, beside: anchorPanelID, axis: axis)
+          }
+        )
+      }
+    }
+
+    public static func removingPanel(
+      _ panelID: PanelID,
+      from root: SplitNode
+    ) -> SplitNode? {
+      switch root {
+      case .panel(let currentPanelID):
+        return currentPanelID == panelID ? nil : root
+
+      case .split(let axis, let children):
+        let remainingChildren = children.compactMap { removingPanel(panelID, from: $0) }
+        switch remainingChildren.count {
+        case 0:
+          return nil
+        case 1:
+          return remainingChildren[0]
+        default:
+          return .split(axis: axis, children: remainingChildren)
+        }
+      }
+    }
+
+    public static func replacingPanel(
+      _ currentPanelID: PanelID,
+      with replacementPanelID: PanelID,
+      in root: SplitNode
+    ) -> SplitNode {
+      switch root {
+      case .panel(let panelID):
+        return .panel(panelID == currentPanelID ? replacementPanelID : panelID)
+
+      case .split(let axis, let children):
+        return .split(
+          axis: axis,
+          children: children.map {
+            replacingPanel(currentPanelID, with: replacementPanelID, in: $0)
+          }
+        )
+      }
+    }
+  }
+}

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/RegularTerminalWorkspaceTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/RegularTerminalWorkspaceTests.swift
@@ -1,0 +1,158 @@
+import AppKit
+import Testing
+
+@testable import AgentHubCore
+
+@Suite("Regular terminal workspace")
+struct RegularTerminalWorkspaceTests {
+  @Test("Regular terminal tabs are hidden for launch")
+  func regularTerminalTabsAreHiddenForLaunch() {
+    #expect(RegularTerminalLaunchFeatures.tabsEnabled == false)
+  }
+
+  @Test("Shortcut mapping includes tab and split commands")
+  func shortcutMappingIncludesTabAndSplitCommands() {
+    #expect(RegularTerminalShortcut.action(
+      keyCode: 3,
+      charactersIgnoringModifiers: "f",
+      modifierFlags: [.command]
+    ) == .startSearch)
+
+    #expect(RegularTerminalShortcut.action(
+      keyCode: 17,
+      charactersIgnoringModifiers: "t",
+      modifierFlags: [.command]
+    ) == .openTab)
+
+    #expect(RegularTerminalShortcut.action(
+      keyCode: 2,
+      charactersIgnoringModifiers: "d",
+      modifierFlags: [.command]
+    ) == .openPane(axis: .horizontal))
+
+    #expect(RegularTerminalShortcut.action(
+      keyCode: 2,
+      charactersIgnoringModifiers: "D",
+      modifierFlags: [.command, .shift]
+    ) == .openPane(axis: .vertical))
+
+    #expect(RegularTerminalShortcut.action(
+      keyCode: 13,
+      charactersIgnoringModifiers: "w",
+      modifierFlags: [.command]
+    ) == nil)
+  }
+
+  @Test("Shortcut mapping includes pane and tab navigation")
+  func shortcutMappingIncludesPaneAndTabNavigation() {
+    #expect(RegularTerminalShortcut.action(
+      keyCode: 123,
+      charactersIgnoringModifiers: nil,
+      modifierFlags: [.command, .numericPad]
+    ) == .focusPanel(.left))
+
+    #expect(RegularTerminalShortcut.action(
+      keyCode: 124,
+      charactersIgnoringModifiers: nil,
+      modifierFlags: [.command, .shift, .numericPad]
+    ) == .selectTab(.next))
+
+    #expect(RegularTerminalShortcut.action(
+      keyCode: 13,
+      charactersIgnoringModifiers: "w",
+      modifierFlags: [.command, .shift]
+    ) == .closePanel)
+  }
+
+  @Test("Split layout builder adds and removes panels")
+  func splitLayoutBuilderAddsAndRemovesPanels() {
+    let primary = RegularTerminalPanelID(UUID(uuidString: "00000000-0000-0000-0000-000000000001")!)
+    let shell = RegularTerminalPanelID(UUID(uuidString: "00000000-0000-0000-0000-000000000002")!)
+    let root = RegularTerminalSplitNode.panel(primary)
+
+    let split = RegularTerminalSplitLayoutBuilder.addingPanel(
+      shell,
+      to: root,
+      beside: primary,
+      axis: .horizontal
+    )
+
+    #expect(split == .split(axis: .horizontal, children: [.panel(primary), .panel(shell)]))
+    #expect(RegularTerminalSplitLayoutBuilder.removingPanel(shell, from: split) == .panel(primary))
+  }
+
+  @Test("Removing a nested split panel collapses the empty branch")
+  func removingNestedPanelCollapsesSplitBranch() {
+    let primary = RegularTerminalPanelID(UUID(uuidString: "00000000-0000-0000-0000-000000000001")!)
+    let shell1 = RegularTerminalPanelID(UUID(uuidString: "00000000-0000-0000-0000-000000000002")!)
+    let shell2 = RegularTerminalPanelID(UUID(uuidString: "00000000-0000-0000-0000-000000000003")!)
+    let root = RegularTerminalSplitNode.split(
+      axis: .horizontal,
+      children: [
+        .panel(primary),
+        .split(axis: .vertical, children: [.panel(shell1), .panel(shell2)])
+      ]
+    )
+
+    let result = RegularTerminalSplitLayoutBuilder.removingPanel(shell1, from: root)
+
+    #expect(result == .split(axis: .horizontal, children: [.panel(primary), .panel(shell2)]))
+  }
+
+  @MainActor
+  @Test("Panel kit opens tabs and panels without replacing existing payloads")
+  func panelKitOpensTabsAndPanels() {
+    let agent = TerminalPanelKit.Tab(role: .agent, payload: "agent")
+    let session = TerminalPanelKit.Session(primaryTab: agent, primaryName: "Claude")
+
+    let shellTab = TerminalPanelKit.Tab(role: .shell, payload: "shell-tab")
+    #expect(session.appendTab(shellTab, in: session.primaryPanelID))
+
+    let shellPanelTab = TerminalPanelKit.Tab(role: .shell, payload: "shell-panel")
+    let shellPanel = session.openPanel(
+      with: shellPanelTab,
+      beside: session.primaryPanelID,
+      axis: .horizontal
+    )
+
+    #expect(session.panels.count == 2)
+    #expect(session.primaryPanel?.tabs.map(\.payload) == ["agent", "shell-tab"])
+    #expect(shellPanel?.activeTab?.payload == "shell-panel")
+    #expect(session.activePanelID == shellPanel?.id)
+  }
+
+  @MainActor
+  @Test("Panel kit closes tabs and returns payloads for deferred termination")
+  func panelKitClosesTabsWithPayloads() {
+    let agent = TerminalPanelKit.Tab(role: .agent, payload: "agent")
+    let session = TerminalPanelKit.Session(primaryTab: agent)
+    let shell = TerminalPanelKit.Tab(role: .shell, payload: "shell")
+    #expect(session.appendTab(shell, in: session.primaryPanelID))
+
+    let result = session.closeTab(shell.id, in: session.primaryPanelID)
+
+    #expect(result.payloads == ["shell"])
+    #expect(session.primaryPanel?.tabs.map(\.payload) == ["agent"])
+    #expect(session.primaryPanel?.activeTab?.payload == "agent")
+  }
+
+  @MainActor
+  @Test("Panel kit reset keeps primary tab and closes auxiliary payloads")
+  func panelKitResetKeepsPrimaryTab() {
+    let agent = TerminalPanelKit.Tab(role: .agent, payload: "agent")
+    let session = TerminalPanelKit.Session(primaryTab: agent)
+    let extraPrimary = TerminalPanelKit.Tab(role: .shell, payload: "primary-shell")
+    #expect(session.appendTab(extraPrimary, in: session.primaryPanelID))
+    _ = session.openPanel(
+      with: TerminalPanelKit.Tab(role: .shell, payload: "panel-shell"),
+      beside: session.primaryPanelID,
+      axis: .horizontal
+    )
+
+    let result = session.resetToPrimary(keeping: agent.id)
+
+    #expect(session.panels.count == 1)
+    #expect(session.primaryPanel?.tabs.map(\.payload) == ["agent"])
+    #expect(Set(result.payloads) == Set(["primary-shell", "panel-shell"]))
+  }
+}


### PR DESCRIPTION
## Summary
- Extracts a backend-neutral `TerminalPanelKit` for panel/tab state, split layout, shortcuts, focus, and close behavior.
- Migrates the regular SwiftTerm terminal surface onto the panel workspace so regular mode supports split-right/split-below panes, pane focus, pane close, and workspace snapshot capture/restore.
- Keeps regular terminal tabs hidden behind `RegularTerminalLaunchFeatures.tabsEnabled = false` with a TODO for after launch; tab shortcuts no-op and persisted regular snapshots flatten to one tab per pane while the flag is off.
- Matches Ghostty active-pane selection behavior by only drawing the accent border when more than one pane is visible.

## Validation
- PASS: `git diff --check`
- PASS: `xcodebuild build -project app/AgentHub.xcodeproj -scheme AgentHub -destination 'platform=macOS'`
- BLOCKED: `swift test --package-path app/modules/AgentHubCore --filter RegularTerminalWorkspaceTests` stops in the existing `CodeEditSymbols` dependency with `Bundle.module` errors before these tests run.
- BLOCKED: `xcodebuild test` is not available for the `AgentHub` / `AgentHubCore` schemes because they are not configured for the test action.
