### PR TITLE
[codex] Fix Codex approval mode mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ The Claude tool lists in Settings accept either comma-separated values or one pa
 AgentHub maps Codex defaults to the current interactive CLI flags:
 
 - `Model` → `--model <model>`
-- `Approval` → `-a untrusted|on-request|never` or `--full-auto`
+- `Approval` → `-a untrusted|on-request|never`; `Full-Auto` maps to `--sandbox workspace-write`
 - `Effort` → `-c model_reasoning_effort="low|medium|high|xhigh"`
 
 These mappings are verified in unit tests against the current CLI surface exposed by `codex --help` and `claude --help`.

--- a/app/modules/AgentHubCore/Sources/AgentHub/Configuration/CLICommandConfiguration.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Configuration/CLICommandConfiguration.swift
@@ -125,7 +125,7 @@ public struct CLICommandConfiguration: Codable, Sendable {
       if let codexApprovalPolicy {
         switch codexApprovalPolicy {
         case "full-auto":
-          args.append("--full-auto")
+          args += ["--sandbox", "workspace-write"]
         case "untrusted", "on-request", "never":
           args += ["-a", codexApprovalPolicy]
         default:

--- a/app/modules/AgentHubCore/Sources/AgentHub/Models/AIConfigRecord.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Models/AIConfigRecord.swift
@@ -23,7 +23,8 @@ public struct AIConfigRecord: Codable, Sendable, FetchableRecord, PersistableRec
   public var allowedTools: String
   /// Comma-separated disallowed tool patterns, Claude only
   public var disallowedTools: String
-  /// Codex approval policy: "untrusted", "on-request", "never", or "full-auto" (empty = CLI default)
+  /// Codex approval policy: "untrusted", "on-request", "never", or "full-auto" (empty = CLI default).
+  /// "full-auto" is AgentHub's compatibility value for Codex workspace-write sandbox mode.
   public var approvalPolicy: String
   /// Last update timestamp
   public var updatedAt: Date

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/AIConfigSettingsView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/AIConfigSettingsView.swift
@@ -21,6 +21,10 @@ public final class AIConfigSettingsViewModel {
   var codexApprovalPolicy: String = ""
   var codexReasoningEffort: String = ""
 
+  var codexApprovalPolicyDescription: String {
+    Self.codexApprovalPolicyDescription(for: codexApprovalPolicy)
+  }
+
   @ObservationIgnored private var aiConfigService: (any AIConfigServiceProtocol)?
   @ObservationIgnored
   private var isLoaded = false
@@ -74,6 +78,21 @@ public final class AIConfigSettingsViewModel {
       value
     default:
       ""
+    }
+  }
+
+  static func codexApprovalPolicyDescription(for value: String) -> String {
+    switch sanitizedCodexApprovalPolicy(value) {
+    case "untrusted":
+      "Only trusted commands run automatically. Other commands ask before running."
+    case "on-request":
+      "Codex decides when to ask before running commands."
+    case "never":
+      "Codex never asks before running commands; failures are returned immediately."
+    case "full-auto":
+      "Runs with Codex workspace-write sandbox: can edit this workspace, but this is not Full Access."
+    default:
+      "Uses the installed Codex CLI defaults for approval and sandbox behavior."
     }
   }
 }
@@ -163,6 +182,12 @@ struct CodexAIConfigView: View {
         .labelsHidden()
         .onChange(of: viewModel.codexApprovalPolicy) { viewModel.saveCodex() }
         .frame(maxWidth: 220, alignment: .leading)
+
+        Text(viewModel.codexApprovalPolicyDescription)
+          .font(.caption2)
+          .foregroundStyle(.secondary)
+          .fixedSize(horizontal: false, vertical: true)
+          .frame(maxWidth: 420, alignment: .leading)
       }
 
       settingsField("Effort") {

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/AIConfigSettingsTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/AIConfigSettingsTests.swift
@@ -118,7 +118,7 @@ struct CodexAIConfigArgumentTests {
     #expect(args[idx! + 1] == "on-request")
   }
 
-  @Test("Passes full-auto flag for Codex")
+  @Test("Maps Codex full-auto setting to workspace-write sandbox")
   func fullAutoFlag() {
     let args = config.argumentsForSession(
       sessionId: nil,
@@ -126,7 +126,10 @@ struct CodexAIConfigArgumentTests {
       codexApprovalPolicy: "full-auto"
     )
 
-    #expect(args.contains("--full-auto"))
+    let sandboxIdx = args.firstIndex(of: "--sandbox")
+    #expect(sandboxIdx != nil)
+    #expect(args[sandboxIdx! + 1] == "workspace-write")
+    #expect(!args.contains("--full-auto"))
     #expect(!args.contains("-a"))
   }
 
@@ -140,6 +143,7 @@ struct CodexAIConfigArgumentTests {
 
     #expect(!args.contains("-a"))
     #expect(!args.contains("--full-auto"))
+    #expect(!args.contains("--sandbox"))
   }
 
   @Test("Passes reasoning effort via config override for new Codex session")
@@ -180,6 +184,7 @@ struct CodexAIConfigArgumentTests {
     #expect(!args.contains("--model"))
     #expect(!args.contains("-a"))
     #expect(!args.contains("--full-auto"))
+    #expect(!args.contains("--sandbox"))
     #expect(args.contains("resume"))
     #expect(args.contains("session-1"))
   }
@@ -390,6 +395,31 @@ struct AIConfigSettingsViewModelTests {
     await viewModel.load(service: service)
 
     #expect(viewModel.codexApprovalPolicy.isEmpty)
+  }
+
+  @Test("Codex approval policy descriptions explain each launch mode")
+  @MainActor
+  func codexApprovalPolicyDescriptions() {
+    let viewModel = AIConfigSettingsViewModel()
+
+    viewModel.codexApprovalPolicy = ""
+    #expect(viewModel.codexApprovalPolicyDescription.contains("CLI defaults"))
+
+    viewModel.codexApprovalPolicy = "untrusted"
+    #expect(viewModel.codexApprovalPolicyDescription.contains("trusted commands"))
+
+    viewModel.codexApprovalPolicy = "on-request"
+    #expect(viewModel.codexApprovalPolicyDescription.contains("Codex decides"))
+
+    viewModel.codexApprovalPolicy = "never"
+    #expect(viewModel.codexApprovalPolicyDescription.contains("never asks"))
+
+    viewModel.codexApprovalPolicy = "full-auto"
+    #expect(viewModel.codexApprovalPolicyDescription.contains("workspace-write sandbox"))
+    #expect(viewModel.codexApprovalPolicyDescription.contains("not Full Access"))
+
+    viewModel.codexApprovalPolicy = "suggest"
+    #expect(viewModel.codexApprovalPolicyDescription.contains("CLI defaults"))
   }
 }
 


### PR DESCRIPTION
## Summary

- Map AgentHub's Codex `Full-Auto` setting to the current `--sandbox workspace-write` CLI flag instead of removed `--full-auto`.
- Add a visible explanation under the Codex approval picker for each selected mode, including that `Full-Auto` is not Full Access.
- Update tests and README documentation for the new mapping.

## Root Cause

Codex CLI 0.130.0 no longer accepts `--full-auto` for interactive launches. AgentHub still emitted that flag when the saved Codex approval policy was `full-auto`, causing new sessions to fail at argument parsing.

## Validation

- `codex --sandbox workspace-write --version`
- `xcodebuild build -project app/AgentHub.xcodeproj -scheme AgentHub -destination 'platform=macOS'`

## Notes

Targeted test execution is currently blocked by project setup: the Xcode schemes are not configured for the test action, and direct `swift test` fails before these tests on the existing `CodeEditSymbols` `Bundle.module` issue.