### PR TITLE
[codex] Fix focused session shortcuts

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/CommandPaletteView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/CommandPaletteView.swift
@@ -38,7 +38,7 @@ public enum CommandPaletteAction: Identifiable {
     case .openSettings: return "Open Settings"
     case .toggleSidebar: return "Toggle Sidebar"
     case .toggleFocusMode: return "Toggle Focus Mode"
-    case .toggleTerminalEditor: return "Swap Terminal and Files"
+    case .toggleTerminalEditor: return "Next Session Tab"
     }
   }
 
@@ -57,7 +57,7 @@ public enum CommandPaletteAction: Identifiable {
     case .openSettings: return "Open application settings"
     case .toggleSidebar: return "Show or hide the sidebar"
     case .toggleFocusMode: return "Expand focused session or restore previous layout"
-    case .toggleTerminalEditor: return "Switch the focused session between terminal and files"
+    case .toggleTerminalEditor: return "Cycle the focused session through visible tabs"
     }
   }
 
@@ -69,7 +69,7 @@ public enum CommandPaletteAction: Identifiable {
     case .openSettings: return "gear"
     case .toggleSidebar: return "sidebar.left"
     case .toggleFocusMode: return "arrow.up.left.and.arrow.down.right"
-    case .toggleTerminalEditor: return "rectangle.2.swap"
+    case .toggleTerminalEditor: return "arrow.triangle.2.circlepath"
     }
   }
 
@@ -79,7 +79,7 @@ public enum CommandPaletteAction: Identifiable {
     case .toggleSidebar: return "⌘B"
     case .openSettings: return "⌘,"
     case .toggleFocusMode: return "⌘\\"
-    case .toggleTerminalEditor: return "⌃`"
+    case .toggleTerminalEditor: return "⌥`"
     default: return nil
     }
   }

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/CommandPaletteView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/CommandPaletteView.swift
@@ -44,7 +44,7 @@ public enum CommandPaletteAction: Identifiable {
 
   var subtitle: String? {
     switch self {
-    case .newSession: return "Start a new Claude or Codex session"
+    case .newSession: return "Start from the focused session's worktree"
     case .switchToSession(_, _, let provider, let firstMessage):
       if let firstMessage {
         let trimmed = firstMessage.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringEditorState.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringEditorState.swift
@@ -7,7 +7,7 @@ import AgentHubGitDiff
 import Foundation
 
 extension Notification.Name {
-  /// Request the focused monitoring card to swap between Terminal and Files content modes.
+  /// Request the focused monitoring card to cycle to its next visible content mode.
   static let toggleMonitoringContentMode = Notification.Name("com.agenthub.toggleMonitoringContentMode")
 }
 
@@ -97,10 +97,16 @@ enum MonitoringEditorStateStore {
     availableModes.contains(contentMode) ? contentMode : .terminal
   }
 
-  static func toggledTerminalFilesMode(
-    from contentMode: MonitoringCardContentMode
+  static func nextContentMode(
+    after contentMode: MonitoringCardContentMode,
+    availableModes: [MonitoringCardContentMode]
   ) -> MonitoringCardContentMode {
-    contentMode == .terminal ? .editor : .terminal
+    guard !availableModes.isEmpty else { return .terminal }
+    guard let currentIndex = availableModes.firstIndex(of: contentMode) else {
+      return availableModes[0]
+    }
+    let nextIndex = availableModes.index(after: currentIndex)
+    return nextIndex == availableModes.endIndex ? availableModes[0] : availableModes[nextIndex]
   }
 
   static func state(

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderMonitoringPanelView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderMonitoringPanelView.swift
@@ -209,6 +209,8 @@ public struct MultiProviderMonitoringPanelView: View {
   private var flatSessionLayout: Bool = false
   @AppStorage(AgentHubDefaults.worktreeDisplayMode)
   private var worktreeDisplayModeRawValue: String = WorktreeDisplayMode.parent.rawValue
+  @AppStorage(AgentHubDefaults.diffDisplayMode)
+  private var diffDisplayModeRawValue: String = DiffDisplayMode.inline.rawValue
   @State private var showQuickFilePicker = false
   @State private var gitHubPopOutItem: GitHubPopOutItem?
   @Environment(\.colorScheme) private var colorScheme
@@ -322,6 +324,9 @@ public struct MultiProviderMonitoringPanelView: View {
       Group {
         Button("") { showQuickFilePicker = true }
           .keyboardShortcut("p", modifiers: [.command])
+
+        Button("") { togglePrimarySessionContentMode() }
+          .keyboardShortcut("`", modifiers: [.option])
 
         Button("") { togglePrimarySessionContentMode() }
           .keyboardShortcut("`", modifiers: [.control])
@@ -1435,6 +1440,10 @@ public struct MultiProviderMonitoringPanelView: View {
     WorktreeDisplayMode(rawValue: worktreeDisplayModeRawValue) ?? .parent
   }
 
+  private var diffDisplayMode: DiffDisplayMode {
+    DiffDisplayMode(rawValue: diffDisplayModeRawValue) ?? .inline
+  }
+
   private var emptyStateViewModel: CLISessionsViewModel {
     if !claudeViewModel.selectedRepositories.isEmpty { return claudeViewModel }
     if !codexViewModel.selectedRepositories.isEmpty { return codexViewModel }
@@ -1675,10 +1684,18 @@ public struct MultiProviderMonitoringPanelView: View {
   private func togglePrimarySessionContentMode() {
     guard activeModuleLandingPath(snapshot: makeItemSnapshot()) == nil else { return }
     guard let item = effectivePrimaryItem else { return }
-    let nextMode = MonitoringEditorStateStore.toggledTerminalFilesMode(
-      from: editorState(for: item).contentMode
+    let nextMode = MonitoringEditorStateStore.nextContentMode(
+      after: editorState(for: item).contentMode,
+      availableModes: availableContentModes(for: item)
     )
     setContentMode(nextMode, for: item)
+  }
+
+  private func availableContentModes(for item: ProviderMonitoringItem) -> [MonitoringCardContentMode] {
+    MonitoringEditorStateStore.availableContentModes(
+      diffDisplayMode: diffDisplayMode,
+      diffAvailabilityStatus: item.viewModel.diffAvailabilityStatus(for: item.projectPath)
+    )
   }
 
   private func showTerminalWithPrompt(

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
@@ -454,7 +454,7 @@ public struct MultiProviderSessionsListView: View {
         .keyboardShortcut("k", modifiers: .command)
         .hidden()
 
-      Button("") { handleCommandPaletteAction(.newSession) }
+      Button("") { triggerFocusedNewSessionFlow() }
         .keyboardShortcut("n", modifiers: .command)
         .hidden()
 
@@ -1665,7 +1665,7 @@ public struct MultiProviderSessionsListView: View {
   private func handleCommandPaletteAction(_ action: CommandPaletteAction) {
     switch action {
     case .newSession:
-      triggerNewSessionFlow()
+      triggerFocusedNewSessionFlow()
 
     case .switchToSession(let id, _, _, _):
       if let item = selectedSessionItems.first(where: { $0.id == id }) {
@@ -1714,7 +1714,32 @@ public struct MultiProviderSessionsListView: View {
     columnVisibility = previousVisibility
   }
 
-  private func triggerNewSessionFlow(preferredRepositoryPath: String? = nil) {
+  private var focusedSessionLaunchPath: String? {
+    FocusedSessionLaunchTargetResolver.launchPath(
+      primarySessionId: primarySessionId,
+      selectedModuleLandingPath: selectedModuleLandingPath,
+      items: selectedSessionItems.map {
+        FocusedSessionLaunchTargetResolver.SessionItem(
+          id: $0.id,
+          projectPath: $0.session.projectPath
+        )
+      },
+      repositories: orderedTrackedRepos
+    )
+  }
+
+  private func triggerFocusedNewSessionFlow() {
+    guard let focusedSessionLaunchPath else { return }
+    triggerNewSessionFlow(
+      preferredRepositoryPath: focusedSessionLaunchPath,
+      fallsBackToRepositoryPicker: false
+    )
+  }
+
+  private func triggerNewSessionFlow(
+    preferredRepositoryPath: String? = nil,
+    fallsBackToRepositoryPicker: Bool = true
+  ) {
     guard let multiLaunchViewModel else { return }
     multiLaunchViewModel.reset()
 
@@ -1728,7 +1753,7 @@ public struct MultiProviderSessionsListView: View {
       let didPreselect = await multiLaunchViewModel.preselectRepository(path: preferredRepositoryPath)
       if didPreselect {
         isStartSessionSheetPresented = true
-      } else {
+      } else if fallsBackToRepositoryPicker {
         isStartSessionSheetPresented = true
         multiLaunchViewModel.selectRepository()
       }

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/WelcomeView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/WelcomeView.swift
@@ -113,7 +113,6 @@ public struct WelcomeView: View {
       sectionHeader(title: "Quick Start", icon: "bolt.fill")
 
       VStack(spacing: 10) {
-        shortcutRow(key: "⌘ N", description: "Start new session", icon: "plus.circle")
         shortcutRow(key: "⌘ K", description: "Command palette", icon: "command")
         shortcutRow(key: "⌘ B", description: "Toggle sidebar", icon: "sidebar.left")
         shortcutRow(key: "⌘ [ / ]", description: "Navigate between sessions", icon: "arrow.left.arrow.right")

--- a/app/modules/AgentHubCore/Sources/AgentHub/Utils/FocusedSessionLaunchTargetResolver.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Utils/FocusedSessionLaunchTargetResolver.swift
@@ -1,0 +1,32 @@
+//
+//  FocusedSessionLaunchTargetResolver.swift
+//  AgentHub
+//
+
+import Foundation
+
+enum FocusedSessionLaunchTargetResolver {
+  struct SessionItem: Equatable {
+    let id: String
+    let projectPath: String
+  }
+
+  static func launchPath(
+    primarySessionId: String?,
+    selectedModuleLandingPath: String?,
+    items: [SessionItem],
+    repositories: [SelectedRepository]
+  ) -> String? {
+    guard selectedModuleLandingPath == nil,
+          let primarySessionId,
+          let item = items.first(where: { $0.id == primarySessionId }),
+          let match = WorktreeModuleResolver.bestMatch(for: item.projectPath, repositories: repositories) else {
+      return nil
+    }
+
+    if match.worktree.isWorktree {
+      return WorktreeModuleResolver.normalizedDirectoryPath(match.worktree.path)
+    }
+    return WorktreeModuleResolver.normalizedDirectoryPath(match.repository.path)
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/MultiSessionLaunchViewModel.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/MultiSessionLaunchViewModel.swift
@@ -311,24 +311,29 @@ public final class MultiSessionLaunchViewModel {
   @discardableResult
   public func preselectRepository(path: String) async -> Bool {
     let combined = claudeViewModel.selectedRepositories + codexViewModel.selectedRepositories
-    if let repository = combined.last(where: { $0.path == path }) {
+    let normalizedPath = WorktreeModuleResolver.normalizedDirectoryPath(path)
+    if let repository = combined.last(where: {
+      WorktreeModuleResolver.normalizedDirectoryPath($0.path) == normalizedPath
+    }) {
       selectedRepository = repository
       await loadBranches()
       return true
     }
 
-    guard let match = WorktreeModuleResolver.bestMatch(for: path, repositories: combined),
-          match.worktree.isWorktree,
-          match.worktree.path == WorktreeModuleResolver.normalizedDirectoryPath(path) else {
+    guard let match = WorktreeModuleResolver.bestMatch(for: path, repositories: combined) else {
       return false
     }
 
-    selectedRepository = SelectedRepository(
-      path: match.worktree.path,
-      name: URL(fileURLWithPath: match.worktree.path).lastPathComponent,
-      worktrees: [match.worktree],
-      isExpanded: true
-    )
+    if match.worktree.isWorktree {
+      selectedRepository = SelectedRepository(
+        path: match.worktree.path,
+        name: URL(fileURLWithPath: match.worktree.path).lastPathComponent,
+        worktrees: [match.worktree],
+        isExpanded: true
+      )
+    } else {
+      selectedRepository = match.repository
+    }
     await loadBranches()
     return true
   }

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/FocusedSessionLaunchTargetResolverTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/FocusedSessionLaunchTargetResolverTests.swift
@@ -1,0 +1,224 @@
+import Combine
+import Foundation
+import Testing
+
+@testable import AgentHubCore
+
+@Suite("FocusedSessionLaunchTargetResolver")
+struct FocusedSessionLaunchTargetResolverTests {
+  @Test("No primary session returns no launch path")
+  func noPrimarySessionReturnsNil() {
+    let repository = repositoryWithWorktree()
+
+    let path = FocusedSessionLaunchTargetResolver.launchPath(
+      primarySessionId: nil,
+      selectedModuleLandingPath: nil,
+      items: [
+        .init(id: "claude-session", projectPath: "/tmp/Repo")
+      ],
+      repositories: [repository]
+    )
+
+    #expect(path == nil)
+  }
+
+  @Test("Module landing selection returns no launch path")
+  func moduleLandingSelectionReturnsNil() {
+    let repository = repositoryWithWorktree()
+
+    let path = FocusedSessionLaunchTargetResolver.launchPath(
+      primarySessionId: "claude-session",
+      selectedModuleLandingPath: "/tmp/Repo",
+      items: [
+        .init(id: "claude-session", projectPath: "/tmp/Repo")
+      ],
+      repositories: [repository]
+    )
+
+    #expect(path == nil)
+  }
+
+  @Test("Focused worktree session resolves to worktree root")
+  func focusedWorktreeSessionResolvesToWorktreeRoot() {
+    let repository = repositoryWithWorktree()
+
+    let path = FocusedSessionLaunchTargetResolver.launchPath(
+      primarySessionId: "codex-session",
+      selectedModuleLandingPath: nil,
+      items: [
+        .init(id: "codex-session", projectPath: "/tmp/Repo-feature/app")
+      ],
+      repositories: [repository]
+    )
+
+    #expect(path == "/tmp/Repo-feature")
+  }
+
+  @Test("Focused main repo session resolves to repository root")
+  func focusedMainRepoSessionResolvesToRepositoryRoot() {
+    let repository = repositoryWithWorktree()
+
+    let path = FocusedSessionLaunchTargetResolver.launchPath(
+      primarySessionId: "claude-session",
+      selectedModuleLandingPath: nil,
+      items: [
+        .init(id: "claude-session", projectPath: "/tmp/Repo/Sources")
+      ],
+      repositories: [repository]
+    )
+
+    #expect(path == "/tmp/Repo")
+  }
+
+  @Test("Unmatched focused session returns no launch path")
+  func unmatchedFocusedSessionReturnsNil() {
+    let repository = repositoryWithWorktree()
+
+    let path = FocusedSessionLaunchTargetResolver.launchPath(
+      primarySessionId: "claude-session",
+      selectedModuleLandingPath: nil,
+      items: [
+        .init(id: "claude-session", projectPath: "/tmp/Other")
+      ],
+      repositories: [repository]
+    )
+
+    #expect(path == nil)
+  }
+}
+
+@Suite("MultiSessionLaunchViewModel preselection")
+@MainActor
+struct MultiSessionLaunchViewModelPreselectionTests {
+  @Test("Preselect accepts a path inside a tracked main repository")
+  func preselectAcceptsNestedMainRepositoryPath() async throws {
+    let repository = repositoryWithWorktree()
+    let fixture = makePreselectionFixture()
+
+    await fixture.claudeMonitor.setRepositories([repository])
+    try await waitUntil { fixture.claudeViewModel.selectedRepositories == [repository] }
+
+    let didPreselect = await fixture.launchViewModel.preselectRepository(path: "/tmp/Repo/app")
+
+    #expect(didPreselect)
+    #expect(fixture.launchViewModel.selectedRepository?.path == "/tmp/Repo")
+  }
+
+  @Test("Preselect accepts a path inside a tracked worktree")
+  func preselectAcceptsNestedWorktreePath() async throws {
+    let repository = repositoryWithWorktree()
+    let fixture = makePreselectionFixture()
+
+    await fixture.claudeMonitor.setRepositories([repository])
+    try await waitUntil { fixture.claudeViewModel.selectedRepositories == [repository] }
+
+    let didPreselect = await fixture.launchViewModel.preselectRepository(path: "/tmp/Repo-feature/app")
+
+    #expect(didPreselect)
+    #expect(fixture.launchViewModel.selectedRepository?.path == "/tmp/Repo-feature")
+  }
+}
+
+private func repositoryWithWorktree() -> SelectedRepository {
+  SelectedRepository(
+    path: "/tmp/Repo",
+    worktrees: [
+      WorktreeBranch(name: "main", path: "/tmp/Repo", isWorktree: false),
+      WorktreeBranch(name: "feature", path: "/tmp/Repo-feature", isWorktree: true)
+    ]
+  )
+}
+
+@MainActor
+private func makePreselectionFixture() -> (
+  launchViewModel: MultiSessionLaunchViewModel,
+  claudeViewModel: CLISessionsViewModel,
+  claudeMonitor: PreselectionMonitorService
+) {
+  let claudeMonitor = PreselectionMonitorService()
+  let codexMonitor = PreselectionMonitorService()
+  let claudeViewModel = CLISessionsViewModel(
+    monitorService: claudeMonitor,
+    fileWatcher: PreselectionFileWatcher(),
+    searchService: nil,
+    cliConfiguration: .claudeDefault,
+    providerKind: .claude,
+    approvalNotificationService: NoOpApprovalNotificationService()
+  )
+  let codexViewModel = CLISessionsViewModel(
+    monitorService: codexMonitor,
+    fileWatcher: PreselectionFileWatcher(),
+    searchService: nil,
+    cliConfiguration: .codexDefault,
+    providerKind: .codex,
+    approvalNotificationService: NoOpApprovalNotificationService()
+  )
+  let launchViewModel = MultiSessionLaunchViewModel(
+    claudeViewModel: claudeViewModel,
+    codexViewModel: codexViewModel
+  )
+  return (launchViewModel, claudeViewModel, claudeMonitor)
+}
+
+@MainActor
+private func waitUntil(
+  _ condition: @escaping () -> Bool,
+  timeoutAttempts: Int = 50
+) async throws {
+  for _ in 0..<timeoutAttempts {
+    if condition() { return }
+    try await Task.sleep(for: .milliseconds(20))
+  }
+  #expect(condition())
+}
+
+private final class PreselectionMonitorService: SessionMonitorServiceProtocol, @unchecked Sendable {
+  private let subject = CurrentValueSubject<[SelectedRepository], Never>([])
+  private var repositories: [SelectedRepository] = []
+
+  var repositoriesPublisher: AnyPublisher<[SelectedRepository], Never> {
+    subject.eraseToAnyPublisher()
+  }
+
+  func setRepositories(_ repositories: [SelectedRepository]) async {
+    self.repositories = repositories
+    subject.send(repositories)
+  }
+
+  func addRepository(_ path: String) async -> SelectedRepository? {
+    guard !repositories.contains(where: { $0.path == path }) else {
+      return nil
+    }
+
+    let repository = SelectedRepository(path: path)
+    repositories.append(repository)
+    subject.send(repositories)
+    return repository
+  }
+
+  func removeRepository(_ path: String) async {}
+
+  func getSelectedRepositories() async -> [SelectedRepository] {
+    repositories
+  }
+
+  func setSelectedRepositories(_ repositories: [SelectedRepository]) async {
+    await setRepositories(repositories)
+  }
+
+  func refreshSessions(skipWorktreeRedetection: Bool) async {}
+}
+
+private final class PreselectionFileWatcher: SessionFileWatcherProtocol, @unchecked Sendable {
+  private let subject = PassthroughSubject<SessionFileWatcher.StateUpdate, Never>()
+
+  var statePublisher: AnyPublisher<SessionFileWatcher.StateUpdate, Never> {
+    subject.eraseToAnyPublisher()
+  }
+
+  func startMonitoring(sessionId: String, projectPath: String, sessionFilePath: String?) async {}
+  func stopMonitoring(sessionId: String) async {}
+  func getState(sessionId: String) async -> SessionMonitorState? { nil }
+  func refreshState(sessionId: String) async {}
+  func setApprovalTimeout(_ seconds: Int) async {}
+}

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/MonitoringEditorStateTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/MonitoringEditorStateTests.swift
@@ -125,11 +125,25 @@ struct MonitoringEditorStateTests {
     #expect(mode == .terminal)
   }
 
-  @Test("Terminal files shortcut ignores diffs")
-  func terminalFilesShortcutIgnoresDiffs() {
-    #expect(MonitoringEditorStateStore.toggledTerminalFilesMode(from: .terminal) == .editor)
-    #expect(MonitoringEditorStateStore.toggledTerminalFilesMode(from: .editor) == .terminal)
-    #expect(MonitoringEditorStateStore.toggledTerminalFilesMode(from: .diffs) == .terminal)
+  @Test("Content shortcut cycles visible modes by index")
+  func contentShortcutCyclesVisibleModesByIndex() {
+    let modes: [MonitoringCardContentMode] = [.terminal, .editor, .diffs]
+
+    #expect(MonitoringEditorStateStore.nextContentMode(after: .terminal, availableModes: modes) == .editor)
+    #expect(MonitoringEditorStateStore.nextContentMode(after: .editor, availableModes: modes) == .diffs)
+    #expect(MonitoringEditorStateStore.nextContentMode(after: .diffs, availableModes: modes) == .terminal)
+  }
+
+  @Test("Content shortcut falls back to first visible mode when current mode disappears")
+  func contentShortcutFallsBackToFirstVisibleMode() {
+    #expect(MonitoringEditorStateStore.nextContentMode(
+      after: .diffs,
+      availableModes: [.terminal, .editor]
+    ) == .terminal)
+    #expect(MonitoringEditorStateStore.nextContentMode(
+      after: .terminal,
+      availableModes: []
+    ) == .terminal)
   }
 
   @Test("Inline available modes include diffs only when available")


### PR DESCRIPTION
## Summary
- Change Cmd+N to open the Start Session flow only for the currently focused session's repo/worktree.
- Resolve focused launch targets through tracked repo/worktree metadata and avoid falling back to the repository picker when nothing is focused.
- Change the monitoring content shortcut to cycle through visible tabs, including diffs when available, and update the command palette copy.

## Validation
- `xcodebuild build -project app/AgentHub.xcodeproj -scheme AgentHubCore -destination 'platform=macOS' -quiet`

## Notes
- The project schemes are not configured for test actions, so the new focused unit tests were added but not run through `xcodebuild test` in this checkout.