### PR TITLE
Scope worktree sessions to AgentHub-owned worktrees

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ https://github.com/user-attachments/assets/ee453a78-e417-488a-96c7-20732d1d1f60
 - **Inline diff review** — Full split-pane diff view with inline editor to send change requests directly to Claude
 - **GitHub support** — Browse pull requests and issues for the current repository, inspect PR diffs and CI checks, monitor current-branch PR status from session rows, and send GitHub context back into a session
 - **File explorer and built-in editor** — Browse the project tree, jump to files with Cmd+P, edit files in-app with syntax highlighting, and save changes without leaving AgentHub
-- **Git worktree management** — Create and delete worktrees from the UI; launch sessions on new branches
+- **Git worktree management** — Create and delete worktrees from the UI, launch sessions on new branches, and choose whether AgentHub-owned worktree sessions appear under the parent module or as separate modules
 - **Remix with provider picker** — Branch any session into an isolated git worktree and continue it in Claude or Codex; the original session's transcript is passed as context to the new session
 - **Multi-session launcher** — Launch parallel sessions across Claude and Codex with manual prompts or AI-planned orchestration (Smart mode)
 - **Mermaid diagrams** — Detects Mermaid diagram syntax in session output and renders it natively; diagrams can be exported as images
@@ -224,10 +224,11 @@ When active, a teal indicator appears below the prompt.
 
 ## Configuration
 
-AgentHub's settings window is organized into three tabs:
+AgentHub's settings window is organized into four tabs:
 
 - **General** — Notifications and app-wide behavior such as opening the file explorer in a modal window
 - **Configuration** — Claude and Codex CLI commands, provider-specific defaults, and Smart mode
+- **Worktrees** — Worktree module grouping and generated branch naming
 - **Appearance** — Flat session layout, terminal preferences, and theme selection
 
 ### Display Mode
@@ -238,6 +239,12 @@ AgentHub supports two display modes:
 - **Popover Mode** — Stats appear as a toolbar button in the app window
 
 Toggle between modes in the app settings.
+
+### Worktree Grouping
+
+Worktree sessions are grouped under their parent module by default, so `ModuleA` shows its regular sessions plus AgentHub-owned worktree sessions. The Worktrees settings tab can switch to separate modules, where each AgentHub-owned worktree appears as its own module section.
+
+AgentHub only treats worktrees it created, explicitly added, or focused through monitored sessions as owned. External Git worktrees discovered from the repository are ignored for session grouping, which keeps large local worktree setups from flooding the session list.
 
 ### Provider Defaults
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubDefaults.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubDefaults.swift
@@ -179,6 +179,10 @@ public enum AgentHubDefaults {
   /// Type: String (default: "")
   public static let worktreeBranchPrefix = "\(keyPrefix)worktree.generatedBranchPrefix"
 
+  /// How worktree sessions are grouped in module-oriented UI.
+  /// Type: String (default: WorktreeDisplayMode.parent.rawValue)
+  public static let worktreeDisplayMode = "\(keyPrefix)worktree.displayMode"
+
   // MARK: - Theme Settings
 
   /// Selected color theme name

--- a/app/modules/AgentHubCore/Sources/AgentHub/Models/ModuleLandingSelection.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Models/ModuleLandingSelection.swift
@@ -6,31 +6,19 @@ enum ModuleLandingSelection {
   static func activeModulePath(
     selectedPath: String?,
     repositories: [SelectedRepository],
-    itemProjectPaths: [String]
+    itemProjectPaths: [String],
+    mode: WorktreeDisplayMode = .parent
   ) -> String? {
     guard let selectedPath else { return nil }
-    guard repositories.contains(where: { $0.path == selectedPath }) else { return nil }
+    guard WorktreeModuleResolver.modulePaths(for: repositories, mode: mode).contains(selectedPath) else { return nil }
 
     let hasItems = itemProjectPaths.contains { itemPath in
-      parentModulePath(for: itemPath, repositories: repositories) == selectedPath
+      WorktreeModuleResolver.modulePath(
+        for: itemPath,
+        repositories: repositories,
+        mode: mode
+      ) == selectedPath
     }
     return hasItems ? nil : selectedPath
-  }
-
-  private static func parentModulePath(
-    for itemPath: String,
-    repositories: [SelectedRepository]
-  ) -> String {
-    for repository in repositories {
-      if repository.path == itemPath {
-        return repository.path
-      }
-
-      if repository.worktrees.contains(where: { $0.path == itemPath }) {
-        return repository.path
-      }
-    }
-
-    return itemPath
   }
 }

--- a/app/modules/AgentHubCore/Sources/AgentHub/Models/SessionWorkspaceState.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Models/SessionWorkspaceState.swift
@@ -9,15 +9,18 @@ import Foundation
 public struct SessionWorkspaceState: Codable, Equatable, Sendable {
   public var selectedRepositoryPaths: [String]
   public var monitoredSessionIds: [String]
+  public var ownedWorktreePaths: [String]
   public var expansionState: [String: Bool]
 
   public init(
     selectedRepositoryPaths: [String] = [],
     monitoredSessionIds: [String] = [],
+    ownedWorktreePaths: [String] = [],
     expansionState: [String: Bool] = [:]
   ) {
     self.selectedRepositoryPaths = selectedRepositoryPaths
     self.monitoredSessionIds = monitoredSessionIds
+    self.ownedWorktreePaths = ownedWorktreePaths
     self.expansionState = expansionState
   }
 }

--- a/app/modules/AgentHubCore/Sources/AgentHub/Models/SessionWorkspaceStateRecord.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Models/SessionWorkspaceStateRecord.swift
@@ -13,6 +13,7 @@ public struct SessionWorkspaceStateRecord: Codable, Sendable, FetchableRecord, P
   public var provider: String
   public var selectedRepositoryPathsData: Data
   public var monitoredSessionIdsData: Data
+  public var ownedWorktreePathsData: Data?
   public var expansionStateData: Data
   public var updatedAt: Date
 
@@ -24,6 +25,7 @@ public struct SessionWorkspaceStateRecord: Codable, Sendable, FetchableRecord, P
     self.provider = provider
     self.selectedRepositoryPathsData = try JSONEncoder().encode(state.selectedRepositoryPaths)
     self.monitoredSessionIdsData = try JSONEncoder().encode(state.monitoredSessionIds)
+    self.ownedWorktreePathsData = try JSONEncoder().encode(state.ownedWorktreePaths)
     self.expansionStateData = try JSONEncoder().encode(state.expansionState)
     self.updatedAt = updatedAt
   }
@@ -32,6 +34,9 @@ public struct SessionWorkspaceStateRecord: Codable, Sendable, FetchableRecord, P
     SessionWorkspaceState(
       selectedRepositoryPaths: (try? JSONDecoder().decode([String].self, from: selectedRepositoryPathsData)) ?? [],
       monitoredSessionIds: (try? JSONDecoder().decode([String].self, from: monitoredSessionIdsData)) ?? [],
+      ownedWorktreePaths: ownedWorktreePathsData.flatMap {
+        try? JSONDecoder().decode([String].self, from: $0)
+      } ?? [],
       expansionState: (try? JSONDecoder().decode([String: Bool].self, from: expansionStateData)) ?? [:]
     )
   }

--- a/app/modules/AgentHubCore/Sources/AgentHub/Models/WorktreeDisplayMode.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Models/WorktreeDisplayMode.swift
@@ -1,0 +1,31 @@
+//
+//  WorktreeDisplayMode.swift
+//  AgentHub
+//
+
+import Foundation
+
+public enum WorktreeDisplayMode: String, CaseIterable, Identifiable, Sendable, Codable {
+  case parent
+  case separateModules
+
+  public var id: String { rawValue }
+
+  public var label: String {
+    switch self {
+    case .parent:
+      return "Group under parent module"
+    case .separateModules:
+      return "Show worktrees as modules"
+    }
+  }
+
+  public var settingsDescription: String {
+    switch self {
+    case .parent:
+      return "Worktree sessions appear under their parent module."
+    case .separateModules:
+      return "Worktrees appear as separate module sections without adding them as saved repositories."
+    }
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/CLISessionMonitorService.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/CLISessionMonitorService.swift
@@ -45,6 +45,16 @@ public actor CLISessionMonitorService {
   /// Cache of worktree detection results keyed by repository path.
   private var worktreeCache: [String: [WorktreeBranch]] = [:]
 
+  /// Worktrees explicitly created or focused through AgentHub.
+  private var ownedWorktreePaths: Set<String> = []
+
+  /// Sessions explicitly started or focused through AgentHub.
+  private var focusedSessionIds: Set<String> = []
+
+  /// Git worktrees detected for tracked repositories but not owned by AgentHub.
+  /// Used to avoid attributing their sessions to the parent repository.
+  private var ignoredWorktreePathsByRepository: [String: Set<String>] = [:]
+
   // MARK: - Initialization
 
   public init(claudeDataPath: String? = nil, metadataStore: SessionMetadataStore? = nil) {
@@ -59,16 +69,19 @@ public actor CLISessionMonitorService {
   /// - Returns: The created SelectedRepository with detected worktrees, or nil for a duplicate add
   @discardableResult
   public func addRepository(_ path: String) async -> SelectedRepository? {
+    await markInputWorktreeAsOwnedIfNeeded(path)
+    let repositoryPath = await normalizedRepositoryPath(for: path)
+
     // Check if already added
-    guard !selectedRepositories.contains(where: { $0.path == path }) else {
+    guard !selectedRepositories.contains(where: { $0.path == repositoryPath }) else {
       return nil
     }
 
     // Detect worktrees for this repository
-    let worktrees = await detectWorktrees(at: path)
+    let worktrees = await detectWorktrees(at: repositoryPath)
 
     let repository = SelectedRepository(
-      path: path,
+      path: repositoryPath,
       worktrees: worktrees,
       isExpanded: true
     )
@@ -86,8 +99,13 @@ public actor CLISessionMonitorService {
   /// Adds multiple repositories at once, detecting worktrees in parallel and
   /// calling refreshSessions only once at the end (instead of N times).
   public func addRepositories(_ paths: [String]) async {
+    for path in paths {
+      await markInputWorktreeAsOwnedIfNeeded(path)
+    }
+    let normalizedPaths = await normalizedRepositoryPaths(paths)
+
     // Filter out already-added repos
-    let newPaths = paths.filter { path in
+    let newPaths = normalizedPaths.filter { path in
       !selectedRepositories.contains(where: { $0.path == path })
     }
     guard !newPaths.isEmpty else { return }
@@ -114,8 +132,10 @@ public actor CLISessionMonitorService {
   /// Restores selected repositories and worktrees without scanning every session.
   /// Used on app launch so the main monitored-session list can appear quickly.
   public func restoreRepositoriesSkeleton(_ paths: [String]) async -> [SelectedRepository] {
-    var seen: Set<String> = []
-    let uniquePaths = paths.filter { seen.insert($0).inserted }
+    for path in paths {
+      await markInputWorktreeAsOwnedIfNeeded(path)
+    }
+    let uniquePaths = await normalizedRepositoryPaths(paths)
 
     guard !uniquePaths.isEmpty else {
       selectedRepositories = []
@@ -140,7 +160,63 @@ public actor CLISessionMonitorService {
   /// Removes a repository from monitoring
   /// - Parameter path: Path to the repository to remove
   public func removeRepository(_ path: String) async {
-    selectedRepositories.removeAll { $0.path == path }
+    let repositoryPath = await normalizedRepositoryPath(for: path)
+    if let repository = selectedRepositories.first(where: { $0.path == repositoryPath }) {
+      ownedWorktreePaths.subtract(repository.worktrees.map(\.path))
+    }
+    ignoredWorktreePathsByRepository.removeValue(forKey: repositoryPath)
+    selectedRepositories.removeAll { $0.path == repositoryPath }
+    invalidateHistoryCache()
+    repositoriesSubject.send(selectedRepositories)
+  }
+
+  public func setOwnedWorktreePaths(_ paths: Set<String>) async {
+    let normalizedPaths = Set(paths.map { WorktreeModuleResolver.normalizedDirectoryPath($0) })
+    guard normalizedPaths != ownedWorktreePaths else { return }
+    ownedWorktreePaths = normalizedPaths
+    worktreeCache.removeAll()
+    invalidateHistoryCache()
+  }
+
+  public func setFocusedSessionIds(_ ids: Set<String>) async {
+    guard ids != focusedSessionIds else { return }
+    focusedSessionIds = ids
+    invalidateHistoryCache()
+  }
+
+  public func registerWorktree(_ worktree: WorktreeBranch, parentRepositoryPath: String) async {
+    let repositoryPath = await normalizedRepositoryPath(for: parentRepositoryPath)
+    let normalizedWorktree = WorktreeBranch(
+      name: worktree.name,
+      path: WorktreeModuleResolver.normalizedDirectoryPath(worktree.path),
+      isWorktree: worktree.isWorktree,
+      sessions: worktree.sessions,
+      isExpanded: true
+    )
+    if normalizedWorktree.isWorktree {
+      ownedWorktreePaths.insert(normalizedWorktree.path)
+      ignoredWorktreePathsByRepository[repositoryPath]?.remove(normalizedWorktree.path)
+    }
+
+    if let index = selectedRepositories.firstIndex(where: { $0.path == repositoryPath }) {
+      upsertWorktree(normalizedWorktree, inRepositoryAt: index)
+      worktreeCache[repositoryPath] = selectedRepositories[index].worktrees
+      invalidateHistoryCache()
+      repositoriesSubject.send(selectedRepositories)
+      return
+    }
+
+    var worktrees = await detectWorktrees(at: repositoryPath)
+    if !worktrees.contains(where: { $0.path == normalizedWorktree.path }) {
+      worktrees.append(normalizedWorktree)
+    }
+    let repository = SelectedRepository(
+      path: repositoryPath,
+      worktrees: worktrees,
+      isExpanded: true
+    )
+    selectedRepositories.append(repository)
+    worktreeCache[repositoryPath] = worktrees
     invalidateHistoryCache()
     repositoriesSubject.send(selectedRepositories)
   }
@@ -155,6 +231,54 @@ public actor CLISessionMonitorService {
     selectedRepositories = repositories
     invalidateHistoryCache()
     await refreshSessions()
+  }
+
+  private func normalizedRepositoryPath(for path: String) async -> String {
+    let normalizedPath = WorktreeModuleResolver.normalizedDirectoryPath(path)
+    guard let info = await GitWorktreeDetector.detectWorktreeInfo(for: normalizedPath),
+          info.isWorktree,
+          let mainRepoPath = info.mainRepoPath,
+          !mainRepoPath.isEmpty else {
+      return normalizedPath
+    }
+    return WorktreeModuleResolver.normalizedDirectoryPath(mainRepoPath)
+  }
+
+  private func markInputWorktreeAsOwnedIfNeeded(_ path: String) async {
+    let normalizedPath = WorktreeModuleResolver.normalizedDirectoryPath(path)
+    guard let info = await GitWorktreeDetector.detectWorktreeInfo(for: normalizedPath),
+          info.isWorktree else {
+      return
+    }
+    ownedWorktreePaths.insert(normalizedPath)
+  }
+
+  private func normalizedRepositoryPaths(_ paths: [String]) async -> [String] {
+    var seen: Set<String> = []
+    var normalizedPaths: [String] = []
+
+    for path in paths {
+      let normalizedPath = await normalizedRepositoryPath(for: path)
+      guard seen.insert(normalizedPath).inserted else { continue }
+      normalizedPaths.append(normalizedPath)
+    }
+
+    return normalizedPaths
+  }
+
+  private func upsertWorktree(_ worktree: WorktreeBranch, inRepositoryAt index: Int) {
+    if let worktreeIndex = selectedRepositories[index].worktrees.firstIndex(where: { $0.path == worktree.path }) {
+      let existing = selectedRepositories[index].worktrees[worktreeIndex]
+      selectedRepositories[index].worktrees[worktreeIndex] = WorktreeBranch(
+        name: worktree.name,
+        path: worktree.path,
+        isWorktree: worktree.isWorktree,
+        sessions: worktree.sessions.isEmpty ? existing.sessions : worktree.sessions,
+        isExpanded: existing.isExpanded || worktree.isExpanded
+      )
+    } else {
+      selectedRepositories[index].worktrees.append(worktree)
+    }
   }
 
   /// Loads only the requested Claude sessions from their JSONL files.
@@ -224,11 +348,10 @@ public actor CLISessionMonitorService {
       }
     }
 
-    // Get all paths to filter by (including worktree paths)
-    let allPaths = getAllMonitoredPaths()
+    let discoveryScope = makeSessionDiscoveryScope()
 
     // Parse history for selected paths only
-    let sessionSummaries = await parseHistoryForPaths(allPaths)
+    let sessionSummaries = await parseHistory(in: discoveryScope)
 
     // Build a map of session ID -> (gitBranch, slug) (read from session files in parallel)
     let sessionMetadata = await readSessionMetadataBatch(sessionSummaries: sessionSummaries)
@@ -427,6 +550,7 @@ public actor CLISessionMonitorService {
     let worktrees = await GitWorktreeDetector.listWorktrees(at: repoPath)
 
     if worktrees.isEmpty {
+      ignoredWorktreePathsByRepository[repoPath] = []
       // If no worktrees detected, just use the main repo with current branch
       let info = await GitWorktreeDetector.detectWorktreeInfo(for: repoPath)
 
@@ -440,13 +564,23 @@ public actor CLISessionMonitorService {
       ]
     }
 
-    return worktrees.map { info in
+    let allWorktrees = worktrees.map { info in
       WorktreeBranch(
         name: info.branch ?? URL(fileURLWithPath: info.path).lastPathComponent,
-        path: info.path,
+        path: WorktreeModuleResolver.normalizedDirectoryPath(info.path),
         isWorktree: info.isWorktree,
         sessions: []
       )
+    }
+
+    ignoredWorktreePathsByRepository[repoPath] = Set(
+      allWorktrees
+        .filter { $0.isWorktree && !ownedWorktreePaths.contains($0.path) }
+        .map(\.path)
+    )
+
+    return allWorktrees.filter { worktree in
+      !worktree.isWorktree || ownedWorktreePaths.contains(worktree.path)
     }
   }
 
@@ -508,15 +642,26 @@ public actor CLISessionMonitorService {
 
   // MARK: - Path Collection
 
-  private func getAllMonitoredPaths() -> Set<String> {
-    var paths = Set<String>()
+  private func makeSessionDiscoveryScope() -> SessionDiscoveryScope {
+    var repositoryPaths = Set<String>()
+    var ownedPaths = Set<String>()
     for repo in selectedRepositories {
-      paths.insert(repo.path)
-      for worktree in repo.worktrees {
-        paths.insert(worktree.path)
+      repositoryPaths.insert(repo.path)
+      for worktree in repo.worktrees where worktree.isWorktree {
+        ownedPaths.insert(worktree.path)
       }
     }
-    return paths
+
+    let ignoredPaths = ignoredWorktreePathsByRepository.values.reduce(into: Set<String>()) { result, paths in
+      result.formUnion(paths)
+    }
+
+    return SessionDiscoveryScope(
+      repositoryPaths: repositoryPaths,
+      ownedWorktreePaths: ownedPaths.union(ownedWorktreePaths),
+      ignoredWorktreePaths: ignoredPaths,
+      focusedSessionIds: focusedSessionIds
+    )
   }
 
   private func restoreSession(sessionId: String, filePath: String) -> CLISession? {
@@ -787,7 +932,7 @@ public actor CLISessionMonitorService {
   /// Parses history.jsonl incrementally — only reads new bytes since last parse.
   /// On first call or if the file was truncated, does a full parse.
   /// Uses Task.detached to run heavy I/O and parsing off the actor's isolation context.
-  private func parseHistoryForPaths(_ paths: Set<String>) async -> [String: HistorySessionSummary] {
+  private func parseHistory(in scope: SessionDiscoveryScope) async -> [String: HistorySessionSummary] {
     let historyPath = claudeDataPath + "/history.jsonl"
     let previousOffset = lastHistoryOffset
     let previousSummaries = cachedHistorySummaries
@@ -845,7 +990,7 @@ public actor CLISessionMonitorService {
           return entry
         }
       var summaries = needsFullParse ? [String: HistorySessionSummary]() : previousSummaries
-      CLISessionMonitorService.accumulateHistoryEntries(parsed, filteredBy: paths, into: &summaries)
+      CLISessionMonitorService.accumulateHistoryEntries(parsed, filteredBy: scope, into: &summaries)
       return (summaries, fileSize)
     }.value
 
@@ -861,7 +1006,21 @@ public actor CLISessionMonitorService {
     filteredBy paths: Set<String>,
     into summaries: inout [String: HistorySessionSummary]
   ) {
-    for entry in entries where matchesMonitoredPath(entry.project, monitoredPaths: paths) {
+    let scope = SessionDiscoveryScope(
+      repositoryPaths: paths,
+      ownedWorktreePaths: [],
+      ignoredWorktreePaths: [],
+      focusedSessionIds: []
+    )
+    accumulateHistoryEntries(entries, filteredBy: scope, into: &summaries)
+  }
+
+  static func accumulateHistoryEntries(
+    _ entries: [HistoryEntry],
+    filteredBy scope: SessionDiscoveryScope,
+    into summaries: inout [String: HistorySessionSummary]
+  ) {
+    for entry in entries where scope.includes(projectPath: entry.project, sessionId: entry.sessionId) {
       mergeHistoryEntry(entry, into: &summaries)
     }
   }

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/CodexSessionMonitorService.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/CodexSessionMonitorService.swift
@@ -25,6 +25,9 @@ public actor CodexSessionMonitorService {
   // MARK: - State
 
   private var selectedRepositories: [SelectedRepository] = []
+  private var ownedWorktreePaths: Set<String> = []
+  private var focusedSessionIds: Set<String> = []
+  private var ignoredWorktreePathsByRepository: [String: Set<String>] = [:]
 
   // MARK: - Initialization
 
@@ -37,13 +40,15 @@ public actor CodexSessionMonitorService {
 
   @discardableResult
   public func addRepository(_ path: String) async -> SelectedRepository? {
-    guard !selectedRepositories.contains(where: { $0.path == path }) else {
+    await markInputWorktreeAsOwnedIfNeeded(path)
+    let repositoryPath = await normalizedRepositoryPath(for: path)
+    guard !selectedRepositories.contains(where: { $0.path == repositoryPath }) else {
       return nil
     }
 
-    let worktrees = await detectWorktrees(at: path)
+    let worktrees = await detectWorktrees(at: repositoryPath)
     let repository = SelectedRepository(
-      path: path,
+      path: repositoryPath,
       worktrees: worktrees,
       isExpanded: true
     )
@@ -54,8 +59,10 @@ public actor CodexSessionMonitorService {
   }
 
   public func restoreRepositoriesSkeleton(_ paths: [String]) async -> [SelectedRepository] {
-    var seen: Set<String> = []
-    let uniquePaths = paths.filter { seen.insert($0).inserted }
+    for path in paths {
+      await markInputWorktreeAsOwnedIfNeeded(path)
+    }
+    let uniquePaths = await normalizedRepositoryPaths(paths)
 
     guard !uniquePaths.isEmpty else {
       selectedRepositories = []
@@ -76,7 +83,52 @@ public actor CodexSessionMonitorService {
   }
 
   public func removeRepository(_ path: String) async {
-    selectedRepositories.removeAll { $0.path == path }
+    let repositoryPath = await normalizedRepositoryPath(for: path)
+    if let repository = selectedRepositories.first(where: { $0.path == repositoryPath }) {
+      ownedWorktreePaths.subtract(repository.worktrees.map(\.path))
+    }
+    ignoredWorktreePathsByRepository.removeValue(forKey: repositoryPath)
+    selectedRepositories.removeAll { $0.path == repositoryPath }
+    repositoriesSubject.send(selectedRepositories)
+  }
+
+  public func setOwnedWorktreePaths(_ paths: Set<String>) async {
+    ownedWorktreePaths = Set(paths.map { WorktreeModuleResolver.normalizedDirectoryPath($0) })
+  }
+
+  public func setFocusedSessionIds(_ ids: Set<String>) async {
+    focusedSessionIds = ids
+  }
+
+  public func registerWorktree(_ worktree: WorktreeBranch, parentRepositoryPath: String) async {
+    let repositoryPath = await normalizedRepositoryPath(for: parentRepositoryPath)
+    let normalizedWorktree = WorktreeBranch(
+      name: worktree.name,
+      path: WorktreeModuleResolver.normalizedDirectoryPath(worktree.path),
+      isWorktree: worktree.isWorktree,
+      sessions: worktree.sessions,
+      isExpanded: true
+    )
+    if normalizedWorktree.isWorktree {
+      ownedWorktreePaths.insert(normalizedWorktree.path)
+      ignoredWorktreePathsByRepository[repositoryPath]?.remove(normalizedWorktree.path)
+    }
+
+    if let index = selectedRepositories.firstIndex(where: { $0.path == repositoryPath }) {
+      upsertWorktree(normalizedWorktree, inRepositoryAt: index)
+      repositoriesSubject.send(selectedRepositories)
+      return
+    }
+
+    var worktrees = await detectWorktrees(at: repositoryPath)
+    if !worktrees.contains(where: { $0.path == normalizedWorktree.path }) {
+      worktrees.append(normalizedWorktree)
+    }
+    selectedRepositories.append(SelectedRepository(
+      path: repositoryPath,
+      worktrees: worktrees,
+      isExpanded: true
+    ))
     repositoriesSubject.send(selectedRepositories)
   }
 
@@ -87,6 +139,54 @@ public actor CodexSessionMonitorService {
   public func setSelectedRepositories(_ repositories: [SelectedRepository]) async {
     selectedRepositories = repositories
     await refreshSessions()
+  }
+
+  private func normalizedRepositoryPath(for path: String) async -> String {
+    let normalizedPath = WorktreeModuleResolver.normalizedDirectoryPath(path)
+    guard let info = await GitWorktreeDetector.detectWorktreeInfo(for: normalizedPath),
+          info.isWorktree,
+          let mainRepoPath = info.mainRepoPath,
+          !mainRepoPath.isEmpty else {
+      return normalizedPath
+    }
+    return WorktreeModuleResolver.normalizedDirectoryPath(mainRepoPath)
+  }
+
+  private func markInputWorktreeAsOwnedIfNeeded(_ path: String) async {
+    let normalizedPath = WorktreeModuleResolver.normalizedDirectoryPath(path)
+    guard let info = await GitWorktreeDetector.detectWorktreeInfo(for: normalizedPath),
+          info.isWorktree else {
+      return
+    }
+    ownedWorktreePaths.insert(normalizedPath)
+  }
+
+  private func normalizedRepositoryPaths(_ paths: [String]) async -> [String] {
+    var seen: Set<String> = []
+    var normalizedPaths: [String] = []
+
+    for path in paths {
+      let normalizedPath = await normalizedRepositoryPath(for: path)
+      guard seen.insert(normalizedPath).inserted else { continue }
+      normalizedPaths.append(normalizedPath)
+    }
+
+    return normalizedPaths
+  }
+
+  private func upsertWorktree(_ worktree: WorktreeBranch, inRepositoryAt index: Int) {
+    if let worktreeIndex = selectedRepositories[index].worktrees.firstIndex(where: { $0.path == worktree.path }) {
+      let existing = selectedRepositories[index].worktrees[worktreeIndex]
+      selectedRepositories[index].worktrees[worktreeIndex] = WorktreeBranch(
+        name: worktree.name,
+        path: worktree.path,
+        isWorktree: worktree.isWorktree,
+        sessions: worktree.sessions.isEmpty ? existing.sessions : worktree.sessions,
+        isExpanded: existing.isExpanded || worktree.isExpanded
+      )
+    } else {
+      selectedRepositories[index].worktrees.append(worktree)
+    }
   }
 
   public func loadSessions(ids: Set<String>) async -> [CLISession] {
@@ -156,12 +256,12 @@ public actor CodexSessionMonitorService {
       }
     }
 
-    let allPaths = getAllMonitoredPaths()
+    let discoveryScope = makeSessionDiscoveryScope()
 
     let historyEntries = parseHistory()
     let historyBySession = Dictionary(grouping: historyEntries) { $0.sessionId }
 
-    let sessionMetas = scanSessions(for: allPaths)
+    let sessionMetas = scanSessions(in: discoveryScope)
 
     var updatedRepositories = selectedRepositories
     var assignedSessionIds: Set<String> = []
@@ -264,17 +364,15 @@ public actor CodexSessionMonitorService {
       }
   }
 
-  private func scanSessions(for paths: Set<String>) -> [CodexSessionInfo] {
+  private func scanSessions(in scope: SessionDiscoveryScope) -> [CodexSessionInfo] {
     let files = CodexSessionFileScanner.listSessionFiles(codexDataPath: codexDataPath)
     var results: [CodexSessionInfo] = []
 
     for path in files {
-      guard let meta = CodexSessionFileScanner.readSessionMeta(from: path) else { continue }
-
-      let matchesPath = paths.contains { p in
-        meta.projectPath == p || meta.projectPath.hasPrefix(p + "/")
+      guard let meta = CodexSessionFileScanner.readSessionMeta(from: path),
+            scope.includes(projectPath: meta.projectPath, sessionId: meta.sessionId) else {
+        continue
       }
-      guard matchesPath else { continue }
 
       let lastActivity = fileModificationDate(path)
 
@@ -349,6 +447,7 @@ public actor CodexSessionMonitorService {
     let worktrees = await GitWorktreeDetector.listWorktrees(at: repoPath)
 
     if worktrees.isEmpty {
+      ignoredWorktreePathsByRepository[repoPath] = []
       let info = await GitWorktreeDetector.detectWorktreeInfo(for: repoPath)
       return [
         WorktreeBranch(
@@ -360,13 +459,23 @@ public actor CodexSessionMonitorService {
       ]
     }
 
-    return worktrees.map { info in
+    let allWorktrees = worktrees.map { info in
       WorktreeBranch(
         name: info.branch ?? URL(fileURLWithPath: info.path).lastPathComponent,
-        path: info.path,
+        path: WorktreeModuleResolver.normalizedDirectoryPath(info.path),
         isWorktree: info.isWorktree,
         sessions: []
       )
+    }
+
+    ignoredWorktreePathsByRepository[repoPath] = Set(
+      allWorktrees
+        .filter { $0.isWorktree && !ownedWorktreePaths.contains($0.path) }
+        .map(\.path)
+    )
+
+    return allWorktrees.filter { worktree in
+      !worktree.isWorktree || ownedWorktreePaths.contains(worktree.path)
     }
   }
 
@@ -387,15 +496,26 @@ public actor CodexSessionMonitorService {
     }
   }
 
-  private func getAllMonitoredPaths() -> Set<String> {
-    var paths = Set<String>()
+  private func makeSessionDiscoveryScope() -> SessionDiscoveryScope {
+    var repositoryPaths = Set<String>()
+    var ownedPaths = Set<String>()
     for repo in selectedRepositories {
-      paths.insert(repo.path)
-      for worktree in repo.worktrees {
-        paths.insert(worktree.path)
+      repositoryPaths.insert(repo.path)
+      for worktree in repo.worktrees where worktree.isWorktree {
+        ownedPaths.insert(worktree.path)
       }
     }
-    return paths
+
+    let ignoredPaths = ignoredWorktreePathsByRepository.values.reduce(into: Set<String>()) { result, paths in
+      result.formUnion(paths)
+    }
+
+    return SessionDiscoveryScope(
+      repositoryPaths: repositoryPaths,
+      ownedWorktreePaths: ownedPaths.union(ownedWorktreePaths),
+      ignoredWorktreePaths: ignoredPaths,
+      focusedSessionIds: focusedSessionIds
+    )
   }
 }
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/SessionMetadataStore.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/SessionMetadataStore.swift
@@ -23,6 +23,7 @@ public actor SessionMetadataStore: TerminalWorkspaceStoreProtocol {
     static let createSessionWorkspaceState = "v6_create_session_workspace_state"
     static let createManagedProcesses = "v7_create_managed_processes"
     static let createClaudeHookInstallations = "v8_create_claude_hook_installations"
+    static let addOwnedWorktreePaths = "v9_add_owned_worktree_paths"
   }
 
   static let migrationIdentifiers = [
@@ -33,7 +34,8 @@ public actor SessionMetadataStore: TerminalWorkspaceStoreProtocol {
     MigrationID.createTerminalWorkspaces,
     MigrationID.createSessionWorkspaceState,
     MigrationID.createManagedProcesses,
-    MigrationID.createClaudeHookInstallations
+    MigrationID.createClaudeHookInstallations,
+    MigrationID.addOwnedWorktreePaths
   ]
 
   private let dbQueue: DatabaseQueue
@@ -151,6 +153,12 @@ public actor SessionMetadataStore: TerminalWorkspaceStoreProtocol {
         t.column("projectPath", .text).primaryKey()
         t.column("installedAt", .datetime).notNull()
         t.column("updatedAt", .datetime).notNull()
+      }
+    }
+
+    migrator.registerMigration(MigrationID.addOwnedWorktreePaths) { db in
+      try db.alter(table: "session_workspace_state") { t in
+        t.add(column: "ownedWorktreePathsData", .blob)
       }
     }
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/SessionProviderProtocols.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/SessionProviderProtocols.swift
@@ -37,6 +37,9 @@ public protocol SessionMonitorServiceProtocol: AnyObject, Sendable {
   func restoreRepositoriesSkeleton(_ paths: [String]) async -> [SelectedRepository]
   func loadSessions(ids: Set<String>) async -> [CLISession]
   func removeRepository(_ path: String) async
+  func setOwnedWorktreePaths(_ paths: Set<String>) async
+  func setFocusedSessionIds(_ ids: Set<String>) async
+  func registerWorktree(_ worktree: WorktreeBranch, parentRepositoryPath: String) async
   func getSelectedRepositories() async -> [SelectedRepository]
   func setSelectedRepositories(_ repositories: [SelectedRepository]) async
   func refreshSessions(skipWorktreeRedetection: Bool) async
@@ -68,6 +71,12 @@ public extension SessionMonitorServiceProtocol {
       .flatMap { $0.sessions }
       .filter { ids.contains($0.id) }
   }
+
+  func registerWorktree(_ worktree: WorktreeBranch, parentRepositoryPath: String) async {}
+
+  func setOwnedWorktreePaths(_ paths: Set<String>) async {}
+
+  func setFocusedSessionIds(_ ids: Set<String>) async {}
 }
 
 // MARK: - SessionFileWatcherProtocol

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/CLISessionsListView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/CLISessionsListView.swift
@@ -29,6 +29,8 @@ public struct CLISessionsListView: View {
   @State private var isSearchSheetVisible: Bool = false
   @State private var primarySessionId: String?
   @State private var createWorktreeRepository: SelectedRepository?
+  @AppStorage(AgentHubDefaults.worktreeDisplayMode)
+  private var worktreeDisplayModeRawValue: String = WorktreeDisplayMode.parent.rawValue
   @Environment(\.colorScheme) private var colorScheme
   @Environment(\.runtimeTheme) private var runtimeTheme
   @FocusState private var isSearchFieldFocused: Bool
@@ -580,7 +582,11 @@ public struct CLISessionsListView: View {
       }
 
       HStack {
-        Text("\(viewModel.selectedRepositories.count) \(viewModel.selectedRepositories.count == 1 ? "module" : "modules") selected · \(viewModel.totalSessionCount) sessions")
+        let moduleCount = WorktreeModuleResolver.modulePaths(
+          for: viewModel.selectedRepositories,
+          mode: worktreeDisplayMode
+        ).count
+        Text("\(moduleCount) \(moduleCount == 1 ? "module" : "modules") selected · \(viewModel.totalSessionCount) sessions")
           .font(.secondaryCaption)
           .foregroundColor(.secondary)
 
@@ -663,6 +669,10 @@ public struct CLISessionsListView: View {
       }
     }
     .padding(.horizontal, DesignTokens.Spacing.xs)
+  }
+
+  private var worktreeDisplayMode: WorktreeDisplayMode {
+    WorktreeDisplayMode(rawValue: worktreeDisplayModeRawValue) ?? .parent
   }
 }
 
@@ -837,6 +847,7 @@ private struct SessionFileSheetView: View {
       return .handled
     }
   }
+
 }
 
 // MARK: - Preview

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringPanelView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringPanelView.swift
@@ -82,6 +82,8 @@ public struct MonitoringPanelView: View {
   private var previousLayoutModeRawValue: Int = -1
   @AppStorage(AgentHubDefaults.flatSessionLayout)
   private var flatSessionLayout: Bool = false
+  @AppStorage(AgentHubDefaults.worktreeDisplayMode)
+  private var worktreeDisplayModeRawValue: String = WorktreeDisplayMode.parent.rawValue
   @Environment(\.colorScheme) private var colorScheme
   @Environment(\.runtimeTheme) private var runtimeTheme
   @State private var cardHeights: [String: CGFloat] = [:]
@@ -98,23 +100,17 @@ public struct MonitoringPanelView: View {
     self._primarySessionId = primarySessionId
   }
 
-  /// Finds the main module path for an item (maps worktree paths to their parent repository)
-  private func findModulePath(for item: MonitoringItem) -> String {
-    let itemPath: String
-    switch item {
-    case .pending(let p): itemPath = p.worktree.path
-    case .monitored(let s, _): itemPath = s.projectPath
-    }
+  private var worktreeDisplayMode: WorktreeDisplayMode {
+    WorktreeDisplayMode(rawValue: worktreeDisplayModeRawValue) ?? .parent
+  }
 
-    // Find which SelectedRepository contains this path
-    for repo in viewModel.selectedRepositories {
-      for worktree in repo.worktrees {
-        if worktree.path == itemPath {
-          return repo.path  // Return main module path
-        }
-      }
-    }
-    return itemPath  // Fallback to original path
+  /// Finds the display module path for an item.
+  private func findModulePath(for item: MonitoringItem) -> String {
+    WorktreeModuleResolver.modulePath(
+      for: item.projectPath,
+      repositories: viewModel.selectedRepositories,
+      mode: worktreeDisplayMode
+    )
   }
 
   private var allItems: [MonitoringItem] {

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderMonitoringPanelView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderMonitoringPanelView.swift
@@ -207,6 +207,8 @@ public struct MultiProviderMonitoringPanelView: View {
   private var previousLayoutModeRawValue: Int = -1
   @AppStorage(AgentHubDefaults.flatSessionLayout)
   private var flatSessionLayout: Bool = false
+  @AppStorage(AgentHubDefaults.worktreeDisplayMode)
+  private var worktreeDisplayModeRawValue: String = WorktreeDisplayMode.parent.rawValue
   @State private var showQuickFilePicker = false
   @State private var gitHubPopOutItem: GitHubPopOutItem?
   @Environment(\.colorScheme) private var colorScheme
@@ -1424,14 +1426,13 @@ public struct MultiProviderMonitoringPanelView: View {
   }
 
   private var allSelectedRepositories: [SelectedRepository] {
-    var map: [String: SelectedRepository] = [:]
-    for repo in claudeViewModel.selectedRepositories {
-      map[repo.path] = repo
-    }
-    for repo in codexViewModel.selectedRepositories where map[repo.path] == nil {
-      map[repo.path] = repo
-    }
-    return map.values.sorted { $0.path < $1.path }
+    WorktreeModuleResolver.mergedRepositories(
+      claudeViewModel.selectedRepositories + codexViewModel.selectedRepositories
+    ).sorted { $0.path < $1.path }
+  }
+
+  private var worktreeDisplayMode: WorktreeDisplayMode {
+    WorktreeDisplayMode(rawValue: worktreeDisplayModeRawValue) ?? .parent
   }
 
   private var emptyStateViewModel: CLISessionsViewModel {
@@ -1441,16 +1442,11 @@ public struct MultiProviderMonitoringPanelView: View {
   }
 
   private func findModulePath(for item: ProviderMonitoringItem) -> String {
-    let itemPath = item.projectPath
-
-    for repo in allSelectedRepositories {
-      for worktree in repo.worktrees {
-        if worktree.path == itemPath {
-          return repo.path
-        }
-      }
-    }
-    return itemPath
+    WorktreeModuleResolver.modulePath(
+      for: item.projectPath,
+      repositories: allSelectedRepositories,
+      mode: worktreeDisplayMode
+    )
   }
 
   private func openSessionFile(for session: CLISession, viewModel: CLISessionsViewModel) {
@@ -1740,7 +1736,8 @@ public struct MultiProviderMonitoringPanelView: View {
     ModuleLandingSelection.activeModulePath(
       selectedPath: selectedModuleLandingPath,
       repositories: allSelectedRepositories,
-      itemProjectPaths: snapshot.allItems.map(\.projectPath)
+      itemProjectPaths: snapshot.allItems.map(\.projectPath),
+      mode: worktreeDisplayMode
     )
   }
 }

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
@@ -178,6 +178,8 @@ public struct MultiProviderSessionsListView: View {
   private let showLegacyLauncher = false
 
   @AppStorage(AgentHubDefaults.auxiliaryShellVisible) private var isAuxiliaryShellVisible = false
+  @AppStorage(AgentHubDefaults.worktreeDisplayMode)
+  private var worktreeDisplayModeRawValue: String = WorktreeDisplayMode.parent.rawValue
   @State private var isEmbeddedTrailingPanelVisible = false
   @State private var sidebarVisibilityBeforeAutoHide: NavigationSplitViewVisibility?
   @FocusState private var isSearchFieldFocused: Bool
@@ -859,29 +861,23 @@ public struct MultiProviderSessionsListView: View {
   /// Deduplicated tracked repos from both providers, preserving insertion order,
   /// newest-first. Claude's repos are walked first, then Codex-only repos.
   private var orderedTrackedRepos: [SelectedRepository] {
-    var seen: Set<String> = []
-    var combined: [SelectedRepository] = []
-    for repo in claudeViewModel.selectedRepositories {
-      if seen.insert(repo.path).inserted { combined.append(repo) }
-    }
-    for repo in codexViewModel.selectedRepositories {
-      if seen.insert(repo.path).inserted { combined.append(repo) }
-    }
+    let combined = WorktreeModuleResolver.mergedRepositories(
+      claudeViewModel.selectedRepositories + codexViewModel.selectedRepositories
+    )
     // Newest-added first (reverse of insertion order).
     return combined.reversed()
   }
 
-  /// Returns the parent repo path for an arbitrary session path — handles both
-  /// "path is the repo root" and "path is a worktree under the repo". Falls back
-  /// to the original path when no tracked repo matches (used for the orphan group).
-  private func findParentRepoPath(for itemPath: String) -> String {
-    for repo in orderedTrackedRepos {
-      if repo.path == itemPath { return repo.path }
-      if repo.worktrees.contains(where: { $0.path == itemPath }) {
-        return repo.path
-      }
-    }
-    return itemPath
+  private var worktreeDisplayMode: WorktreeDisplayMode {
+    WorktreeDisplayMode(rawValue: worktreeDisplayModeRawValue) ?? .parent
+  }
+
+  private func findModulePath(for itemPath: String) -> String {
+    WorktreeModuleResolver.modulePath(
+      for: itemPath,
+      repositories: orderedTrackedRepos,
+      mode: worktreeDisplayMode
+    )
   }
 
   private var pinnedSessionSnapshot: ProviderScopedPinnedSessions {
@@ -910,22 +906,22 @@ public struct MultiProviderSessionsListView: View {
     let allItems = selectedSessionItems.filter { !isPinned($0) }
     var byRepo: [String: [SelectedSessionItem]] = [:]
     for item in allItems {
-      let key = findParentRepoPath(for: item.session.projectPath)
+      let key = findModulePath(for: item.session.projectPath)
       byRepo[key, default: []].append(item)
     }
 
     var groups: [SessionGroup] = []
     var handledKeys: Set<String> = []
 
-    // Tracked repos — always emit a header, even if empty.
-    for repo in orderedTrackedRepos {
-      let items = (byRepo[repo.path] ?? []).sorted { $0.timestamp > $1.timestamp }
+    // Tracked modules — always emit a header, even if empty.
+    for modulePath in WorktreeModuleResolver.modulePaths(for: Array(orderedTrackedRepos), mode: worktreeDisplayMode) {
+      let items = (byRepo[modulePath] ?? []).sorted { $0.timestamp > $1.timestamp }
       groups.append(SessionGroup(
-        id: repo.path,
-        displayName: URL(fileURLWithPath: repo.path).lastPathComponent,
+        id: modulePath,
+        displayName: URL(fileURLWithPath: modulePath).lastPathComponent,
         items: items
       ))
-      handledKeys.insert(repo.path)
+      handledKeys.insert(modulePath)
     }
 
     // Orphan sessions (repo not tracked yet — e.g. a brand-new pending one).
@@ -1048,7 +1044,7 @@ public struct MultiProviderSessionsListView: View {
                   }
                 }
               },
-              onRemove: {
+              onRemove: orderedTrackedRepos.contains(where: { $0.path == group.id }) ? {
                 removeConfirmation = RemoveConfirmation(
                   repoName: group.displayName,
                   sessionCount: group.items.count
@@ -1063,7 +1059,7 @@ public struct MultiProviderSessionsListView: View {
                     codexViewModel.removeRepository(repo)
                   }
                 }
-              }
+              } : nil
             )
 
             if isExpanded {
@@ -1338,7 +1334,8 @@ public struct MultiProviderSessionsListView: View {
       }
 
       HStack {
-        Text("\(currentViewModel.selectedRepositories.count) \(currentViewModel.selectedRepositories.count == 1 ? "module" : "modules") · \(currentViewModel.allSessions.count) \(currentViewModel.allSessions.count == 1 ? "session" : "sessions")")
+        let moduleCount = displayModuleCount(for: currentViewModel)
+        Text("\(moduleCount) \(moduleCount == 1 ? "module" : "modules") · \(currentViewModel.allSessions.count) \(currentViewModel.allSessions.count == 1 ? "session" : "sessions")")
           .font(.secondaryCaption)
           .foregroundColor(.secondary)
 
@@ -1582,7 +1579,8 @@ public struct MultiProviderSessionsListView: View {
     let activePath = ModuleLandingSelection.activeModulePath(
       selectedPath: selectedModuleLandingPath,
       repositories: orderedTrackedRepos,
-      itemProjectPaths: selectedSessionItems.map { $0.session.projectPath }
+      itemProjectPaths: selectedSessionItems.map { $0.session.projectPath },
+      mode: worktreeDisplayMode
     )
 
     if activePath == nil {
@@ -1630,18 +1628,20 @@ public struct MultiProviderSessionsListView: View {
   }
 
   private var allRepositories: [SelectedRepository] {
-    var map: [String: SelectedRepository] = [:]
-    for repo in claudeViewModel.selectedRepositories {
-      map[repo.path] = repo
-    }
-    for repo in codexViewModel.selectedRepositories where map[repo.path] == nil {
-      map[repo.path] = repo
-    }
-    return map.values.sorted { $0.path < $1.path }
+    WorktreeModuleResolver.mergedRepositories(
+      claudeViewModel.selectedRepositories + codexViewModel.selectedRepositories
+    ).sorted { $0.path < $1.path }
   }
 
   private var totalSessionCount: Int {
     claudeViewModel.totalSessionCount + codexViewModel.totalSessionCount
+  }
+
+  private func displayModuleCount(for viewModel: CLISessionsViewModel) -> Int {
+    WorktreeModuleResolver.modulePaths(
+      for: viewModel.selectedRepositories,
+      mode: worktreeDisplayMode
+    ).count
   }
 
   // MARK: - Keyboard Shortcuts
@@ -1849,7 +1849,7 @@ private struct ProjectGroupHeader: View {
   let onOpenInFinder: () -> Void
   let onOpenGitHub: () -> Void
   let onArchiveSessions: (() -> Void)?
-  let onRemove: () -> Void
+  let onRemove: (() -> Void)?
 
   @State private var isHovered: Bool = false
   @Environment(\.colorScheme) private var colorScheme
@@ -1893,8 +1893,10 @@ private struct ProjectGroupHeader: View {
             Label("Archive Sessions", systemImage: "archivebox")
           }
         }
-        Button(action: onRemove) {
-          Label("Remove", systemImage: "xmark")
+        if let onRemove {
+          Button(action: onRemove) {
+            Label("Remove", systemImage: "xmark")
+          }
         }
       }
       .opacity(isHovered ? 1 : 0)

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/SelectedSessionsPanelView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/SelectedSessionsPanelView.swift
@@ -12,6 +12,8 @@ import SwiftUI
 public struct SelectedSessionsPanelView: View {
   @Bindable var viewModel: CLISessionsViewModel
   @Binding var primarySessionId: String?
+  @AppStorage(AgentHubDefaults.worktreeDisplayMode)
+  private var worktreeDisplayModeRawValue: String = WorktreeDisplayMode.parent.rawValue
 
   public init(
     viewModel: CLISessionsViewModel,
@@ -141,12 +143,15 @@ public struct SelectedSessionsPanelView: View {
   }
 
   private func findModulePath(for itemPath: String) -> String {
-    for repo in viewModel.selectedRepositories {
-      for worktree in repo.worktrees where worktree.path == itemPath {
-        return repo.path
-      }
-    }
-    return itemPath
+    WorktreeModuleResolver.modulePath(
+      for: itemPath,
+      repositories: viewModel.selectedRepositories,
+      mode: worktreeDisplayMode
+    )
+  }
+
+  private var worktreeDisplayMode: WorktreeDisplayMode {
+    WorktreeDisplayMode(rawValue: worktreeDisplayModeRawValue) ?? .parent
   }
 
   private func ensurePrimarySelection() {
@@ -169,6 +174,8 @@ public struct MultiProviderSelectedSessionsPanelView: View {
   @Bindable var claudeViewModel: CLISessionsViewModel
   @Bindable var codexViewModel: CLISessionsViewModel
   @Binding var primarySessionId: String?
+  @AppStorage(AgentHubDefaults.worktreeDisplayMode)
+  private var worktreeDisplayModeRawValue: String = WorktreeDisplayMode.parent.rawValue
 
   public init(
     claudeViewModel: CLISessionsViewModel,
@@ -325,23 +332,21 @@ public struct MultiProviderSelectedSessionsPanelView: View {
   }
 
   private var allSelectedRepositories: [SelectedRepository] {
-    var map: [String: SelectedRepository] = [:]
-    for repo in claudeViewModel.selectedRepositories {
-      map[repo.path] = repo
-    }
-    for repo in codexViewModel.selectedRepositories where map[repo.path] == nil {
-      map[repo.path] = repo
-    }
-    return map.values.sorted { $0.path < $1.path }
+    WorktreeModuleResolver.mergedRepositories(
+      claudeViewModel.selectedRepositories + codexViewModel.selectedRepositories
+    ).sorted { $0.path < $1.path }
   }
 
   private func findModulePath(for itemPath: String) -> String {
-    for repo in allSelectedRepositories {
-      for worktree in repo.worktrees where worktree.path == itemPath {
-        return repo.path
-      }
-    }
-    return itemPath
+    WorktreeModuleResolver.modulePath(
+      for: itemPath,
+      repositories: allSelectedRepositories,
+      mode: worktreeDisplayMode
+    )
+  }
+
+  private var worktreeDisplayMode: WorktreeDisplayMode {
+    WorktreeDisplayMode(rawValue: worktreeDisplayModeRawValue) ?? .parent
   }
 
   private func customName(for item: SelectedSessionItem) -> String? {

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/SessionsBrowserPanel.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/SessionsBrowserPanel.swift
@@ -18,6 +18,8 @@ public struct SessionsBrowserPanel: View {
   @Bindable var codexViewModel: CLISessionsViewModel
 
   @Environment(\.colorScheme) private var colorScheme
+  @AppStorage(AgentHubDefaults.worktreeDisplayMode)
+  private var worktreeDisplayModeRawValue: String = WorktreeDisplayMode.parent.rawValue
 
   public init(claudeViewModel: CLISessionsViewModel, codexViewModel: CLISessionsViewModel) {
     self.claudeViewModel = claudeViewModel
@@ -184,27 +186,21 @@ public struct SessionsBrowserPanel: View {
   }
 
   private var allSelectedRepositories: [SelectedRepository] {
-    var map: [String: SelectedRepository] = [:]
-    for repo in claudeViewModel.selectedRepositories {
-      map[repo.path] = repo
-    }
-    for repo in codexViewModel.selectedRepositories where map[repo.path] == nil {
-      map[repo.path] = repo
-    }
-    return map.values.sorted { $0.path < $1.path }
+    WorktreeModuleResolver.mergedRepositories(
+      claudeViewModel.selectedRepositories + codexViewModel.selectedRepositories
+    ).sorted { $0.path < $1.path }
   }
 
   private func findModulePath(for item: ProviderMonitoringItem) -> String {
-    let itemPath = item.projectPath
+    WorktreeModuleResolver.modulePath(
+      for: item.projectPath,
+      repositories: allSelectedRepositories,
+      mode: worktreeDisplayMode
+    )
+  }
 
-    for repo in allSelectedRepositories {
-      for worktree in repo.worktrees {
-        if worktree.path == itemPath {
-          return repo.path
-        }
-      }
-    }
-    return itemPath
+  private var worktreeDisplayMode: WorktreeDisplayMode {
+    WorktreeDisplayMode(rawValue: worktreeDisplayModeRawValue) ?? .parent
   }
 
   // MARK: - Focus/Selection Logic

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/WorktreeSettingsView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/WorktreeSettingsView.swift
@@ -11,10 +11,25 @@ public struct WorktreeSettingsView: View {
   @AppStorage(AgentHubDefaults.worktreeBranchPrefix)
   private var worktreeBranchPrefix: String = ""
 
+  @AppStorage(AgentHubDefaults.worktreeDisplayMode)
+  private var worktreeDisplayModeRawValue: String = WorktreeDisplayMode.parent.rawValue
+
   public init() {}
 
   public var body: some View {
     Form {
+      Section("Display") {
+        Picker("Module grouping", selection: $worktreeDisplayModeRawValue) {
+          ForEach(WorktreeDisplayMode.allCases) { mode in
+            Text(mode.label).tag(mode.rawValue)
+          }
+        }
+
+        Text(selectedDisplayMode.settingsDescription)
+          .font(.caption)
+          .foregroundStyle(.secondary)
+      }
+
       Section("Generated Branches") {
         VStack(alignment: .leading, spacing: 8) {
           Text("Branch prefix")
@@ -74,5 +89,9 @@ public struct WorktreeSettingsView: View {
       RoundedRectangle(cornerRadius: 8)
         .stroke(Color.primary.opacity(0.12), lineWidth: 1)
     )
+  }
+
+  private var selectedDisplayMode: WorktreeDisplayMode {
+    WorktreeDisplayMode(rawValue: worktreeDisplayModeRawValue) ?? .parent
   }
 }

--- a/app/modules/AgentHubCore/Sources/AgentHub/Utils/SessionDiscoveryScope.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Utils/SessionDiscoveryScope.swift
@@ -1,0 +1,53 @@
+//
+//  SessionDiscoveryScope.swift
+//  AgentHub
+//
+
+import Foundation
+
+struct SessionDiscoveryScope: Sendable {
+  let repositoryPaths: Set<String>
+  let ownedWorktreePaths: Set<String>
+  let ignoredWorktreePaths: Set<String>
+  let focusedSessionIds: Set<String>
+
+  init(
+    repositoryPaths: Set<String>,
+    ownedWorktreePaths: Set<String>,
+    ignoredWorktreePaths: Set<String>,
+    focusedSessionIds: Set<String>
+  ) {
+    self.repositoryPaths = Self.normalizedSet(repositoryPaths)
+    self.ownedWorktreePaths = Self.normalizedSet(ownedWorktreePaths)
+    self.ignoredWorktreePaths = Self.normalizedSet(ignoredWorktreePaths)
+    self.focusedSessionIds = focusedSessionIds
+  }
+
+  var monitoredPaths: Set<String> {
+    repositoryPaths.union(ownedWorktreePaths)
+  }
+
+  func includes(projectPath: String, sessionId: String) -> Bool {
+    let normalizedProjectPath = WorktreeModuleResolver.normalizedDirectoryPath(projectPath)
+
+    if Self.path(normalizedProjectPath, isContainedInAnyOf: ownedWorktreePaths) {
+      return focusedSessionIds.contains(sessionId)
+    }
+
+    if Self.path(normalizedProjectPath, isContainedInAnyOf: ignoredWorktreePaths) {
+      return false
+    }
+
+    return Self.path(normalizedProjectPath, isContainedInAnyOf: repositoryPaths)
+  }
+
+  static func path(_ path: String, isContainedInAnyOf roots: Set<String>) -> Bool {
+    roots.contains { root in
+      path == root || path.hasPrefix(root + "/")
+    }
+  }
+
+  private static func normalizedSet(_ paths: Set<String>) -> Set<String> {
+    Set(paths.map { WorktreeModuleResolver.normalizedDirectoryPath($0) })
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/Utils/WorktreeModuleResolver.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Utils/WorktreeModuleResolver.swift
@@ -1,0 +1,131 @@
+//
+//  WorktreeModuleResolver.swift
+//  AgentHub
+//
+
+import Foundation
+
+public enum WorktreeModuleResolver {
+  public struct Match: Sendable, Equatable {
+    public let repository: SelectedRepository
+    public let worktree: WorktreeBranch
+  }
+
+  public static func modulePath(
+    for itemPath: String,
+    repositories: [SelectedRepository],
+    mode: WorktreeDisplayMode
+  ) -> String {
+    guard let match = bestMatch(for: itemPath, repositories: repositories) else {
+      return normalizedDirectoryPath(itemPath)
+    }
+
+    switch mode {
+    case .parent:
+      return match.repository.path
+    case .separateModules:
+      return match.worktree.isWorktree ? match.worktree.path : match.repository.path
+    }
+  }
+
+  public static func bestMatch(
+    for itemPath: String,
+    repositories: [SelectedRepository]
+  ) -> Match? {
+    let normalizedItemPath = normalizedDirectoryPath(itemPath)
+    var best: Match?
+
+    for repository in repositories {
+      let normalizedRepositoryPath = normalizedDirectoryPath(repository.path)
+      if path(normalizedItemPath, isContainedIn: normalizedRepositoryPath) {
+        let mainWorktree = repository.worktrees.first(where: { !$0.isWorktree && normalizedDirectoryPath($0.path) == normalizedRepositoryPath })
+          ?? WorktreeBranch(name: repository.name, path: repository.path, isWorktree: false)
+        best = preferLongerPath(
+          current: best,
+          candidate: Match(repository: repository, worktree: mainWorktree)
+        )
+      }
+
+      for worktree in repository.worktrees {
+        let worktreePath = normalizedDirectoryPath(worktree.path)
+        guard path(normalizedItemPath, isContainedIn: worktreePath) else { continue }
+        best = preferLongerPath(
+          current: best,
+          candidate: Match(repository: repository, worktree: worktree)
+        )
+      }
+    }
+
+    return best
+  }
+
+  public static func modulePaths(
+    for repositories: [SelectedRepository],
+    mode: WorktreeDisplayMode
+  ) -> [String] {
+    var seen: Set<String> = []
+    var paths: [String] = []
+
+    for repository in repositories {
+      append(repository.path, to: &paths, seen: &seen)
+
+      guard mode == .separateModules else { continue }
+      for worktree in repository.worktrees where worktree.isWorktree {
+        append(worktree.path, to: &paths, seen: &seen)
+      }
+    }
+
+    return paths
+  }
+
+  public static func mergedRepositories(_ repositories: [SelectedRepository]) -> [SelectedRepository] {
+    var result: [SelectedRepository] = []
+    var indicesByPath: [String: Int] = [:]
+
+    for repository in repositories {
+      let path = normalizedDirectoryPath(repository.path)
+      if let index = indicesByPath[path] {
+        result[index] = merge(result[index], with: repository)
+      } else {
+        indicesByPath[path] = result.count
+        result.append(repository)
+      }
+    }
+
+    return result
+  }
+
+  public static func normalizedDirectoryPath(_ path: String) -> String {
+    var normalized = path
+    while normalized.count > 1 && normalized.hasSuffix("/") {
+      normalized.removeLast()
+    }
+    return normalized
+  }
+
+  private static func path(_ path: String, isContainedIn root: String) -> Bool {
+    path == root || path.hasPrefix(root + "/")
+  }
+
+  private static func preferLongerPath(current: Match?, candidate: Match) -> Match {
+    guard let current else { return candidate }
+    return candidate.worktree.path.count > current.worktree.path.count ? candidate : current
+  }
+
+  private static func append(_ path: String, to paths: inout [String], seen: inout Set<String>) {
+    let normalized = normalizedDirectoryPath(path)
+    guard seen.insert(normalized).inserted else { return }
+    paths.append(normalized)
+  }
+
+  private static func merge(_ existing: SelectedRepository, with incoming: SelectedRepository) -> SelectedRepository {
+    var merged = existing
+    var worktreePaths = Set(existing.worktrees.map { normalizedDirectoryPath($0.path) })
+
+    for worktree in incoming.worktrees where worktreePaths.insert(normalizedDirectoryPath(worktree.path)).inserted {
+      merged.worktrees.append(worktree)
+    }
+
+    return merged
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/CLISessionsViewModel.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/CLISessionsViewModel.swift
@@ -855,6 +855,9 @@ public final class CLISessionsViewModel {
   /// Set of session IDs currently being monitored
   public private(set) var monitoredSessionIds: Set<String> = []
 
+  /// Worktrees explicitly created or focused through AgentHub.
+  private var ownedWorktreePaths: Set<String> = []
+
   /// Current monitoring states keyed by session ID
   public private(set) var monitorStates: [String: SessionMonitorState] = [:]
 
@@ -1165,6 +1168,51 @@ public final class CLISessionsViewModel {
     return false
   }
 
+  private func normalizeWorktreePaths(_ paths: Set<String>) -> Set<String> {
+    Set(paths.map { WorktreeModuleResolver.normalizedDirectoryPath($0) })
+  }
+
+  private func setOwnedWorktreePaths(_ paths: Set<String>) async {
+    ownedWorktreePaths = normalizeWorktreePaths(paths)
+    await monitorService.setOwnedWorktreePaths(ownedWorktreePaths)
+  }
+
+  private func syncOwnedWorktreePathsToMonitor() {
+    let paths = ownedWorktreePaths
+    Task {
+      await monitorService.setOwnedWorktreePaths(paths)
+    }
+  }
+
+  private func syncFocusedSessionIdsToMonitor(extraSessionIds: Set<String> = []) {
+    let sessionIds = monitoredSessionIds.union(extraSessionIds)
+    Task {
+      await monitorService.setFocusedSessionIds(sessionIds)
+    }
+  }
+
+  private func registerOwnedWorktreePath(_ path: String) {
+    let normalizedPath = WorktreeModuleResolver.normalizedDirectoryPath(path)
+    guard ownedWorktreePaths.insert(normalizedPath).inserted else { return }
+    syncOwnedWorktreePathsToMonitor()
+  }
+
+  private func removeOwnedWorktreePath(_ path: String) {
+    let normalizedPath = WorktreeModuleResolver.normalizedDirectoryPath(path)
+    guard ownedWorktreePaths.remove(normalizedPath) != nil else { return }
+    syncOwnedWorktreePathsToMonitor()
+  }
+
+  private func filterOwnedWorktrees(in repositories: [SelectedRepository]) -> [SelectedRepository] {
+    repositories.map { repository in
+      var filtered = repository
+      filtered.worktrees = repository.worktrees.filter { worktree in
+        !worktree.isWorktree || ownedWorktreePaths.contains(WorktreeModuleResolver.normalizedDirectoryPath(worktree.path))
+      }
+      return filtered
+    }
+  }
+
   /// Merges updated repositories while preserving expanded state from current repositories
   private func mergePreservingExpandedState(
     current: [SelectedRepository],
@@ -1182,7 +1230,7 @@ public final class CLISessionsViewModel {
     }
 
     // Apply preserved states to updated repositories
-    var result = updated
+    var result = filterOwnedWorktrees(in: updated)
     for i in result.indices {
       if let expanded = repoExpandedState[result[i].id] {
         result[i].isExpanded = expanded
@@ -1216,6 +1264,38 @@ public final class CLISessionsViewModel {
       if !persistedSessionIds.isEmpty {
         pendingRestorationSessionIds = persistedSessionIds
       }
+
+      var restoredOwnedWorktreePaths = Set(workspaceState.ownedWorktreePaths)
+      for path in paths {
+        let normalizedPath = WorktreeModuleResolver.normalizedDirectoryPath(path)
+        if let info = await GitWorktreeDetector.detectWorktreeInfo(for: normalizedPath),
+           info.isWorktree {
+          restoredOwnedWorktreePaths.insert(normalizedPath)
+        }
+      }
+      if !persistedSessionIds.isEmpty,
+         let mappings = try? await metadataStore?.getRepoMappings(for: Array(persistedSessionIds)) {
+        var restoredRepositoryPaths = Set(paths.map { WorktreeModuleResolver.normalizedDirectoryPath($0) })
+        for path in paths {
+          let normalizedPath = WorktreeModuleResolver.normalizedDirectoryPath(path)
+          if let info = await GitWorktreeDetector.detectWorktreeInfo(for: normalizedPath),
+             info.isWorktree,
+             let mainRepoPath = info.mainRepoPath {
+            restoredRepositoryPaths.insert(WorktreeModuleResolver.normalizedDirectoryPath(mainRepoPath))
+          }
+        }
+        for mapping in mappings.values {
+          let parentPath = WorktreeModuleResolver.normalizedDirectoryPath(mapping.parentRepoPath)
+          let worktreePath = WorktreeModuleResolver.normalizedDirectoryPath(mapping.worktreePath)
+          guard restoredRepositoryPaths.contains(parentPath),
+                worktreePath != parentPath else {
+            continue
+          }
+          restoredOwnedWorktreePaths.insert(worktreePath)
+        }
+      }
+      await setOwnedWorktreePaths(restoredOwnedWorktreePaths)
+      await monitorService.setFocusedSessionIds(persistedSessionIds)
 
       // Restore repository/worktree shells first. Full all-session scanning is
       // deferred until the Browse panel is opened.
@@ -1368,6 +1448,7 @@ public final class CLISessionsViewModel {
     return SessionWorkspaceState(
       selectedRepositoryPaths: selectedRepositories.map(\.path),
       monitoredSessionIds: Array(sessionIdsToPersist).sorted(),
+      ownedWorktreePaths: Array(ownedWorktreePaths).sorted(),
       expansionState: state
     )
   }
@@ -1521,6 +1602,7 @@ public final class CLISessionsViewModel {
       loadingState = .addingRepository(name: repoName)
       let previousBrowseSessionsLoadState = browseSessionsLoadState
       browseSessionsLoadState = .loading
+      await focusWorktreeIfNeeded(at: path)
       // [CLISessionsVM] Calling monitorService.addRepository...")
       let addedRepository = await monitorService.addRepository(path)
       // [CLISessionsVM] monitorService.addRepository completed")
@@ -1528,6 +1610,15 @@ public final class CLISessionsViewModel {
       loadingState = .idle
       // [CLISessionsVM] loadingState = .idle")
     }
+  }
+
+  private func focusWorktreeIfNeeded(at path: String) async {
+    let normalizedPath = WorktreeModuleResolver.normalizedDirectoryPath(path)
+    guard let info = await GitWorktreeDetector.detectWorktreeInfo(for: normalizedPath),
+          info.isWorktree else {
+      return
+    }
+    await setOwnedWorktreePaths(ownedWorktreePaths.union([normalizedPath]))
   }
 
   /// Removes a repository from monitoring
@@ -1548,6 +1639,9 @@ public final class CLISessionsViewModel {
       stopMonitoring(sessionId: sessionId)
     }
 
+    ownedWorktreePaths.subtract(repository.worktrees.filter(\.isWorktree).map(\.path))
+    syncOwnedWorktreePathsToMonitor()
+
     Task {
       await monitorService.removeRepository(repository.path)
     }
@@ -1561,7 +1655,7 @@ public final class CLISessionsViewModel {
     baseBranch: String?,
     onProgress: @escaping @Sendable (WorktreeCreationProgress) async -> Void
   ) async throws {
-    _ = try await worktreeService.createWorktreeWithNewBranch(
+    let worktreePath = try await worktreeService.createWorktreeWithNewBranch(
       at: repository.path,
       newBranchName: branchName,
       directoryName: directoryName,
@@ -1569,7 +1663,38 @@ public final class CLISessionsViewModel {
       operationID: WorktreeCreationOperationID(),
       onProgress: onProgress
     )
+    await registerCreatedWorktree(
+      name: branchName,
+      path: worktreePath,
+      parentRepositoryPath: repository.path
+    )
     refresh()
+  }
+
+  @discardableResult
+  public func registerCreatedWorktree(
+    name: String,
+    path: String,
+    parentRepositoryPath: String
+  ) async -> WorktreeBranch {
+    let worktree = WorktreeBranch(
+      name: name,
+      path: path,
+      isWorktree: true,
+      sessions: [],
+      isExpanded: true
+    )
+
+    await setOwnedWorktreePaths(ownedWorktreePaths.union([worktree.path]))
+    await monitorService.registerWorktree(worktree, parentRepositoryPath: parentRepositoryPath)
+    let updatedRepositories = await monitorService.getSelectedRepositories()
+    selectedRepositories = mergePreservingExpandedState(
+      current: selectedRepositories,
+      updated: updatedRepositories
+    )
+    persistSelectedRepositories()
+    syncClaudeHookInstalls()
+    return worktree
   }
 
   /// Finds the parent repository path for a worktree by searching selectedRepositories.
@@ -1600,6 +1725,7 @@ public final class CLISessionsViewModel {
           NSLocalizedDescriptionKey: "Cannot find parent repository for worktree at \(worktree.path)"
         ])
       }
+      removeOwnedWorktreePath(worktree.path)
       deletingWorktreePath = nil
       clearWorktreeDeletionError()
       refresh()
@@ -1633,6 +1759,7 @@ public final class CLISessionsViewModel {
 
     do {
       try await worktreeService.removeOrphanedWorktree(at: worktree.path, parentRepoPath: parentRepoPath)
+      removeOwnedWorktreePath(worktree.path)
       deletingWorktreePath = nil
       clearWorktreeDeletionError()
       refresh()
@@ -1673,6 +1800,7 @@ public final class CLISessionsViewModel {
     deletingWorktreePath = session.projectPath
     do {
       try await worktreeService.removeWorktree(at: session.projectPath, force: force)
+      removeOwnedWorktreePath(session.projectPath)
       deletingWorktreePath = nil
       stopMonitoring(session: session)
       refresh()
@@ -1978,14 +2106,6 @@ public final class CLISessionsViewModel {
           try await worktreeService.applyStash(stashRef, at: worktreePath)
         }
 
-        let worktree = WorktreeBranch(
-          name: branchName,
-          path: worktreePath,
-          isWorktree: true,
-          sessions: [],
-          isExpanded: true
-        )
-
         // Build a transcript reference to orient the new session.
         // sessionFilePath is the canonical, provider-agnostic path already stored on the model:
         //   - Claude sessions: ~/.claude/projects/{encoded-path}/{sessionId}.jsonl
@@ -2008,8 +2128,18 @@ public final class CLISessionsViewModel {
             ? hub.claudeSessionsViewModel
             : hub.codexSessionsViewModel
           targetViewModel.addRepository(at: session.projectPath)
+          let worktree = await targetViewModel.registerCreatedWorktree(
+            name: branchName,
+            path: worktreePath,
+            parentRepositoryPath: session.projectPath
+          )
           targetViewModel.startNewSessionInHub(worktree, initialPrompt: reference)
         } else {
+          let worktree = await registerCreatedWorktree(
+            name: branchName,
+            path: worktreePath,
+            parentRepositoryPath: session.projectPath
+          )
           startNewSessionInHub(worktree, initialPrompt: reference)
         }
       } catch {
@@ -2227,8 +2357,23 @@ public final class CLISessionsViewModel {
 #endif
     // Refresh to get the real session object with retry loop
     Task {
+      if let worktreeName = pending.worktreeName, !worktreeName.isEmpty {
+        let expectedWorktreePath = worktree.path + "/.claude/worktrees/" + worktreeName
+        await registerCreatedWorktree(
+          name: worktreeName,
+          path: expectedWorktreePath,
+          parentRepositoryPath: worktree.path
+        )
+      }
+      await monitorService.setFocusedSessionIds(monitoredSessionIds.union([sessionId]))
       // Retry loop: wait up to 2 seconds for session to appear in selectedRepositories
       let maxAttempts = 10  // 10 × 200ms = 2 seconds
+      let expectedWorktreePath: String
+      if let worktreeName = pending.worktreeName, !worktreeName.isEmpty {
+        expectedWorktreePath = worktree.path + "/.claude/worktrees/" + worktreeName
+      } else {
+        expectedWorktreePath = worktree.path
+      }
 
       for attempt in 1...maxAttempts {
         await monitorService.refreshSessions()
@@ -2240,7 +2385,7 @@ public final class CLISessionsViewModel {
         // Find and monitor the new session (try path matching first)
         var found = false
         for repo in selectedRepositories {
-          if let matchingWorktree = repo.worktrees.first(where: { $0.path == worktree.path }),
+          if let matchingWorktree = repo.worktrees.first(where: { $0.path == expectedWorktreePath || $0.path == worktree.path }),
              let session = matchingWorktree.sessions.first(where: { $0.id == sessionId }) {
             // Remove pending only after finding the real session
             pendingHubSessions.removeAll { $0.id == pending.id }
@@ -2468,10 +2613,11 @@ public final class CLISessionsViewModel {
           "[PollWorktreeHistory] pendingId=\(pending.id.uuidString, privacy: .public) found sessionId=\(sessionId, privacy: .public) at \(projectPath, privacy: .public)"
         )
 #endif
-        let resolvedWorktree = WorktreeBranch(
-          name: URL(fileURLWithPath: projectPath).lastPathComponent,
+        let worktreeName = URL(fileURLWithPath: projectPath).lastPathComponent
+        let resolvedWorktree = await registerCreatedWorktree(
+          name: worktreeName,
           path: projectPath,
-          isWorktree: true
+          parentRepositoryPath: repoPath
         )
         handleNewSessionFound(sessionId: sessionId, pending: pending, worktree: resolvedWorktree)
         return
@@ -2644,6 +2790,12 @@ public final class CLISessionsViewModel {
 
     monitoredSessionIds.insert(session.id)
     monitoredSessionBackup[session.id] = session
+    if session.isWorktree {
+      let worktreePath = WorktreeModuleResolver.bestMatch(for: session.projectPath, repositories: selectedRepositories)?.worktree.path
+        ?? session.projectPath
+      registerOwnedWorktreePath(worktreePath)
+    }
+    syncFocusedSessionIdsToMonitor()
 
     persistMonitoredSessions()
 
@@ -2667,6 +2819,7 @@ public final class CLISessionsViewModel {
     removeTerminal(forKey: sessionId)
     removeAuxiliaryShellTerminal(forKey: sessionId)
 
+    syncFocusedSessionIdsToMonitor()
     persistMonitoredSessions()
 
     Task {

--- a/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/MultiSessionLaunchViewModel.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/MultiSessionLaunchViewModel.swift
@@ -311,11 +311,24 @@ public final class MultiSessionLaunchViewModel {
   @discardableResult
   public func preselectRepository(path: String) async -> Bool {
     let combined = claudeViewModel.selectedRepositories + codexViewModel.selectedRepositories
-    guard let repository = combined.last(where: { $0.path == path }) else {
+    if let repository = combined.last(where: { $0.path == path }) {
+      selectedRepository = repository
+      await loadBranches()
+      return true
+    }
+
+    guard let match = WorktreeModuleResolver.bestMatch(for: path, repositories: combined),
+          match.worktree.isWorktree,
+          match.worktree.path == WorktreeModuleResolver.normalizedDirectoryPath(path) else {
       return false
     }
 
-    selectedRepository = repository
+    selectedRepository = SelectedRepository(
+      path: match.worktree.path,
+      name: URL(fileURLWithPath: match.worktree.path).lastPathComponent,
+      worktrees: [match.worktree],
+      isExpanded: true
+    )
     await loadBranches()
     return true
   }
@@ -692,7 +705,11 @@ public final class MultiSessionLaunchViewModel {
         try await Task.sleep(for: .milliseconds(500))
         try Task.checkCancellation()
 
-        let worktree = WorktreeBranch(name: session.branchName, path: worktreePath, isWorktree: true)
+        let worktree = await viewModel.registerCreatedWorktree(
+          name: session.branchName,
+          path: worktreePath,
+          parentRepositoryPath: repoPath
+        )
         viewModel.startNewSessionInHub(
           worktree,
           initialPrompt: session.prompt,
@@ -768,7 +785,11 @@ public final class MultiSessionLaunchViewModel {
       try await Task.sleep(for: .milliseconds(500))
       try Task.checkCancellation()
 
-      let worktree = WorktreeBranch(name: branchName, path: worktreePath, isWorktree: true)
+      let worktree = await viewModel.registerCreatedWorktree(
+        name: branchName,
+        path: worktreePath,
+        parentRepositoryPath: repoPath
+      )
       viewModel.startNewSessionInHub(
         worktree,
         initialPrompt: initialPrompt,
@@ -956,7 +977,11 @@ public final class MultiSessionLaunchViewModel {
     try Task.checkCancellation()
 
     if let path = claudeWorktreePath {
-      let worktree = WorktreeBranch(name: claudeBranchName, path: path, isWorktree: true)
+      let worktree = await claudeViewModel.registerCreatedWorktree(
+        name: claudeBranchName,
+        path: path,
+        parentRepositoryPath: repoPath
+      )
       claudeViewModel.startNewSessionInHub(
         worktree,
         initialPrompt: initialPrompt,
@@ -970,7 +995,11 @@ public final class MultiSessionLaunchViewModel {
     try Task.checkCancellation()
 
     if let path = codexWorktreePath {
-      let worktree = WorktreeBranch(name: codexBranchName, path: path, isWorktree: true)
+      let worktree = await codexViewModel.registerCreatedWorktree(
+        name: codexBranchName,
+        path: path,
+        parentRepositoryPath: repoPath
+      )
       codexViewModel.startNewSessionInHub(
         worktree,
         initialPrompt: initialPrompt,
@@ -1024,7 +1053,11 @@ public final class MultiSessionLaunchViewModel {
     try await Task.sleep(for: .milliseconds(500))
     try Task.checkCancellation()
 
-    let worktree = WorktreeBranch(name: branchName, path: path, isWorktree: true)
+    let worktree = await viewModel.registerCreatedWorktree(
+      name: branchName,
+      path: path,
+      parentRepositoryPath: repoPath
+    )
     viewModel.startNewSessionInHub(
       worktree,
       initialPrompt: initialPrompt,

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/LazyBrowseSessionsLoadingTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/LazyBrowseSessionsLoadingTests.swift
@@ -62,7 +62,10 @@ struct LazyBrowseSessionsLoadingTests {
   func launchRestoreSyncsClaudeHooksOnce() async throws {
     let store = try SessionMetadataStore(path: temporaryDatabasePath())
     try await store.saveWorkspaceState(
-      SessionWorkspaceState(selectedRepositoryPaths: ["/tmp/project"]),
+      SessionWorkspaceState(
+        selectedRepositoryPaths: ["/tmp/project"],
+        ownedWorktreePaths: ["/tmp/project-feature"]
+      ),
       for: .claude
     )
 
@@ -106,8 +109,15 @@ struct LazyBrowseSessionsLoadingTests {
       path: "/tmp/project",
       worktreePath: "/tmp/project-feature"
     )
+    try await store.saveWorkspaceState(
+      SessionWorkspaceState(
+        selectedRepositoryPaths: ["/tmp/project"],
+        ownedWorktreePaths: ["/tmp/project-feature"]
+      ),
+      for: .claude
+    )
     let monitor = LazyBrowseMockMonitorService(
-      skeletonRepositories: [],
+      skeletonRepositories: [repository],
       browseRepositories: [repository]
     )
     let hookInstaller = RecordingClaudeHookInstaller()

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/SessionDiscoveryScopeTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/SessionDiscoveryScopeTests.swift
@@ -1,0 +1,34 @@
+import Testing
+
+@testable import AgentHubCore
+
+@Suite("Session discovery scope")
+struct SessionDiscoveryScopeTests {
+  @Test("Owned worktree sessions must be focused")
+  func ownedWorktreeSessionsMustBeFocused() {
+    let scope = SessionDiscoveryScope(
+      repositoryPaths: ["/tmp/project"],
+      ownedWorktreePaths: ["/tmp/project-feature"],
+      ignoredWorktreePaths: [],
+      focusedSessionIds: ["focused-session"]
+    )
+
+    #expect(scope.includes(projectPath: "/tmp/project", sessionId: "external-main"))
+    #expect(scope.includes(projectPath: "/tmp/project-feature", sessionId: "focused-session"))
+    #expect(!scope.includes(projectPath: "/tmp/project-feature", sessionId: "external-worktree"))
+  }
+
+  @Test("Ignored worktrees are not attributed to parent repository")
+  func ignoredWorktreesAreNotAttributedToParentRepository() {
+    let scope = SessionDiscoveryScope(
+      repositoryPaths: ["/tmp/project"],
+      ownedWorktreePaths: [],
+      ignoredWorktreePaths: ["/tmp/project/.claude/worktrees/external"],
+      focusedSessionIds: []
+    )
+
+    #expect(scope.includes(projectPath: "/tmp/project/src", sessionId: "main-session"))
+    #expect(!scope.includes(projectPath: "/tmp/project/.claude/worktrees/external", sessionId: "external"))
+    #expect(!scope.includes(projectPath: "/tmp/project/.claude/worktrees/external/app", sessionId: "external-subdir"))
+  }
+}

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/SessionMonitorWorktreeNormalizationTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/SessionMonitorWorktreeNormalizationTests.swift
@@ -1,0 +1,89 @@
+import Foundation
+import Testing
+
+@testable import AgentHubCore
+
+@Suite("Session monitor worktree normalization")
+struct SessionMonitorWorktreeNormalizationTests {
+  @Test("Claude monitor adds a worktree path as its parent repository")
+  func claudeAddRepositoryNormalizesWorktreePath() async throws {
+    let fixture = try GitRepoFixture.create()
+    defer { fixture.cleanup() }
+    let worktreePath = try fixture.addWorktree(branch: "feature-normalization")
+
+    let service = CLISessionMonitorService(claudeDataPath: fixture.parentDir + "/claude")
+    let added = await service.addRepository(worktreePath)
+    let repositories = await service.getSelectedRepositories()
+
+    #expect(added?.path == fixture.repoPath)
+    #expect(repositories.map(\.path) == [fixture.repoPath])
+    #expect(repositories.first?.worktrees.contains(where: { $0.path == worktreePath }) == true)
+  }
+
+  @Test("Claude restore dedupes parent and worktree paths")
+  func claudeRestoreDedupesWorktreePath() async throws {
+    let fixture = try GitRepoFixture.create()
+    defer { fixture.cleanup() }
+    let worktreePath = try fixture.addWorktree(branch: "feature-restore")
+
+    let service = CLISessionMonitorService(claudeDataPath: fixture.parentDir + "/claude")
+    let repositories = await service.restoreRepositoriesSkeleton([fixture.repoPath, worktreePath])
+
+    #expect(repositories.map(\.path) == [fixture.repoPath])
+    #expect(repositories.first?.worktrees.contains(where: { $0.path == worktreePath }) == true)
+  }
+
+  @Test("Claude parent add hides external worktrees")
+  func claudeParentAddHidesExternalWorktrees() async throws {
+    let fixture = try GitRepoFixture.create()
+    defer { fixture.cleanup() }
+    let worktreePath = try fixture.addWorktree(branch: "feature-external")
+
+    let service = CLISessionMonitorService(claudeDataPath: fixture.parentDir + "/claude")
+    let added = await service.addRepository(fixture.repoPath)
+
+    #expect(added?.path == fixture.repoPath)
+    #expect(added?.worktrees.contains(where: { $0.path == worktreePath }) == false)
+  }
+
+  @Test("Codex monitor adds a worktree path as its parent repository")
+  func codexAddRepositoryNormalizesWorktreePath() async throws {
+    let fixture = try GitRepoFixture.create()
+    defer { fixture.cleanup() }
+    let worktreePath = try fixture.addWorktree(branch: "feature-codex-normalization")
+
+    let service = CodexSessionMonitorService(codexDataPath: fixture.parentDir + "/codex")
+    let added = await service.addRepository(worktreePath)
+    let repositories = await service.getSelectedRepositories()
+
+    #expect(added?.path == fixture.repoPath)
+    #expect(repositories.map(\.path) == [fixture.repoPath])
+    #expect(repositories.first?.worktrees.contains(where: { $0.path == worktreePath }) == true)
+  }
+
+  @Test("Codex restore dedupes parent and worktree paths")
+  func codexRestoreDedupesWorktreePath() async throws {
+    let fixture = try GitRepoFixture.create()
+    defer { fixture.cleanup() }
+    let worktreePath = try fixture.addWorktree(branch: "feature-codex-restore")
+
+    let service = CodexSessionMonitorService(codexDataPath: fixture.parentDir + "/codex")
+    let repositories = await service.restoreRepositoriesSkeleton([fixture.repoPath, worktreePath])
+
+    #expect(repositories.map(\.path) == [fixture.repoPath])
+    #expect(repositories.first?.worktrees.contains(where: { $0.path == worktreePath }) == true)
+  }
+
+  @Test("Codex parent add hides external worktrees")
+  func codexParentAddHidesExternalWorktrees() async throws {
+    let fixture = try GitRepoFixture.create()
+    defer { fixture.cleanup() }
+    let worktreePath = try fixture.addWorktree(branch: "feature-codex-external")
+
+    let service = CodexSessionMonitorService(codexDataPath: fixture.parentDir + "/codex")
+    let added = await service.addRepository(fixture.repoPath)
+
+    #expect(added?.path == fixture.repoPath)
+    #expect(added?.worktrees.contains(where: { $0.path == worktreePath }) == false)
+  }
+}

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/SessionWorkspaceStatePersistenceTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/SessionWorkspaceStatePersistenceTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import GRDB
 import Testing
 
 @testable import AgentHubCore
@@ -12,6 +13,7 @@ struct SessionWorkspaceStatePersistenceTests {
     let state = SessionWorkspaceState(
       selectedRepositoryPaths: ["/tmp/project-a", "/tmp/project-b"],
       monitoredSessionIds: ["session-1", "session-2"],
+      ownedWorktreePaths: ["/tmp/project-a/worktrees/feature"],
       expansionState: [
         "repo:/tmp/project-a": true,
         "wt:/tmp/project-a/worktrees/feature": false
@@ -22,6 +24,54 @@ struct SessionWorkspaceStatePersistenceTests {
 
     #expect(store.getWorkspaceStateSync(for: .claude) == state)
     #expect(store.getWorkspaceStateSync(for: .codex) == SessionWorkspaceState())
+  }
+
+  @Test("Owned worktree migration preserves existing workspace state")
+  func ownedWorktreeMigrationPreservesExistingWorkspaceState() async throws {
+    let path = temporaryWorkspaceStateDatabasePath()
+    let dbQueue = try DatabaseQueue(path: path)
+    let selectedRepositoryPathsData = try JSONEncoder().encode(["/tmp/project"])
+    let monitoredSessionIdsData = try JSONEncoder().encode(["session-1"])
+    let expansionStateData = try JSONEncoder().encode(["repo:/tmp/project": true])
+
+    try dbQueue.write { db in
+      try db.execute(sql: "CREATE TABLE grdb_migrations (identifier TEXT NOT NULL PRIMARY KEY)")
+      for identifier in SessionMetadataStore.migrationIdentifiers.dropLast() {
+        try db.execute(sql: "INSERT INTO grdb_migrations (identifier) VALUES (?)", arguments: [identifier])
+      }
+
+      try db.create(table: "session_workspace_state") { t in
+        t.column("provider", .text).primaryKey()
+        t.column("selectedRepositoryPathsData", .blob).notNull()
+        t.column("monitoredSessionIdsData", .blob).notNull()
+        t.column("expansionStateData", .blob).notNull()
+        t.column("updatedAt", .datetime).notNull()
+      }
+      try db.execute(
+        sql: """
+        INSERT INTO session_workspace_state
+        (provider, selectedRepositoryPathsData, monitoredSessionIdsData, expansionStateData, updatedAt)
+        VALUES (?, ?, ?, ?, ?)
+        """,
+        arguments: [
+          SessionProviderKind.claude.rawValue,
+          selectedRepositoryPathsData,
+          monitoredSessionIdsData,
+          expansionStateData,
+          Date(timeIntervalSince1970: 1_000)
+        ]
+      )
+    }
+
+    let store = try SessionMetadataStore(path: path)
+    #expect(
+      store.getWorkspaceStateSync(for: .claude) == SessionWorkspaceState(
+        selectedRepositoryPaths: ["/tmp/project"],
+        monitoredSessionIds: ["session-1"],
+        ownedWorktreePaths: [],
+        expansionState: ["repo:/tmp/project": true]
+      )
+    )
   }
 
   @Test("Clear all removes workspace state")

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/WorktreeModuleResolverTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/WorktreeModuleResolverTests.swift
@@ -1,0 +1,104 @@
+import Foundation
+import Testing
+
+@testable import AgentHubCore
+
+@Suite("WorktreeModuleResolver")
+struct WorktreeModuleResolverTests {
+  @Test("Parent mode groups worktree sessions under the parent repository")
+  func parentModeUsesParentRepository() {
+    let repositories = [
+      repositoryWithWorktree(
+        repoPath: "/tmp/ModuleA",
+        worktreePath: "/tmp/ModuleA-feature"
+      )
+    ]
+
+    #expect(WorktreeModuleResolver.modulePath(
+      for: "/tmp/ModuleA-feature",
+      repositories: repositories,
+      mode: .parent
+    ) == "/tmp/ModuleA")
+
+    #expect(WorktreeModuleResolver.modulePath(
+      for: "/tmp/ModuleA-feature/app/Sources",
+      repositories: repositories,
+      mode: .parent
+    ) == "/tmp/ModuleA")
+  }
+
+  @Test("Separate mode groups worktree sessions under the worktree path")
+  func separateModeUsesWorktreePath() {
+    let repositories = [
+      repositoryWithWorktree(
+        repoPath: "/tmp/ModuleA",
+        worktreePath: "/tmp/ModuleA-feature"
+      )
+    ]
+
+    #expect(WorktreeModuleResolver.modulePath(
+      for: "/tmp/ModuleA-feature",
+      repositories: repositories,
+      mode: .separateModules
+    ) == "/tmp/ModuleA-feature")
+
+    #expect(WorktreeModuleResolver.modulePath(
+      for: "/tmp/ModuleA-feature/app/Sources",
+      repositories: repositories,
+      mode: .separateModules
+    ) == "/tmp/ModuleA-feature")
+  }
+
+  @Test("Module path list follows the selected worktree display mode")
+  func modulePathsFollowDisplayMode() {
+    let repositories = [
+      repositoryWithWorktree(
+        repoPath: "/tmp/ModuleA",
+        worktreePath: "/tmp/ModuleA-feature"
+      )
+    ]
+
+    #expect(WorktreeModuleResolver.modulePaths(for: repositories, mode: .parent) == [
+      "/tmp/ModuleA"
+    ])
+    #expect(WorktreeModuleResolver.modulePaths(for: repositories, mode: .separateModules) == [
+      "/tmp/ModuleA",
+      "/tmp/ModuleA-feature"
+    ])
+  }
+
+  @Test("Merged repositories keep worktrees from both providers")
+  func mergedRepositoriesKeepProviderWorktrees() throws {
+    let claude = SelectedRepository(
+      path: "/tmp/ModuleA",
+      worktrees: [
+        WorktreeBranch(name: "main", path: "/tmp/ModuleA", isWorktree: false)
+      ]
+    )
+    let codex = SelectedRepository(
+      path: "/tmp/ModuleA",
+      worktrees: [
+        WorktreeBranch(name: "feature", path: "/tmp/ModuleA-feature", isWorktree: true)
+      ]
+    )
+
+    let merged = WorktreeModuleResolver.mergedRepositories([claude, codex])
+    let repository = try #require(merged.first)
+
+    #expect(merged.count == 1)
+    #expect(repository.worktrees.map(\.path).sorted() == [
+      "/tmp/ModuleA",
+      "/tmp/ModuleA-feature"
+    ])
+  }
+}
+
+private func repositoryWithWorktree(repoPath: String, worktreePath: String) -> SelectedRepository {
+  SelectedRepository(
+    path: repoPath,
+    worktrees: [
+      WorktreeBranch(name: "main", path: repoPath, isWorktree: false),
+      WorktreeBranch(name: "feature", path: worktreePath, isWorktree: true)
+    ]
+  )
+}


### PR DESCRIPTION
## Summary
- Add configurable worktree module grouping with parent grouping as the default
- Persist AgentHub-owned worktree paths in SQLite and scope worktree session discovery to owned/focused worktrees
- Ignore external Git worktrees for grouping so large local worktree sets do not flood the session list
- Document the new worktree grouping behavior in the README

## Validation
- git diff --check
- xcodebuild build -project app/AgentHub.xcodeproj -scheme AgentHubCore -destination 'platform=macOS'

## Notes
Focused test execution was blocked by existing project/package issues unrelated to this change: CodeEditSymbols missing Bundle.module, the AgentHub scheme not configured for test-without-building, and existing SwiftLint/Yams build artifact errors when targeting AgentHubTests.