### PR TITLE
[codex] Use Spotlight for quick file search

### DIFF
--- a/app/modules/AgentHubCore/Package.swift
+++ b/app/modules/AgentHubCore/Package.swift
@@ -20,6 +20,10 @@ let package = Package(
       name: "AgentHubGitDiff",
       targets: ["AgentHubGitDiff"]
     ),
+    .library(
+      name: "AgentHubFileSearch",
+      targets: ["AgentHubFileSearch"]
+    ),
   ],
   dependencies: [
     .package(path: "../AgentHubCLI"),
@@ -62,10 +66,18 @@ let package = Package(
       ]
     ),
     .target(
+      name: "AgentHubFileSearch",
+      path: "Sources/AgentHubFileSearch",
+      swiftSettings: [
+        .swiftLanguageMode(.v5)
+      ]
+    ),
+    .target(
       name: "AgentHubCore",
       dependencies: [
         "ClaudeCodeClient",
         "AgentHubGitDiff",
+        "AgentHubFileSearch",
         .product(name: "AgentHubCLIKit", package: "AgentHubCLI"),
         .product(name: "AgentHubGitHub", package: "AgentHubGitHub"),
         .product(name: "Storybook", package: "Storybook"),
@@ -98,10 +110,19 @@ let package = Package(
       ]
     ),
     .testTarget(
+      name: "AgentHubFileSearchTests",
+      dependencies: ["AgentHubFileSearch"],
+      path: "Tests/AgentHubFileSearchTests",
+      swiftSettings: [
+        .swiftLanguageMode(.v5)
+      ]
+    ),
+    .testTarget(
       name: "AgentHubTests",
       dependencies: [
         "AgentHubCore",
         "AgentHubGitDiff",
+        "AgentHubFileSearch",
         "ClaudeCodeClient",
       ],
       path: "Tests/AgentHubTests",

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/FileIndexService.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/FileIndexService.swift
@@ -2,9 +2,10 @@
 //  FileIndexService.swift
 //  AgentHub
 //
-//  Actor-based file index service with gitignore support and fuzzy search.
+//  Actor-based file tree service with gitignore support and Spotlight-backed search.
 //
 
+import AgentHubFileSearch
 import Foundation
 
 // MARK: - FileIndexService
@@ -15,7 +16,7 @@ public enum FileSearchIndexStatus: Sendable {
   case ready
 }
 
-/// Scans project directories, respects .gitignore, caches the index, and provides fuzzy search.
+/// Scans project directories, respects .gitignore, caches tree nodes, and provides project file search.
 public actor FileIndexService {
 
   // MARK: - Shared Instance
@@ -86,10 +87,17 @@ public actor FileIndexService {
   private var searchBuildTasks: [String: Task<SearchCacheEntry, Never>] = [:]
   private var recentPaths: [String] = []
   private static let maxRecentFiles = 20
+  private let projectFileSearchService: any ProjectFileSearchServiceProtocol
 
   // MARK: - Initialization
 
-  public init() {}
+  public init() {
+    self.projectFileSearchService = SpotlightProjectFileSearchService.shared
+  }
+
+  init(projectFileSearchService: any ProjectFileSearchServiceProtocol) {
+    self.projectFileSearchService = projectFileSearchService
+  }
 
   // MARK: - Public API
 
@@ -140,25 +148,21 @@ public actor FileIndexService {
   }
 
   public func prepareSearchIndex(projectPath: String) async {
-    let resolvedProjectPath = Self.resolvedURL(for: projectPath).path
-    guard searchCache[resolvedProjectPath].map({ !isCacheStale($0.date) }) != true else { return }
-    if searchBuildTasks[resolvedProjectPath] == nil {
-      searchBuildTasks[resolvedProjectPath] = makeSearchBuildTask(projectPath: resolvedProjectPath)
-    }
+    // Spotlight is queried directly for Cmd+P. Keep the legacy fallback warm only
+    // for callers that explicitly request preloading.
+    _ = await searchIndex(projectPath: Self.resolvedURL(for: projectPath).path)
   }
 
   public func searchIndexStatus(projectPath: String) async -> FileSearchIndexStatus {
     let resolvedProjectPath = Self.resolvedURL(for: projectPath).path
-    if let entry = searchCache[resolvedProjectPath], !isCacheStale(entry.date) {
-      return .ready
-    }
     if searchBuildTasks[resolvedProjectPath] != nil {
       return .building
     }
-    return .idle
+    return .ready
   }
 
-  /// Searches files using a strict 3-tier approach:
+  /// Searches files using Spotlight first, then falls back to the legacy in-process index if
+  /// Spotlight has no usable results for the project. Ranking uses a strict 3-tier approach:
   /// 1. Filename starts with query → highest score
   /// 2. Filename contains query as substring → high score
   /// 3. Path contains query as substring → medium score
@@ -166,6 +170,34 @@ public actor FileIndexService {
   public func search(query: String, in projectPath: String) async -> [FileSearchResult] {
     guard !query.isEmpty, query.count < 200 else { return [] }
     let resolvedProjectPath = Self.resolvedURL(for: projectPath).path
+    let spotlightResults = await projectFileSearchService.search(
+      query: query,
+      in: resolvedProjectPath,
+      limit: Self.maxSearchResults * 10
+    )
+    let filteredSpotlightResults = spotlightResults
+      .compactMap { spotlightResult -> FileSearchResult? in
+        let absolutePath = Self.resolvedURL(for: spotlightResult.absolutePath).path
+        guard Self.shouldIncludeSearchResult(at: absolutePath, rootPath: resolvedProjectPath),
+              let relativePath = Self.relativePathIfContained(absolutePath, within: resolvedProjectPath) else {
+          return nil
+        }
+        let name = URL(fileURLWithPath: absolutePath).lastPathComponent
+
+        return FileSearchResult(
+          id: absolutePath,
+          name: name,
+          relativePath: relativePath,
+          absolutePath: absolutePath,
+          score: spotlightResult.score
+        )
+      }
+      .sortedBySearchScore()
+
+    if !filteredSpotlightResults.isEmpty {
+      return Array(filteredSpotlightResults.prefix(Self.maxSearchResults))
+    }
+
     let allFiles = await searchIndex(projectPath: resolvedProjectPath)
     let q = query.lowercased()
 
@@ -466,6 +498,34 @@ public actor FileIndexService {
     return !isIgnored(relativePath: relativePath, isDirectory: entry.isDirectory, rules: rules)
   }
 
+  private static func shouldIncludeSearchResult(at path: String, rootPath: String) -> Bool {
+    let resolvedRootPath = resolvedURL(for: rootPath).path
+    let resolvedPath = resolvedURL(for: path).path
+    guard isPath(resolvedPath, within: resolvedRootPath),
+          resolvedPath != resolvedRootPath else {
+      return false
+    }
+
+    let url = URL(fileURLWithPath: resolvedPath)
+    guard let values = try? url.resourceValues(forKeys: [.isDirectoryKey, .isSymbolicLinkKey]),
+          values.isDirectory != true,
+          values.isSymbolicLink != true else {
+      return false
+    }
+
+    let directoryPath = (resolvedPath as NSString).deletingLastPathComponent
+    let rules = ignoreRules(forDirectoryAt: directoryPath, rootPath: resolvedRootPath)
+    return shouldIncludeEntry(
+      DirectoryEntry(
+        name: url.lastPathComponent,
+        path: resolvedPath,
+        isDirectory: false
+      ),
+      rootPath: resolvedRootPath,
+      rules: rules
+    )
+  }
+
   // MARK: - Gitignore Parsing
 
   private static func parseGitignore(at directoryPath: String, relativeTo rootPath: String) -> [IgnoreRule] {
@@ -629,4 +689,15 @@ public actor FileIndexService {
 
   // MARK: - Search Helpers
 
+}
+
+private extension Array where Element == FileSearchResult {
+  func sortedBySearchScore() -> [FileSearchResult] {
+    sorted {
+      if $0.score != $1.score { return $0.score > $1.score }
+      let nameOrder = $0.name.localizedStandardCompare($1.name)
+      if nameOrder != .orderedSame { return nameOrder == .orderedAscending }
+      return $0.relativePath.localizedStandardCompare($1.relativePath) == .orderedAscending
+    }
+  }
 }

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/QuickFilePickerView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/QuickFilePickerView.swift
@@ -2,7 +2,7 @@
 //  QuickFilePickerView.swift
 //  AgentHub
 //
-//  Cmd+P modal for fuzzy file search within a project.
+//  Cmd+P modal for Spotlight-backed file search within a project.
 //
 
 import SwiftUI
@@ -104,10 +104,10 @@ public struct QuickFilePickerView: View {
         VStack(spacing: 8) {
           ProgressView()
             .controlSize(.small)
-          Text("Indexing files…")
+          Text("Searching files…")
             .font(.caption)
             .foregroundColor(.secondary)
-          Text("Large repositories are indexed in the background the first time you search.")
+          Text("Large repositories may take a moment if Spotlight has not indexed them yet.")
             .font(.caption2)
             .foregroundColor(.secondary.opacity(0.7))
             .multilineTextAlignment(.center)
@@ -191,11 +191,7 @@ public struct QuickFilePickerView: View {
       isIndexing = false
       try? await Task.sleep(for: .milliseconds(150))
       guard !Task.isCancelled else { return }
-      let status = await FileIndexService.shared.searchIndexStatus(projectPath: projectPath)
-      if status != .ready {
-        isIndexing = true
-        await FileIndexService.shared.prepareSearchIndex(projectPath: projectPath)
-      }
+      isIndexing = true
       let found = await FileIndexService.shared.search(query: searchQuery, in: projectPath)
       guard !Task.isCancelled else { return }
       isIndexing = false

--- a/app/modules/AgentHubCore/Sources/AgentHubFileSearch/ProjectFileSearchResult.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHubFileSearch/ProjectFileSearchResult.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+public struct ProjectFileSearchResult: Identifiable, Equatable, Sendable {
+  public let id: String
+  public let name: String
+  public let relativePath: String
+  public let absolutePath: String
+  public let score: Int
+
+  public init(
+    id: String,
+    name: String,
+    relativePath: String,
+    absolutePath: String,
+    score: Int
+  ) {
+    self.id = id
+    self.name = name
+    self.relativePath = relativePath
+    self.absolutePath = absolutePath
+    self.score = score
+  }
+}
+

--- a/app/modules/AgentHubCore/Sources/AgentHubFileSearch/ProjectFileSearchServiceProtocol.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHubFileSearch/ProjectFileSearchServiceProtocol.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+public protocol ProjectFileSearchServiceProtocol: Sendable {
+  func search(query: String, in projectPath: String, limit: Int) async -> [ProjectFileSearchResult]
+}
+

--- a/app/modules/AgentHubCore/Sources/AgentHubFileSearch/SpotlightProjectFileSearchService.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHubFileSearch/SpotlightProjectFileSearchService.swift
@@ -1,0 +1,236 @@
+import CoreServices
+import Foundation
+
+public actor SpotlightProjectFileSearchService: ProjectFileSearchServiceProtocol {
+  public static let shared = SpotlightProjectFileSearchService()
+
+  private let metadataClient: any SpotlightMetadataQuerying
+  private let fileChecker: any SearchableFileChecking
+
+  public init() {
+    self.init(
+      metadataClient: CoreServicesSpotlightMetadataClient(),
+      fileChecker: FileManagerSearchableFileChecker()
+    )
+  }
+
+  init(
+    metadataClient: any SpotlightMetadataQuerying,
+    fileChecker: any SearchableFileChecking
+  ) {
+    self.metadataClient = metadataClient
+    self.fileChecker = fileChecker
+  }
+
+  public func search(query: String, in projectPath: String, limit: Int) async -> [ProjectFileSearchResult] {
+    guard !query.isEmpty, query.count < 200, limit > 0 else { return [] }
+
+    let resolvedProjectPath = Self.resolvedURL(for: projectPath).path
+    let candidateLimit = max(limit * 8, 200)
+    let metadataClient = metadataClient
+    let paths = await Task.detached(priority: .userInitiated) {
+      metadataClient.searchFilePaths(
+        matching: query,
+        in: resolvedProjectPath,
+        limit: candidateLimit
+      )
+    }.value
+
+    return SpotlightFileSearchRanker.rankedResults(
+      paths: paths,
+      query: query,
+      projectPath: resolvedProjectPath,
+      limit: limit,
+      fileChecker: fileChecker
+    )
+  }
+
+  private static func resolvedURL(for path: String) -> URL {
+    URL(fileURLWithPath: path).standardizedFileURL.resolvingSymlinksInPath()
+  }
+}
+
+protocol SpotlightMetadataQuerying: Sendable {
+  func searchFilePaths(matching query: String, in projectPath: String, limit: Int) -> [String]
+}
+
+struct CoreServicesSpotlightMetadataClient: SpotlightMetadataQuerying {
+  func searchFilePaths(matching query: String, in projectPath: String, limit: Int) -> [String] {
+    guard limit > 0,
+          let queryExpression = SpotlightQueryBuilder.expression(for: query),
+          let metadataQuery = MDQueryCreate(
+            kCFAllocatorDefault,
+            queryExpression as CFString,
+            nil,
+            nil
+          ) else {
+      return []
+    }
+
+    MDQuerySetSearchScope(metadataQuery, [projectPath] as CFArray, 0)
+    MDQuerySetMaxCount(metadataQuery, limit)
+    guard MDQueryExecute(metadataQuery, CFOptionFlags(kMDQuerySynchronous.rawValue)) else {
+      MDQueryStop(metadataQuery)
+      return []
+    }
+    defer { MDQueryStop(metadataQuery) }
+
+    let resultCount = min(MDQueryGetResultCount(metadataQuery), limit)
+    var paths: [String] = []
+    var seenPaths = Set<String>()
+    paths.reserveCapacity(resultCount)
+
+    for index in 0..<resultCount {
+      guard let rawItem = MDQueryGetResultAtIndex(metadataQuery, index) else {
+        continue
+      }
+
+      let metadataItem = Unmanaged<MDItem>.fromOpaque(rawItem).takeUnretainedValue()
+      guard let path = MDItemCopyAttribute(metadataItem, kMDItemPath as CFString) as? String,
+            seenPaths.insert(path).inserted else {
+        continue
+      }
+
+      paths.append(path)
+    }
+
+    return paths
+  }
+}
+
+enum SpotlightQueryBuilder {
+  private static let searchableAttributes = [
+    "kMDItemDisplayName",
+    "kMDItemFSName",
+    "kMDItemPath"
+  ]
+
+  static func expression(for query: String) -> String? {
+    let term = normalizedTerm(query)
+    guard !term.isEmpty else { return nil }
+
+    let pattern = "*\(escapeQuotedString(term))*"
+    let clauses = searchableAttributes.map { attribute in
+      "\(attribute) == \"\(pattern)\"cd"
+    }
+    return "(\(clauses.joined(separator: " || ")))"
+  }
+
+  private static func normalizedTerm(_ query: String) -> String {
+    let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+    let scalars = trimmed.unicodeScalars.map { scalar in
+      CharacterSet.controlCharacters.contains(scalar) ? " " : String(scalar)
+    }
+    return scalars.joined()
+  }
+
+  private static func escapeQuotedString(_ value: String) -> String {
+    value
+      .replacingOccurrences(of: "\\", with: "\\\\")
+      .replacingOccurrences(of: "\"", with: "\\\"")
+  }
+}
+
+protocol SearchableFileChecking: Sendable {
+  func isSearchableFile(at path: String) -> Bool
+}
+
+struct FileManagerSearchableFileChecker: SearchableFileChecking {
+  func isSearchableFile(at path: String) -> Bool {
+    let url = URL(fileURLWithPath: path)
+    guard let values = try? url.resourceValues(forKeys: [.isDirectoryKey, .isSymbolicLinkKey]),
+          values.isDirectory != true,
+          values.isSymbolicLink != true else {
+      return false
+    }
+
+    return true
+  }
+}
+
+enum SpotlightFileSearchRanker {
+  static func rankedResults(
+    paths: [String],
+    query: String,
+    projectPath: String,
+    limit: Int,
+    fileChecker: any SearchableFileChecking
+  ) -> [ProjectFileSearchResult] {
+    let resolvedProjectPath = resolvedURL(for: projectPath).path
+    let q = query.lowercased()
+
+    var results: [ProjectFileSearchResult] = []
+    var seenResolvedPaths = Set<String>()
+    results.reserveCapacity(min(paths.count, limit))
+
+    for rawPath in paths {
+      let resolvedPath = resolvedURL(for: rawPath).path
+      guard isPath(resolvedPath, within: resolvedProjectPath),
+            resolvedPath != resolvedProjectPath,
+            seenResolvedPaths.insert(resolvedPath).inserted,
+            fileChecker.isSearchableFile(at: resolvedPath) else {
+        continue
+      }
+
+      let relativePath = String(resolvedPath.dropFirst(resolvedProjectPath.count + 1))
+      let name = URL(fileURLWithPath: resolvedPath).lastPathComponent
+      let score = score(name: name, relativePath: relativePath, query: q)
+      guard score > 0 else { continue }
+
+      results.append(ProjectFileSearchResult(
+        id: resolvedPath,
+        name: name,
+        relativePath: relativePath,
+        absolutePath: resolvedPath,
+        score: score
+      ))
+    }
+
+    results.sort {
+      if $0.score != $1.score { return $0.score > $1.score }
+      let nameOrder = $0.name.localizedStandardCompare($1.name)
+      if nameOrder != .orderedSame { return nameOrder == .orderedAscending }
+      return $0.relativePath.localizedStandardCompare($1.relativePath) == .orderedAscending
+    }
+
+    return Array(results.prefix(limit))
+  }
+
+  private static func score(name: String, relativePath: String, query: String) -> Int {
+    let nameLower = name.lowercased()
+    let nameNoExt = (name as NSString).deletingPathExtension.lowercased()
+    let pathLower = relativePath.lowercased()
+
+    if nameNoExt == query {
+      return 5000
+    }
+
+    if nameNoExt.hasPrefix(query) {
+      return 4000 + (100 - min(nameLower.count, 100))
+    }
+
+    if nameLower.hasPrefix(query) {
+      return 3500 + (100 - min(nameLower.count, 100))
+    }
+
+    if nameLower.contains(query), let nameRange = nameLower.range(of: query) {
+      let position = nameRange.lowerBound.utf16Offset(in: nameLower)
+      return 2000 + (200 - position) + (100 - min(nameLower.count, 100))
+    }
+
+    if pathLower.contains(query), let pathRange = pathLower.range(of: query) {
+      let position = pathRange.lowerBound.utf16Offset(in: pathLower)
+      return 1000 + (500 - min(position, 500))
+    }
+
+    return 0
+  }
+
+  private static func resolvedURL(for path: String) -> URL {
+    URL(fileURLWithPath: path).standardizedFileURL.resolvingSymlinksInPath()
+  }
+
+  private static func isPath(_ path: String, within rootPath: String) -> Bool {
+    path == rootPath || path.hasPrefix(rootPath + "/")
+  }
+}

--- a/app/modules/AgentHubCore/Tests/AgentHubFileSearchTests/SpotlightProjectFileSearchServiceTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubFileSearchTests/SpotlightProjectFileSearchServiceTests.swift
@@ -1,0 +1,114 @@
+import Foundation
+import Testing
+
+@testable import AgentHubFileSearch
+
+private struct SpotlightSearchFixture {
+  let tempDir: String
+  let projectPath: String
+  let externalPath: String
+
+  static func create() throws -> SpotlightSearchFixture {
+    var resolved = [CChar](repeating: 0, count: Int(PATH_MAX))
+    guard realpath(NSTemporaryDirectory(), &resolved) != nil else {
+      throw CocoaError(.fileNoSuchFile)
+    }
+
+    let tempBase = String(cString: resolved)
+    let tempDir = tempBase + "/AgentHubSpotlightSearchTests-\(UUID().uuidString)"
+    let projectPath = tempDir + "/project"
+    let externalPath = tempDir + "/external"
+
+    try FileManager.default.createDirectory(atPath: projectPath, withIntermediateDirectories: true)
+    try FileManager.default.createDirectory(atPath: externalPath, withIntermediateDirectories: true)
+
+    return SpotlightSearchFixture(tempDir: tempDir, projectPath: projectPath, externalPath: externalPath)
+  }
+
+  func cleanup() {
+    try? FileManager.default.removeItem(atPath: tempDir)
+  }
+
+  func writeProjectFile(_ relativePath: String, content: String = "") throws -> String {
+    try writeFile(at: projectPath + "/" + relativePath, content: content)
+    return projectPath + "/" + relativePath
+  }
+
+  func writeExternalFile(_ relativePath: String, content: String = "") throws -> String {
+    try writeFile(at: externalPath + "/" + relativePath, content: content)
+    return externalPath + "/" + relativePath
+  }
+
+  func createProjectDirectory(_ relativePath: String) throws -> String {
+    let path = projectPath + "/" + relativePath
+    try FileManager.default.createDirectory(atPath: path, withIntermediateDirectories: true)
+    return path
+  }
+
+  private func writeFile(at path: String, content: String) throws {
+    let parentPath = URL(fileURLWithPath: path).deletingLastPathComponent().path
+    try FileManager.default.createDirectory(atPath: parentPath, withIntermediateDirectories: true)
+    try content.write(toFile: path, atomically: true, encoding: .utf8)
+  }
+}
+
+private struct FakeSpotlightMetadataClient: SpotlightMetadataQuerying {
+  let paths: [String]
+
+  func searchFilePaths(matching query: String, in projectPath: String, limit: Int) -> [String] {
+    Array(paths.prefix(limit))
+  }
+}
+
+@Suite("SpotlightProjectFileSearchService")
+struct SpotlightProjectFileSearchServiceTests {
+  @Test("Builds the Spotlight metadata query across file name and path attributes")
+  func buildsQueryExpression() {
+    let expression = SpotlightQueryBuilder.expression(for: "App")
+
+    #expect(expression == """
+    (kMDItemDisplayName == "*App*"cd || kMDItemFSName == "*App*"cd || kMDItemPath == "*App*"cd)
+    """)
+    #expect(SpotlightQueryBuilder.expression(for: "   ") == nil)
+  }
+
+  @Test("Escapes quoted query literals before building the metadata query")
+  func escapesQueryExpression() {
+    let expression = SpotlightQueryBuilder.expression(for: #"a"b\c"#)
+
+    #expect(expression?.contains(#"*a\"b\\c*"#) == true)
+  }
+
+  @Test("Ranks Spotlight paths and filters directories and paths outside the project")
+  func ranksAndFiltersMetadataPaths() async throws {
+    let fixture = try SpotlightSearchFixture.create()
+    defer { fixture.cleanup() }
+
+    let appPath = try fixture.writeProjectFile("Sources/App.swift", content: "struct App {}")
+    let notesPath = try fixture.writeProjectFile("docs/app-notes.md", content: "# Notes")
+    let readmePath = try fixture.writeProjectFile("README.md", content: "# Project")
+    let directoryPath = try fixture.createProjectDirectory("AppDirectory")
+    let externalPath = try fixture.writeExternalFile("AppSecret.swift", content: "let token = true")
+
+    let service = SpotlightProjectFileSearchService(
+      metadataClient: FakeSpotlightMetadataClient(paths: [
+        readmePath,
+        externalPath,
+        directoryPath,
+        notesPath,
+        appPath,
+        appPath
+      ]),
+      fileChecker: FileManagerSearchableFileChecker()
+    )
+
+    let results = await service.search(query: "app", in: fixture.projectPath, limit: 10)
+
+    #expect(results.map(\.relativePath) == [
+      "Sources/App.swift",
+      "docs/app-notes.md"
+    ])
+    #expect(results.allSatisfy { $0.absolutePath.hasPrefix(fixture.projectPath + "/") })
+  }
+}
+

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/FileIndexServiceTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/FileIndexServiceTests.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Testing
 
+import AgentHubFileSearch
 @testable import AgentHubCore
 
 private struct FileIndexFixture {
@@ -48,6 +49,14 @@ private struct FileIndexFixture {
     let parentPath = URL(fileURLWithPath: path).deletingLastPathComponent().path
     try FileManager.default.createDirectory(atPath: parentPath, withIntermediateDirectories: true)
     try content.write(toFile: path, atomically: true, encoding: .utf8)
+  }
+}
+
+private struct FakeProjectFileSearchService: ProjectFileSearchServiceProtocol {
+  let results: [ProjectFileSearchResult]
+
+  func search(query: String, in projectPath: String, limit: Int) async -> [ProjectFileSearchResult] {
+    Array(results.prefix(limit))
   }
 }
 
@@ -199,6 +208,39 @@ struct FileIndexServicePrivacyTests {
     #expect(rootNodes.contains { $0.name == "Sources" })
     #expect(!rootNodes.contains { $0.name == "Generated" })
     #expect(searchResults.isEmpty)
+  }
+
+  @Test("Filters Spotlight results through project ignore rules before showing Cmd+P results")
+  func filtersSpotlightResultsThroughProjectIgnoreRules() async throws {
+    let fixture = try FileIndexFixture.create()
+    defer { fixture.cleanup() }
+
+    try fixture.writeProjectFile(".gitignore", content: "secrets/\n")
+    try fixture.writeProjectFile("secrets/token.swift", content: "let hidden = true")
+    try fixture.writeProjectFile("Sources/token.swift", content: "let visible = true")
+
+    let hiddenPath = fixture.projectPath + "/secrets/token.swift"
+    let visiblePath = fixture.projectPath + "/Sources/token.swift"
+    let service = FileIndexService(projectFileSearchService: FakeProjectFileSearchService(results: [
+      ProjectFileSearchResult(
+        id: hiddenPath,
+        name: "token.swift",
+        relativePath: "secrets/token.swift",
+        absolutePath: hiddenPath,
+        score: 5000
+      ),
+      ProjectFileSearchResult(
+        id: visiblePath,
+        name: "token.swift",
+        relativePath: "Sources/token.swift",
+        absolutePath: visiblePath,
+        score: 4000
+      )
+    ]))
+
+    let results = await service.search(query: "token", in: fixture.projectPath)
+
+    #expect(results.map(\.relativePath) == ["Sources/token.swift"])
   }
 
   @Test("Content-only writes keep the search index warm")


### PR DESCRIPTION
## Summary

- Add a new `AgentHubFileSearch` module backed by Spotlight/CoreServices metadata queries.
- Route Cmd+P file search through Spotlight first, with the existing FileManager scan as a fallback when Spotlight has no usable results.
- Preserve AgentHub filtering for project boundaries, symlinks, `.gitignore`, hard-excluded directories, and sensitive hidden files.
- Add focused tests for Spotlight query/ranking behavior and AgentHub filtering of Spotlight results.

## Validation

- `swift build --target AgentHubFileSearch`
- `swiftc -typecheck -target arm64-apple-macosx14.0 -I .build/arm64-apple-macosx/debug/Modules Sources/AgentHub/Models/FileTreeNode.swift Sources/AgentHub/Services/FileIndexService.swift`
- `xcodebuild -project app/AgentHub.xcodeproj -scheme AgentHub -configuration Debug build`
- `xcodebuild -project app/AgentHub.xcodeproj -scheme AgentHub -configuration Release build`

Notes: the broad SwiftPM package build still hits the existing `CodeEditSymbols` `Bundle.module` resource issue, and Xcode logs existing SwiftLint plugin failures for CodeEdit dependency targets even though the app build succeeds.