### PR TITLE
[codex] Add manual worktree naming

### DIFF
--- a/app/AgentHubTests/WorktreeCreationTests.swift
+++ b/app/AgentHubTests/WorktreeCreationTests.swift
@@ -407,6 +407,137 @@ struct MultiSessionLaunchViewModelResetTests {
     #expect(vm.branchNamingStartedAt == nil)
     #expect(vm.branchNamingCompletedAt == nil)
   }
+
+  @Test("reset() clears manual worktree naming state")
+  @MainActor
+  func resetClearsManualWorktreeNamingState() {
+    let vm = makeViewModel()
+    vm.worktreeNamingMode = .manual
+    vm.manualSingleBranchName = "feature/manual"
+    vm.manualSingleDirectoryName = "manual-dir"
+    vm.manualClaudeBranchName = "feature/claude"
+    vm.manualClaudeDirectoryName = "claude-dir"
+    vm.manualCodexBranchName = "feature/codex"
+    vm.manualCodexDirectoryName = "codex-dir"
+
+    vm.reset()
+
+    #expect(vm.worktreeNamingMode == .automatic)
+    #expect(vm.manualSingleBranchName == "")
+    #expect(vm.manualSingleDirectoryName == "")
+    #expect(vm.manualClaudeBranchName == "")
+    #expect(vm.manualClaudeDirectoryName == "")
+    #expect(vm.manualCodexBranchName == "")
+    #expect(vm.manualCodexDirectoryName == "")
+  }
+}
+
+@Suite("MultiSessionLaunchViewModel — manual worktree naming")
+struct MultiSessionLaunchViewModelManualWorktreeNamingTests {
+
+  @Test("Manual naming requires both branch and worktree names")
+  @MainActor
+  func manualNamingRequiresBranchAndDirectory() {
+    let vm = makeViewModel()
+    vm.selectedRepository = SelectedRepository(path: "/repo", name: "repo")
+    vm.workMode = .worktree
+    vm.worktreeNamingMode = .manual
+    vm.isCodexSelected = true
+
+    #expect(vm.isValid == false)
+
+    vm.manualSingleBranchName = "feature/manual-launch"
+    #expect(vm.isValid == false)
+
+    vm.manualSingleDirectoryName = "manual-launch-dir"
+    #expect(vm.isValid == true)
+  }
+
+  @Test("Manual single-provider launch bypasses naming service and uses entered names")
+  @MainActor
+  func manualSingleProviderLaunchUsesEnteredNames() async throws {
+    let repo = try LauncherGitRepoFixture.create()
+    defer { repo.cleanup() }
+
+    let namingService = MockWorktreeBranchNamingService(
+      result: WorktreeBranchNamingResult(
+        single: "feature/should-not-be-used",
+        source: .ai
+      )
+    )
+    let fixture = makeViewModelFixture(namingService: namingService)
+    let viewModel = fixture.viewModel
+    let codexViewModel = fixture.codexViewModel
+
+    viewModel.selectedRepository = SelectedRepository(path: repo.repoPath, name: "repo")
+    await viewModel.loadBranches()
+    viewModel.workMode = .worktree
+    viewModel.worktreeNamingMode = .manual
+    viewModel.isCodexSelected = true
+    viewModel.manualSingleBranchName = "feature/manual-launch"
+    viewModel.manualSingleDirectoryName = "manual-launch-dir"
+
+    await viewModel.launchSessions()
+
+    let requests = await namingService.recordedRequests()
+    #expect(requests.isEmpty)
+
+    #expect(codexViewModel.pendingHubSessions.count == 1)
+    let pending = try #require(codexViewModel.pendingHubSessions.first)
+    #expect(pending.worktree.name == "feature/manual-launch")
+    #expect(URL(fileURLWithPath: pending.worktree.path).lastPathComponent == "manual-launch-dir")
+    #expect(FileManager.default.fileExists(atPath: pending.worktree.path))
+
+    let branch = try repo.runGit("branch", "--show-current", at: pending.worktree.path)
+    #expect(branch == "feature/manual-launch")
+
+    codexViewModel.pendingHubSessions.removeAll()
+  }
+
+  @Test("Manual dual-provider launch uses provider-specific names")
+  @MainActor
+  func manualDualProviderLaunchUsesProviderSpecificNames() async throws {
+    let repo = try LauncherGitRepoFixture.create()
+    defer { repo.cleanup() }
+
+    let namingService = MockWorktreeBranchNamingService(
+      result: WorktreeBranchNamingResult(
+        claude: "feature/should-not-be-used-claude",
+        codex: "feature/should-not-be-used-codex",
+        source: .ai
+      )
+    )
+    let fixture = makeViewModelFixture(namingService: namingService)
+    let viewModel = fixture.viewModel
+    let claudeViewModel = fixture.claudeViewModel
+    let codexViewModel = fixture.codexViewModel
+
+    viewModel.selectedRepository = SelectedRepository(path: repo.repoPath, name: "repo")
+    await viewModel.loadBranches()
+    viewModel.workMode = .worktree
+    viewModel.worktreeNamingMode = .manual
+    viewModel.claudeMode = .enabled
+    viewModel.isCodexSelected = true
+    viewModel.manualClaudeBranchName = "feature/manual-claude"
+    viewModel.manualClaudeDirectoryName = "manual-claude-dir"
+    viewModel.manualCodexBranchName = "feature/manual-codex"
+    viewModel.manualCodexDirectoryName = "manual-codex-dir"
+
+    await viewModel.launchSessions()
+
+    let requests = await namingService.recordedRequests()
+    #expect(requests.isEmpty)
+
+    let claudePending = try #require(claudeViewModel.pendingHubSessions.first)
+    let codexPending = try #require(codexViewModel.pendingHubSessions.first)
+    #expect(claudePending.worktree.name == "feature/manual-claude")
+    #expect(codexPending.worktree.name == "feature/manual-codex")
+    #expect(URL(fileURLWithPath: claudePending.worktree.path).lastPathComponent == "manual-claude-dir")
+    #expect(URL(fileURLWithPath: codexPending.worktree.path).lastPathComponent == "manual-codex-dir")
+
+    claudeViewModel.pendingHubSessions.removeAll()
+    codexViewModel.pendingHubSessions.removeAll()
+  }
 }
 
 @Suite("MultiSessionLaunchViewModel — AI worktree naming")

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiSessionLaunchView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiSessionLaunchView.swift
@@ -84,6 +84,7 @@ public struct MultiSessionLaunchView: View {
 
             if viewModel.selectedRepository != nil {
               workModeRow
+              worktreeNamingSection
             }
           } else {
             // Full order: work mode first, then providers.
@@ -92,6 +93,8 @@ public struct MultiSessionLaunchView: View {
             }
 
             providerPills
+
+            worktreeNamingSection
 
             if viewModel.selectedRepository != nil && viewModel.isClaudeSelected && !viewModel.isCodexSelected && viewModel.workMode == .local {
               worktreeRow
@@ -615,6 +618,166 @@ public struct MultiSessionLaunchView: View {
         .labelsHidden()
         .fixedSize()
       }
+    }
+  }
+
+  // MARK: - Worktree Naming
+
+  @ViewBuilder
+  private var worktreeNamingSection: some View {
+    if viewModel.selectedRepository != nil && viewModel.workMode == .worktree {
+      VStack(alignment: .leading, spacing: 8) {
+        ViewThatFits(in: .horizontal) {
+          HStack(spacing: 10) {
+            worktreeNamingModePicker
+            manualWorktreeNamingFields
+          }
+
+          VStack(alignment: .leading, spacing: 8) {
+            worktreeNamingModePicker
+            manualWorktreeNamingFields
+          }
+        }
+      }
+      .transition(.opacity.combined(with: .move(edge: .top)))
+      .animation(.easeInOut(duration: 0.2), value: viewModel.worktreeNamingMode)
+    }
+  }
+
+  private var worktreeNamingModePicker: some View {
+    HStack(spacing: 8) {
+      Text("Naming")
+        .font(.secondarySmall)
+        .foregroundColor(.secondary)
+
+      BracketedSegmentedControl(
+        selection: worktreeNamingModeSelection,
+        items: worktreeNamingModeItems,
+        selectedColor: Color.brandPrimary
+      )
+      .help("Choose worktree naming mode")
+    }
+    .fixedSize()
+  }
+
+  private var worktreeNamingModeItems: [BracketedSegmentedControlItem<WorktreeNamingMode>] {
+    WorktreeNamingMode.allCases.map { mode in
+      BracketedSegmentedControlItem(
+        value: mode,
+        title: mode.rawValue.lowercased(),
+        helpText: mode.rawValue
+      )
+    }
+  }
+
+  private var worktreeNamingModeSelection: Binding<WorktreeNamingMode> {
+    Binding(
+      get: { viewModel.worktreeNamingMode },
+      set: { newValue in
+        withAnimation(.easeInOut(duration: 0.2)) {
+          viewModel.worktreeNamingMode = newValue
+        }
+      }
+    )
+  }
+
+  @ViewBuilder
+  private var manualWorktreeNamingFields: some View {
+    if viewModel.worktreeNamingMode == .manual {
+      if viewModel.isClaudeSelected && viewModel.isCodexSelected {
+        VStack(alignment: .leading, spacing: 6) {
+          manualWorktreeNamingRow(
+            providerLabel: "Claude",
+            branchName: $viewModel.manualClaudeBranchName,
+            directoryName: $viewModel.manualClaudeDirectoryName
+          )
+          manualWorktreeNamingRow(
+            providerLabel: "Codex",
+            branchName: $viewModel.manualCodexBranchName,
+            directoryName: $viewModel.manualCodexDirectoryName
+          )
+        }
+        .transition(manualNamingFieldsTransition)
+      } else if viewModel.hasAnyProviderSelected {
+        manualWorktreeNamingRow(
+          providerLabel: nil,
+          branchName: $viewModel.manualSingleBranchName,
+          directoryName: $viewModel.manualSingleDirectoryName
+        )
+        .transition(manualNamingFieldsTransition)
+      }
+    }
+  }
+
+  private var manualNamingFieldsTransition: AnyTransition {
+    .asymmetric(
+      insertion: .opacity.combined(with: .move(edge: .leading)),
+      removal: .opacity.combined(with: .move(edge: .leading))
+    )
+  }
+
+  private func manualWorktreeNamingRow(
+    providerLabel: String?,
+    branchName: Binding<String>,
+    directoryName: Binding<String>
+  ) -> some View {
+    ViewThatFits(in: .horizontal) {
+      HStack(spacing: 8) {
+        manualProviderLabel(providerLabel)
+        manualNameField("branch", text: branchName, width: 220)
+        manualNameField("worktree", text: directoryName, width: 170)
+      }
+
+      VStack(alignment: .leading, spacing: 6) {
+        manualProviderLabel(providerLabel)
+        HStack(spacing: 8) {
+          manualNameField("branch", text: branchName, width: 220)
+          manualNameField("worktree", text: directoryName, width: 170)
+        }
+      }
+    }
+    .onChange(of: branchName.wrappedValue) { oldValue, newValue in
+      syncDefaultDirectoryName(
+        directoryName,
+        oldBranchName: oldValue,
+        newBranchName: newValue
+      )
+    }
+  }
+
+  @ViewBuilder
+  private func manualProviderLabel(_ label: String?) -> some View {
+    if let label {
+      Text(label)
+        .font(.secondarySmall)
+        .foregroundColor(.secondary)
+        .frame(width: 44, alignment: .trailing)
+    }
+  }
+
+  private func manualNameField(_ placeholder: String, text: Binding<String>, width: CGFloat) -> some View {
+    TextField(placeholder, text: text)
+      .font(.system(size: 11))
+      .textFieldStyle(.plain)
+      .padding(.horizontal, 10)
+      .padding(.vertical, 5)
+      .background(
+        RoundedRectangle(cornerRadius: 6)
+          .fill(Color.primary.opacity(0.05))
+      )
+      .frame(width: width)
+  }
+
+  private func syncDefaultDirectoryName(
+    _ directoryName: Binding<String>,
+    oldBranchName: String,
+    newBranchName: String
+  ) {
+    let currentDirectory = directoryName.wrappedValue.trimmingCharacters(in: .whitespacesAndNewlines)
+    let oldDefault = viewModel.directoryName(for: oldBranchName)
+
+    if currentDirectory.isEmpty || currentDirectory == oldDefault {
+      directoryName.wrappedValue = viewModel.directoryName(for: newBranchName)
     }
   }
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/MultiSessionLaunchViewModel.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/MultiSessionLaunchViewModel.swift
@@ -23,6 +23,13 @@ public enum WorkMode: String, CaseIterable, Sendable {
   case worktree = "Worktree"
 }
 
+// MARK: - WorktreeNamingMode
+
+public enum WorktreeNamingMode: String, CaseIterable, Sendable, Hashable {
+  case automatic = "Default"
+  case manual = "Manual"
+}
+
 // MARK: - ClaudeMode
 
 public enum ClaudeMode: CaseIterable, Sendable {
@@ -107,6 +114,11 @@ public final class MultiSessionLaunchViewModel {
     let startedAt: Date
   }
 
+  private struct WorktreeLaunchNames {
+    let branchName: String
+    let directoryName: String
+  }
+
   // MARK: - Dependencies
 
   private let claudeViewModel: CLISessionsViewModel
@@ -123,6 +135,7 @@ public final class MultiSessionLaunchViewModel {
 
   public var launchMode: LaunchMode = .manual
   public var workMode: WorkMode = .local
+  public var worktreeNamingMode: WorktreeNamingMode = .automatic
   public var claudeMode: ClaudeMode = .disabled
   public var claudeUseWorktree: Bool = false
   public var claudeWorktreeName: String = ""
@@ -133,6 +146,12 @@ public final class MultiSessionLaunchViewModel {
   public var claudeBranchName: String = ""
   public var codexBranchName: String = ""
   public var singleBranchName: String = ""
+  public var manualSingleBranchName: String = ""
+  public var manualSingleDirectoryName: String = ""
+  public var manualClaudeBranchName: String = ""
+  public var manualClaudeDirectoryName: String = ""
+  public var manualCodexBranchName: String = ""
+  public var manualCodexDirectoryName: String = ""
   public var baseBranch: RemoteBranch?
   public var selectedRepository: SelectedRepository?
 
@@ -199,11 +218,16 @@ public final class MultiSessionLaunchViewModel {
     let hasRepo = selectedRepository != nil
     switch launchMode {
     case .manual:
-      return hasRepo && hasAnyProviderSelected
+      return hasRepo && hasAnyProviderSelected && manualWorktreeNamingIsValid
     case .smart:
       let hasPrompt = !sharedPrompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
       return hasRepo && hasPrompt
     }
+  }
+
+  public var manualWorktreeNamingIsValid: Bool {
+    guard workMode == .worktree && worktreeNamingMode == .manual else { return true }
+    return validateManualWorktreeNames(for: selectedProviders)
   }
 
   // MARK: - Init
@@ -433,24 +457,37 @@ public final class MultiSessionLaunchViewModel {
       try await launchLocalSessions(initialPrompt: initialPrompt, initialInputText: initialInputText, repoPath: repoPath)
     case .worktree:
       let providers = selectedProviders
+      let worktreeNamingModeName = worktreeNamingMode.rawValue
       AppLogger.intelligence.info(
-        "\(Self.aiWorktreeLogPrefix, privacy: .public) Entering launcher worktree naming flow for providers=\(providers.map(\.rawValue).joined(separator: ","), privacy: .public)"
+        "\(Self.aiWorktreeLogPrefix, privacy: .public) Entering launcher worktree naming flow for providers=\(providers.map(\.rawValue).joined(separator: ","), privacy: .public) mode=\(worktreeNamingModeName, privacy: .public)"
       )
-      let namingResult = try await resolveGeneratedBranchNames(
-        for: repo,
-        launchContext: .manualWorktree,
-        promptText: trimmedPrompt,
-        providerKinds: providers
-      )
-      applyResolvedBranchNames(namingResult)
-      guard validateResolvedBranchNames(for: providers) else {
-        AppLogger.intelligence.error(
-          "\(Self.aiWorktreeLogPrefix, privacy: .public) Worktree naming completed without usable branch names"
+      switch worktreeNamingMode {
+      case .automatic:
+        let namingResult = try await resolveGeneratedBranchNames(
+          for: repo,
+          launchContext: .manualWorktree,
+          promptText: trimmedPrompt,
+          providerKinds: providers
         )
-        applyBranchNamingProgress(.failed(message: "AgentHub could not resolve a usable branch name"))
-        launchError = "Failed to resolve worktree branch names."
-        isLaunching = false
-        return
+        applyResolvedBranchNames(namingResult)
+        guard validateResolvedBranchNames(for: providers) else {
+          AppLogger.intelligence.error(
+            "\(Self.aiWorktreeLogPrefix, privacy: .public) Worktree naming completed without usable branch names"
+          )
+          applyBranchNamingProgress(.failed(message: "AgentHub could not resolve a usable branch name"))
+          launchError = "Failed to resolve worktree branch names."
+          isLaunching = false
+          return
+        }
+      case .manual:
+        guard applyManualWorktreeNames(for: providers) else {
+          AppLogger.intelligence.error(
+            "\(Self.aiWorktreeLogPrefix, privacy: .public) Manual worktree naming missing required names"
+          )
+          launchError = "Enter branch and worktree names before launching."
+          isLaunching = false
+          return
+        }
       }
 
       if providers.count > 1 {
@@ -464,6 +501,7 @@ public final class MultiSessionLaunchViewModel {
             repoPath: repoPath,
             branchName: singleBranchName,
             viewModel: claudeViewModel,
+            providerKind: .claude,
             providerLabel: SessionProviderKind.claude.rawValue,
             dangerouslySkipPermissions: claudeMode.dangerouslySkipPermissions,
             permissionModePlan: isPlanModeEnabled,
@@ -476,6 +514,7 @@ public final class MultiSessionLaunchViewModel {
             repoPath: repoPath,
             branchName: singleBranchName,
             viewModel: codexViewModel,
+            providerKind: .codex,
             providerLabel: SessionProviderKind.codex.rawValue,
             permissionModePlan: isPlanModeEnabled,
             progressKeyPath: \.codexProgress
@@ -780,9 +819,16 @@ public final class MultiSessionLaunchViewModel {
     currentBranchName = ""
     launchMode = .manual
     workMode = .local
+    worktreeNamingMode = .automatic
     claudeMode = .disabled
     claudeUseWorktree = false
     claudeWorktreeName = ""
+    manualSingleBranchName = ""
+    manualSingleDirectoryName = ""
+    manualClaudeBranchName = ""
+    manualClaudeDirectoryName = ""
+    manualCodexBranchName = ""
+    manualCodexDirectoryName = ""
     isCodexSelected = false
     isPlanModeEnabled = false
     playedWorktreeSuccessPaths.removeAll()
@@ -863,7 +909,7 @@ public final class MultiSessionLaunchViewModel {
     // 1. Create Claude worktree
     var claudeWorktreePath: String?
     do {
-      let dirName = directoryName(for: claudeBranchName)
+      let dirName = directoryNameForLaunch(branchName: claudeBranchName, provider: .claude)
       claudeWorktreePath = try await createWorktreeForLaunch(
         providerLabel: SessionProviderKind.claude.rawValue,
         repoPath: repoPath,
@@ -884,7 +930,7 @@ public final class MultiSessionLaunchViewModel {
     // 2. Create Codex worktree
     var codexWorktreePath: String?
     do {
-      let dirName = directoryName(for: codexBranchName)
+      let dirName = directoryNameForLaunch(branchName: codexBranchName, provider: .codex)
       codexWorktreePath = try await createWorktreeForLaunch(
         providerLabel: SessionProviderKind.codex.rawValue,
         repoPath: repoPath,
@@ -943,6 +989,7 @@ public final class MultiSessionLaunchViewModel {
     repoPath: String,
     branchName: String,
     viewModel: CLISessionsViewModel,
+    providerKind: SessionProviderKind,
     providerLabel: String,
     dangerouslySkipPermissions: Bool = false,
     permissionModePlan: Bool = false,
@@ -954,7 +1001,7 @@ public final class MultiSessionLaunchViewModel {
 
     var worktreePath: String?
     do {
-      let dirName = directoryName(for: branchName)
+      let dirName = directoryNameForLaunch(branchName: branchName, provider: providerKind)
       worktreePath = try await createWorktreeForLaunch(
         providerLabel: providerLabel,
         repoPath: repoPath,
@@ -1074,6 +1121,30 @@ public final class MultiSessionLaunchViewModel {
     )
   }
 
+  private func applyManualWorktreeNames(for providers: [SessionProviderKind]) -> Bool {
+    guard validateManualWorktreeNames(for: providers) else { return false }
+
+    if providers.count > 1 {
+      singleBranchName = ""
+      claudeBranchName = manualNames(for: .claude, providerCount: providers.count)?.branchName ?? ""
+      codexBranchName = manualNames(for: .codex, providerCount: providers.count)?.branchName ?? ""
+    } else if let provider = providers.first,
+              let names = manualNames(for: provider, providerCount: providers.count) {
+      singleBranchName = names.branchName
+      claudeBranchName = ""
+      codexBranchName = ""
+    }
+
+    resetBranchNamingProgress()
+    let appliedSingle = singleBranchName
+    let appliedClaude = claudeBranchName
+    let appliedCodex = codexBranchName
+    AppLogger.intelligence.info(
+      "\(Self.aiWorktreeLogPrefix, privacy: .public) Applied manual worktree names single=\(appliedSingle, privacy: .public) claude=\(appliedClaude, privacy: .public) codex=\(appliedCodex, privacy: .public)"
+    )
+    return true
+  }
+
   private func validateResolvedBranchNames(for providers: [SessionProviderKind]) -> Bool {
     if providers.count > 1 {
       return (!claudeBranchName.isEmpty || !codexBranchName.isEmpty)
@@ -1081,6 +1152,51 @@ public final class MultiSessionLaunchViewModel {
         && (!providers.contains(.codex) || !codexBranchName.isEmpty)
     }
     return !singleBranchName.isEmpty
+  }
+
+  private func validateManualWorktreeNames(for providers: [SessionProviderKind]) -> Bool {
+    guard !providers.isEmpty else { return false }
+    return providers.allSatisfy { provider in
+      guard let names = manualNames(for: provider, providerCount: providers.count) else { return false }
+      return !names.branchName.isEmpty && !names.directoryName.isEmpty
+    }
+  }
+
+  private func manualNames(for provider: SessionProviderKind, providerCount: Int) -> WorktreeLaunchNames? {
+    let branchName: String
+    let directoryName: String
+
+    if providerCount > 1 {
+      switch provider {
+      case .claude:
+        branchName = Self.trimmed(manualClaudeBranchName)
+        directoryName = Self.trimmed(manualClaudeDirectoryName)
+      case .codex:
+        branchName = Self.trimmed(manualCodexBranchName)
+        directoryName = Self.trimmed(manualCodexDirectoryName)
+      }
+    } else {
+      branchName = Self.trimmed(manualSingleBranchName)
+      directoryName = Self.trimmed(manualSingleDirectoryName)
+    }
+
+    guard !branchName.isEmpty || !directoryName.isEmpty else { return nil }
+    return WorktreeLaunchNames(branchName: branchName, directoryName: directoryName)
+  }
+
+  private func directoryNameForLaunch(branchName: String, provider: SessionProviderKind) -> String {
+    if workMode == .worktree,
+       worktreeNamingMode == .manual,
+       let names = manualNames(for: provider, providerCount: selectedProviders.count),
+       !names.directoryName.isEmpty {
+      return names.directoryName
+    }
+
+    return directoryName(for: branchName)
+  }
+
+  private static func trimmed(_ value: String) -> String {
+    value.trimmingCharacters(in: .whitespacesAndNewlines)
   }
 
   private func applyBranchNamingProgress(_ progress: WorktreeBranchNamingProgress) {


### PR DESCRIPTION
## Summary

Adds a worktree naming mode control to the Start Session flow so users can keep the existing default naming behavior or switch to manual branch and worktree directory names.

## Changes

- Adds `WorktreeNamingMode` and manual branch/directory state to the multi-session launch view model.
- Keeps default AI-generated naming as the default path, while manual mode bypasses the naming service and validates explicit names before launch.
- Adds the bracketed segmented control UI used by the terminal/files/diffs tabs, plus animated transitions for the manual naming fields.
- Covers reset behavior, validation, and single/dual-provider manual worktree launches in tests.

## Validation

- `git diff --check`
- `xcodebuild -workspace app/AgentHub.xcodeproj/project.xcworkspace -scheme AgentHub -destination 'platform=macOS' build`

The build command exited successfully and reported `** BUILD SUCCEEDED **`; Xcode also printed non-fatal external package SwiftLint summary lines for CodeEdit packages.