### PR TITLE
[codex] Fix duplicate diff review prompt delivery

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/EmbeddedTerminalView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/EmbeddedTerminalView.swift
@@ -158,12 +158,12 @@ public struct EmbeddedTerminalView: NSViewRepresentable {
     }
     terminal.syncAppearance(isDark: colorScheme == .dark, fontSize: CGFloat(terminalFontSize), fontFamily: terminalFontFamily, theme: runtimeTheme)
 
-    // If there's a pending prompt in the viewModel, send it (and clear it)
-    // Use terminalKey (not sessionId) since it works for both pending and real sessions
-    if let prompt = viewModel?.pendingPrompt(for: terminalKey) {
+    // Use terminalKey (not sessionId) since it works for both pending and real sessions.
+    // Consuming here prevents duplicated delivery when multiple terminal views render
+    // the same stale initialPrompt value during a layout transition.
+    if let prompt = viewModel?.consumePendingPrompt(for: terminalKey) {
       terminal.resetPromptDeliveryFlag()
       terminal.sendPromptIfNeeded(prompt)
-      viewModel?.clearPendingPrompt(for: terminalKey)
     }
   }
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/CLISessionsViewModel.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/CLISessionsViewModel.swift
@@ -308,6 +308,13 @@ public final class CLISessionsViewModel {
     pendingTerminalPrompts[sessionId]
   }
 
+  /// Returns and clears the pending prompt for a session.
+  public func consumePendingPrompt(for sessionId: String) -> String? {
+    guard let prompt = pendingTerminalPrompts[sessionId] else { return nil }
+    pendingTerminalPrompts.removeValue(forKey: sessionId)
+    return prompt
+  }
+
   /// Clears the pending prompt after terminal has started (call from onAppear)
   public func clearPendingPrompt(for sessionId: String) {
     pendingTerminalPrompts.removeValue(forKey: sessionId)
@@ -622,13 +629,21 @@ public final class CLISessionsViewModel {
   ) -> any EmbeddedTerminalSurface {
     let config = cliConfiguration ?? self.currentCLIConfiguration
     let queuedInputText = consumePendingTerminalInputText(for: key)
-    let descriptorInputText = key.hasPrefix("pending-") ? combinedInputText(initialInputText, queuedInputText) : queuedInputText
+    let isNewSession = (
+      sessionId == nil
+        || sessionId?.isEmpty == true
+        || sessionId?.hasPrefix("pending-") == true
+    )
+    let launchInitialPrompt = isNewSession ? initialPrompt : nil
+    let descriptorInputText = key.hasPrefix("pending-")
+      ? combinedInputText(initialInputText, queuedInputText)
+      : queuedInputText
     let createInputText = combinedInputText(initialInputText, queuedInputText)
     let descriptor = TerminalSurfaceDescriptor.cli(
       sessionId: sessionId,
       projectPath: projectPath,
       cliConfiguration: config,
-      initialPrompt: key.hasPrefix("pending-") ? initialPrompt : nil,
+      initialPrompt: launchInitialPrompt,
       initialInputText: descriptorInputText,
       isDark: isDark,
       dangerouslySkipPermissions: dangerouslySkipPermissions,
@@ -639,16 +654,6 @@ public final class CLISessionsViewModel {
     if let existing = activeTerminals[key] {
       if activeTerminalDescriptors[key] == nil {
         activeTerminalDescriptors[key] = descriptor
-      }
-      // Send prompt to existing terminal if provided
-      if let prompt = initialPrompt {
-        if !key.hasPrefix("pending-") {
-          // Resume scenario: send prompt to existing terminal (e.g., inline edit).
-          // For pending sessions, the prompt is already embedded in CLI args — don't re-send.
-          existing.resetPromptDeliveryFlag()
-          existing.sendPromptIfNeeded(prompt)
-        }
-        clearPendingPrompt(for: key)  // Clear after sending
       }
       if let inputText = initialInputText, !inputText.isEmpty {
         existing.typeInitialTextIfNeeded(inputText)
@@ -668,7 +673,7 @@ public final class CLISessionsViewModel {
       sessionId: sessionId,
       projectPath: projectPath,
       cliConfiguration: config,
-      initialPrompt: initialPrompt,
+      initialPrompt: launchInitialPrompt,
       initialInputText: createInputText,
       isDark: isDark,
       dangerouslySkipPermissions: dangerouslySkipPermissions,

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/AuxiliaryShellTerminalManagementTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/AuxiliaryShellTerminalManagementTests.swift
@@ -61,9 +61,11 @@ private final class TestTerminalSurface: NSView, EmbeddedTerminalSurface {
   var onWorkspaceChanged: ((TerminalWorkspaceSnapshot) -> Void)?
   private(set) var configuredProjectPath: String?
   private(set) var configuredShellPath: String?
+  private(set) var configuredInitialPrompt: String?
   private(set) var configuredInitialInputText: String?
   private(set) var typedTexts: [String] = []
   private(set) var initialTypedTexts: [String] = []
+  private(set) var sentPrompts: [String] = []
   private(set) var restoredWorkspaceSnapshot: TerminalWorkspaceSnapshot?
   var workspaceSnapshotToCapture: TerminalWorkspaceSnapshot?
   private(set) var configureCallCount = 0
@@ -85,6 +87,7 @@ private final class TestTerminalSurface: NSView, EmbeddedTerminalSurface {
     metadataStore: SessionMetadataStore?
   ) {
     configuredProjectPath = projectPath
+    configuredInitialPrompt = initialPrompt
     configuredInitialInputText = initialInputText
     configureCallCount += 1
   }
@@ -102,7 +105,9 @@ private final class TestTerminalSurface: NSView, EmbeddedTerminalSurface {
   }
 
   func resetPromptDeliveryFlag() {}
-  func sendPromptIfNeeded(_ prompt: String) {}
+  func sendPromptIfNeeded(_ prompt: String) {
+    sentPrompts.append(prompt)
+  }
   func submitPromptImmediately(_ prompt: String) -> Bool { true }
   func typeText(_ text: String) {
     typedTexts.append(text)
@@ -241,6 +246,93 @@ struct AuxiliaryShellTerminalManagementTests {
 
     #expect(terminal.configuredInitialInputText == command)
     #expect(viewModel.pendingTerminalInputTexts["session-123"] == nil)
+  }
+
+  @Test("Pending prompts are consumed once")
+  @MainActor
+  func pendingPromptIsConsumedOnce() {
+    let viewModel = makeAuxiliaryShellViewModel()
+    let session = CLISession(
+      id: "session-123",
+      projectPath: "/tmp/project",
+      branchName: "main"
+    )
+
+    viewModel.showTerminalWithPrompt(for: session, prompt: "Review these changes")
+
+    #expect(viewModel.consumePendingPrompt(for: session.id) == "Review these changes")
+    #expect(viewModel.consumePendingPrompt(for: session.id) == nil)
+  }
+
+  @Test("Real session terminal launch does not embed follow-up prompt")
+  @MainActor
+  func realSessionTerminalLaunchDoesNotEmbedFollowUpPrompt() {
+    let terminal = TestTerminalSurface()
+    let factory = RecordingTerminalSurfaceFactory(surfaces: [terminal])
+    let viewModel = makeAuxiliaryShellViewModel(terminalSurfaceFactory: factory, terminalBackend: .regular)
+
+    _ = viewModel.getOrCreateTerminal(
+      forKey: "session-123",
+      sessionId: "session-123",
+      projectPath: "/tmp/project",
+      cliConfiguration: CLICommandConfiguration(command: "claude", mode: .claude),
+      initialPrompt: "Review these changes",
+      initialInputText: nil,
+      isDark: true
+    )
+
+    #expect(terminal.configuredInitialPrompt == nil)
+  }
+
+  @Test("Pending session terminal launch keeps initial prompt")
+  @MainActor
+  func pendingSessionTerminalLaunchKeepsInitialPrompt() {
+    let terminal = TestTerminalSurface()
+    let factory = RecordingTerminalSurfaceFactory(surfaces: [terminal])
+    let viewModel = makeAuxiliaryShellViewModel(terminalSurfaceFactory: factory, terminalBackend: .regular)
+    let pendingKey = "pending-\(UUID().uuidString)"
+
+    _ = viewModel.getOrCreateTerminal(
+      forKey: pendingKey,
+      sessionId: pendingKey,
+      projectPath: "/tmp/project",
+      cliConfiguration: CLICommandConfiguration(command: "claude", mode: .claude),
+      initialPrompt: "Build the feature",
+      initialInputText: nil,
+      isDark: true
+    )
+
+    #expect(terminal.configuredInitialPrompt == "Build the feature")
+  }
+
+  @Test("Existing terminal ignores stale initial prompt props")
+  @MainActor
+  func existingTerminalIgnoresStaleInitialPromptProps() {
+    let viewModel = makeAuxiliaryShellViewModel()
+    let terminal = TestTerminalSurface()
+    viewModel.activeTerminals["session-123"] = terminal
+
+    _ = viewModel.getOrCreateTerminal(
+      forKey: "session-123",
+      sessionId: "session-123",
+      projectPath: "/tmp/project",
+      cliConfiguration: CLICommandConfiguration(command: "claude", mode: .claude),
+      initialPrompt: "Review these changes",
+      initialInputText: nil,
+      isDark: true
+    )
+
+    _ = viewModel.getOrCreateTerminal(
+      forKey: "session-123",
+      sessionId: "session-123",
+      projectPath: "/tmp/project",
+      cliConfiguration: CLICommandConfiguration(command: "claude", mode: .claude),
+      initialPrompt: "Review these changes",
+      initialInputText: nil,
+      isDark: true
+    )
+
+    #expect(terminal.sentPrompts.isEmpty)
   }
 
   @Test("Transfers auxiliary shell terminal from pending key to resolved session ID")

--- a/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalSurface.swift
+++ b/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalSurface.swift
@@ -26,6 +26,7 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
   private var pendingMount: PendingMount?
   private var pendingMountTask: Task<Void, Never>?
   private var pendingWorkspaceSnapshot: TerminalWorkspaceSnapshot?
+  private var pendingInitialPrompt: String?
   private var isConfigured = false
   private var hasDeliveredInitialPrompt = false
   private var hasPrefilledInitialInputText = false
@@ -227,9 +228,18 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
 
   public func sendPromptIfNeeded(_ prompt: String) {
     guard !hasDeliveredInitialPrompt else { return }
+    guard protectedAgentController != nil else {
+      pendingInitialPrompt = prompt
+      return
+    }
+
+    deliverPrompt(prompt)
+  }
+
+  private func deliverPrompt(_ prompt: String) {
+    guard !hasDeliveredInitialPrompt else { return }
     hasDeliveredInitialPrompt = true
     focusProtectedAgentTab()
-
     let planFeedbackPrefix = "\u{1B}[B\u{1B}[B\u{1B}[B\r"
     if prompt.hasPrefix(planFeedbackPrefix) {
       let feedback = String(prompt.dropFirst(planFeedbackPrefix.count))
@@ -256,6 +266,12 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
       try? await Task.sleep(for: .milliseconds(100))
       self?.protectedAgentController?.sendReturnKey()
     }
+  }
+
+  private func deliverPendingInitialPromptIfNeeded() {
+    guard let prompt = pendingInitialPrompt else { return }
+    pendingInitialPrompt = nil
+    deliverPrompt(prompt)
   }
 
   public func submitPromptImmediately(_ prompt: String) -> Bool {
@@ -433,6 +449,7 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
       terminalSession = session
       restorePendingWorkspaceSnapshotIfNeeded()
       installInteractionMonitorIfNeeded()
+      deliverPendingInitialPromptIfNeeded()
     } catch {
       mountError(error.localizedDescription)
     }


### PR DESCRIPTION
## Summary

Fixes duplicated review feedback when sending batched diff comments back to Claude or Codex sessions.

## What changed

- Added one-shot consumption for pending terminal prompts so a rendered terminal cannot replay the same diff feedback payload.
- Prevented real resumed sessions from embedding follow-up prompts in CLI resume launch arguments; follow-up prompts are delivered through the terminal input path instead.
- Preserved pending/new session startup prompt behavior.
- Added Ghostty-backed prompt queuing so a consumed prompt is delivered once the protected agent tab is ready.
- Added regression tests covering one-time prompt consumption, real-session follow-up launch behavior, pending-session startup prompts, and stale `initialPrompt` props.

## Root cause

The diff feedback prompt could be passed through two paths for resumed sessions: embedded in the CLI resume command and also sent from the terminal view after reading pending prompt state. During terminal layout/render updates, stale `initialPrompt` props could also replay the same payload.

## Validation

- `git diff --check`
- `xcodebuild build -project app/AgentHub.xcodeproj -scheme AgentHubCore -destination 'platform=macOS' -quiet`
- `xcodebuild build -project app/AgentHub.xcodeproj -scheme Ghostty -destination 'platform=macOS' -quiet`

## Note

A targeted `AgentHubCore-Package` test run was attempted, but the package test target still fails to compile before execution because `SessionWorkspaceStatePersistenceTests.swift:37` has an unrelated async call missing `await`.