### PR TITLE
[codex] Add GitHub PR observation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,6 +81,19 @@ protocol SessionSearchServiceProtocol {
 
 Storybook-enabled projects swap the Preview button for a Storybook button (never both). `WebPreviewMode { .app, .storybook }` routes the preview pane; the storybook server runs at compound key `"{sessionId}:storybook"` in `DevServerManager` so it coexists with the primary app server. Read **Storybook** in `README.md` before editing this area.
 
+## GitHub PR/CI Observation
+
+Read `GitHubMonitor.md` before editing GitHub PR/check observation, session-row GitHub state, GitHub panel refresh behavior, or related tests.
+
+Key invariants:
+
+- Shared GitHub PR/check observation lives in `AgentHubGitHub` behind `GitHubPRObservationServiceProtocol`; UI code should consume the protocol rather than starting per-view polling loops.
+- `AgentHubProvider.gitHubPRObservationService` is the shared service used by the GitHub panel, monitoring cards, and side-panel session rows.
+- Session rows must stay quiet when the current branch has no PR. Only render compact row GitHub state when a `currentBranchPR` exists.
+- Preserve launch performance: initial GitHub refresh work must remain delayed, bounded, activity-driven, or manually triggered.
+- Keep no-PR CLI output non-fatal. GitHub CLI's "no pull requests found for branch ..." response maps to a nil PR, not a row-level error.
+- Changes to polling cadence, target deduplication, no-PR parsing, row visibility, or refresh behavior need focused unit tests in `AgentHubGitHubTests` or matching UI/view-model tests.
+
 ## Claude Code Approval Hook Invariants
 
 AgentHub installs Claude Code hooks to surface pending approvals in real time (see `CLAUDE.md` → "Approval Detection"). `PermissionRequest` is the only hook event that represents a real pending approval; `PreToolUse` is only an observed tool/mode signal used to track dynamic permission-mode changes. When modifying `ClaudeHookInstaller`, `ClaudeHookSidecarWatcher`, `SessionFileWatcher`, `ApprovalClaimStore`, or `HookPendingStalenessFilter`, these invariants must hold:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -282,6 +282,12 @@ Claude Code buffers `tool_use` blocks until the turn commits, so JSONL alone can
 
 **Invariants when editing this area:** only `.claude/settings.local.json` is ever written inside a user's repo (never `.claude/hooks/`, never `.gitignore`); our merge identifies its own entry by the absolute script path; launch reconcile and terminate flush both block on a semaphore so AppKit can't kill cleanup mid-flight.
 
+## GitHub PR/CI Observation
+
+GitHub PR/check monitoring is documented in `GitHubMonitor.md`. Read that file before changing `GitHubPRObservationService`, `GitHubViewModel` observation paths, `SessionGitHubQuickAccessViewModel`, session-row GitHub status, or sidebar refresh behavior.
+
+The short version: GitHub observation is a shared actor service in `AgentHubGitHub`, injected through `AgentHubProvider.gitHubPRObservationService`. UI surfaces subscribe to target snapshots instead of polling independently. Current-branch rows only render GitHub state when a PR exists; no-PR branches should remain visually quiet. Initial refresh is delayed and bounded so GitHub checks do not affect app launch time.
+
 ## Important Patterns
 
 - File watchers use byte-offset tracking to read only new JSONL lines (never re-read entire files)

--- a/GitHubMonitor.md
+++ b/GitHubMonitor.md
@@ -1,0 +1,130 @@
+# GitHub PR/CI Monitor
+
+AgentHub observes GitHub pull request state and CI checks through a shared service in the `AgentHubGitHub` module. The goal is to let multiple UI surfaces show current PR/check state without each surface starting its own `gh` polling loop.
+
+## User Behavior
+
+- GitHub monitoring is optional and only works when the GitHub CLI (`gh`) is installed, authenticated, and the session project is a GitHub repository.
+- Session rows show GitHub status only when the current session branch has a pull request. Branches with no PR stay visually quiet.
+- When a PR exists, the side-panel session row shows a compact bottom line with PR state and CI summary, for example `Draft PR #20 - CI passing 1/1`.
+- Monitoring cards can expose the current branch PR as quick access.
+- The GitHub panel observes the current branch PR and the selected PR detail/check state.
+- The side panel refresh button forces a refresh for the visible session branch targets.
+
+## Architecture
+
+The shared service is `GitHubPRObservationService`, an actor that implements `GitHubPRObservationServiceProtocol`.
+
+Core types:
+
+- `GitHubPRObservationTarget`
+  - `.currentBranch(projectPath:branchName:)`
+  - `.pullRequest(projectPath:number:)`
+- `GitHubPRObservationSnapshot`
+  - target
+  - optional pull request
+  - check runs
+  - derived `GitHubCISummary`
+  - observation state
+  - last refresh date
+- `GitHubPRObservationState`
+  - `.idle`
+  - `.refreshing`
+  - `.ready`
+  - `.error(String)`
+  - `.paused(String)`
+
+The service is injected from `AgentHubProvider` as `gitHubPRObservationService`, alongside the regular `gitHubService`.
+
+Consumers subscribe with `AsyncStream<GitHubPRObservationSnapshot>`. Subscriptions are keyed by target, so multiple surfaces watching the same repository branch or PR share one fetch/poll loop.
+
+## Data Flow
+
+```
+SwiftUI surface
+  -> SessionGitHubQuickAccessViewModel or GitHubViewModel
+  -> GitHubPRObservationService.subscribe(...)
+  -> GitHubCLIService
+  -> gh CLI
+  -> GitHubPRObservationSnapshot
+  -> SwiftUI state update
+```
+
+For current-branch targets, the service calls:
+
+1. `getCurrentBranchPR(at:)`
+2. `getChecks(prNumber:at:)` only if a PR exists
+
+For explicit PR targets, the service fetches PR metadata and checks concurrently.
+
+`GitHubCLIService.getCurrentBranchPR(at:)` treats GitHub CLI's "no pull requests found for branch ..." response as a valid no-PR result, not as a UI error.
+
+## Polling And Performance
+
+Default observation configuration:
+
+- Pending checks or no discovered PR: refresh every 30 seconds while active
+- Settled PR checks: refresh every 120 seconds while active
+- Idle timeout: stop automatic polling after 5 minutes without session activity
+- Transient error backoff: 60 seconds, 120 seconds, then 300 seconds
+
+Performance rules:
+
+- The service only polls targets with active subscribers.
+- Unsubscribing the last subscriber cancels the scheduled polling task for that target.
+- Multiple subscribers for the same target share one snapshot and one scheduled refresh.
+- If a refresh is already running, additional activity is coalesced and evaluated after the current refresh finishes.
+- Terminal setup errors (`gh` missing, unauthenticated, not a git repository, no remote) pause automatic polling until new activity or a manual refresh reactivates the target.
+- Session row subscriptions can opt out of immediate fetches with `refreshOnSubscribe: false`; activity timestamps decide whether observation should start.
+- Initial sidebar refresh is delayed until after launch and limited to a small batch so GitHub state does not block app startup.
+- Manual refresh walks the current branch targets sequentially with a short delay between targets to avoid a burst of `gh` processes.
+
+## UI Integration
+
+`SessionGitHubQuickAccessViewModel` is the lightweight row/card adapter. It can use:
+
+- `GitHubPRObservationServiceProtocol` for shared PR/check observation
+- `SessionGitHubQuickAccessCoordinatorProtocol` as a legacy PR-only shared source
+- direct `GitHubCLIServiceProtocol` fallback when no shared source is available
+
+`CollapsibleSessionRow` subscribes to current-branch observation through the shared service. It starts with a small per-session stagger, records session activity, and stops polling on disappear. The GitHub row renders only when `currentBranchPR` is non-nil.
+
+`MonitoringCardView` uses the same quick-access view model for current branch PR access in the full session card.
+
+`GitHubViewModel` subscribes to:
+
+- the current branch target during panel setup
+- the selected PR target while a PR detail view is active
+
+The selected PR observation keeps PR metadata and CI checks fresh without reloading slower diff/file/comment payloads on every check update.
+
+`MultiProviderSessionsListView` owns the sidebar refresh behavior. It gathers unique current-branch targets from selected sessions, schedules a delayed initial refresh, and exposes a manual refresh action in the sessions header.
+
+## Testing
+
+Tests cover:
+
+- target subscription deduplication
+- deferred initial fetch until recent activity
+- faster cadence for pending checks
+- slower cadence for settled checks
+- terminal error pause/reactivation
+- cancellation when the last subscriber unsubscribes
+- view model propagation of observed PR/check snapshots
+- no-PR CLI output parsing
+
+Relevant test files:
+
+- `app/modules/AgentHubGitHub/Tests/AgentHubGitHubTests/GitHubPRObservationServiceTests.swift`
+- `app/modules/AgentHubGitHub/Tests/AgentHubGitHubTests/SessionGitHubQuickAccessViewModelTests.swift`
+- `app/modules/AgentHubGitHub/Tests/AgentHubGitHubTests/GitHubViewModelObservationTests.swift`
+- `app/modules/AgentHubGitHub/Tests/AgentHubGitHubTests/GitHubCLIServiceTests.swift`
+
+## Editing Guidelines
+
+- Keep GitHub observation in `AgentHubGitHub`; UI modules should consume `GitHubPRObservationServiceProtocol`.
+- Do not create per-view polling loops when a shared observation target can be reused.
+- Preserve launch performance: new GitHub refresh work must be delayed, activity-driven, or manually triggered.
+- Do not show no-PR states in compact session rows.
+- Keep `gh` errors non-fatal for session rows; rows should fail quiet unless a PR is already known.
+- Add or update unit tests when changing polling cadence, no-PR parsing, target deduplication, or UI visibility rules.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ https://github.com/user-attachments/assets/ee453a78-e417-488a-96c7-20732d1d1f60
 - **Auxiliary Hub shell** — Toggle a session-scoped shell dock from the Hub with **Cmd+J**; it follows the selected session's worktree and preserves shell state per session
 - **Resizable list cards** — In list mode, monitoring cards can be resized with a preview guide for a smoother, less distracting resize experience
 - **Inline diff review** — Full split-pane diff view with inline editor to send change requests directly to Claude
-- **GitHub support** — Browse pull requests and issues for the current repository, inspect PR diffs and CI checks, and send GitHub context back into a session
+- **GitHub support** — Browse pull requests and issues for the current repository, inspect PR diffs and CI checks, monitor current-branch PR status from session rows, and send GitHub context back into a session
 - **File explorer and built-in editor** — Browse the project tree, jump to files with Cmd+P, edit files in-app with syntax highlighting, and save changes without leaving AgentHub
 - **Git worktree management** — Create and delete worktrees from the UI; launch sessions on new branches
 - **Remix with provider picker** — Branch any session into an isolated git worktree and continue it in Claude or Codex; the original session's transcript is passed as context to the new session
@@ -72,9 +72,17 @@ AgentHub can surface repository GitHub data directly inside the app through the 
 
 - Browse pull requests and issues for the active repository
 - Open the current branch PR directly from the session card
+- See current-branch PR state and CI status on active session rows when a PR exists
+- Force-refresh GitHub PR/CI state from the session list header
 - Review PR overview content, changed files, CI checks, and comments
 - Render PR file diffs with the same inline diff viewer used elsewhere in AgentHub
 - Send PR or issue context back into the active Claude Code or Codex session
+
+### GitHub Monitoring
+
+AgentHub can monitor the current branch PR for each visible session and show its PR state plus CI summary in the session row. Branches with no pull request stay quiet, so the list only adds GitHub context when there is something actionable to show.
+
+Monitoring is designed to avoid slowing down launch: initial GitHub refresh work is delayed after the app appears, session rows observe through a shared service, and the refresh button in the session list header can force an update whenever you want fresh GitHub state.
 
 ### GitHub Setup
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubProvider.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubProvider.swift
@@ -177,6 +177,11 @@ public final class AgentHubProvider {
     SessionGitHubQuickAccessCoordinator(service: gitHubService)
   }()
 
+  /// Shared GitHub PR/check observation service for panels and session rows
+  public private(set) lazy var gitHubPRObservationService: any GitHubPRObservationServiceProtocol = {
+    GitHubPRObservationService(service: gitHubService)
+  }()
+
   // MARK: - Theme Management
 
   /// Theme manager for YAML and built-in themes

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/CollapsibleSessionRow.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/CollapsibleSessionRow.swift
@@ -1,3 +1,4 @@
+import AgentHubGitHub
 import SwiftUI
 
 // MARK: - CollapsibleSessionRow
@@ -22,6 +23,8 @@ struct CollapsibleSessionRow: View {
   @State private var showArchiveConfirm = false
   @State private var pulseScale: CGFloat = 1.0
   @State private var isPulseAnimating = false
+  @State private var sessionGitHubQuickAccessViewModel = SessionGitHubQuickAccessViewModel()
+  @Environment(\.agentHub) private var agentHub
 
   // MARK: - Computed
 
@@ -62,6 +65,21 @@ struct CollapsibleSessionRow: View {
 
   private var showActions: Bool {
     isHovered && !isPending && (onPin != nil || onArchive != nil || onDeleteWorktree != nil)
+  }
+
+  private var gitHubObservationTaskID: String {
+    let repositoryKey = SessionGitHubQuickAccessViewModel.repositoryKey(
+      projectPath: session.projectPath,
+      branchName: session.branchName
+    )
+    return "\(repositoryKey)|\(isPending)|\(agentHub != nil)"
+  }
+
+  private var observationStartupDelayMilliseconds: Int {
+    let bucket = session.id.unicodeScalars.reduce(0) { partialResult, scalar in
+      (partialResult + Int(scalar.value)) % 1_500
+    }
+    return 250 + bucket
   }
 
   // MARK: - Body
@@ -121,6 +139,15 @@ struct CollapsibleSessionRow: View {
             .opacity(showActions ? 1 : 0)
             .animation(.easeInOut(duration: 0.25), value: showActions)
         }
+
+        if let pullRequest = sessionGitHubQuickAccessViewModel.currentBranchPR {
+          GitHubSessionRowStatusLine(
+            pullRequest: pullRequest,
+            summary: sessionGitHubQuickAccessViewModel.ciSummary,
+            observationState: sessionGitHubQuickAccessViewModel.observationState
+          )
+          .transition(.opacity)
+        }
       }
     }
     .padding(.horizontal, 10)
@@ -145,6 +172,17 @@ struct CollapsibleSessionRow: View {
     .onAppear { startPulseAnimation() }
     .onChange(of: sessionStatus) { _, _ in startPulseAnimation() }
     .onChange(of: isPending) { _, _ in startPulseAnimation() }
+    .task(id: gitHubObservationTaskID) {
+      await observeGitHubIfAvailable()
+    }
+    .onDisappear {
+      sessionGitHubQuickAccessViewModel.stopPolling()
+    }
+    .onChange(of: timestamp) { _, newValue in
+      Task {
+        await sessionGitHubQuickAccessViewModel.notifySessionActivity(at: newValue)
+      }
+    }
   }
 
   @ViewBuilder
@@ -267,6 +305,185 @@ struct CollapsibleSessionRow: View {
       .repeatForever(autoreverses: true)
     ) {
       pulseScale = 1.4
+    }
+  }
+
+  private func observeGitHubIfAvailable() async {
+    guard !isPending, let observationService = agentHub?.gitHubPRObservationService else {
+      sessionGitHubQuickAccessViewModel.stopPolling()
+      return
+    }
+
+    try? await Task.sleep(for: .milliseconds(observationStartupDelayMilliseconds))
+    guard !Task.isCancelled else { return }
+
+    await sessionGitHubQuickAccessViewModel.load(
+      projectPath: session.projectPath,
+      branchName: session.branchName,
+      observationService: observationService,
+      refreshOnSubscribe: false,
+      recordInitialActivity: false
+    )
+    await sessionGitHubQuickAccessViewModel.notifySessionActivity(at: timestamp)
+  }
+}
+
+// MARK: - GitHubSessionRowStatusLine
+
+private struct GitHubSessionRowStatusLine: View {
+  let pullRequest: GitHubPullRequest
+  let summary: GitHubCISummary
+  let observationState: GitHubPRObservationState
+
+  var body: some View {
+    HStack(spacing: 5) {
+      Image(systemName: primaryIcon)
+        .font(.system(size: 10, weight: .semibold))
+        .foregroundStyle(primaryColor)
+        .frame(width: 12, height: 12)
+
+      Text(primaryText)
+        .font(.geist(size: 10, weight: .medium))
+        .foregroundColor(.secondary.opacity(0.95))
+
+      if let secondaryText {
+        Text("·")
+          .font(.secondaryCaption)
+          .foregroundColor(.secondary.opacity(0.55))
+
+        Image(systemName: secondaryIcon)
+          .font(.system(size: 9, weight: .semibold))
+          .foregroundStyle(secondaryColor)
+          .frame(width: 11, height: 11)
+
+        Text(secondaryText)
+          .font(.secondaryCaption)
+          .foregroundColor(.secondary.opacity(0.86))
+      }
+    }
+    .lineLimit(1)
+    .truncationMode(.tail)
+    .frame(maxWidth: .infinity, alignment: .leading)
+    .help(helpText)
+    .accessibilityLabel(helpText)
+  }
+
+  private var primaryText: String {
+    switch pullRequest.stateKind {
+    case .open:
+      return pullRequest.isDraft ? "Draft PR #\(pullRequest.number)" : "Open PR #\(pullRequest.number)"
+    case .closed:
+      return "Closed PR #\(pullRequest.number)"
+    case .merged:
+      return "Merged PR #\(pullRequest.number)"
+    case .unknown:
+      return "PR #\(pullRequest.number)"
+    }
+  }
+
+  private var secondaryText: String? {
+    if observationState.isRefreshing && summary.total == 0 {
+      return "Refreshing checks"
+    }
+
+    guard summary.total > 0 else {
+      return "No CI checks"
+    }
+
+    switch summary.overallStatus {
+    case .success:
+      return "CI passing \(summary.passed)/\(summary.total)"
+    case .failure:
+      return "CI failing \(summary.failed) failed"
+    case .pending:
+      return "CI running \(summary.pending) pending"
+    case .none:
+      if summary.skipped > 0 {
+        return "CI skipped \(summary.skipped)"
+      }
+      return "No CI checks"
+    }
+  }
+
+  private var primaryIcon: String {
+    return pullRequest.stateIcon
+  }
+
+  private var secondaryIcon: String {
+    if observationState.isRefreshing && summary.total == 0 {
+      return "arrow.clockwise"
+    }
+    return summary.overallStatus.icon
+  }
+
+  private var primaryColor: Color {
+    switch pullRequest.stateKind {
+    case .open:
+      return pullRequest.isDraft ? .secondary : .green
+    case .closed:
+      return .red
+    case .merged:
+      return .purple
+    case .unknown:
+      return .secondary
+    }
+  }
+
+  private var secondaryColor: Color {
+    if observationState.isRefreshing && summary.total == 0 {
+      return .orange
+    }
+    switch summary.overallStatus {
+    case .success:
+      return .green
+    case .failure:
+      return .red
+    case .pending:
+      return .orange
+    case .none:
+      return .secondary
+    }
+  }
+
+  private var helpText: String {
+    let prText: String
+    switch pullRequest.stateKind {
+    case .open:
+      prText = pullRequest.isDraft
+        ? "Draft PR #\(pullRequest.number)"
+        : "Open PR #\(pullRequest.number)"
+    case .closed:
+      prText = "Closed PR #\(pullRequest.number)"
+    case .merged:
+      prText = "Merged PR #\(pullRequest.number)"
+    case .unknown:
+      prText = "PR #\(pullRequest.number) has an unknown state"
+    }
+
+    return "\(prText). \(ciHelpText)"
+  }
+
+  private var ciHelpText: String {
+    if observationState.isRefreshing && summary.total == 0 {
+      return "CI checks are refreshing."
+    }
+
+    guard summary.total > 0 else {
+      return "No CI checks are reported."
+    }
+
+    switch summary.overallStatus {
+    case .success:
+      return "CI passing: \(summary.passed) of \(summary.total) checks passed."
+    case .failure:
+      return "CI failing: \(summary.failed) failed, \(summary.passed) passed, \(summary.pending) pending."
+    case .pending:
+      return "CI running: \(summary.pending) pending, \(summary.passed) passed, \(summary.failed) failed."
+    case .none:
+      if summary.skipped > 0 {
+        return "CI checks are skipped or neutral: \(summary.skipped) of \(summary.total)."
+      }
+      return "No CI checks are reported."
     }
   }
 }
@@ -440,8 +657,6 @@ struct CollapsibleSessionRow: View {
   .background(Color(nsColor: .windowBackgroundColor))
   .preferredColorScheme(.dark)
 }
-
-// MARK: - Preview Helpers
 
 @ViewBuilder
 private func sectionHeader(_ title: String) -> some View {

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/GitHubPanelView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/GitHubPanelView.swift
@@ -14,33 +14,38 @@ import SwiftUI
 /// Panel view for GitHub integration — lists PRs, issues, and shows details
 public struct GitHubPanelView: View {
   let projectPath: String
+  let branchName: String?
   let onDismiss: () -> Void
   var isEmbedded: Bool = false
   var onSendToSession: ((String, CLISession) -> Void)?
   var onStartNewSession: ((String, SessionProviderKind) -> Void)?
   var session: CLISession?
-  var onPopOut: (() -> Void)?
+  var onPopOut: ((GitHubViewModel) -> Void)?
 
-  @State private var viewModel = GitHubViewModel()
+  @State private var viewModel: GitHubViewModel
   @Environment(\.colorScheme) private var colorScheme
   @Environment(\.runtimeTheme) private var runtimeTheme
 
   public init(
     projectPath: String,
+    branchName: String? = nil,
     onDismiss: @escaping () -> Void,
     isEmbedded: Bool = false,
     session: CLISession? = nil,
+    viewModel: GitHubViewModel? = nil,
     onSendToSession: ((String, CLISession) -> Void)? = nil,
     onStartNewSession: ((String, SessionProviderKind) -> Void)? = nil,
-    onPopOut: (() -> Void)? = nil
+    onPopOut: ((GitHubViewModel) -> Void)? = nil
   ) {
     self.projectPath = projectPath
+    self.branchName = branchName
     self.onDismiss = onDismiss
     self.isEmbedded = isEmbedded
     self.session = session
     self.onSendToSession = onSendToSession
     self.onStartNewSession = onStartNewSession
     self.onPopOut = onPopOut
+    self._viewModel = State(initialValue: viewModel ?? GitHubViewModel())
   }
 
   public var body: some View {
@@ -55,9 +60,13 @@ public struct GitHubPanelView: View {
     )
     .background(panelBackground)
     .task {
-      await viewModel.setup(repoPath: projectPath)
+      if !viewModel.isConfigured(repoPath: projectPath, branchName: branchName) {
+        await viewModel.setup(repoPath: projectPath, branchName: branchName)
+      }
       if viewModel.setupState == .ready {
-        await viewModel.loadPullRequests()
+        if viewModel.pullRequests.isEmpty {
+          await viewModel.loadPullRequests()
+        }
         await viewModel.loadCurrentBranchPR()
       }
     }
@@ -93,7 +102,7 @@ public struct GitHubPanelView: View {
       Spacer()
 
       if isEmbedded, let onPopOut {
-        Button { onPopOut() } label: {
+        Button { onPopOut(viewModel) } label: {
           Image(systemName: "rectangle.portrait.and.arrow.right")
             .font(.system(size: 14))
             .foregroundStyle(.secondary)
@@ -102,7 +111,10 @@ public struct GitHubPanelView: View {
         .help("Open in separate window")
       }
 
-      Button("Close") { onDismiss() }
+      Button("Close") {
+        viewModel.stopObserving()
+        onDismiss()
+      }
         .controlSize(.small)
     }
     .padding(.horizontal, DesignTokens.Spacing.sm)
@@ -361,8 +373,7 @@ public struct GitHubPanelView: View {
 
     return ScrollView {
       LazyVStack(spacing: 0, pinnedViews: []) {
-        if let branchPR = currentBranchPR,
-           viewModel.pullRequests.contains(where: { $0.number == branchPR.number }) {
+        if let branchPR = currentBranchPR {
           GitHubSectionHeader(title: "Current Branch")
           GitHubPRRow(pr: branchPR, isCurrentBranch: true) {
             viewModel.selectPR(branchPR)

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringCardView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringCardView.swift
@@ -213,6 +213,10 @@ public struct MonitoringCardView: View {
     viewModel?.agentHubProvider?.gitHubQuickAccessCoordinator ?? agentHub?.gitHubQuickAccessCoordinator
   }
 
+  private var gitHubPRObservationService: (any GitHubPRObservationServiceProtocol)? {
+    viewModel?.agentHubProvider?.gitHubPRObservationService ?? agentHub?.gitHubPRObservationService
+  }
+
   public var body: some View {
     VStack(alignment: .leading, spacing: 0) {
       // Header with session info and actions
@@ -284,7 +288,8 @@ public struct MonitoringCardView: View {
       await sessionGitHubQuickAccessViewModel.load(
         projectPath: session.projectPath,
         branchName: session.branchName,
-        coordinator: gitHubQuickAccessCoordinator
+        coordinator: gitHubQuickAccessCoordinator,
+        observationService: gitHubPRObservationService
       )
       if let lastActivityAt = state?.lastActivityAt {
         await sessionGitHubQuickAccessViewModel.notifySessionActivity(at: lastActivityAt)

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderMonitoringPanelView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderMonitoringPanelView.swift
@@ -52,6 +52,8 @@ private struct GitHubPopOutItem: Identifiable {
   let id = UUID()
   let session: CLISession
   let projectPath: String
+  let viewModel: GitHubViewModel
+  let onSendToSession: ((String, CLISession) -> Void)?
 }
 
 
@@ -353,10 +355,16 @@ public struct MultiProviderMonitoringPanelView: View {
     ) { item in
       GitHubPanelView(
         projectPath: item.projectPath,
+        branchName: item.session.branchName,
         onDismiss: { gitHubPopOutItem = nil },
         isEmbedded: false,
-        session: item.session
+        session: item.session,
+        viewModel: item.viewModel,
+        onSendToSession: item.onSendToSession
       )
+      .onDisappear {
+        item.viewModel.stopObserving()
+      }
     }
     .sheet(item: $sessionFileSheetItem) { item in
       MonitoringSessionFileSheetView(
@@ -916,15 +924,26 @@ public struct MultiProviderMonitoringPanelView: View {
         isEmbedded: true
       )
     case .gitHub(_, let session, let projectPath):
+      let gitHubViewModel = GitHubViewModel(
+        service: viewModel.agentHubProvider?.gitHubService ?? GitHubCLIService(),
+        observationService: viewModel.agentHubProvider?.gitHubPRObservationService
+      )
       GitHubPanelView(
         projectPath: projectPath,
+        branchName: session.branchName,
         onDismiss: closeEmbeddedSidePanel,
         isEmbedded: true,
         session: session,
+        viewModel: gitHubViewModel,
         onSendToSession: { prompt, sess in viewModel.showTerminalWithPrompt(for: sess, prompt: prompt) },
-        onPopOut: {
+        onPopOut: { panelViewModel in
           closeEmbeddedSidePanel()
-          gitHubPopOutItem = GitHubPopOutItem(session: session, projectPath: projectPath)
+          gitHubPopOutItem = GitHubPopOutItem(
+            session: session,
+            projectPath: projectPath,
+            viewModel: panelViewModel,
+            onSendToSession: { prompt, sess in viewModel.showTerminalWithPrompt(for: sess, prompt: prompt) }
+          )
         }
       )
     case .edits(let sessionId, let session):

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
@@ -6,6 +6,7 @@
 //
 
 import AppKit
+import AgentHubGitHub
 import Foundation
 import PierreDiffsSwift
 import SwiftUI
@@ -168,6 +169,8 @@ public struct MultiProviderSessionsListView: View {
   @State private var selectedModuleLandingPath: String?
   @State private var pendingAddedModulePaths: [String] = []
   @State private var isStartSessionSheetPresented = false
+  @State private var isRefreshingGitHubStates = false
+  @State private var didScheduleInitialGitHubStateRefresh = false
 
   // TODO: Remove along with MultiSessionLaunchView once the new Threads-based
   // session-start flow is fully implemented. Flip to `true` to restore the
@@ -268,6 +271,7 @@ public struct MultiProviderSessionsListView: View {
         )
       }
       ensurePrimarySelection()
+      scheduleInitialGitHubStateRefreshIfNeeded()
     }
     .onChange(of: claudeViewModel.resolvedPendingSessions) { _, newResolutions in
       handleResolvedSessions(newResolutions, provider: .claude, viewModel: claudeViewModel)
@@ -291,6 +295,7 @@ public struct MultiProviderSessionsListView: View {
       if selectedSessionItems.isEmpty {
         setAuxiliaryShellVisible(false)
       }
+      scheduleInitialGitHubStateRefreshIfNeeded()
     }
     .onChange(of: orderedTrackedRepos.map(\.path)) { _, _ in
       syncPendingModuleRows()
@@ -400,10 +405,15 @@ public struct MultiProviderSessionsListView: View {
       )
     }
     .sheet(item: $gitHubSheetItem) { item in
+      let provider = claudeViewModel.agentHubProvider ?? codexViewModel.agentHubProvider
       GitHubPanelView(
         projectPath: item.projectPath,
         onDismiss: { gitHubSheetItem = nil },
         isEmbedded: false,
+        viewModel: GitHubViewModel(
+          service: provider?.gitHubService ?? GitHubCLIService(),
+          observationService: provider?.gitHubPRObservationService
+        ),
         onSendToSession: { prompt, session in
           claudeViewModel.showTerminalWithPrompt(for: session, prompt: prompt)
         },
@@ -952,6 +962,9 @@ public struct MultiProviderSessionsListView: View {
         repos: orderedTrackedRepos,
         launchViewModel: multiLaunchViewModel,
         intelligenceViewModel: intelligenceViewModel,
+        isRefreshingGitHubStates: isRefreshingGitHubStates,
+        canRefreshGitHubStates: canRefreshGitHubStates,
+        onRefreshGitHubStates: refreshGitHubStates,
         onAddFolder: { showAddRepositoryPicker() }
       )
 
@@ -1445,12 +1458,79 @@ public struct MultiProviderSessionsListView: View {
     selectedProvider == .claude ? claudeViewModel : codexViewModel
   }
 
+  private var gitHubPRObservationService: (any GitHubPRObservationServiceProtocol)? {
+    claudeViewModel.agentHubProvider?.gitHubPRObservationService
+      ?? codexViewModel.agentHubProvider?.gitHubPRObservationService
+  }
+
+  private var gitHubRefreshTargets: [GitHubPRObservationTarget] {
+    var seen = Set<GitHubPRObservationTarget>()
+    var targets: [GitHubPRObservationTarget] = []
+
+    for item in selectedSessionItems where !item.isPending {
+      let target = GitHubPRObservationTarget.currentBranch(
+        projectPath: item.session.projectPath,
+        branchName: item.session.branchName
+      )
+      guard seen.insert(target).inserted else { continue }
+      targets.append(target)
+    }
+
+    return targets
+  }
+
+  private var canRefreshGitHubStates: Bool {
+    gitHubPRObservationService != nil && !gitHubRefreshTargets.isEmpty
+  }
+
   private var hasCurrentProviderRepositories: Bool {
     !currentViewModel.selectedRepositories.isEmpty
   }
 
   private func toggleShowLastMessage() {
     currentViewModel.showLastMessage.toggle()
+  }
+
+  private func refreshGitHubStates() {
+    scheduleGitHubStateRefresh(limit: nil, showsIndicator: true)
+  }
+
+  private func scheduleInitialGitHubStateRefreshIfNeeded() {
+    guard !didScheduleInitialGitHubStateRefresh,
+          canRefreshGitHubStates else {
+      return
+    }
+
+    didScheduleInitialGitHubStateRefresh = true
+    Task { @MainActor in
+      try? await Task.sleep(for: .seconds(3))
+      guard !Task.isCancelled else { return }
+      scheduleGitHubStateRefresh(limit: 12, showsIndicator: false)
+    }
+  }
+
+  private func scheduleGitHubStateRefresh(limit: Int?, showsIndicator: Bool) {
+    guard !isRefreshingGitHubStates,
+          let observationService = gitHubPRObservationService else {
+      return
+    }
+
+    let targets = Array(gitHubRefreshTargets.prefix(limit ?? Int.max))
+    guard !targets.isEmpty else { return }
+
+    isRefreshingGitHubStates = true
+    Task { @MainActor in
+      for target in targets {
+        await observationService.refresh(target)
+        try? await Task.sleep(for: .milliseconds(120))
+      }
+      if !showsIndicator {
+        isRefreshingGitHubStates = false
+        return
+      }
+      try? await Task.sleep(for: .milliseconds(350))
+      isRefreshingGitHubStates = false
+    }
   }
 
   private func handleResolvedSessions(
@@ -1996,6 +2076,9 @@ private struct SessionsSectionHeader: View {
   let repos: [SelectedRepository]
   let launchViewModel: MultiSessionLaunchViewModel?
   let intelligenceViewModel: IntelligenceViewModel?
+  let isRefreshingGitHubStates: Bool
+  let canRefreshGitHubStates: Bool
+  let onRefreshGitHubStates: () -> Void
   let onAddFolder: () -> Void
 
   @State private var showGroupPopover = false
@@ -2019,6 +2102,13 @@ private struct SessionsSectionHeader: View {
         .popover(isPresented: $showGroupPopover, arrowEdge: .bottom) {
           GroupByPopover(groupMode: $groupMode)
         }
+
+        HeaderIconButton(
+          systemName: isRefreshingGitHubStates ? "arrow.triangle.2.circlepath" : "arrow.clockwise",
+          help: "Refresh GitHub PR and CI states",
+          isDisabled: !canRefreshGitHubStates || isRefreshingGitHubStates,
+          action: onRefreshGitHubStates
+        )
 
         HeaderIconButton(
           systemName: "folder.badge.plus",
@@ -2111,13 +2201,17 @@ private struct HeaderIconButton: View {
   let systemName: String
   var size: CGFloat = DesignTokens.IconSize.sm
   var help: String? = nil
+  var isDisabled = false
   let action: () -> Void
 
   var body: some View {
     Button(action: action) {
-      Image(systemName: systemName).headerIconStyle(size: size)
+      Image(systemName: systemName)
+        .headerIconStyle(size: size)
+        .opacity(isDisabled ? 0.35 : 1)
     }
     .buttonStyle(.plain)
+    .disabled(isDisabled)
     .help(help ?? "")
   }
 }

--- a/app/modules/AgentHubGitHub/Sources/AgentHubGitHub/Services/GitHubCLIService.swift
+++ b/app/modules/AgentHubGitHub/Sources/AgentHubGitHub/Services/GitHubCLIService.swift
@@ -45,6 +45,7 @@ public actor GitHubCLIService {
 
   private static let commandTimeout: TimeInterval = 30.0
   static let checksJSONFields = "name,state,link,bucket"
+  static let noPullRequestsFoundMessageFragment = "no pull requests found"
 
   /// Cached gh executable path
   private var ghPath: String?
@@ -215,11 +216,12 @@ public actor GitHubCLIService {
     do {
       let json = try await runGH(
         ["pr", "view", "--json", fields],
-        at: repoPath
+        at: repoPath,
+        quietFailureMessages: [Self.noPullRequestsFoundMessageFragment]
       )
       return try decodePR(json)
     } catch let error as GitHubCLIError {
-      if case .commandFailed(let msg) = error, msg.contains("no pull requests found") {
+      if case .commandFailed(let msg) = error, Self.isNoCurrentBranchPRMessage(msg) {
         return nil
       }
       throw error
@@ -449,7 +451,8 @@ public actor GitHubCLIService {
     _ arguments: [String],
     at path: String,
     timeout: TimeInterval = commandTimeout,
-    allowedExitCodes: Set<Int> = [0]
+    allowedExitCodes: Set<Int> = [0],
+    quietFailureMessages: [String] = []
   ) async throws -> String {
     guard let executable = await findGHExecutable() else {
       throw GitHubCLIError.cliNotInstalled
@@ -460,7 +463,8 @@ public actor GitHubCLIService {
       arguments: arguments,
       at: path,
       timeout: timeout,
-      allowedExitCodes: allowedExitCodes
+      allowedExitCodes: allowedExitCodes,
+      quietFailureMessages: quietFailureMessages
     )
   }
 
@@ -470,7 +474,8 @@ public actor GitHubCLIService {
     arguments: [String],
     at path: String? = nil,
     timeout: TimeInterval = commandTimeout,
-    allowedExitCodes: Set<Int> = [0]
+    allowedExitCodes: Set<Int> = [0],
+    quietFailureMessages: [String] = []
   ) async throws -> String {
     let cmdDescription = ([executable] + arguments).joined(separator: " ")
     GitHubLogger.github.debug("[runCommand] START timeout=\(timeout)s cmd=\(cmdDescription)")
@@ -564,7 +569,11 @@ public actor GitHubCLIService {
     if !allowedExitCodes.contains(Int(process.terminationStatus)) {
       let errMsg = errorOutput.trimmingCharacters(in: .whitespacesAndNewlines)
       let exitCode = process.terminationStatus
-      GitHubLogger.github.error("[runCommand] FAILED in \(cmdElapsed)s exitCode=\(exitCode) stderr=\(errMsg) cmd=\(cmdDescription)")
+      if Self.shouldLogFailureQuietly(errMsg, quietFailureMessages: quietFailureMessages) {
+        GitHubLogger.github.debug("[runCommand] EXPECTED_FAILURE in \(cmdElapsed)s exitCode=\(exitCode) stderr=\(errMsg) cmd=\(cmdDescription)")
+      } else {
+        GitHubLogger.github.error("[runCommand] FAILED in \(cmdElapsed)s exitCode=\(exitCode) stderr=\(errMsg) cmd=\(cmdDescription)")
+      }
 
       if errMsg.contains("not logged") || errMsg.contains("auth login") {
         throw GitHubCLIError.notAuthenticated
@@ -581,6 +590,19 @@ public actor GitHubCLIService {
 
     GitHubLogger.github.debug("[runCommand] OK in \(cmdElapsed)s stdout=\(outputBytes) bytes cmd=\(cmdDescription)")
     return output
+  }
+
+  static func isNoCurrentBranchPRMessage(_ message: String) -> Bool {
+    message.localizedCaseInsensitiveContains(noPullRequestsFoundMessageFragment)
+  }
+
+  private static func shouldLogFailureQuietly(
+    _ message: String,
+    quietFailureMessages: [String]
+  ) -> Bool {
+    quietFailureMessages.contains { fragment in
+      message.localizedCaseInsensitiveContains(fragment)
+    }
   }
 
   // MARK: - JSON Parsing

--- a/app/modules/AgentHubGitHub/Sources/AgentHubGitHub/Services/GitHubPRObservationService.swift
+++ b/app/modules/AgentHubGitHub/Sources/AgentHubGitHub/Services/GitHubPRObservationService.swift
@@ -1,0 +1,534 @@
+//
+//  GitHubPRObservationService.swift
+//  AgentHub
+//
+//  Shared PR/check observation for GitHub surfaces.
+//
+
+import Foundation
+
+public enum GitHubPRObservationTarget: Hashable, Sendable {
+  case currentBranch(projectPath: String, branchName: String?)
+  case pullRequest(projectPath: String, number: Int)
+
+  public var projectPath: String {
+    switch self {
+    case .currentBranch(let projectPath, _), .pullRequest(let projectPath, _):
+      return projectPath
+    }
+  }
+
+  public var pullRequestNumber: Int? {
+    switch self {
+    case .currentBranch:
+      return nil
+    case .pullRequest(_, let number):
+      return number
+    }
+  }
+
+  var key: String {
+    switch self {
+    case .currentBranch(let projectPath, let branchName):
+      return "current|\(projectPath)|\(branchName ?? "")"
+    case .pullRequest(let projectPath, let number):
+      return "pr|\(projectPath)|\(number)"
+    }
+  }
+}
+
+public enum GitHubPRObservationState: Equatable, Sendable {
+  case idle
+  case refreshing
+  case ready
+  case error(String)
+  case paused(String)
+
+  public var isRefreshing: Bool {
+    if case .refreshing = self { return true }
+    return false
+  }
+}
+
+public struct GitHubCISummary: Equatable, Sendable {
+  public let passed: Int
+  public let failed: Int
+  public let pending: Int
+  public let skipped: Int
+  public let total: Int
+
+  public init(checks: [GitHubCheckRun]) {
+    var passed = 0
+    var failed = 0
+    var pending = 0
+    var skipped = 0
+
+    for check in checks {
+      switch check.ciStatus {
+      case .success:
+        passed += 1
+      case .failure:
+        failed += 1
+      case .pending:
+        pending += 1
+      case .none:
+        skipped += 1
+      }
+    }
+
+    self.passed = passed
+    self.failed = failed
+    self.pending = pending
+    self.skipped = skipped
+    self.total = checks.count
+  }
+
+  public var overallStatus: CIStatus {
+    if failed > 0 { return .failure }
+    if pending > 0 { return .pending }
+    if passed > 0 { return .success }
+    return .none
+  }
+}
+
+public struct GitHubPRObservationSnapshot: Equatable, Sendable {
+  public let target: GitHubPRObservationTarget
+  public let pullRequest: GitHubPullRequest?
+  public let checks: [GitHubCheckRun]
+  public let ciSummary: GitHubCISummary
+  public let state: GitHubPRObservationState
+  public let lastRefreshedAt: Date?
+
+  public init(
+    target: GitHubPRObservationTarget,
+    pullRequest: GitHubPullRequest?,
+    checks: [GitHubCheckRun],
+    state: GitHubPRObservationState,
+    lastRefreshedAt: Date?
+  ) {
+    self.target = target
+    self.pullRequest = pullRequest
+    self.checks = checks
+    self.ciSummary = GitHubCISummary(checks: checks)
+    self.state = state
+    self.lastRefreshedAt = lastRefreshedAt
+  }
+
+  public static func initial(target: GitHubPRObservationTarget) -> GitHubPRObservationSnapshot {
+    GitHubPRObservationSnapshot(
+      target: target,
+      pullRequest: nil,
+      checks: [],
+      state: .idle,
+      lastRefreshedAt: nil
+    )
+  }
+}
+
+public struct GitHubPRObservationSubscription: Sendable {
+  public let id: UUID
+  public let updates: AsyncStream<GitHubPRObservationSnapshot>
+
+  public init(id: UUID, updates: AsyncStream<GitHubPRObservationSnapshot>) {
+    self.id = id
+    self.updates = updates
+  }
+}
+
+public protocol GitHubPRObservationServiceProtocol: AnyObject, Sendable {
+  func subscribe(
+    to target: GitHubPRObservationTarget,
+    refreshOnSubscribe: Bool
+  ) async -> GitHubPRObservationSubscription
+  func unsubscribe(subscriptionID: UUID) async
+  func refresh(_ target: GitHubPRObservationTarget) async
+  func recordActivity(for target: GitHubPRObservationTarget, at: Date) async
+}
+
+public extension GitHubPRObservationServiceProtocol {
+  func subscribe(to target: GitHubPRObservationTarget) async -> GitHubPRObservationSubscription {
+    await subscribe(to: target, refreshOnSubscribe: true)
+  }
+}
+
+public struct GitHubPRObservationConfiguration: Sendable {
+  public var pendingPollInterval: TimeInterval
+  public var settledPollInterval: TimeInterval
+  public var idleTimeout: TimeInterval
+  public var errorBackoff: [TimeInterval]
+
+  public init(
+    pendingPollInterval: TimeInterval = 30,
+    settledPollInterval: TimeInterval = 120,
+    idleTimeout: TimeInterval = 5 * 60,
+    errorBackoff: [TimeInterval] = [60, 120, 300]
+  ) {
+    self.pendingPollInterval = pendingPollInterval
+    self.settledPollInterval = settledPollInterval
+    self.idleTimeout = idleTimeout
+    self.errorBackoff = errorBackoff
+  }
+}
+
+public actor GitHubPRObservationService: GitHubPRObservationServiceProtocol {
+  private struct Entry {
+    let target: GitHubPRObservationTarget
+    var snapshot: GitHubPRObservationSnapshot
+    var lastActivityAt: Date?
+    var consecutiveErrorCount = 0
+    var isTerminallyPaused = false
+    var isRefreshing = false
+    var pendingPostRefreshEvaluation = false
+    var scheduledRefreshTask: Task<Void, Never>?
+    var subscribers: [UUID: AsyncStream<GitHubPRObservationSnapshot>.Continuation] = [:]
+  }
+
+  private let service: any GitHubCLIServiceProtocol
+  private let configuration: GitHubPRObservationConfiguration
+  private var entries: [String: Entry] = [:]
+  private var subscriptionKeys: [UUID: String] = [:]
+
+  public init(
+    service: any GitHubCLIServiceProtocol = GitHubCLIService(),
+    configuration: GitHubPRObservationConfiguration = GitHubPRObservationConfiguration()
+  ) {
+    self.service = service
+    self.configuration = configuration
+  }
+
+  public func subscribe(
+    to target: GitHubPRObservationTarget,
+    refreshOnSubscribe: Bool = true
+  ) async -> GitHubPRObservationSubscription {
+    let subscriptionID = UUID()
+    var continuation: AsyncStream<GitHubPRObservationSnapshot>.Continuation?
+    let updates = AsyncStream<GitHubPRObservationSnapshot> { streamContinuation in
+      continuation = streamContinuation
+    }
+
+    guard let continuation else {
+      return GitHubPRObservationSubscription(id: subscriptionID, updates: updates)
+    }
+
+    continuation.onTermination = { [subscriptionID] _ in
+      Task {
+        await self.unsubscribe(subscriptionID: subscriptionID)
+      }
+    }
+
+    let key = target.key
+    var entry = entries[key] ?? Entry(target: target, snapshot: .initial(target: target))
+    entry.subscribers[subscriptionID] = continuation
+    if !entry.isTerminallyPaused || entry.consecutiveErrorCount == 0 {
+      entry.isTerminallyPaused = false
+    }
+    entries[key] = entry
+    subscriptionKeys[subscriptionID] = key
+
+    continuation.yield(entry.snapshot)
+    if refreshOnSubscribe {
+      scheduleRefreshIfNeeded(for: key, forceImmediate: needsImmediateRefresh(entry, now: .now))
+    }
+
+    return GitHubPRObservationSubscription(id: subscriptionID, updates: updates)
+  }
+
+  public func unsubscribe(subscriptionID: UUID) async {
+    guard let key = subscriptionKeys.removeValue(forKey: subscriptionID),
+          var entry = entries[key] else {
+      return
+    }
+
+    entry.subscribers.removeValue(forKey: subscriptionID)?.finish()
+    if entry.subscribers.isEmpty {
+      entry.scheduledRefreshTask?.cancel()
+      entry.scheduledRefreshTask = nil
+    }
+    entries[key] = entry
+  }
+
+  public func refresh(_ target: GitHubPRObservationTarget) async {
+    let key = target.key
+    if entries[key] == nil {
+      entries[key] = Entry(target: target, snapshot: .initial(target: target))
+    }
+    scheduleRefreshIfNeeded(for: key, forceImmediate: true)
+  }
+
+  public func recordActivity(for target: GitHubPRObservationTarget, at date: Date) async {
+    let key = target.key
+    guard var entry = entries[key] else { return }
+
+    if let previousActivity = entry.lastActivityAt, previousActivity >= date {
+      entries[key] = entry
+      return
+    }
+
+    entry.lastActivityAt = date
+    guard !entry.subscribers.isEmpty else {
+      entries[key] = entry
+      return
+    }
+    guard Date.now.timeIntervalSince(date) <= configuration.idleTimeout else {
+      entries[key] = entry
+      return
+    }
+
+    let shouldReactivate = entry.isTerminallyPaused
+    if entry.isRefreshing {
+      entry.pendingPostRefreshEvaluation = true
+      entries[key] = entry
+      return
+    }
+
+    entry.isTerminallyPaused = false
+    entries[key] = entry
+
+    scheduleRefreshIfNeeded(
+      for: key,
+      forceImmediate: shouldReactivate || needsImmediateRefresh(entry, now: date)
+    )
+  }
+
+  // MARK: - Scheduling
+
+  private func scheduleRefreshIfNeeded(for key: String, forceImmediate: Bool) {
+    guard var entry = entries[key], !entry.subscribers.isEmpty else { return }
+
+    if entry.isRefreshing {
+      entry.pendingPostRefreshEvaluation = true
+      entries[key] = entry
+      return
+    }
+
+    if !forceImmediate, entry.scheduledRefreshTask != nil {
+      entries[key] = entry
+      return
+    }
+
+    let now = Date.now
+    let interval: TimeInterval
+    if forceImmediate {
+      interval = 0
+    } else if canAutoRefresh(entry, now: now) {
+      interval = remainingRefreshInterval(for: entry, now: now)
+    } else {
+      entries[key] = entry
+      return
+    }
+
+    entry.scheduledRefreshTask?.cancel()
+    entry.scheduledRefreshTask = Task {
+      if interval > 0 {
+        try? await Task.sleep(for: Self.duration(for: interval))
+      }
+      guard !Task.isCancelled else { return }
+      await self.executeScheduledRefresh(for: key)
+    }
+    entries[key] = entry
+  }
+
+  private func executeScheduledRefresh(for key: String) async {
+    guard var entry = entries[key] else { return }
+
+    guard !entry.subscribers.isEmpty else {
+      entry.scheduledRefreshTask = nil
+      entry.isRefreshing = false
+      entry.pendingPostRefreshEvaluation = false
+      entries[key] = entry
+      return
+    }
+
+    if entry.snapshot.lastRefreshedAt != nil, !canAutoRefresh(entry, now: .now) {
+      entry.scheduledRefreshTask = nil
+      entry.isRefreshing = false
+      entry.pendingPostRefreshEvaluation = false
+      entries[key] = entry
+      return
+    }
+
+    entry.isRefreshing = true
+    entry.scheduledRefreshTask = nil
+    entry.snapshot = GitHubPRObservationSnapshot(
+      target: entry.target,
+      pullRequest: entry.snapshot.pullRequest,
+      checks: entry.snapshot.checks,
+      state: .refreshing,
+      lastRefreshedAt: entry.snapshot.lastRefreshedAt
+    )
+    entries[key] = entry
+    broadcast(entry.snapshot, for: key)
+
+    let refreshResult = await refreshSnapshot(for: entry.target)
+
+    guard var refreshedEntry = entries[key] else { return }
+    refreshedEntry.isRefreshing = false
+    refreshedEntry.scheduledRefreshTask = nil
+    let hadCoalescedActivity = refreshedEntry.pendingPostRefreshEvaluation
+    refreshedEntry.pendingPostRefreshEvaluation = false
+
+    guard !Task.isCancelled, !refreshedEntry.subscribers.isEmpty else {
+      entries[key] = refreshedEntry
+      return
+    }
+
+    switch refreshResult {
+    case .success(let snapshot):
+      refreshedEntry.snapshot = snapshot
+      refreshedEntry.consecutiveErrorCount = 0
+      refreshedEntry.isTerminallyPaused = false
+      entries[key] = refreshedEntry
+      broadcast(snapshot, for: key)
+
+      if canAutoRefresh(refreshedEntry, now: .now) {
+        scheduleRefreshIfNeeded(for: key, forceImmediate: false)
+      }
+
+    case .failure(let error):
+      let message = error.localizedDescription
+      if isTerminal(error) {
+        refreshedEntry.isTerminallyPaused = true
+        refreshedEntry.consecutiveErrorCount = 0
+        refreshedEntry.snapshot = GitHubPRObservationSnapshot(
+          target: refreshedEntry.target,
+          pullRequest: refreshedEntry.snapshot.pullRequest,
+          checks: refreshedEntry.snapshot.checks,
+          state: .paused(message),
+          lastRefreshedAt: refreshedEntry.snapshot.lastRefreshedAt
+        )
+        entries[key] = refreshedEntry
+        broadcast(refreshedEntry.snapshot, for: key)
+        return
+      }
+
+      refreshedEntry.consecutiveErrorCount += 1
+      refreshedEntry.isTerminallyPaused = false
+      refreshedEntry.snapshot = GitHubPRObservationSnapshot(
+        target: refreshedEntry.target,
+        pullRequest: refreshedEntry.snapshot.pullRequest,
+        checks: refreshedEntry.snapshot.checks,
+        state: .error(message),
+        lastRefreshedAt: refreshedEntry.snapshot.lastRefreshedAt
+      )
+      entries[key] = refreshedEntry
+      broadcast(refreshedEntry.snapshot, for: key)
+
+      if canAutoRefresh(refreshedEntry, now: .now) {
+        scheduleBackoffRefresh(for: key, errorCount: refreshedEntry.consecutiveErrorCount)
+      }
+    }
+
+    if hadCoalescedActivity {
+      scheduleRefreshIfNeeded(for: key, forceImmediate: false)
+    }
+  }
+
+  private func scheduleBackoffRefresh(for key: String, errorCount: Int) {
+    guard var entry = entries[key], !entry.subscribers.isEmpty else { return }
+
+    let intervals = configuration.errorBackoff
+    let index = min(max(0, errorCount - 1), max(0, intervals.count - 1))
+    let interval = intervals.isEmpty ? configuration.pendingPollInterval : intervals[index]
+
+    entry.scheduledRefreshTask?.cancel()
+    entry.scheduledRefreshTask = Task {
+      if interval > 0 {
+        try? await Task.sleep(for: Self.duration(for: interval))
+      }
+      guard !Task.isCancelled else { return }
+      await self.executeScheduledRefresh(for: key)
+    }
+    entries[key] = entry
+  }
+
+  private func broadcast(_ snapshot: GitHubPRObservationSnapshot, for key: String) {
+    guard let entry = entries[key] else { return }
+    for continuation in entry.subscribers.values {
+      continuation.yield(snapshot)
+    }
+  }
+
+  // MARK: - Fetching
+
+  private func refreshSnapshot(
+    for target: GitHubPRObservationTarget
+  ) async -> Result<GitHubPRObservationSnapshot, Error> {
+    do {
+      switch target {
+      case .currentBranch(let projectPath, _):
+        guard let pullRequest = try await service.getCurrentBranchPR(at: projectPath) else {
+          return .success(GitHubPRObservationSnapshot(
+            target: target,
+            pullRequest: nil,
+            checks: [],
+            state: .ready,
+            lastRefreshedAt: .now
+          ))
+        }
+        let checks = try await service.getChecks(prNumber: pullRequest.number, at: projectPath)
+        return .success(GitHubPRObservationSnapshot(
+          target: target,
+          pullRequest: pullRequest,
+          checks: checks,
+          state: .ready,
+          lastRefreshedAt: .now
+        ))
+
+      case .pullRequest(let projectPath, let number):
+        async let pullRequest = service.getPullRequest(number: number, at: projectPath)
+        async let checks = service.getChecks(prNumber: number, at: projectPath)
+        let (resolvedPullRequest, resolvedChecks) = try await (pullRequest, checks)
+        let snapshot = GitHubPRObservationSnapshot(
+          target: target,
+          pullRequest: resolvedPullRequest,
+          checks: resolvedChecks,
+          state: .ready,
+          lastRefreshedAt: .now
+        )
+        return .success(snapshot)
+      }
+    } catch {
+      return .failure(error)
+    }
+  }
+
+  // MARK: - Helpers
+
+  private func canAutoRefresh(_ entry: Entry, now: Date) -> Bool {
+    guard !entry.isTerminallyPaused, !entry.subscribers.isEmpty else { return false }
+    guard let lastActivityAt = entry.lastActivityAt else { return entry.snapshot.lastRefreshedAt == nil }
+    return now.timeIntervalSince(lastActivityAt) <= configuration.idleTimeout
+  }
+
+  private func needsImmediateRefresh(_ entry: Entry, now: Date) -> Bool {
+    guard let lastRefreshedAt = entry.snapshot.lastRefreshedAt else { return true }
+    return now.timeIntervalSince(lastRefreshedAt) >= pollingInterval(for: entry.snapshot)
+  }
+
+  private func remainingRefreshInterval(for entry: Entry, now: Date) -> TimeInterval {
+    guard let lastRefreshedAt = entry.snapshot.lastRefreshedAt else { return 0 }
+    return max(0, pollingInterval(for: entry.snapshot) - now.timeIntervalSince(lastRefreshedAt))
+  }
+
+  private func pollingInterval(for snapshot: GitHubPRObservationSnapshot) -> TimeInterval {
+    if snapshot.pullRequest == nil || snapshot.ciSummary.pending > 0 {
+      return configuration.pendingPollInterval
+    }
+    return configuration.settledPollInterval
+  }
+
+  private func isTerminal(_ error: Error) -> Bool {
+    guard let gitHubError = error as? GitHubCLIError else { return false }
+
+    switch gitHubError {
+    case .cliNotInstalled, .notAuthenticated, .notAGitRepository, .noRemoteRepository:
+      return true
+    case .commandFailed, .parseError, .timeout:
+      return false
+    }
+  }
+
+  private static func duration(for interval: TimeInterval) -> Duration {
+    .milliseconds(max(0, Int(interval * 1_000)))
+  }
+}

--- a/app/modules/AgentHubGitHub/Sources/AgentHubGitHub/ViewModels/GitHubViewModel.swift
+++ b/app/modules/AgentHubGitHub/Sources/AgentHubGitHub/ViewModels/GitHubViewModel.swift
@@ -129,6 +129,9 @@ public final class GitHubViewModel {
 
   /// PR for the current branch
   public var currentBranchPR: GitHubPullRequest?
+  public var currentBranchChecks: [GitHubCheckRun] = []
+  public var currentBranchObservationState: GitHubPRObservationState = .idle
+  public var currentBranchLastRefreshedAt: Date?
 
   /// Issue list state
   public var issues: [GitHubIssue] = []
@@ -153,6 +156,8 @@ public final class GitHubViewModel {
   public var checks: [GitHubCheckRun] = []
   public var checksLoadingState: GitHubLoadingState = .idle
   public private(set) var loadedChecksPRNumber: Int?
+  public var selectedPRObservationState: GitHubPRObservationState = .idle
+  public var selectedPRLastRefreshedAt: Date?
 
   /// Comment input
   public var newCommentText: String = ""
@@ -171,23 +176,49 @@ public final class GitHubViewModel {
   // MARK: - Dependencies
 
   private let service: any GitHubCLIServiceProtocol
+  private let observationService: (any GitHubPRObservationServiceProtocol)?
   private var currentRepoPath: String?
+  private var currentBranchName: String?
   private var prDetailTask: Task<Void, Never>?
   private var issueDetailTask: Task<Void, Never>?
+  private var currentBranchObservationTask: Task<Void, Never>?
+  private var selectedPRObservationTask: Task<Void, Never>?
+  private var currentBranchSubscriptionID: UUID?
+  private var selectedPRSubscriptionID: UUID?
 
   // MARK: - Init
 
-  public init(service: any GitHubCLIServiceProtocol = GitHubCLIService()) {
+  public init(
+    service: any GitHubCLIServiceProtocol = GitHubCLIService(),
+    observationService: (any GitHubPRObservationServiceProtocol)? = nil
+  ) {
     self.service = service
+    self.observationService = observationService
+  }
+
+  public var usesObservationService: Bool {
+    observationService != nil
+  }
+
+  public func stopObserving() {
+    stopCurrentBranchObservation()
+    stopSelectedPRObservation()
   }
 
   // MARK: - Setup
 
   /// Initializes the GitHub integration for a repository path
-  public func setup(repoPath: String) async {
+  public func setup(repoPath: String, branchName: String? = nil) async {
     currentRepoPath = repoPath
+    currentBranchName = branchName
     setupState = .checking
     repoInfo = nil
+    stopCurrentBranchObservation()
+    stopSelectedPRObservation()
+    currentBranchPR = nil
+    currentBranchChecks = []
+    currentBranchObservationState = .idle
+    currentBranchLastRefreshedAt = nil
 
     isGHInstalled = await service.isInstalled()
     guard isGHInstalled else {
@@ -209,6 +240,11 @@ public final class GitHubViewModel {
     }
 
     setupState = .ready
+    await startCurrentBranchObservationIfAvailable()
+  }
+
+  public func isConfigured(repoPath: String, branchName: String?) -> Bool {
+    currentRepoPath == repoPath && currentBranchName == branchName && setupState != .checking
   }
 
   // MARK: - Pull Requests
@@ -280,17 +316,29 @@ public final class GitHubViewModel {
     prDetailLoadingState = .loading
 
     do {
-      async let prTask = service.getPullRequest(number: number, at: repoPath)
-      async let diffTask = service.getPullRequestDiff(number: number, at: repoPath)
-      async let commentsTask = service.getPullRequestReviewComments(number: number, at: repoPath)
+      if observationService == nil {
+        async let prTask = service.getPullRequest(number: number, at: repoPath)
+        async let diffTask = service.getPullRequestDiff(number: number, at: repoPath)
+        async let commentsTask = service.getPullRequestReviewComments(number: number, at: repoPath)
 
-      let (pr, diff, comments) = try await (prTask, diffTask, commentsTask)
-      guard !Task.isCancelled, selectedPR == nil || selectedPR?.number == number else { return }
+        let (pr, diff, comments) = try await (prTask, diffTask, commentsTask)
+        guard !Task.isCancelled, selectedPR == nil || selectedPR?.number == number else { return }
 
-      selectedPR = pr
-      selectedPRDiff = diff
-      selectedPRReviewComments = comments
-      prDetailLoadingState = .loaded
+        selectedPR = pr
+        selectedPRDiff = diff
+        selectedPRReviewComments = comments
+        prDetailLoadingState = .loaded
+      } else {
+        async let diffTask = service.getPullRequestDiff(number: number, at: repoPath)
+        async let commentsTask = service.getPullRequestReviewComments(number: number, at: repoPath)
+
+        let (diff, comments) = try await (diffTask, commentsTask)
+        guard !Task.isCancelled, selectedPR == nil || selectedPR?.number == number else { return }
+
+        selectedPRDiff = diff
+        selectedPRReviewComments = comments
+        prDetailLoadingState = .loaded
+      }
 
       // Load files separately (can be slower)
       do {
@@ -310,6 +358,11 @@ public final class GitHubViewModel {
   /// Loads the PR for the current branch
   public func loadCurrentBranchPR() async {
     guard let repoPath = currentRepoPath else { return }
+    if observationService != nil {
+      await refreshCurrentBranchObservation()
+      return
+    }
+
     do {
       currentBranchPR = try await service.getCurrentBranchPR(at: repoPath)
     } catch {
@@ -429,6 +482,18 @@ public final class GitHubViewModel {
   /// Loads CI checks for a PR
   public func loadChecks(prNumber: Int? = nil) async {
     guard let repoPath = currentRepoPath else { return }
+    if let observationService {
+      if let prNumber {
+        checksLoadingState = .loading
+        let target = GitHubPRObservationTarget.pullRequest(projectPath: repoPath, number: prNumber)
+        await observationService.recordActivity(for: target, at: .now)
+        await observationService.refresh(target)
+      } else {
+        await refreshCurrentBranchObservation()
+      }
+      return
+    }
+
     checksLoadingState = .loading
 
     do {
@@ -453,6 +518,10 @@ public final class GitHubViewModel {
     checks = []
     checksLoadingState = .idle
     loadedChecksPRNumber = nil
+    selectedPRObservationState = .idle
+    selectedPRLastRefreshedAt = nil
+
+    startSelectedPRObservationIfAvailable(number: pr.number)
 
     prDetailTask = Task { [number = pr.number] in
       await loadPRDetail(number: number)
@@ -470,6 +539,9 @@ public final class GitHubViewModel {
     checks = []
     checksLoadingState = .idle
     loadedChecksPRNumber = nil
+    selectedPRObservationState = .idle
+    selectedPRLastRefreshedAt = nil
+    stopSelectedPRObservation()
   }
 
   /// Selects an issue and loads its details
@@ -486,5 +558,127 @@ public final class GitHubViewModel {
     issueDetailTask?.cancel()
     selectedIssue = nil
     issueDetailLoadingState = .idle
+  }
+
+  // MARK: - Observation
+
+  private func startCurrentBranchObservationIfAvailable() async {
+    guard let observationService, let repoPath = currentRepoPath else { return }
+    let target = GitHubPRObservationTarget.currentBranch(
+      projectPath: repoPath,
+      branchName: currentBranchName
+    )
+    let subscription = await observationService.subscribe(to: target)
+    currentBranchSubscriptionID = subscription.id
+    currentBranchObservationTask = Task { [weak self] in
+      for await snapshot in subscription.updates {
+        guard let self else { return }
+        self.applyCurrentBranchObservation(snapshot)
+      }
+    }
+    await observationService.recordActivity(for: target, at: .now)
+  }
+
+  private func refreshCurrentBranchObservation() async {
+    guard let observationService, let repoPath = currentRepoPath else { return }
+    let target = GitHubPRObservationTarget.currentBranch(
+      projectPath: repoPath,
+      branchName: currentBranchName
+    )
+    await observationService.recordActivity(for: target, at: .now)
+    await observationService.refresh(target)
+  }
+
+  private func startSelectedPRObservationIfAvailable(number: Int) {
+    guard let observationService, let repoPath = currentRepoPath else { return }
+    stopSelectedPRObservation()
+
+    let target = GitHubPRObservationTarget.pullRequest(projectPath: repoPath, number: number)
+    selectedPRObservationTask = Task { [weak self] in
+      let subscription = await observationService.subscribe(to: target)
+      await MainActor.run {
+        self?.selectedPRSubscriptionID = subscription.id
+      }
+      await observationService.recordActivity(for: target, at: .now)
+
+      for await snapshot in subscription.updates {
+        guard let self else { return }
+        self.applySelectedPRObservation(snapshot, expectedNumber: number)
+      }
+    }
+  }
+
+  private func stopCurrentBranchObservation() {
+    currentBranchObservationTask?.cancel()
+    currentBranchObservationTask = nil
+    let subscriptionID = currentBranchSubscriptionID
+    currentBranchSubscriptionID = nil
+    if let subscriptionID, let observationService {
+      Task {
+        await observationService.unsubscribe(subscriptionID: subscriptionID)
+      }
+    }
+  }
+
+  private func stopSelectedPRObservation() {
+    selectedPRObservationTask?.cancel()
+    selectedPRObservationTask = nil
+    let subscriptionID = selectedPRSubscriptionID
+    selectedPRSubscriptionID = nil
+    if let subscriptionID, let observationService {
+      Task {
+        await observationService.unsubscribe(subscriptionID: subscriptionID)
+      }
+    }
+  }
+
+  private func applyCurrentBranchObservation(_ snapshot: GitHubPRObservationSnapshot) {
+    currentBranchObservationState = snapshot.state
+    currentBranchLastRefreshedAt = snapshot.lastRefreshedAt
+    currentBranchPR = snapshot.pullRequest
+    currentBranchChecks = snapshot.checks
+
+    if let pullRequest = snapshot.pullRequest {
+      replaceLoadedPullRequest(pullRequest)
+    }
+  }
+
+  private func applySelectedPRObservation(
+    _ snapshot: GitHubPRObservationSnapshot,
+    expectedNumber: Int
+  ) {
+    guard selectedPR?.number == expectedNumber else { return }
+
+    selectedPRObservationState = snapshot.state
+    selectedPRLastRefreshedAt = snapshot.lastRefreshedAt
+
+    if let pullRequest = snapshot.pullRequest {
+      selectedPR = pullRequest
+      replaceLoadedPullRequest(pullRequest)
+    }
+
+    checks = snapshot.checks
+    loadedChecksPRNumber = expectedNumber
+    checksLoadingState = loadingState(from: snapshot.state)
+  }
+
+  private func replaceLoadedPullRequest(_ pullRequest: GitHubPullRequest) {
+    guard let index = pullRequests.firstIndex(where: { $0.number == pullRequest.number }) else {
+      return
+    }
+    pullRequests[index] = pullRequest
+  }
+
+  private func loadingState(from observationState: GitHubPRObservationState) -> GitHubLoadingState {
+    switch observationState {
+    case .idle:
+      return .idle
+    case .refreshing:
+      return .loading
+    case .ready:
+      return .loaded
+    case .error(let message), .paused(let message):
+      return .error(message)
+    }
   }
 }

--- a/app/modules/AgentHubGitHub/Sources/AgentHubGitHub/ViewModels/SessionGitHubQuickAccessViewModel.swift
+++ b/app/modules/AgentHubGitHub/Sources/AgentHubGitHub/ViewModels/SessionGitHubQuickAccessViewModel.swift
@@ -12,39 +12,56 @@ import Foundation
 public final class SessionGitHubQuickAccessViewModel {
 
   public private(set) var currentBranchPR: GitHubPullRequest?
+  public private(set) var currentBranchChecks: [GitHubCheckRun] = []
+  public private(set) var observationState: GitHubPRObservationState = .idle
+  public private(set) var lastRefreshedAt: Date?
+
+  public var ciSummary: GitHubCISummary {
+    GitHubCISummary(checks: currentBranchChecks)
+  }
 
   private var coordinator: (any SessionGitHubQuickAccessCoordinatorProtocol)?
+  private var observationService: (any GitHubPRObservationServiceProtocol)?
   private let service: any GitHubCLIServiceProtocol
   private var loadedRepositoryKey: String?
   private var subscriptionID: UUID?
+  private var observationSubscriptionID: UUID?
   private var subscriptionTask: Task<Void, Never>?
   private var currentProjectPath: String?
   private var currentBranchName: String?
 
   public init(
     coordinator: (any SessionGitHubQuickAccessCoordinatorProtocol)? = nil,
+    observationService: (any GitHubPRObservationServiceProtocol)? = nil,
     service: any GitHubCLIServiceProtocol = GitHubCLIService()
   ) {
     self.coordinator = coordinator
+    self.observationService = observationService
     self.service = service
   }
 
   public func load(
     projectPath: String,
     branchName: String?,
-    coordinator: (any SessionGitHubQuickAccessCoordinatorProtocol)? = nil
+    coordinator: (any SessionGitHubQuickAccessCoordinatorProtocol)? = nil,
+    observationService: (any GitHubPRObservationServiceProtocol)? = nil,
+    refreshOnSubscribe: Bool = true,
+    recordInitialActivity: Bool = true
   ) async {
     let repositoryKey = Self.repositoryKey(projectPath: projectPath, branchName: branchName)
     if let coordinator {
       self.coordinator = coordinator
     }
+    if let observationService {
+      self.observationService = observationService
+    }
 
-    let isUsingSharedCoordinator = self.coordinator != nil
-    let alreadySubscribed = loadedRepositoryKey == repositoryKey && (!isUsingSharedCoordinator || subscriptionTask != nil)
+    let isUsingSharedSource = self.coordinator != nil || self.observationService != nil
+    let alreadySubscribed = loadedRepositoryKey == repositoryKey && (!isUsingSharedSource || subscriptionTask != nil)
     guard !alreadySubscribed else { return }
 
     if loadedRepositoryKey != repositoryKey {
-      currentBranchPR = nil
+      clearState()
     }
     await stopCurrentSubscription()
 
@@ -52,41 +69,66 @@ public final class SessionGitHubQuickAccessViewModel {
     currentProjectPath = projectPath
     currentBranchName = branchName
 
-    if let coordinator = self.coordinator {
+    if let observationService = self.observationService {
+      let target = GitHubPRObservationTarget.currentBranch(
+        projectPath: projectPath,
+        branchName: branchName
+      )
+      let subscription = await observationService.subscribe(to: target, refreshOnSubscribe: refreshOnSubscribe)
+      observationSubscriptionID = subscription.id
+      subscriptionTask = Task { [weak self] in
+        for await snapshot in subscription.updates {
+          guard let self else { return }
+          self.apply(snapshot: snapshot, for: repositoryKey)
+        }
+      }
+      if recordInitialActivity {
+        await observationService.recordActivity(for: target, at: .now)
+      }
+      return
+    } else if let coordinator = self.coordinator {
       let subscription = await coordinator.subscribe(projectPath: projectPath, branchName: branchName)
       subscriptionID = subscription.id
       subscriptionTask = Task { [weak self] in
         for await currentBranchPR in subscription.updates {
           guard let self else { return }
-          self.apply(currentBranchPR: currentBranchPR, for: repositoryKey)
+          self.apply(currentBranchPR: currentBranchPR, for: repositoryKey, state: .ready)
         }
       }
       return
     }
 
-    currentBranchPR = nil
+    clearState()
 
     do {
       let pullRequest = try await service.getCurrentBranchPR(at: projectPath)
       guard !Task.isCancelled, loadedRepositoryKey == repositoryKey else { return }
       currentBranchPR = pullRequest
+      observationState = .ready
+      lastRefreshedAt = .now
     } catch {
       guard !Task.isCancelled, loadedRepositoryKey == repositoryKey else { return }
-      currentBranchPR = nil
+      clearState(state: .ready)
     }
   }
 
   public func notifySessionActivity(at activityDate: Date = .now) async {
-    guard let coordinator,
-          let projectPath = currentProjectPath else {
+    guard let projectPath = currentProjectPath else {
       return
     }
 
-    await coordinator.recordActivity(
-      projectPath: projectPath,
-      branchName: currentBranchName,
-      at: activityDate
-    )
+    if let observationService {
+      await observationService.recordActivity(
+        for: .currentBranch(projectPath: projectPath, branchName: currentBranchName),
+        at: activityDate
+      )
+    } else if let coordinator {
+      await coordinator.recordActivity(
+        projectPath: projectPath,
+        branchName: currentBranchName,
+        at: activityDate
+      )
+    }
   }
 
   public func stopPolling() {
@@ -96,10 +138,18 @@ public final class SessionGitHubQuickAccessViewModel {
     subscriptionTask?.cancel()
     subscriptionTask = nil
     self.subscriptionID = nil
+    let observationSubscriptionID = self.observationSubscriptionID
+    let observationService = self.observationService
+    self.observationSubscriptionID = nil
 
     if let subscriptionID, let coordinator {
       Task {
         await coordinator.unsubscribe(subscriptionID: subscriptionID)
+      }
+    }
+    if let observationSubscriptionID, let observationService {
+      Task {
+        await observationService.unsubscribe(subscriptionID: observationSubscriptionID)
       }
     }
   }
@@ -113,15 +163,43 @@ public final class SessionGitHubQuickAccessViewModel {
     subscriptionTask?.cancel()
     subscriptionTask = nil
     self.subscriptionID = nil
+    let observationSubscriptionID = self.observationSubscriptionID
+    let observationService = self.observationService
+    self.observationSubscriptionID = nil
 
     if let subscriptionID, let coordinator {
       await coordinator.unsubscribe(subscriptionID: subscriptionID)
     }
+    if let observationSubscriptionID, let observationService {
+      await observationService.unsubscribe(subscriptionID: observationSubscriptionID)
+    }
   }
 
-  private func apply(currentBranchPR: GitHubPullRequest?, for repositoryKey: String) {
+  private func apply(
+    currentBranchPR: GitHubPullRequest?,
+    for repositoryKey: String,
+    state: GitHubPRObservationState
+  ) {
     guard loadedRepositoryKey == repositoryKey else { return }
     self.currentBranchPR = currentBranchPR
+    currentBranchChecks = []
+    observationState = state
+    lastRefreshedAt = .now
+  }
+
+  private func apply(snapshot: GitHubPRObservationSnapshot, for repositoryKey: String) {
+    guard loadedRepositoryKey == repositoryKey else { return }
+    currentBranchPR = snapshot.pullRequest
+    currentBranchChecks = snapshot.checks
+    observationState = snapshot.state
+    lastRefreshedAt = snapshot.lastRefreshedAt
+  }
+
+  private func clearState(state: GitHubPRObservationState = .idle) {
+    currentBranchPR = nil
+    currentBranchChecks = []
+    observationState = state
+    lastRefreshedAt = nil
   }
 
   public nonisolated static func repositoryKey(projectPath: String, branchName: String?) -> String {

--- a/app/modules/AgentHubGitHub/Tests/AgentHubGitHubTests/GitHubCLIServiceTests.swift
+++ b/app/modules/AgentHubGitHub/Tests/AgentHubGitHubTests/GitHubCLIServiceTests.swift
@@ -36,6 +36,14 @@ struct GitHubCLIServiceParsingTests {
     #expect(checks[0].statusDisplayName == "Pending")
   }
 
+  @Test("current branch no-PR message is recognized")
+  func currentBranchNoPRMessageIsRecognized() {
+    #expect(GitHubCLIService.isNoCurrentBranchPRMessage(
+      #"no pull requests found for branch "github-observe""#
+    ))
+    #expect(!GitHubCLIService.isNoCurrentBranchPRMessage("authentication required"))
+  }
+
   @Test("parsePRFiles handles slurped paginated arrays")
   func parsePRFilesHandlesSlurpedPages() throws {
     let json = """

--- a/app/modules/AgentHubGitHub/Tests/AgentHubGitHubTests/GitHubPRObservationServiceTests.swift
+++ b/app/modules/AgentHubGitHub/Tests/AgentHubGitHubTests/GitHubPRObservationServiceTests.swift
@@ -1,0 +1,233 @@
+//
+//  GitHubPRObservationServiceTests.swift
+//  AgentHubTests
+//
+//  Tests for shared GitHub PR/check observation.
+//
+
+import Foundation
+import Testing
+
+@testable import AgentHubGitHub
+
+private func makeObservedPR(number: Int = 1, title: String = "Observed PR") -> GitHubPullRequest {
+  GitHubPullRequest(
+    number: number,
+    title: title,
+    body: nil,
+    state: "OPEN",
+    url: "https://github.com/test/repo/pull/\(number)",
+    headRefName: "feature",
+    baseRefName: "main",
+    author: GitHubAuthor(login: "testuser", name: nil),
+    createdAt: .now,
+    updatedAt: .now,
+    isDraft: false,
+    mergeable: "MERGEABLE",
+    additions: 10,
+    deletions: 2,
+    changedFiles: 3,
+    reviewDecision: nil,
+    statusCheckRollup: nil,
+    labels: nil,
+    reviewRequests: nil,
+    comments: nil
+  )
+}
+
+private func makeObservedCheck(
+  name: String,
+  status: String = "COMPLETED",
+  conclusion: String? = "SUCCESS",
+  bucket: String? = nil
+) -> GitHubCheckRun {
+  GitHubCheckRun(name: name, status: status, conclusion: conclusion, bucket: bucket, detailsUrl: nil)
+}
+
+private func makeObservationConfiguration(
+  pendingPollInterval: TimeInterval = 0.02,
+  settledPollInterval: TimeInterval = 0.2,
+  idleTimeout: TimeInterval = 1,
+  errorBackoff: [TimeInterval] = [0.02, 0.03]
+) -> GitHubPRObservationConfiguration {
+  GitHubPRObservationConfiguration(
+    pendingPollInterval: pendingPollInterval,
+    settledPollInterval: settledPollInterval,
+    idleTimeout: idleTimeout,
+    errorBackoff: errorBackoff
+  )
+}
+
+@Suite("GitHubPRObservationService")
+struct GitHubPRObservationServiceTests {
+
+  @Test("deduplicates subscribers for the same current-branch target")
+  func deduplicatesSubscribers() async {
+    let service = MockGitHubCLIService()
+    service.currentBranchPRResult = makeObservedPR(number: 10)
+    service.checksResult = [makeObservedCheck(name: "Build")]
+    let observer = GitHubPRObservationService(
+      service: service,
+      configuration: makeObservationConfiguration()
+    )
+    let target = GitHubPRObservationTarget.currentBranch(projectPath: "/tmp/repo", branchName: "feature")
+
+    let first = await observer.subscribe(to: target)
+    let second = await observer.subscribe(to: target)
+    await observer.recordActivity(for: target, at: .now)
+    try? await Task.sleep(for: .milliseconds(30))
+
+    #expect(service.getCurrentBranchPRCallCount == 1)
+    #expect(service.getChecksCallCount == 1)
+
+    await observer.unsubscribe(subscriptionID: first.id)
+    await observer.unsubscribe(subscriptionID: second.id)
+  }
+
+  @Test("selected PR subscription fetches PR metadata and checks")
+  func selectedPRFetchesMetadataAndChecks() async {
+    let service = MockGitHubCLIService()
+    service.pullRequestResult = makeObservedPR(number: 42)
+    service.checksResult = [
+      makeObservedCheck(name: "Build"),
+      makeObservedCheck(name: "Tests", conclusion: "FAILURE"),
+    ]
+    let observer = GitHubPRObservationService(
+      service: service,
+      configuration: makeObservationConfiguration()
+    )
+    let target = GitHubPRObservationTarget.pullRequest(projectPath: "/tmp/repo", number: 42)
+
+    let subscription = await observer.subscribe(to: target)
+    await observer.recordActivity(for: target, at: .now)
+    try? await Task.sleep(for: .milliseconds(30))
+
+    #expect(service.getPullRequestCallCount == 1)
+    #expect(service.getPullRequestNumber == 42)
+    #expect(service.getChecksCallCount == 1)
+    #expect(service.getChecksPRNumber == 42)
+
+    await observer.unsubscribe(subscriptionID: subscription.id)
+  }
+
+  @Test("subscribe can defer initial fetch until recent activity")
+  func subscribeCanDeferInitialFetchUntilRecentActivity() async {
+    let service = MockGitHubCLIService()
+    service.currentBranchPRResult = makeObservedPR(number: 11)
+    service.checksResult = [makeObservedCheck(name: "Build")]
+    let observer = GitHubPRObservationService(
+      service: service,
+      configuration: makeObservationConfiguration(idleTimeout: 1)
+    )
+    let target = GitHubPRObservationTarget.currentBranch(projectPath: "/tmp/repo", branchName: "feature")
+
+    let subscription = await observer.subscribe(to: target, refreshOnSubscribe: false)
+    try? await Task.sleep(for: .milliseconds(30))
+    #expect(service.getCurrentBranchPRCallCount == 0)
+
+    await observer.recordActivity(for: target, at: Date.now.addingTimeInterval(-10))
+    try? await Task.sleep(for: .milliseconds(30))
+    #expect(service.getCurrentBranchPRCallCount == 0)
+
+    await observer.recordActivity(for: target, at: .now)
+    try? await Task.sleep(for: .milliseconds(30))
+    #expect(service.getCurrentBranchPRCallCount == 1)
+
+    await observer.unsubscribe(subscriptionID: subscription.id)
+  }
+
+  @Test("pending checks use the faster cadence")
+  func pendingChecksUseFastCadence() async {
+    let service = MockGitHubCLIService()
+    service.currentBranchPRResult = makeObservedPR(number: 7)
+    service.checksResults = [
+      .success([makeObservedCheck(name: "Build", status: "IN_PROGRESS", conclusion: nil, bucket: "pending")]),
+      .success([makeObservedCheck(name: "Build")]),
+    ]
+    let observer = GitHubPRObservationService(
+      service: service,
+      configuration: makeObservationConfiguration(pendingPollInterval: 0.02, settledPollInterval: 0.2)
+    )
+    let target = GitHubPRObservationTarget.currentBranch(projectPath: "/tmp/repo", branchName: "feature")
+
+    let subscription = await observer.subscribe(to: target)
+    await observer.recordActivity(for: target, at: .now)
+    try? await Task.sleep(for: .milliseconds(70))
+
+    #expect(service.getChecksCallCount >= 2)
+
+    await observer.unsubscribe(subscriptionID: subscription.id)
+  }
+
+  @Test("settled checks keep the slower cadence")
+  func settledChecksUseSlowCadence() async {
+    let service = MockGitHubCLIService()
+    service.currentBranchPRResult = makeObservedPR(number: 7)
+    service.checksResult = [makeObservedCheck(name: "Build")]
+    let observer = GitHubPRObservationService(
+      service: service,
+      configuration: makeObservationConfiguration(pendingPollInterval: 0.02, settledPollInterval: 0.2)
+    )
+    let target = GitHubPRObservationTarget.currentBranch(projectPath: "/tmp/repo", branchName: "feature")
+
+    let subscription = await observer.subscribe(to: target)
+    await observer.recordActivity(for: target, at: .now)
+    try? await Task.sleep(for: .milliseconds(70))
+
+    #expect(service.getChecksCallCount == 1)
+
+    await observer.unsubscribe(subscriptionID: subscription.id)
+  }
+
+  @Test("terminal errors pause until activity reactivates observation")
+  func terminalErrorsPauseUntilActivity() async {
+    let service = MockGitHubCLIService()
+    service.currentBranchPRResults = [
+      .failure(GitHubCLIError.notAuthenticated),
+      .success(makeObservedPR(number: 9)),
+    ]
+    service.checksResult = [makeObservedCheck(name: "Build")]
+    let observer = GitHubPRObservationService(
+      service: service,
+      configuration: makeObservationConfiguration(pendingPollInterval: 0.02, settledPollInterval: 0.2)
+    )
+    let target = GitHubPRObservationTarget.currentBranch(projectPath: "/tmp/repo", branchName: "feature")
+
+    let subscription = await observer.subscribe(to: target)
+    try? await Task.sleep(for: .milliseconds(30))
+    #expect(service.getCurrentBranchPRCallCount == 1)
+
+    try? await Task.sleep(for: .milliseconds(40))
+    #expect(service.getCurrentBranchPRCallCount == 1)
+
+    await observer.recordActivity(for: target, at: .now)
+    try? await Task.sleep(for: .milliseconds(30))
+    #expect(service.getCurrentBranchPRCallCount == 2)
+
+    await observer.unsubscribe(subscriptionID: subscription.id)
+  }
+
+  @Test("unsubscribing the last subscriber cancels polling")
+  func unsubscribeCancelsPolling() async {
+    let service = MockGitHubCLIService()
+    service.currentBranchPRResult = makeObservedPR(number: 7)
+    service.checksResult = [
+      makeObservedCheck(name: "Build", status: "IN_PROGRESS", conclusion: nil, bucket: "pending")
+    ]
+    let observer = GitHubPRObservationService(
+      service: service,
+      configuration: makeObservationConfiguration(pendingPollInterval: 0.02, settledPollInterval: 0.2)
+    )
+    let target = GitHubPRObservationTarget.currentBranch(projectPath: "/tmp/repo", branchName: "feature")
+
+    let subscription = await observer.subscribe(to: target)
+    await observer.recordActivity(for: target, at: .now)
+    try? await Task.sleep(for: .milliseconds(30))
+    let callsBeforeUnsubscribe = service.getChecksCallCount
+
+    await observer.unsubscribe(subscriptionID: subscription.id)
+    try? await Task.sleep(for: .milliseconds(50))
+
+    #expect(service.getChecksCallCount == callsBeforeUnsubscribe)
+  }
+}

--- a/app/modules/AgentHubGitHub/Tests/AgentHubGitHubTests/GitHubViewModelObservationTests.swift
+++ b/app/modules/AgentHubGitHub/Tests/AgentHubGitHubTests/GitHubViewModelObservationTests.swift
@@ -1,0 +1,200 @@
+//
+//  GitHubViewModelObservationTests.swift
+//  AgentHubTests
+//
+//  Tests for GitHubViewModel observation integration.
+//
+
+import Foundation
+import Testing
+
+@testable import AgentHubGitHub
+
+private extension NSLock {
+  func withLock<T>(_ body: () throws -> T) rethrows -> T {
+    lock()
+    defer { unlock() }
+    return try body()
+  }
+}
+
+private func makeViewModelObservationPR(
+  number: Int = 1,
+  title: String = "Observed PR"
+) -> GitHubPullRequest {
+  GitHubPullRequest(
+    number: number,
+    title: title,
+    body: nil,
+    state: "OPEN",
+    url: "https://github.com/test/repo/pull/\(number)",
+    headRefName: "feature",
+    baseRefName: "main",
+    author: GitHubAuthor(login: "testuser", name: nil),
+    createdAt: .now,
+    updatedAt: .now,
+    isDraft: false,
+    mergeable: "MERGEABLE",
+    additions: 4,
+    deletions: 1,
+    changedFiles: 2,
+    reviewDecision: nil,
+    statusCheckRollup: nil,
+    labels: nil,
+    reviewRequests: nil,
+    comments: nil
+  )
+}
+
+private func makeViewModelObservationCheck(name: String = "Build") -> GitHubCheckRun {
+  GitHubCheckRun(name: name, status: "COMPLETED", conclusion: "SUCCESS", bucket: nil, detailsUrl: nil)
+}
+
+private final class MockGitHubPRObservationService: GitHubPRObservationServiceProtocol, @unchecked Sendable {
+  private let lock = NSLock()
+  private var continuations: [UUID: AsyncStream<GitHubPRObservationSnapshot>.Continuation] = [:]
+  private var targetsByID: [UUID: GitHubPRObservationTarget] = [:]
+
+  private(set) var subscribedTargets: [GitHubPRObservationTarget] = []
+  private(set) var unsubscribedIDs: [UUID] = []
+  private(set) var refreshedTargets: [GitHubPRObservationTarget] = []
+  private(set) var activityTargets: [GitHubPRObservationTarget] = []
+
+  func subscribe(
+    to target: GitHubPRObservationTarget,
+    refreshOnSubscribe: Bool
+  ) async -> GitHubPRObservationSubscription {
+    let id = UUID()
+    var continuation: AsyncStream<GitHubPRObservationSnapshot>.Continuation?
+    let updates = AsyncStream<GitHubPRObservationSnapshot> { streamContinuation in
+      continuation = streamContinuation
+    }
+
+    lock.withLock {
+      subscribedTargets.append(target)
+      targetsByID[id] = target
+      if let continuation {
+        continuations[id] = continuation
+      }
+    }
+
+    continuation?.yield(.initial(target: target))
+    return GitHubPRObservationSubscription(id: id, updates: updates)
+  }
+
+  func unsubscribe(subscriptionID: UUID) async {
+    let continuation = lock.withLock {
+      unsubscribedIDs.append(subscriptionID)
+      targetsByID.removeValue(forKey: subscriptionID)
+      return continuations.removeValue(forKey: subscriptionID)
+    }
+    continuation?.finish()
+  }
+
+  func refresh(_ target: GitHubPRObservationTarget) async {
+    lock.withLock {
+      refreshedTargets.append(target)
+    }
+  }
+
+  func recordActivity(for target: GitHubPRObservationTarget, at: Date) async {
+    lock.withLock {
+      activityTargets.append(target)
+    }
+  }
+
+  func publish(_ snapshot: GitHubPRObservationSnapshot) {
+    let continuations = lock.withLock {
+      self.continuations.filter { id, _ in
+        targetsByID[id] == snapshot.target
+      }.map(\.value)
+    }
+    for continuation in continuations {
+      continuation.yield(snapshot)
+    }
+  }
+
+  func activeSubscriptionCount(for target: GitHubPRObservationTarget) -> Int {
+    lock.withLock {
+      targetsByID.values.count { $0 == target }
+    }
+  }
+}
+
+@Suite("GitHubViewModel Observation")
+struct GitHubViewModelObservationTests {
+
+  @Test("setup starts current branch observation and applies snapshots")
+  @MainActor
+  func setupStartsCurrentBranchObservation() async {
+    let service = MockGitHubCLIService()
+    service.repoInfoResult = GitHubRepoInfo(
+      owner: "test",
+      name: "repo",
+      fullName: "test/repo",
+      defaultBranch: "main",
+      isPrivate: false,
+      url: "https://github.com/test/repo"
+    )
+    let observer = MockGitHubPRObservationService()
+    let viewModel = GitHubViewModel(service: service, observationService: observer)
+    let target = GitHubPRObservationTarget.currentBranch(projectPath: "/tmp/repo", branchName: "feature")
+
+    await viewModel.setup(repoPath: "/tmp/repo", branchName: "feature")
+    try? await Task.sleep(for: .milliseconds(10))
+
+    #expect(observer.subscribedTargets == [target])
+
+    observer.publish(GitHubPRObservationSnapshot(
+      target: target,
+      pullRequest: makeViewModelObservationPR(number: 12),
+      checks: [makeViewModelObservationCheck()],
+      state: .ready,
+      lastRefreshedAt: .now
+    ))
+    try? await Task.sleep(for: .milliseconds(10))
+
+    #expect(viewModel.currentBranchPR?.number == 12)
+    #expect(viewModel.currentBranchChecks.count == 1)
+    #expect(viewModel.currentBranchObservationState == .ready)
+  }
+
+  @Test("selectPR starts selected PR observation and updates checks")
+  @MainActor
+  func selectPRStartsSelectedObservation() async {
+    let service = MockGitHubCLIService()
+    service.repoInfoResult = GitHubRepoInfo(
+      owner: "test",
+      name: "repo",
+      fullName: "test/repo",
+      defaultBranch: "main",
+      isPrivate: false,
+      url: "https://github.com/test/repo"
+    )
+    service.pullRequestDiffResult = ""
+    service.pullRequestFilesResult = []
+    service.reviewCommentsResult = []
+    let observer = MockGitHubPRObservationService()
+    let viewModel = GitHubViewModel(service: service, observationService: observer)
+    await viewModel.setup(repoPath: "/tmp/repo", branchName: "feature")
+
+    viewModel.selectPR(makeViewModelObservationPR(number: 44, title: "Initial"))
+    try? await Task.sleep(for: .milliseconds(10))
+
+    let target = GitHubPRObservationTarget.pullRequest(projectPath: "/tmp/repo", number: 44)
+    #expect(observer.subscribedTargets.contains(target))
+
+    observer.publish(GitHubPRObservationSnapshot(
+      target: target,
+      pullRequest: makeViewModelObservationPR(number: 44, title: "Updated"),
+      checks: [makeViewModelObservationCheck(name: "Tests")],
+      state: .ready,
+      lastRefreshedAt: .now
+    ))
+    try? await Task.sleep(for: .milliseconds(10))
+
+    #expect(viewModel.selectedPR?.title == "Updated")
+    #expect(viewModel.checks.map(\.name) == ["Tests"])
+    #expect(viewModel.loadedChecksPRNumber == 44)
+  }
+}

--- a/app/modules/AgentHubGitHub/Tests/AgentHubGitHubTests/MockGitHubCLIService.swift
+++ b/app/modules/AgentHubGitHub/Tests/AgentHubGitHubTests/MockGitHubCLIService.swift
@@ -83,12 +83,24 @@ final class MockGitHubCLIService: GitHubCLIServiceProtocol, @unchecked Sendable 
   }
 
   var pullRequestResult: GitHubPullRequest?
+  var pullRequestResults: [Result<GitHubPullRequest, Error>] = []
   var getPullRequestCalled = false
+  var getPullRequestCallCount = 0
   var getPullRequestNumber: Int?
 
   func getPullRequest(number: Int, at repoPath: String) async throws -> GitHubPullRequest {
     getPullRequestCalled = true
+    getPullRequestCallCount += 1
     getPullRequestNumber = number
+    if !pullRequestResults.isEmpty {
+      let nextResult = pullRequestResults.removeFirst()
+      switch nextResult {
+      case .success(let result):
+        return result
+      case .failure(let error):
+        throw error
+      }
+    }
     if let error = errorToThrow { throw error }
     guard let result = pullRequestResult else {
       throw GitHubCLIError.commandFailed("No mock pullRequestResult configured")
@@ -247,12 +259,24 @@ final class MockGitHubCLIService: GitHubCLIServiceProtocol, @unchecked Sendable 
   // MARK: - CI/CD
 
   var checksResult: [GitHubCheckRun] = []
+  var checksResults: [Result<[GitHubCheckRun], Error>] = []
   var getChecksCalled = false
+  var getChecksCallCount = 0
   var getChecksPRNumber: Int?
 
   func getChecks(prNumber: Int?, at repoPath: String) async throws -> [GitHubCheckRun] {
     getChecksCalled = true
+    getChecksCallCount += 1
     getChecksPRNumber = prNumber
+    if !checksResults.isEmpty {
+      let nextResult = checksResults.removeFirst()
+      switch nextResult {
+      case .success(let result):
+        return result
+      case .failure(let error):
+        throw error
+      }
+    }
     if let error = errorToThrow { throw error }
     return checksResult
   }
@@ -278,6 +302,7 @@ final class MockGitHubCLIService: GitHubCLIServiceProtocol, @unchecked Sendable 
     listPullRequestsState = nil
     listPullRequestsLimit = nil
     getPullRequestCalled = false
+    getPullRequestCallCount = 0
     getPullRequestNumber = nil
     getCurrentBranchPRCalled = false
     getCurrentBranchPRCallCount = 0
@@ -306,6 +331,7 @@ final class MockGitHubCLIService: GitHubCLIServiceProtocol, @unchecked Sendable 
     addIssueCommentNumber = nil
     addIssueCommentBody = nil
     getChecksCalled = false
+    getChecksCallCount = 0
     getChecksPRNumber = nil
     listWorkflowRunsCalled = false
   }

--- a/app/modules/AgentHubGitHub/Tests/AgentHubGitHubTests/SessionGitHubQuickAccessViewModelTests.swift
+++ b/app/modules/AgentHubGitHub/Tests/AgentHubGitHubTests/SessionGitHubQuickAccessViewModelTests.swift
@@ -41,6 +41,15 @@ private func makeQuickAccessPR(
   )
 }
 
+private func makeQuickAccessCheck(
+  name: String = "Build",
+  status: String = "COMPLETED",
+  conclusion: String? = "SUCCESS",
+  bucket: String? = nil
+) -> GitHubCheckRun {
+  GitHubCheckRun(name: name, status: status, conclusion: conclusion, bucket: bucket, detailsUrl: nil)
+}
+
 actor MockSessionGitHubQuickAccessCoordinator: SessionGitHubQuickAccessCoordinatorProtocol {
   private var continuations: [UUID: AsyncStream<GitHubPullRequest?>.Continuation] = [:]
   private var subscriptionKeys: [UUID: String] = [:]
@@ -109,6 +118,57 @@ actor MockSessionGitHubQuickAccessCoordinator: SessionGitHubQuickAccessCoordinat
   }
 }
 
+private actor MockSessionGitHubPRObservationService: GitHubPRObservationServiceProtocol {
+  private var continuations: [UUID: AsyncStream<GitHubPRObservationSnapshot>.Continuation] = [:]
+  private var subscriptionTargets: [UUID: GitHubPRObservationTarget] = [:]
+
+  private(set) var subscribedTargets: [GitHubPRObservationTarget] = []
+  private(set) var unsubscribedIDs: [UUID] = []
+  private(set) var recordedActivityTargets: [GitHubPRObservationTarget] = []
+
+  func subscribe(
+    to target: GitHubPRObservationTarget,
+    refreshOnSubscribe: Bool
+  ) async -> GitHubPRObservationSubscription {
+    let subscriptionID = UUID()
+    var continuation: AsyncStream<GitHubPRObservationSnapshot>.Continuation?
+    let updates = AsyncStream<GitHubPRObservationSnapshot> { streamContinuation in
+      continuation = streamContinuation
+    }
+
+    if let continuation {
+      continuations[subscriptionID] = continuation
+      subscriptionTargets[subscriptionID] = target
+      subscribedTargets.append(target)
+      continuation.yield(.initial(target: target))
+    }
+
+    return GitHubPRObservationSubscription(id: subscriptionID, updates: updates)
+  }
+
+  func unsubscribe(subscriptionID: UUID) async {
+    unsubscribedIDs.append(subscriptionID)
+    continuations.removeValue(forKey: subscriptionID)?.finish()
+    subscriptionTargets.removeValue(forKey: subscriptionID)
+  }
+
+  func refresh(_ target: GitHubPRObservationTarget) async {}
+
+  func recordActivity(for target: GitHubPRObservationTarget, at: Date) async {
+    recordedActivityTargets.append(target)
+  }
+
+  func publish(_ snapshot: GitHubPRObservationSnapshot) {
+    for (subscriptionID, continuation) in continuations where subscriptionTargets[subscriptionID] == snapshot.target {
+      continuation.yield(snapshot)
+    }
+  }
+
+  func activeSubscriptionCount(for target: GitHubPRObservationTarget) -> Int {
+    subscriptionTargets.values.count { $0 == target }
+  }
+}
+
 @Suite("SessionGitHubQuickAccessViewModel")
 struct SessionGitHubQuickAccessViewModelTests {
 
@@ -152,6 +212,54 @@ struct SessionGitHubQuickAccessViewModelTests {
     #expect(viewModel.currentBranchPR?.number == 42)
     #expect(await coordinator.subscribeCallCount == 1)
     #expect(await coordinator.activeSubscriptionCount(for: "/tmp/repo", branchName: "main") == 1)
+  }
+
+  @Test("observation service updates PR checks and state")
+  @MainActor
+  func observationServiceUpdatesChecksAndState() async {
+    let observer = MockSessionGitHubPRObservationService()
+    let viewModel = SessionGitHubQuickAccessViewModel(observationService: observer)
+    let target = GitHubPRObservationTarget.currentBranch(projectPath: "/tmp/repo", branchName: "feature/github")
+
+    await viewModel.load(projectPath: "/tmp/repo", branchName: "feature/github")
+    await observer.publish(GitHubPRObservationSnapshot(
+      target: target,
+      pullRequest: makeQuickAccessPR(number: 91),
+      checks: [
+        makeQuickAccessCheck(name: "Build"),
+        makeQuickAccessCheck(name: "Tests", status: "IN_PROGRESS", conclusion: nil, bucket: "pending"),
+      ],
+      state: .ready,
+      lastRefreshedAt: .now
+    ))
+    try? await Task.sleep(for: .milliseconds(10))
+
+    #expect(viewModel.currentBranchPR?.number == 91)
+    #expect(viewModel.currentBranchChecks.map(\.name) == ["Build", "Tests"])
+    #expect(viewModel.ciSummary.passed == 1)
+    #expect(viewModel.ciSummary.pending == 1)
+    #expect(viewModel.observationState == .ready)
+    #expect(await observer.subscribedTargets == [target])
+    #expect(await observer.recordedActivityTargets == [target])
+  }
+
+  @Test("observation service can defer initial activity for list rows")
+  @MainActor
+  func observationServiceCanDeferInitialActivity() async {
+    let observer = MockSessionGitHubPRObservationService()
+    let viewModel = SessionGitHubQuickAccessViewModel(observationService: observer)
+    let target = GitHubPRObservationTarget.currentBranch(projectPath: "/tmp/repo", branchName: "feature/github")
+    let activityDate = Date.now.addingTimeInterval(-600)
+
+    await viewModel.load(
+      projectPath: "/tmp/repo",
+      branchName: "feature/github",
+      recordInitialActivity: false
+    )
+    #expect(await observer.recordedActivityTargets.isEmpty)
+
+    await viewModel.notifySessionActivity(at: activityDate)
+    #expect(await observer.recordedActivityTargets == [target])
   }
 
   @Test("same repo load does not create duplicate subscriptions")


### PR DESCRIPTION
## Summary

Adds a shared GitHub PR/CI observation service for AgentHub so session rows, monitoring cards, and the GitHub panel can reuse one observation pipeline instead of starting independent GitHub CLI polling loops.

- Adds `GitHubPRObservationService` with target-based subscriptions, deduped polling, activity-based refresh, idle pause, and error backoff.
- Wires the shared observer through `AgentHubProvider`, `GitHubViewModel`, `SessionGitHubQuickAccessViewModel`, monitoring cards, and side-panel session rows.
- Keeps compact session rows quiet when the current branch has no PR, and shows PR/CI state only when a current-branch PR exists.
- Adds a sidebar GitHub refresh action plus delayed bounded initial refresh so launch time is not blocked by GitHub checks.
- Documents the feature in `README.md`, `AGENTS.md`, `CLAUDE.md`, and the new `GitHubMonitor.md` technical reference.

## Validation

- `git diff --check`
- `swift test --package-path app/modules/AgentHubGitHub` - 63 tests passed
- `xcodebuild -project app/AgentHub.xcodeproj -scheme AgentHub -destination 'platform=macOS,arch=arm64' build -quiet`

The Xcode build still emits the existing libgit2/signing/Info.plist warnings, but exits successfully.