### PR TITLE
[codex] Fix worktree checkout reuse

### DIFF
--- a/app/modules/AgentHubCLI/Sources/AgentHubCLI/AgentHubCLI.swift
+++ b/app/modules/AgentHubCLI/Sources/AgentHubCLI/AgentHubCLI.swift
@@ -102,19 +102,11 @@ struct CheckoutWorktree: AsyncParsableCommand {
   func run() async throws {
     let service = WorktreeManagementService()
     let directoryName = WorktreeNaming.worktreeDirectoryName(for: branch)
-    let worktreesDirectory = try await service.worktreesDirectory(at: options.repositoryPath)
-    let path = (worktreesDirectory as NSString).appendingPathComponent(directoryName)
-
-    let resolvedPath: String
-    if FileManager.default.fileExists(atPath: path) {
-      resolvedPath = path
-    } else {
-      resolvedPath = try await service.createWorktree(
-        at: options.repositoryPath,
-        branch: branch,
-        directoryName: directoryName
-      )
-    }
+    let resolvedPath = try await service.checkoutWorktree(
+      at: options.repositoryPath,
+      branch: branch,
+      directoryName: directoryName
+    )
 
     try printResult(path: resolvedPath, branch: branch, json: options.json)
   }

--- a/app/modules/AgentHubCLI/Sources/AgentHubCLIKit/WorktreeManagementService.swift
+++ b/app/modules/AgentHubCLI/Sources/AgentHubCLIKit/WorktreeManagementService.swift
@@ -10,6 +10,7 @@ public protocol WorktreeManagementServiceProtocol: Sendable {
   func getLocalBranches(at repoPath: String) async throws -> [BranchInfo]
   func getLocalBranchesWithCurrent(at repoPath: String) async throws -> LocalBranchesResult
   func createWorktree(at repoPath: String, branch: String, directoryName: String) async throws -> String
+  func checkoutWorktree(at repoPath: String, branch: String, directoryName: String) async throws -> String
   func createWorktreeWithNewBranch(at repoPath: String, newBranchName: String, directoryName: String, startPoint: String?) async throws -> String
   func createWorktreeWithNewBranch(
     at repoPath: String,
@@ -160,6 +161,23 @@ public actor WorktreeManagementService: WorktreeManagementServiceProtocol {
     )
 
     return worktreePath
+  }
+
+  public func checkoutWorktree(
+    at repoPath: String,
+    branch: String,
+    directoryName: String
+  ) async throws -> String {
+    if let existing = try await listWorktrees(at: repoPath)
+      .first(where: { $0.branch == branch }) {
+      return existing.path
+    }
+
+    return try await createWorktree(
+      at: repoPath,
+      branch: branch,
+      directoryName: directoryName
+    )
   }
 
   public func createWorktreeWithNewBranch(
@@ -515,8 +533,15 @@ private extension WorktreeManagementService {
   }
 
   func branchExists(_ branchName: String, at repoPath: String) async throws -> Bool {
-    let output = try await runGitCommand(["branch", "--list", branchName], at: repoPath)
-    return !output.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    do {
+      try await runGitCommand(
+        ["show-ref", "--verify", "--quiet", "refs/heads/\(branchName)"],
+        at: repoPath
+      )
+      return true
+    } catch WorktreeManagementError.gitCommandFailed(let message) where message.isEmpty {
+      return false
+    }
   }
 
   func parseRemoteBranches(_ output: String) -> [BranchInfo] {

--- a/app/modules/AgentHubCLI/Tests/AgentHubCLIKitTests/WorktreeManagementServiceTests.swift
+++ b/app/modules/AgentHubCLI/Tests/AgentHubCLIKitTests/WorktreeManagementServiceTests.swift
@@ -128,6 +128,23 @@ struct WorktreeConventionTests {
     #expect(FileManager.default.fileExists(atPath: path))
   }
 
+  @Test("Checkout reuses an existing worktree for the branch")
+  func checkoutReusesExistingBranchWorktree() async throws {
+    let fixture = try GitRepoFixture.create()
+    defer { fixture.cleanup() }
+
+    let existingPath = try fixture.addSiblingWorktree(branch: "existing")
+    let service = WorktreeManagementService()
+
+    let path = try await service.checkoutWorktree(
+      at: fixture.repoPath,
+      branch: "existing",
+      directoryName: "existing"
+    )
+
+    #expect(path == existingPath)
+  }
+
   @Test("Uses start point when creating a new branch")
   func usesStartPoint() async throws {
     let fixture = try GitRepoFixture.create()


### PR DESCRIPTION
## Summary

- Add a shared checkout helper that reuses an existing Git worktree for a branch before creating a new AgentHub `.worktrees/<branch-slug>` worktree.
- Route `agenthub worktree checkout` through the shared helper so CLI behavior matches Git single-worktree-per-branch constraints.
- Tighten branch cleanup existence checks to use exact `show-ref --verify --quiet` branch refs instead of pattern matching.
- Add a CLI kit test covering reuse of an existing branch worktree.

## Validation

- `git diff --check HEAD~1 HEAD`
- `swift test --package-path app/modules/AgentHubCLI --filter WorktreeConventionTests/checkoutReusesExistingBranchWorktree --skip-build`

## Notes

A full `swift test --package-path app/modules/AgentHubCLI` passed before commit. After commit, broad `swift test --package-path app/modules/AgentHubCLI --filter Worktree` invocations built successfully but left detached SwiftPM testing-helper processes and timed out before reporting results. AgentHubCore focused tests remain blocked by the existing transitive `CodeEditSymbols` `Bundle.module` package issue.