### PR TITLE
[codex] Fix theme selection hangs

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/Design/Theme/Management/ThemeFileWatcher.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Design/Theme/Management/ThemeFileWatcher.swift
@@ -7,7 +7,12 @@
 
 import Foundation
 
-public final class ThemeFileWatcher {
+protocol ThemeFileWatching: AnyObject {
+  func watch(fileURL: URL, onChange: @escaping () -> Void)
+  func stopWatching(fileURL: URL)
+}
+
+public final class ThemeFileWatcher: ThemeFileWatching {
   private var sources: [URL: DispatchSourceFileSystemObject] = [:]
 
   public init() {}

--- a/app/modules/AgentHubCore/Sources/AgentHub/Design/Theme/Management/ThemeLoadingService.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Design/Theme/Management/ThemeLoadingService.swift
@@ -1,0 +1,108 @@
+//
+//  ThemeLoadingService.swift
+//  AgentHub
+//
+
+import Foundation
+
+struct ThemePalette: Equatable, Sendable {
+  let primary: String
+  let secondary: String
+  let tertiary: String
+}
+
+struct DiscoveredYAMLTheme: Equatable, Sendable {
+  let id: String
+  let name: String
+  let description: String?
+  let fileURL: URL
+}
+
+struct LoadedYAMLTheme: Sendable {
+  let theme: YAMLTheme
+  let palette: ThemePalette
+}
+
+protocol ThemeLoadingServiceProtocol: Sendable {
+  func discoverThemes(in themesDirectory: URL) async throws -> [DiscoveredYAMLTheme]
+  func loadTheme(fileURL: URL) async throws -> LoadedYAMLTheme
+}
+
+protocol ThemePreferenceWriting: Sendable {
+  func persistYAMLPalette(_ palette: ThemePalette) async
+  func persistThemeSelection(_ themeId: String, backend: EmbeddedTerminalBackend) async
+}
+
+actor ThemeLoadingService: ThemeLoadingServiceProtocol {
+  private let parser = YAMLThemeParser()
+  private let fileManager: FileManager
+
+  init(fileManager: FileManager = .default) {
+    self.fileManager = fileManager
+  }
+
+  func discoverThemes(in themesDirectory: URL) async throws -> [DiscoveredYAMLTheme] {
+    guard fileManager.fileExists(atPath: themesDirectory.path) else {
+      try fileManager.createDirectory(at: themesDirectory, withIntermediateDirectories: true)
+      return []
+    }
+
+    let files = try fileManager.contentsOfDirectory(
+      at: themesDirectory,
+      includingPropertiesForKeys: [.nameKey],
+      options: [.skipsHiddenFiles]
+    )
+
+    return files
+      .filter(Self.isYAMLFile)
+      .compactMap { fileURL in
+        guard let loaded = try? loadThemeSynchronously(fileURL: fileURL) else {
+          return nil
+        }
+        return DiscoveredYAMLTheme(
+          id: fileURL.lastPathComponent,
+          name: loaded.theme.name,
+          description: loaded.theme.description,
+          fileURL: fileURL
+        )
+      }
+  }
+
+  func loadTheme(fileURL: URL) async throws -> LoadedYAMLTheme {
+    try loadThemeSynchronously(fileURL: fileURL)
+  }
+
+  private func loadThemeSynchronously(fileURL: URL) throws -> LoadedYAMLTheme {
+    let theme = try parser.parse(fileURL: fileURL)
+    return LoadedYAMLTheme(
+      theme: theme,
+      palette: ThemePalette(
+        primary: theme.colors.brand.primary,
+        secondary: theme.colors.brand.secondary,
+        tertiary: theme.colors.brand.tertiary
+      )
+    )
+  }
+
+  private nonisolated static func isYAMLFile(_ fileURL: URL) -> Bool {
+    fileURL.pathExtension == "yaml" || fileURL.pathExtension == "yml"
+  }
+}
+
+actor ThemePreferenceWriter: ThemePreferenceWriting {
+  private let defaults: UserDefaults
+
+  init(defaults: UserDefaults = .standard) {
+    self.defaults = defaults
+  }
+
+  func persistYAMLPalette(_ palette: ThemePalette) async {
+    defaults.set(palette.primary, forKey: AgentHubDefaults.yamlPrimaryHex)
+    defaults.set(palette.secondary, forKey: AgentHubDefaults.yamlSecondaryHex)
+    defaults.set(palette.tertiary, forKey: AgentHubDefaults.yamlTertiaryHex)
+  }
+
+  func persistThemeSelection(_ themeId: String, backend: EmbeddedTerminalBackend) async {
+    ThemeSelectionPolicy.persistThemeSelection(themeId, defaults: defaults, backend: backend)
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/Design/Theme/Management/ThemeManager.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Design/Theme/Management/ThemeManager.swift
@@ -16,11 +16,15 @@ public final class ThemeManager {
   public private(set) var currentTheme: RuntimeTheme
   public private(set) var availableYAMLThemes: [ThemeMetadata] = []
 
-  @ObservationIgnored private let parser = YAMLThemeParser()
-  @ObservationIgnored private let fileWatcher: ThemeFileWatcher
+  @ObservationIgnored private let loadingService: any ThemeLoadingServiceProtocol
+  @ObservationIgnored private let preferenceWriter: any ThemePreferenceWriting
+  @ObservationIgnored private let fileWatcher: any ThemeFileWatching
+  @ObservationIgnored private let defaults: UserDefaults
+  @ObservationIgnored private let themesDirectoryURL: URL
   @ObservationIgnored private var themeCache: [String: RuntimeTheme] = [:]
-  @ObservationIgnored private var yamlColorCache: [String: (primary: String, secondary: String, tertiary: String)] = [:]
+  @ObservationIgnored private var yamlColorCache: [String: ThemePalette] = [:]
   @ObservationIgnored private var activeWatchedThemeURL: URL?
+  @ObservationIgnored private var selectionGeneration = 0
 
   private static let bundledSentryYAML = """
   name: "Sentry"
@@ -179,7 +183,7 @@ public final class ThemeManager {
       expandedContentDark: "#081220"
   """
 
-  public struct ThemeMetadata: Identifiable {
+  public struct ThemeMetadata: Identifiable, Equatable, Sendable {
     public let id: String
     public let name: String
     public let description: String?
@@ -187,20 +191,50 @@ public final class ThemeManager {
     public let isYAML: Bool
   }
 
-  public init() {
-    // Load the correct built-in theme synchronously to avoid flash on launch
-    let saved = ThemeSelectionPolicy.coercePersistedThemeSelection()
+  public convenience init() {
+    let defaults = UserDefaults.standard
+    self.init(
+      defaults: defaults,
+      themesDirectory: Self.themesDirectory(),
+      loadingService: ThemeLoadingService(),
+      preferenceWriter: ThemePreferenceWriter(defaults: defaults),
+      fileWatcher: ThemeFileWatcher(),
+      installBundledThemes: true,
+      loadSavedThemeAsync: true
+    )
+  }
+
+  init(
+    defaults: UserDefaults,
+    themesDirectory: URL,
+    loadingService: any ThemeLoadingServiceProtocol,
+    preferenceWriter: (any ThemePreferenceWriting)? = nil,
+    fileWatcher: any ThemeFileWatching,
+    installBundledThemes: Bool,
+    loadSavedThemeAsync: Bool
+  ) {
+    self.defaults = defaults
+    self.themesDirectoryURL = themesDirectory
+    self.loadingService = loadingService
+    self.preferenceWriter = preferenceWriter ?? ThemePreferenceWriter(defaults: defaults)
+    self.fileWatcher = fileWatcher
+
+    // Load the correct built-in theme synchronously to avoid flash on launch.
+    // Preference writes happen later through ThemePreferenceWriter so launch does not block on defaults KVO.
+    let backend = EmbeddedTerminalBackend.storedPreference(in: defaults)
+    let saved = ThemeSelectionPolicy.resolvedPersistedThemeSelection(defaults: defaults, backend: backend)
     if let appTheme = AppTheme(rawValue: saved) {
       self.currentTheme = Self.loadBuiltInTheme(appTheme)
     } else {
       // YAML theme — start with neutral sync, async load replaces it
       self.currentTheme = Self.loadBuiltInTheme(.neutral)
     }
-    self.fileWatcher = ThemeFileWatcher()
-    self.installBundledThemesIfNeeded()
+    if installBundledThemes {
+      self.installBundledThemesIfNeeded()
+    }
 
     // Schedule async loading for YAML themes (including the default)
-    if AppTheme(rawValue: saved) == nil {
+    if loadSavedThemeAsync, AppTheme(rawValue: saved) == nil {
       Task { await self.loadSavedTheme() }
     }
   }
@@ -208,36 +242,9 @@ public final class ThemeManager {
   // MARK: - Theme Discovery
 
   public func discoverThemes() async {
-    let themesDir = Self.themesDirectory()
-
-    guard FileManager.default.fileExists(atPath: themesDir.path) else {
-      try? FileManager.default.createDirectory(at: themesDir, withIntermediateDirectories: true)
-      return
-    }
-
     do {
-      let files = try FileManager.default.contentsOfDirectory(
-        at: themesDir,
-        includingPropertiesForKeys: [.nameKey],
-        options: [.skipsHiddenFiles]
-      )
-
-      let yamlFiles = files.filter { $0.pathExtension == "yaml" || $0.pathExtension == "yml" }
-
-      var metadata: [ThemeMetadata] = []
-      for file in yamlFiles {
-        if let theme = try? parser.parse(fileURL: file) {
-          metadata.append(ThemeMetadata(
-            id: file.lastPathComponent,
-            name: theme.name,
-            description: theme.description,
-            fileURL: file,
-            isYAML: true
-          ))
-        }
-      }
-
-      self.availableYAMLThemes = metadata
+      let discoveredThemes = try await loadingService.discoverThemes(in: themesDirectoryURL)
+      self.availableYAMLThemes = discoveredThemes.map(Self.metadata(from:))
     } catch {
       AppLogger.session.error("Failed to discover themes: \(error.localizedDescription)")
     }
@@ -246,40 +253,101 @@ public final class ThemeManager {
   // MARK: - Theme Loading
 
   public func loadTheme(fileURL: URL) async throws {
-    stopWatchingInactiveThemeFile(nextThemeURL: fileURL)
+    let backend = EmbeddedTerminalBackend.storedPreference(in: defaults)
+    let generation = beginThemeSelection()
+    try await loadTheme(
+      fileURL: fileURL,
+      backend: backend,
+      generation: generation,
+      forceReload: false
+    )
+  }
 
-    // Check cache first
+  @discardableResult
+  public func applySelection(_ requestedSelection: String, backend: EmbeddedTerminalBackend) async -> String {
+    let defaultThemeId = ThemeSelectionPolicy.defaultThemeId(for: backend)
+    let selection = ThemeSelectionPolicy.canonicalThemeId(
+      for: requestedSelection,
+      backend: backend
+    ) ?? defaultThemeId
+
+    if backend == .regular, let appTheme = AppTheme(rawValue: selection) {
+      if isCurrentBuiltInTheme(appTheme),
+         isPersistedThemeSelection(appTheme.rawValue, backend: backend) {
+        beginThemeSelection()
+        return appTheme.rawValue
+      }
+
+      beginThemeSelection()
+      await applyBuiltInTheme(appTheme, persistedThemeId: appTheme.rawValue, backend: backend)
+      return appTheme.rawValue
+    }
+
+    let fileId = ThemeSelectionPolicy.matchingBundledYAMLFileId(
+      for: selection,
+      in: ThemeSelectionPolicy.bundledYAMLThemeFileIds(for: backend)
+    ) ?? selection
+
+    if isCurrentYAMLTheme(fileId),
+       isPersistedThemeSelection(fileId, backend: backend) {
+      beginThemeSelection()
+      return fileId
+    }
+
+    let generation = beginThemeSelection()
+    let themeURL = themesDirectoryURL.appendingPathComponent(fileId)
+    do {
+      try await loadTheme(
+        fileURL: themeURL,
+        backend: backend,
+        generation: generation,
+        forceReload: false
+      )
+      return fileId
+    } catch {
+      AppLogger.session.error("Failed to apply theme \(fileId): \(error.localizedDescription)")
+      guard isCurrentGeneration(generation) else { return fileId }
+      await applyBuiltInTheme(.neutral, persistedThemeId: defaultThemeId, backend: backend)
+      return defaultThemeId
+    }
+  }
+
+  private func loadTheme(
+    fileURL: URL,
+    backend: EmbeddedTerminalBackend,
+    generation: Int,
+    forceReload: Bool
+  ) async throws {
     let cacheKey = fileURL.lastPathComponent
-    if let cached = themeCache[cacheKey] {
+    if !forceReload, let cached = themeCache[cacheKey] {
+      guard isCurrentGeneration(generation) else { return }
+      stopWatchingInactiveThemeFile(nextThemeURL: fileURL)
       self.currentTheme = cached
-      persistYAMLPalette(for: cacheKey, runtime: cached)
-      saveCurrentThemeSelection(cacheKey)
       setupHotReload(for: fileURL)
+      await persistYAMLPalette(for: cacheKey)
+      await saveCurrentThemeSelection(cacheKey, backend: backend)
       return
     }
 
-    // Parse and cache
-    let yaml = try parser.parse(fileURL: fileURL)
-    let runtime = RuntimeTheme(from: yaml, sourceFileName: cacheKey)
+    let loaded = try await loadingService.loadTheme(fileURL: fileURL)
+    guard isCurrentGeneration(generation) else { return }
+
+    stopWatchingInactiveThemeFile(nextThemeURL: fileURL)
+    let runtime = RuntimeTheme(from: loaded.theme, sourceFileName: cacheKey)
     themeCache[cacheKey] = runtime
-    yamlColorCache[cacheKey] = (
-      primary: yaml.colors.brand.primary,
-      secondary: yaml.colors.brand.secondary,
-      tertiary: yaml.colors.brand.tertiary
-    )
+    yamlColorCache[cacheKey] = loaded.palette
     self.currentTheme = runtime
-    persistYAMLPalette(for: cacheKey, runtime: runtime)
-    saveCurrentThemeSelection(cacheKey)
 
     // Setup hot-reload
     setupHotReload(for: fileURL)
+    await persistYAMLPalette(for: cacheKey)
+    await saveCurrentThemeSelection(cacheKey, backend: backend)
   }
 
   public func loadBuiltInTheme(_ theme: AppTheme) {
-    stopWatchingInactiveThemeFile(nextThemeURL: nil)
-    let runtime = Self.loadBuiltInTheme(theme)
-    self.currentTheme = runtime
-    saveCurrentThemeSelection(theme.rawValue)
+    beginThemeSelection()
+    let backend = EmbeddedTerminalBackend.storedPreference(in: defaults)
+    applyBuiltInThemeAndPersistLater(theme, persistedThemeId: theme.rawValue, backend: backend)
   }
 
   private static func loadBuiltInTheme(_ theme: AppTheme) -> RuntimeTheme {
@@ -337,8 +405,15 @@ public final class ThemeManager {
         do {
           // Invalidate cache and reload
           let cacheKey = fileURL.lastPathComponent
+          let generation = self.selectionGeneration
+          let backend = EmbeddedTerminalBackend.storedPreference(in: self.defaults)
           self.themeCache.removeValue(forKey: cacheKey)
-          try await self.loadTheme(fileURL: fileURL)
+          try await self.loadTheme(
+            fileURL: fileURL,
+            backend: backend,
+            generation: generation,
+            forceReload: true
+          )
           AppLogger.session.info("Hot-reloaded theme: \(fileURL.lastPathComponent)")
         } catch {
           AppLogger.session.error("Failed to hot-reload theme: \(error.localizedDescription)")
@@ -350,35 +425,17 @@ public final class ThemeManager {
 
   // MARK: - Persistence
 
-  private func saveCurrentThemeSelection(_ themeId: String) {
-    ThemeSelectionPolicy.persistThemeSelection(themeId)
+  private func saveCurrentThemeSelection(
+    _ themeId: String,
+    backend: EmbeddedTerminalBackend
+  ) async {
+    await preferenceWriter.persistThemeSelection(themeId, backend: backend)
   }
 
   public func loadSavedTheme() async {
-    let saved = ThemeSelectionPolicy.coercePersistedThemeSelection()
-
-    // Check if it's a built-in theme
-    if let appTheme = AppTheme(rawValue: saved) {
-      loadBuiltInTheme(appTheme)
-      return
-    }
-
-    // Check if it's a YAML theme
-    let themesDir = Self.themesDirectory()
-    let fileURL = themesDir.appendingPathComponent(saved)
-
-    if FileManager.default.fileExists(atPath: fileURL.path) {
-      try? await loadTheme(fileURL: fileURL)
-    } else {
-      // Fallback: try the backend default, then neutral
-      let fallbackThemeId = ThemeSelectionPolicy.defaultThemeId(for: .storedPreference)
-      let fallbackURL = themesDir.appendingPathComponent(fallbackThemeId)
-      if fallbackThemeId != saved, FileManager.default.fileExists(atPath: fallbackURL.path) {
-        try? await loadTheme(fileURL: fallbackURL)
-      } else {
-        loadBuiltInTheme(.neutral)
-      }
-    }
+    let backend = EmbeddedTerminalBackend.storedPreference(in: defaults)
+    let saved = ThemeSelectionPolicy.resolvedPersistedThemeSelection(defaults: defaults, backend: backend)
+    await applySelection(saved, backend: backend)
   }
 
   // MARK: - Utilities
@@ -389,12 +446,72 @@ public final class ThemeManager {
   }
 
   public func openThemesFolder() {
-    let url = Self.themesDirectory()
+    let url = themesDirectoryURL
     try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
     NSWorkspace.shared.open(url)
   }
 
   // MARK: - Internal Helpers
+
+  private static func metadata(from discoveredTheme: DiscoveredYAMLTheme) -> ThemeMetadata {
+    ThemeMetadata(
+      id: discoveredTheme.id,
+      name: discoveredTheme.name,
+      description: discoveredTheme.description,
+      fileURL: discoveredTheme.fileURL,
+      isYAML: true
+    )
+  }
+
+  @discardableResult
+  private func beginThemeSelection() -> Int {
+    selectionGeneration += 1
+    return selectionGeneration
+  }
+
+  private func isCurrentGeneration(_ generation: Int) -> Bool {
+    selectionGeneration == generation
+  }
+
+  private func isCurrentBuiltInTheme(_ theme: AppTheme) -> Bool {
+    currentTheme.isBuiltIn && currentTheme.id == theme.rawValue
+  }
+
+  private func isCurrentYAMLTheme(_ fileId: String) -> Bool {
+    currentTheme.isYAML && currentTheme.sourceFileName == fileId
+  }
+
+  private func isPersistedThemeSelection(_ themeId: String, backend: EmbeddedTerminalBackend) -> Bool {
+    guard let persistedThemeId = defaults.string(forKey: AgentHubDefaults.selectedTheme) else {
+      return false
+    }
+    return ThemeSelectionPolicy.canonicalThemeId(for: persistedThemeId, backend: backend) == themeId
+  }
+
+  private func applyBuiltInTheme(
+    _ theme: AppTheme,
+    persistedThemeId: String,
+    backend: EmbeddedTerminalBackend
+  ) async {
+    stopWatchingInactiveThemeFile(nextThemeURL: nil)
+    let runtime = Self.loadBuiltInTheme(theme)
+    self.currentTheme = runtime
+    await saveCurrentThemeSelection(persistedThemeId, backend: backend)
+  }
+
+  private func applyBuiltInThemeAndPersistLater(
+    _ theme: AppTheme,
+    persistedThemeId: String,
+    backend: EmbeddedTerminalBackend
+  ) {
+    stopWatchingInactiveThemeFile(nextThemeURL: nil)
+    let runtime = Self.loadBuiltInTheme(theme)
+    self.currentTheme = runtime
+    let preferenceWriter = preferenceWriter
+    Task.detached(priority: .utility) {
+      await preferenceWriter.persistThemeSelection(persistedThemeId, backend: backend)
+    }
+  }
 
   private func stopWatchingInactiveThemeFile(nextThemeURL: URL?) {
     guard activeWatchedThemeURL != nextThemeURL else { return }
@@ -416,7 +533,7 @@ public final class ThemeManager {
   ]
 
   private func installBundledThemesIfNeeded() {
-    let themesDir = Self.themesDirectory()
+    let themesDir = themesDirectoryURL
     do {
       try FileManager.default.createDirectory(at: themesDir, withIntermediateDirectories: true)
     } catch {
@@ -448,7 +565,6 @@ public final class ThemeManager {
         return value.trimmingCharacters(in: CharacterSet(charactersIn: "\"'"))
       }
 
-    let defaults = UserDefaults.standard
     let versionKey = AgentHubDefaults.installedBundledThemeVersion(for: name)
     let installedVersion = defaults.string(forKey: versionKey)
     let destinationURL = themesDir.appendingPathComponent("\(name).yaml")
@@ -492,34 +608,8 @@ public final class ThemeManager {
       .first(where: { $0.lastPathComponent == "\(name).yaml" })
   }
 
-  private func persistYAMLPalette(for cacheKey: String, runtime: RuntimeTheme) {
-    let defaults = UserDefaults.standard
-    if let colors = yamlColorCache[cacheKey] {
-      defaults.set(colors.primary, forKey: AgentHubDefaults.yamlPrimaryHex)
-      defaults.set(colors.secondary, forKey: AgentHubDefaults.yamlSecondaryHex)
-      defaults.set(colors.tertiary, forKey: AgentHubDefaults.yamlTertiaryHex)
-      return
-    }
-
-    // Fallback when serving from runtime-only cache.
-    if let primary = Self.hexString(from: runtime.brandPrimary) {
-      defaults.set(primary, forKey: AgentHubDefaults.yamlPrimaryHex)
-    }
-    if let secondary = Self.hexString(from: runtime.brandSecondary) {
-      defaults.set(secondary, forKey: AgentHubDefaults.yamlSecondaryHex)
-    }
-    if let tertiary = Self.hexString(from: runtime.brandTertiary) {
-      defaults.set(tertiary, forKey: AgentHubDefaults.yamlTertiaryHex)
-    }
-  }
-
-  private static func hexString(from color: Color) -> String? {
-    guard let resolved = NSColor(color).usingColorSpace(.sRGB) else { return nil }
-    var red: CGFloat = .zero
-    var green: CGFloat = .zero
-    var blue: CGFloat = .zero
-    var alpha: CGFloat = .zero
-    resolved.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
-    return String(format: "#%02X%02X%02X", Int(red * 255), Int(green * 255), Int(blue * 255))
+  private func persistYAMLPalette(for cacheKey: String) async {
+    guard let colors = yamlColorCache[cacheKey] else { return }
+    await preferenceWriter.persistYAMLPalette(colors)
   }
 }

--- a/app/modules/AgentHubCore/Sources/AgentHub/Design/Theme/Management/ThemeSelectionPolicy.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Design/Theme/Management/ThemeSelectionPolicy.swift
@@ -75,30 +75,37 @@ enum ThemeSelectionPolicy {
     defaults: UserDefaults = .standard,
     backend: EmbeddedTerminalBackend = .storedPreference
   ) -> String {
+    let selectedThemeId = resolvedPersistedThemeSelection(defaults: defaults, backend: backend)
+
+    if backend == .ghostty,
+       let savedThemeId = defaults.string(forKey: AgentHubDefaults.selectedTheme),
+       !isGhosttyTheme(savedThemeId),
+       let regularThemeId = canonicalRegularThemeId(for: savedThemeId) {
+      defaults.set(regularThemeId, forKey: AgentHubDefaults.previousNonGhosttyTheme)
+    }
+
+    persistThemeSelection(selectedThemeId, defaults: defaults, backend: backend)
+    return selectedThemeId
+  }
+
+  static func resolvedPersistedThemeSelection(
+    defaults: UserDefaults = .standard,
+    backend: EmbeddedTerminalBackend = .storedPreference
+  ) -> String {
     let savedThemeId = defaults.string(forKey: AgentHubDefaults.selectedTheme)
 
     switch backend {
     case .ghostty:
-      if let savedThemeId,
-         !isGhosttyTheme(savedThemeId),
-         let regularThemeId = canonicalRegularThemeId(for: savedThemeId) {
-        defaults.set(regularThemeId, forKey: AgentHubDefaults.previousNonGhosttyTheme)
-      }
-      defaults.set(ghosttyThemeId, forKey: AgentHubDefaults.selectedTheme)
       return ghosttyThemeId
 
     case .regular:
       if let savedThemeId,
          let regularThemeId = canonicalRegularThemeId(for: savedThemeId) {
-        defaults.set(regularThemeId, forKey: AgentHubDefaults.selectedTheme)
-        defaults.set(regularThemeId, forKey: AgentHubDefaults.previousNonGhosttyTheme)
         return regularThemeId
       }
 
       let previousThemeId = defaults.string(forKey: AgentHubDefaults.previousNonGhosttyTheme)
       let restoredThemeId = canonicalRegularThemeId(for: previousThemeId) ?? defaultRegularThemeId
-      defaults.set(restoredThemeId, forKey: AgentHubDefaults.selectedTheme)
-      defaults.set(restoredThemeId, forKey: AgentHubDefaults.previousNonGhosttyTheme)
       return restoredThemeId
     }
   }

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/EmbeddedTerminalBackend.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/EmbeddedTerminalBackend.swift
@@ -17,7 +17,11 @@ public enum EmbeddedTerminalBackend: Int, CaseIterable, Sendable {
   }
 
   public static var storedPreference: EmbeddedTerminalBackend {
-    let rawValue = UserDefaults.standard.object(forKey: AgentHubDefaults.terminalBackend) as? Int
+    storedPreference(in: .standard)
+  }
+
+  public static func storedPreference(in defaults: UserDefaults) -> EmbeddedTerminalBackend {
+    let rawValue = defaults.object(forKey: AgentHubDefaults.terminalBackend) as? Int
       ?? EmbeddedTerminalBackend.regular.rawValue
     return EmbeddedTerminalBackend(rawValue: rawValue) ?? .regular
   }

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/SettingsView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/SettingsView.swift
@@ -83,7 +83,9 @@ public struct SettingsView: View {
   @Environment(ThemeManager.self) private var themeManager
   @Environment(\.colorScheme) private var colorScheme
   @Environment(\.runtimeTheme) private var runtimeTheme
-  @AppStorage(AgentHubDefaults.selectedTheme) private var selectedThemeId: String = "singularity.yaml"
+  @State private var selectedThemeId: String = Self.initialSelectedThemeId()
+  @State private var themeSelectionTask: Task<Void, Never>?
+  @State private var applyingThemeSelectionId: String?
   private let terminalFontFamilies = [
     "SF Mono",
     "JetBrains Mono",
@@ -144,6 +146,11 @@ public struct SettingsView: View {
     .task {
       await ensureSupportedThemeSelection()
       await aiConfigViewModel.load(service: agentHub?.aiConfigService)
+    }
+    .onDisappear {
+      themeSelectionTask?.cancel()
+      themeSelectionTask = nil
+      applyingThemeSelectionId = nil
     }
     .alert(
       "Relaunch AgentHub?",
@@ -328,9 +335,22 @@ public struct SettingsView: View {
       }
 
       Section {
-        Picker("Theme", selection: themeSelectionBinding) {
-          ForEach(bundledYAMLThemeFileIds, id: \.self) { fileId in
-            Text(yamlThemeDisplayName(fileId)).tag(fileId)
+        HStack(spacing: 10) {
+          Picker("Theme", selection: themeSelectionBinding) {
+            ForEach(bundledYAMLThemeFileIds, id: \.self) { fileId in
+              Text(yamlThemeDisplayName(fileId)).tag(fileId)
+            }
+          }
+
+          if applyingThemeSelectionId != nil {
+            HStack(spacing: 6) {
+              ProgressView()
+                .controlSize(.small)
+              Text("Applying...")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            }
+            .transition(.opacity)
           }
         }
 
@@ -340,6 +360,7 @@ public struct SettingsView: View {
           Label("Refresh themes", systemImage: "arrow.clockwise")
         }
         .buttonStyle(.link)
+        .disabled(applyingThemeSelectionId != nil)
       } header: {
         Text("Theme")
       } footer: {
@@ -480,18 +501,20 @@ public struct SettingsView: View {
 
   private var themeSelectionBinding: Binding<String> {
     Binding(
-      get: {
-        if let matchedFileId = matchingBundledYAMLFileId(for: selectedThemeId) {
-          return matchedFileId
-        }
-        if activeTerminalBackend == .regular, let appTheme = AppTheme(rawValue: selectedThemeId) {
-          return appTheme.rawValue
-        }
-        return defaultThemeId
-      },
+      get: { currentThemeSelectionId },
       set: { newValue in
-        Task {
-          await applyThemeSelection(newValue)
+        guard newValue != currentThemeSelectionId else { return }
+        let requestedThemeId = newValue
+        selectedThemeId = requestedThemeId
+        applyingThemeSelectionId = requestedThemeId
+        themeSelectionTask?.cancel()
+        themeSelectionTask = Task {
+          try? await Task.sleep(for: .milliseconds(150))
+          guard !Task.isCancelled else { return }
+          await applyThemeSelection(requestedThemeId)
+          guard !Task.isCancelled, applyingThemeSelectionId == requestedThemeId else { return }
+          applyingThemeSelectionId = nil
+          themeSelectionTask = nil
         }
       }
     )
@@ -558,49 +581,35 @@ public struct SettingsView: View {
   }
 
   private func ensureSupportedThemeSelection() async {
-    let themeId = ThemeSelectionPolicy.coercePersistedThemeSelection(backend: activeTerminalBackend)
-    selectedThemeId = themeId
-    await applyThemeSelection(themeId)
+    let themeId = ThemeSelectionPolicy.canonicalThemeId(
+      for: selectedThemeId,
+      backend: activeTerminalBackend
+    ) ?? defaultThemeId
+    let appliedThemeId = await themeManager.applySelection(themeId, backend: activeTerminalBackend)
+    selectedThemeId = appliedThemeId
   }
 
   private func applyThemeSelection(_ selection: String) async {
-    let selection = ThemeSelectionPolicy.canonicalThemeId(
-      for: selection,
-      backend: activeTerminalBackend
-    ) ?? defaultThemeId
-
-    // Handle built-in themes
-    if activeTerminalBackend == .regular, let appTheme = AppTheme(rawValue: selection) {
-      selectedThemeId = appTheme.rawValue
-      themeManager.loadBuiltInTheme(appTheme)
-      return
-    }
-
-    // Handle bundled YAML themes
-    let fileId = matchingBundledYAMLFileId(for: selection) ?? selection
-    await themeManager.discoverThemes()
-
-    if let yamlTheme = themeManager.availableYAMLThemes.first(where: { $0.id == fileId }),
-       let fileURL = yamlTheme.fileURL {
-      try? await themeManager.loadTheme(fileURL: fileURL)
-      selectedThemeId = yamlTheme.id
-      return
-    }
-
-    let themeURL = ThemeManager.themesDirectory().appendingPathComponent(fileId)
-    if FileManager.default.fileExists(atPath: themeURL.path) {
-      try? await themeManager.loadTheme(fileURL: themeURL)
-      selectedThemeId = fileId
-      return
-    }
-
-    themeManager.loadBuiltInTheme(.neutral)
-    ThemeSelectionPolicy.persistThemeSelection(defaultThemeId, backend: activeTerminalBackend)
-    selectedThemeId = defaultThemeId
+    let appliedThemeId = await themeManager.applySelection(selection, backend: activeTerminalBackend)
+    selectedThemeId = appliedThemeId
   }
 
   private func matchingBundledYAMLFileId(for value: String) -> String? {
     ThemeSelectionPolicy.matchingBundledYAMLFileId(for: value, in: bundledYAMLThemeFileIds)
+  }
+
+  private static func initialSelectedThemeId() -> String {
+    UserDefaults.standard.string(forKey: AgentHubDefaults.selectedTheme) ?? "singularity.yaml"
+  }
+
+  private var currentThemeSelectionId: String {
+    if let matchedFileId = matchingBundledYAMLFileId(for: selectedThemeId) {
+      return matchedFileId
+    }
+    if activeTerminalBackend == .regular, let appTheme = AppTheme(rawValue: selectedThemeId) {
+      return appTheme.rawValue
+    }
+    return defaultThemeId
   }
 
   private func yamlThemeDisplayName(_ fileId: String) -> String {

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/ThemeLoadingServiceTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/ThemeLoadingServiceTests.swift
@@ -1,0 +1,89 @@
+import Foundation
+import Testing
+
+@testable import AgentHubCore
+
+@Suite("Theme loading service")
+struct ThemeLoadingServiceTests {
+
+  @Test("Discovers valid YAML themes and ignores invalid files")
+  func discoversValidYAMLThemes() async throws {
+    let directory = try temporaryDirectory()
+    defer { try? FileManager.default.removeItem(at: directory) }
+
+    try writeTheme(named: "valid.yaml", displayName: "Valid", to: directory)
+    try writeTheme(named: "also-valid.yml", displayName: "Also Valid", to: directory)
+    try "not: valid: yaml".write(
+      to: directory.appendingPathComponent("broken.yaml"),
+      atomically: true,
+      encoding: .utf8
+    )
+    try "ignored".write(
+      to: directory.appendingPathComponent("notes.txt"),
+      atomically: true,
+      encoding: .utf8
+    )
+
+    let service = ThemeLoadingService()
+    let themes = try await service.discoverThemes(in: directory)
+
+    #expect(themes.map(\.id).sorted() == ["also-valid.yml", "valid.yaml"])
+    #expect(themes.map(\.name).sorted() == ["Also Valid", "Valid"])
+  }
+
+  @Test("Loads a YAML theme with its original palette hex values")
+  func loadsThemeWithPaletteHexValues() async throws {
+    let directory = try temporaryDirectory()
+    defer { try? FileManager.default.removeItem(at: directory) }
+
+    let fileURL = try writeTheme(
+      named: "palette.yaml",
+      displayName: "Palette",
+      primary: "#112233",
+      secondary: "#445566",
+      tertiary: "#778899",
+      to: directory
+    )
+
+    let service = ThemeLoadingService()
+    let loaded = try await service.loadTheme(fileURL: fileURL)
+
+    #expect(loaded.theme.name == "Palette")
+    #expect(loaded.palette == ThemePalette(
+      primary: "#112233",
+      secondary: "#445566",
+      tertiary: "#778899"
+    ))
+  }
+
+  @discardableResult
+  private func writeTheme(
+    named fileName: String,
+    displayName: String,
+    primary: String = "#112233",
+    secondary: String = "#445566",
+    tertiary: String = "#778899",
+    to directory: URL
+  ) throws -> URL {
+    let fileURL = directory.appendingPathComponent(fileName)
+    let yaml = """
+    name: "\(displayName)"
+    version: "1.0"
+    description: "\(displayName) theme"
+    colors:
+      brand:
+        primary: "\(primary)"
+        secondary: "\(secondary)"
+        tertiary: "\(tertiary)"
+    """
+    try yaml.write(to: fileURL, atomically: true, encoding: .utf8)
+    return fileURL
+  }
+
+  private func temporaryDirectory() throws -> URL {
+    let url = FileManager.default.temporaryDirectory
+      .appendingPathComponent("ThemeLoadingServiceTests-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+    return url
+  }
+}

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/ThemeManagerTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/ThemeManagerTests.swift
@@ -1,0 +1,265 @@
+import Foundation
+import Testing
+
+@testable import AgentHubCore
+
+private final class CountingUserDefaults: UserDefaults, @unchecked Sendable {
+  private var setCounts: [String: Int] = [:]
+
+  override func set(_ value: Any?, forKey defaultName: String) {
+    setCounts[defaultName, default: 0] += 1
+    super.set(value, forKey: defaultName)
+  }
+
+  func setCount(forKey key: String) -> Int {
+    setCounts[key, default: 0]
+  }
+}
+
+private final class NoOpThemeFileWatcher: ThemeFileWatching {
+  private(set) var watchedURLs: [URL] = []
+  private(set) var stoppedURLs: [URL] = []
+
+  func watch(fileURL: URL, onChange: @escaping () -> Void) {
+    watchedURLs.append(fileURL)
+  }
+
+  func stopWatching(fileURL: URL) {
+    stoppedURLs.append(fileURL)
+  }
+}
+
+private actor RecordingThemeLoadingService: ThemeLoadingServiceProtocol {
+  private var discoveredThemes: [DiscoveredYAMLTheme]
+  private var loadedThemes: [String: LoadedYAMLTheme]
+  private var discoverCallCount = 0
+  private var loadCallCount = 0
+
+  init(
+    discoveredThemes: [DiscoveredYAMLTheme] = [],
+    loadedThemes: [String: LoadedYAMLTheme] = [:]
+  ) {
+    self.discoveredThemes = discoveredThemes
+    self.loadedThemes = loadedThemes
+  }
+
+  func discoverThemes(in themesDirectory: URL) async throws -> [DiscoveredYAMLTheme] {
+    discoverCallCount += 1
+    return discoveredThemes
+  }
+
+  func loadTheme(fileURL: URL) async throws -> LoadedYAMLTheme {
+    loadCallCount += 1
+    let fileName = fileURL.lastPathComponent
+    guard let loadedTheme = loadedThemes[fileName] else {
+      throw CocoaError(.fileNoSuchFile)
+    }
+    return loadedTheme
+  }
+
+  func setLoadedTheme(_ loadedTheme: LoadedYAMLTheme, for fileName: String) {
+    loadedThemes[fileName] = loadedTheme
+  }
+
+  func loadCount() -> Int {
+    loadCallCount
+  }
+
+  func discoverCount() -> Int {
+    discoverCallCount
+  }
+}
+
+private actor DelayedThemeLoadingService: ThemeLoadingServiceProtocol {
+  private var continuation: CheckedContinuation<LoadedYAMLTheme, Error>?
+  private var loadStarted = false
+
+  func discoverThemes(in themesDirectory: URL) async throws -> [DiscoveredYAMLTheme] {
+    []
+  }
+
+  func loadTheme(fileURL: URL) async throws -> LoadedYAMLTheme {
+    loadStarted = true
+    return try await withCheckedThrowingContinuation { continuation in
+      self.continuation = continuation
+    }
+  }
+
+  func waitUntilLoadStarts() async {
+    while !loadStarted || continuation == nil {
+      await Task.yield()
+    }
+  }
+
+  func finish(with loadedTheme: LoadedYAMLTheme) {
+    continuation?.resume(returning: loadedTheme)
+    continuation = nil
+  }
+}
+
+@Suite("Theme manager", .serialized)
+struct ThemeManagerTests {
+
+  @MainActor
+  @Test("Initializing the theme manager resolves saved selection without writing defaults")
+  func initializingThemeManagerDoesNotWriteDefaults() async throws {
+    let fixture = try Fixture()
+    defer { fixture.teardown() }
+    fixture.defaults.set("sentry.yaml", forKey: AgentHubDefaults.selectedTheme)
+    let selectedThemeWrites = fixture.defaults.setCount(forKey: AgentHubDefaults.selectedTheme)
+    let previousThemeWrites = fixture.defaults.setCount(forKey: AgentHubDefaults.previousNonGhosttyTheme)
+
+    _ = fixture.makeManager(loader: RecordingThemeLoadingService())
+
+    #expect(fixture.defaults.setCount(forKey: AgentHubDefaults.selectedTheme) == selectedThemeWrites)
+    #expect(fixture.defaults.setCount(forKey: AgentHubDefaults.previousNonGhosttyTheme) == previousThemeWrites)
+  }
+
+  @MainActor
+  @Test("Selecting a bundled YAML theme does not rediscover all themes")
+  func selectingBundledYAMLDoesNotDiscoverThemes() async throws {
+    let fixture = try Fixture()
+    defer { fixture.teardown() }
+    let loader = RecordingThemeLoadingService(loadedThemes: [
+      "sentry.yaml": try loadedTheme(name: "Sentry")
+    ])
+    let manager = fixture.makeManager(loader: loader)
+
+    let appliedThemeId = await manager.applySelection("sentry.yaml", backend: .regular)
+
+    #expect(appliedThemeId == "sentry.yaml")
+    #expect(manager.currentTheme.sourceFileName == "sentry.yaml")
+    #expect(await loader.loadCount() == 1)
+    #expect(await loader.discoverCount() == 0)
+  }
+
+  @MainActor
+  @Test("Selecting the current YAML theme does not reload or rewrite defaults")
+  func selectingCurrentYAMLDoesNotReload() async throws {
+    let fixture = try Fixture()
+    defer { fixture.teardown() }
+    let loader = RecordingThemeLoadingService(loadedThemes: [
+      "sentry.yaml": try loadedTheme(name: "Sentry")
+    ])
+    let manager = fixture.makeManager(loader: loader)
+
+    await manager.applySelection("sentry.yaml", backend: .regular)
+    let selectedThemeWrites = fixture.defaults.setCount(forKey: AgentHubDefaults.selectedTheme)
+
+    await manager.applySelection("sentry.yaml", backend: .regular)
+
+    #expect(manager.currentTheme.sourceFileName == "sentry.yaml")
+    #expect(await loader.loadCount() == 1)
+    #expect(fixture.defaults.setCount(forKey: AgentHubDefaults.selectedTheme) == selectedThemeWrites)
+  }
+
+  @MainActor
+  @Test("A stale YAML load cannot overwrite a newer built-in theme selection")
+  func staleYAMLLoadCannotOverwriteNewerSelection() async throws {
+    let fixture = try Fixture()
+    defer { fixture.teardown() }
+    let loader = DelayedThemeLoadingService()
+    let manager = fixture.makeManager(loader: loader)
+
+    let slowSelection = Task { @MainActor in
+      await manager.applySelection("slow.yaml", backend: .regular)
+    }
+    await loader.waitUntilLoadStarts()
+
+    let appliedThemeId = await manager.applySelection("neutral", backend: .regular)
+    let loadedSlowTheme = try loadedTheme(name: "Slow", primary: "#AA0000")
+    await loader.finish(with: loadedSlowTheme)
+    _ = await slowSelection.value
+
+    #expect(appliedThemeId == "neutral")
+    #expect(manager.currentTheme.isBuiltIn)
+    #expect(manager.currentTheme.id == "neutral")
+    #expect(fixture.defaults.string(forKey: AgentHubDefaults.selectedTheme) == "neutral")
+  }
+
+  @MainActor
+  @Test("Cached YAML loads reuse parsed runtime theme and persisted palette")
+  func cachedYAMLLoadReusesRuntimeThemeAndPalette() async throws {
+    let fixture = try Fixture()
+    defer { fixture.teardown() }
+    let loader = RecordingThemeLoadingService(loadedThemes: [
+      "cached.yaml": try loadedTheme(
+        name: "Cached",
+        primary: "#112233",
+        secondary: "#445566",
+        tertiary: "#778899"
+      )
+    ])
+    let manager = fixture.makeManager(loader: loader)
+    let themeURL = fixture.themesDirectory.appendingPathComponent("cached.yaml")
+
+    try await manager.loadTheme(fileURL: themeURL)
+    let changedTheme = try loadedTheme(name: "Changed", primary: "#ABCDEF")
+    await loader.setLoadedTheme(changedTheme, for: "cached.yaml")
+    try await manager.loadTheme(fileURL: themeURL)
+
+    #expect(await loader.loadCount() == 1)
+    #expect(manager.currentTheme.name == "Cached")
+    #expect(fixture.defaults.string(forKey: AgentHubDefaults.yamlPrimaryHex) == "#112233")
+    #expect(fixture.defaults.string(forKey: AgentHubDefaults.yamlSecondaryHex) == "#445566")
+    #expect(fixture.defaults.string(forKey: AgentHubDefaults.yamlTertiaryHex) == "#778899")
+  }
+
+  private final class Fixture {
+    let themesDirectory: URL
+    let suiteName: String
+    let defaults: CountingUserDefaults
+
+    init() throws {
+      self.themesDirectory = FileManager.default.temporaryDirectory
+        .appendingPathComponent("ThemeManagerTests-\(UUID().uuidString)", isDirectory: true)
+      try FileManager.default.createDirectory(at: themesDirectory, withIntermediateDirectories: true)
+
+      self.suiteName = "ThemeManagerTests.\(UUID().uuidString)"
+      guard let defaults = CountingUserDefaults(suiteName: suiteName) else {
+        throw CocoaError(.fileNoSuchFile)
+      }
+      defaults.removePersistentDomain(forName: suiteName)
+      self.defaults = defaults
+    }
+
+    @MainActor
+    func makeManager(loader: any ThemeLoadingServiceProtocol) -> ThemeManager {
+      ThemeManager(
+        defaults: defaults,
+        themesDirectory: themesDirectory,
+        loadingService: loader,
+        fileWatcher: NoOpThemeFileWatcher(),
+        installBundledThemes: false,
+        loadSavedThemeAsync: false
+      )
+    }
+
+    func teardown() {
+      try? FileManager.default.removeItem(at: themesDirectory)
+      defaults.removePersistentDomain(forName: suiteName)
+    }
+  }
+
+  private func loadedTheme(
+    name: String,
+    primary: String = "#112233",
+    secondary: String = "#445566",
+    tertiary: String = "#778899"
+  ) throws -> LoadedYAMLTheme {
+    let yaml = """
+    name: "\(name)"
+    version: "1.0"
+    colors:
+      brand:
+        primary: "\(primary)"
+        secondary: "\(secondary)"
+        tertiary: "\(tertiary)"
+    """
+    let theme = try YAMLThemeParser().parse(data: Data(yaml.utf8))
+    return LoadedYAMLTheme(
+      theme: theme,
+      palette: ThemePalette(primary: primary, secondary: secondary, tertiary: tertiary)
+    )
+  }
+}


### PR DESCRIPTION
## Summary

Fixes theme picker hangs by moving expensive YAML theme work and preference writes off the main selection path, then centralizing theme application through `ThemeManager.applySelection(...)`.

## What changed

- Added `ThemeLoadingService` actor for YAML theme discovery and loading.
- Added `ThemePreferenceWriter` actor so YAML palette and theme selection defaults writes do not run directly inside the SwiftUI picker path.
- Removed `@AppStorage(AgentHubDefaults.selectedTheme)` from `SettingsView` and replaced it with local `@State` driven through `ThemeManager`.
- Centralized theme selection through `ThemeManager.applySelection(...)` for built-in and YAML themes.
- Avoided rediscovery on picker changes, added generation guards for stale loads, and reused cached YAML runtime palettes.
- Added `ThemeFileWatching` for test injection.
- Added a visible `Applying...` progress indicator beside the theme picker while a delayed apply is pending, and disabled theme refresh during apply.
- Added `ThemeSelectionPolicy.resolvedPersistedThemeSelection(...)` so saved themes can be resolved without synchronous defaults coercion.
- Added `EmbeddedTerminalBackend.storedPreference(in:)` for injected defaults.

## Root cause

Theme picker changes were doing synchronous YAML parsing, palette persistence, and preference writes on the UI path. The stack trace showed the app stopped in `NSUserDefaults.setObject` while applying a YAML theme, and immediate global theme environment mutation could also interfere with AppKit picker menu tracking.

## Tests

- Added `ThemeLoadingServiceTests.swift` for YAML discovery/loading behavior.
- Added `ThemeManagerTests.swift` for selection flow, stale load guards, cached YAML reuse, and init-time defaults behavior.

## Validation

- `git diff --check`
- `xcodebuild build -project app/AgentHub.xcodeproj -scheme AgentHub -destination 'platform=macOS'`

Notes:
- `swift test --package-path app/modules/AgentHubCore` still fails before these tests due to the existing `CodeEditSymbols` SwiftPM `Bundle.module` issue.
- `xcodebuild test -project app/AgentHub.xcodeproj -scheme AgentHub -destination 'platform=macOS'` is blocked because the scheme is not configured for the test action.