### PR TITLE
[codex] Auto-open edits and plan side panel

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringAutoOpenSidePanelPolicy.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringAutoOpenSidePanelPolicy.swift
@@ -1,0 +1,138 @@
+//
+//  MonitoringAutoOpenSidePanelPolicy.swift
+//  AgentHub
+//
+
+import Foundation
+
+enum MonitoringAutoOpenSidePanelKind: String, Equatable, Hashable, Sendable {
+  case edits
+  case plan
+}
+
+struct MonitoringAutoOpenSidePanelKey: Equatable, Hashable, Sendable {
+  let providerRawValue: String
+  let sessionID: String
+  let kind: MonitoringAutoOpenSidePanelKind
+  let value: String
+
+  static func edits(
+    providerKind: SessionProviderKind,
+    sessionID: String,
+    toolUseId: String
+  ) -> MonitoringAutoOpenSidePanelKey {
+    MonitoringAutoOpenSidePanelKey(
+      providerRawValue: providerKind.rawValue,
+      sessionID: sessionID,
+      kind: .edits,
+      value: toolUseId
+    )
+  }
+
+  static func plan(
+    providerKind: SessionProviderKind,
+    sessionID: String,
+    filePath: String
+  ) -> MonitoringAutoOpenSidePanelKey {
+    MonitoringAutoOpenSidePanelKey(
+      providerRawValue: providerKind.rawValue,
+      sessionID: sessionID,
+      kind: .plan,
+      value: filePath
+    )
+  }
+}
+
+enum MonitoringAutoOpenSidePanelTarget: Equatable, Sendable {
+  case edits
+  case plan(PlanState)
+
+  var kind: MonitoringAutoOpenSidePanelKind {
+    switch self {
+    case .edits:
+      return .edits
+    case .plan:
+      return .plan
+    }
+  }
+}
+
+struct MonitoringAutoOpenSidePanelItem: Equatable, Sendable {
+  let itemID: String
+  let providerKind: SessionProviderKind
+  let session: CLISession
+  let state: SessionMonitorState?
+
+  init(
+    itemID: String,
+    providerKind: SessionProviderKind,
+    session: CLISession,
+    state: SessionMonitorState?
+  ) {
+    self.itemID = itemID
+    self.providerKind = providerKind
+    self.session = session
+    self.state = state
+  }
+}
+
+struct MonitoringAutoOpenSidePanelCandidate: Equatable, Sendable {
+  let itemID: String
+  let providerKind: SessionProviderKind
+  let session: CLISession
+  let target: MonitoringAutoOpenSidePanelTarget
+  let key: MonitoringAutoOpenSidePanelKey
+}
+
+enum MonitoringAutoOpenSidePanelPolicy {
+  static func candidate(
+    layoutMode: HubLayoutMode,
+    maximizedSessionId: String?,
+    activeModuleLandingPath: String?,
+    visibleItem: MonitoringAutoOpenSidePanelItem?,
+    openedKeys: Set<MonitoringAutoOpenSidePanelKey>
+  ) -> MonitoringAutoOpenSidePanelCandidate? {
+    guard layoutMode == .single,
+          maximizedSessionId == nil,
+          activeModuleLandingPath == nil,
+          let visibleItem else {
+      return nil
+    }
+
+    if let pendingToolUse = visibleItem.state?.pendingToolUse,
+       pendingToolUse.isCodeChangeTool {
+      let key = MonitoringAutoOpenSidePanelKey.edits(
+        providerKind: visibleItem.providerKind,
+        sessionID: visibleItem.session.id,
+        toolUseId: pendingToolUse.toolUseId
+      )
+      guard !openedKeys.contains(key) else { return nil }
+      return MonitoringAutoOpenSidePanelCandidate(
+        itemID: visibleItem.itemID,
+        providerKind: visibleItem.providerKind,
+        session: visibleItem.session,
+        target: .edits,
+        key: key
+      )
+    }
+
+    if let activities = visibleItem.state?.recentActivities,
+       let planState = PlanState.from(activities: activities) {
+      let key = MonitoringAutoOpenSidePanelKey.plan(
+        providerKind: visibleItem.providerKind,
+        sessionID: visibleItem.session.id,
+        filePath: planState.filePath
+      )
+      guard !openedKeys.contains(key) else { return nil }
+      return MonitoringAutoOpenSidePanelCandidate(
+        itemID: visibleItem.itemID,
+        providerKind: visibleItem.providerKind,
+        session: visibleItem.session,
+        target: .plan(planState),
+        key: key
+      )
+    }
+
+    return nil
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderMonitoringPanelView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderMonitoringPanelView.swift
@@ -197,6 +197,7 @@ public struct MultiProviderMonitoringPanelView: View {
   @State private var sessionFileSheetItem: SessionFileSheetItem?
   @State private var maximizedSessionId: String?
   @State private var sidePanelPresentation = EmbeddedSidePanelPresentationState<SidePanelPayload>()
+  @State private var autoOpenedSidePanelKeys: Set<MonitoringAutoOpenSidePanelKey> = []
   @State private var editorStates: [String: MonitoringEditorState] = [:]
   @State private var availableDetailWidth: CGFloat = 0
   @Binding var primarySessionId: String?
@@ -272,6 +273,7 @@ public struct MultiProviderMonitoringPanelView: View {
     let snapshot = makeItemSnapshot()
     let wantsSidePanelPresentation = wantsEmbeddedSidePanelPresentation(snapshot: snapshot)
     let auxiliaryTarget = auxiliaryShellTarget(snapshot: snapshot)
+    let autoOpenCandidate = autoOpenSidePanelCandidate(snapshot: snapshot)
 
     GeometryReader { geometry in
       VStack(spacing: 0) {
@@ -296,12 +298,14 @@ public struct MultiProviderMonitoringPanelView: View {
       onEmbeddedSidePanelVisibilityChange(wantsSidePanelPresentation)
       syncEditorStates(snapshot: snapshot)
       syncAuxiliaryShellDockState(target: auxiliaryTarget)
+      openAutoSidePanelIfNeeded(candidate: autoOpenCandidate)
     }
     .onChange(of: wantsSidePanelPresentation) { _, wantsPresentation in
       onEmbeddedSidePanelVisibilityChange(wantsPresentation)
     }
     .onChange(of: snapshot.itemIDs) { _, _ in
       syncEditorStates()
+      pruneAutoOpenedSidePanelKeys()
     }
     .onChange(of: snapshot.effectivePrimaryItemID) { _, _ in
       syncAuxiliaryShellDockState()
@@ -319,6 +323,9 @@ public struct MultiProviderMonitoringPanelView: View {
     }
     .onChange(of: codexViewModel.pendingFileOpen?.filePath) { _, _ in
       consumePendingFileOpen(from: codexViewModel, providerKind: .codex)
+    }
+    .onChange(of: autoOpenCandidate?.key) { _, _ in
+      openAutoSidePanelIfNeeded()
     }
     .overlay {
       Group {
@@ -418,7 +425,13 @@ public struct MultiProviderMonitoringPanelView: View {
           )
         )
       } else {
-        closeEmbeddedSidePanel()
+        if let newId {
+          if currentSidePanelPayload.itemID != newId {
+            closeEmbeddedSidePanel()
+          }
+        } else {
+          closeEmbeddedSidePanel()
+        }
       }
     }
     .onChange(of: primarySessionId) { _, newId in
@@ -806,6 +819,74 @@ public struct MultiProviderMonitoringPanelView: View {
       .webPreview(sessionId: session.id, session: session, projectPath: projectPath, mode: mode),
       forItemID: itemID
     )
+  }
+
+  private func autoOpenSidePanelCandidate(
+    snapshot: MonitoringItemsSnapshot<ProviderMonitoringItem>
+  ) -> MonitoringAutoOpenSidePanelCandidate? {
+    MonitoringAutoOpenSidePanelPolicy.candidate(
+      layoutMode: layoutMode,
+      maximizedSessionId: maximizedSessionId,
+      activeModuleLandingPath: activeModuleLandingPath(snapshot: snapshot),
+      visibleItem: snapshot.visibleItems.first.flatMap { autoOpenSidePanelItem(for: $0) },
+      openedKeys: autoOpenedSidePanelKeys
+    )
+  }
+
+  private func autoOpenSidePanelItem(
+    for item: ProviderMonitoringItem
+  ) -> MonitoringAutoOpenSidePanelItem? {
+    switch item {
+    case .pending:
+      return nil
+    case .monitored(_, _, let session, let state):
+      return MonitoringAutoOpenSidePanelItem(
+        itemID: item.id,
+        providerKind: item.providerKind,
+        session: session,
+        state: state
+      )
+    }
+  }
+
+  private func openAutoSidePanelIfNeeded(
+    candidate: MonitoringAutoOpenSidePanelCandidate? = nil
+  ) {
+    guard let candidate = candidate ?? autoOpenSidePanelCandidate(snapshot: makeItemSnapshot()) else {
+      return
+    }
+
+    autoOpenedSidePanelKeys.insert(candidate.key)
+
+    let payload = SidePanelPayload(
+      itemID: candidate.itemID,
+      providerKind: candidate.providerKind,
+      content: sidePanelContent(for: candidate)
+    )
+    guard sidePanelPresentation.currentPayload != payload else { return }
+    openEmbeddedSidePanel(payload)
+  }
+
+  private func sidePanelContent(
+    for candidate: MonitoringAutoOpenSidePanelCandidate
+  ) -> SidePanelContent {
+    switch candidate.target {
+    case .edits:
+      return .edits(sessionId: candidate.session.id, session: candidate.session)
+    case .plan(let planState):
+      return .plan(
+        sessionId: candidate.session.id,
+        session: candidate.session,
+        planState: planState
+      )
+    }
+  }
+
+  private func pruneAutoOpenedSidePanelKeys() {
+    let activeSessionIDs = Set(allItems.map(\.sessionId))
+    autoOpenedSidePanelKeys = Set(autoOpenedSidePanelKeys.filter {
+      activeSessionIDs.contains($0.sessionID)
+    })
   }
 
   /// Ensures the single-mode inline layout is active for `itemID`, then toggles the requested

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/MonitoringAutoOpenSidePanelPolicyTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/MonitoringAutoOpenSidePanelPolicyTests.swift
@@ -1,0 +1,241 @@
+import Foundation
+import Testing
+
+@testable import AgentHubCore
+
+@Suite("MonitoringAutoOpenSidePanelPolicy")
+struct MonitoringAutoOpenSidePanelPolicyTests {
+  @Test("Returns no candidate outside single layout")
+  func returnsNoCandidateOutsideSingleLayout() {
+    let item = Self.item(state: Self.pendingEditState(toolUseId: "edit-1"))
+
+    let candidate = MonitoringAutoOpenSidePanelPolicy.candidate(
+      layoutMode: .list,
+      maximizedSessionId: nil,
+      activeModuleLandingPath: nil,
+      visibleItem: item,
+      openedKeys: []
+    )
+
+    #expect(candidate == nil)
+  }
+
+  @Test("Returns no candidate while maximized")
+  func returnsNoCandidateWhileMaximized() {
+    let item = Self.item(state: Self.pendingEditState(toolUseId: "edit-1"))
+
+    let candidate = MonitoringAutoOpenSidePanelPolicy.candidate(
+      layoutMode: .single,
+      maximizedSessionId: "session-1",
+      activeModuleLandingPath: nil,
+      visibleItem: item,
+      openedKeys: []
+    )
+
+    #expect(candidate == nil)
+  }
+
+  @Test("Returns no candidate while module landing is active")
+  func returnsNoCandidateWhileModuleLandingIsActive() {
+    let item = Self.item(state: Self.pendingEditState(toolUseId: "edit-1"))
+
+    let candidate = MonitoringAutoOpenSidePanelPolicy.candidate(
+      layoutMode: .single,
+      maximizedSessionId: nil,
+      activeModuleLandingPath: "/tmp/project",
+      visibleItem: item,
+      openedKeys: []
+    )
+
+    #expect(candidate == nil)
+  }
+
+  @Test("Returns edits candidate for code change pending tool")
+  func returnsEditsCandidateForCodeChangePendingTool() throws {
+    let item = Self.item(state: Self.pendingEditState(toolUseId: "edit-1"))
+
+    let candidate = try #require(MonitoringAutoOpenSidePanelPolicy.candidate(
+      layoutMode: .single,
+      maximizedSessionId: nil,
+      activeModuleLandingPath: nil,
+      visibleItem: item,
+      openedKeys: []
+    ))
+
+    #expect(candidate.itemID == "claude-session-1")
+    #expect(candidate.target == .edits)
+    #expect(candidate.key == .edits(
+      providerKind: .claude,
+      sessionID: "session-1",
+      toolUseId: "edit-1"
+    ))
+  }
+
+  @Test("Returns plan candidate for detected plan file")
+  func returnsPlanCandidateForDetectedPlanFile() throws {
+    let path = "/Users/test/.claude/plans/feature-plan.md"
+    let item = Self.item(state: Self.planFileState(filePath: path))
+
+    let candidate = try #require(MonitoringAutoOpenSidePanelPolicy.candidate(
+      layoutMode: .single,
+      maximizedSessionId: nil,
+      activeModuleLandingPath: nil,
+      visibleItem: item,
+      openedKeys: []
+    ))
+
+    #expect(candidate.target == .plan(PlanState(filePath: path)))
+    #expect(candidate.key == .plan(
+      providerKind: .claude,
+      sessionID: "session-1",
+      filePath: path
+    ))
+  }
+
+  @Test("Prefers edits when edits and plan are both available")
+  func prefersEditsWhenEditsAndPlanAreBothAvailable() throws {
+    let item = Self.item(state: SessionMonitorState(
+      pendingToolUse: PendingToolUse(
+        toolName: "MultiEdit",
+        toolUseId: "edit-1",
+        timestamp: Date(timeIntervalSince1970: 1)
+      ),
+      recentActivities: Self.planActivities(
+        filePath: "/Users/test/.claude/plans/feature-plan.md"
+      )
+    ))
+
+    let candidate = try #require(MonitoringAutoOpenSidePanelPolicy.candidate(
+      layoutMode: .single,
+      maximizedSessionId: nil,
+      activeModuleLandingPath: nil,
+      visibleItem: item,
+      openedKeys: []
+    ))
+
+    #expect(candidate.target == .edits)
+    #expect(candidate.key.kind == .edits)
+  }
+
+  @Test("Suppresses an edits candidate after the same tool use was opened")
+  func suppressesSameEditsKeyAfterOpen() {
+    let item = Self.item(state: Self.pendingEditState(toolUseId: "edit-1"))
+    let openedKey = MonitoringAutoOpenSidePanelKey.edits(
+      providerKind: .claude,
+      sessionID: "session-1",
+      toolUseId: "edit-1"
+    )
+
+    let candidate = MonitoringAutoOpenSidePanelPolicy.candidate(
+      layoutMode: .single,
+      maximizedSessionId: nil,
+      activeModuleLandingPath: nil,
+      visibleItem: item,
+      openedKeys: [openedKey]
+    )
+
+    #expect(candidate == nil)
+  }
+
+  @Test("Allows a new edits candidate when the tool use id changes")
+  func allowsNewEditsKey() throws {
+    let item = Self.item(state: Self.pendingEditState(toolUseId: "edit-2"))
+    let openedKey = MonitoringAutoOpenSidePanelKey.edits(
+      providerKind: .claude,
+      sessionID: "session-1",
+      toolUseId: "edit-1"
+    )
+
+    let candidate = try #require(MonitoringAutoOpenSidePanelPolicy.candidate(
+      layoutMode: .single,
+      maximizedSessionId: nil,
+      activeModuleLandingPath: nil,
+      visibleItem: item,
+      openedKeys: [openedKey]
+    ))
+
+    #expect(candidate.key.value == "edit-2")
+  }
+
+  @Test("Suppresses an already-opened plan file path")
+  func suppressesSamePlanKeyAfterOpen() {
+    let path = "/Users/test/.claude/plans/feature-plan.md"
+    let item = Self.item(state: Self.planFileState(filePath: path))
+    let openedKey = MonitoringAutoOpenSidePanelKey.plan(
+      providerKind: .claude,
+      sessionID: "session-1",
+      filePath: path
+    )
+
+    let candidate = MonitoringAutoOpenSidePanelPolicy.candidate(
+      layoutMode: .single,
+      maximizedSessionId: nil,
+      activeModuleLandingPath: nil,
+      visibleItem: item,
+      openedKeys: [openedKey]
+    )
+
+    #expect(candidate == nil)
+  }
+
+  @Test("Allows a new plan candidate when the file path changes")
+  func allowsNewPlanKey() throws {
+    let oldPath = "/Users/test/.claude/plans/old-plan.md"
+    let newPath = "/Users/test/.claude/plans/new-plan.md"
+    let item = Self.item(state: Self.planFileState(filePath: newPath))
+    let openedKey = MonitoringAutoOpenSidePanelKey.plan(
+      providerKind: .claude,
+      sessionID: "session-1",
+      filePath: oldPath
+    )
+
+    let candidate = try #require(MonitoringAutoOpenSidePanelPolicy.candidate(
+      layoutMode: .single,
+      maximizedSessionId: nil,
+      activeModuleLandingPath: nil,
+      visibleItem: item,
+      openedKeys: [openedKey]
+    ))
+
+    #expect(candidate.key.value == newPath)
+  }
+
+  private static func item(
+    state: SessionMonitorState?
+  ) -> MonitoringAutoOpenSidePanelItem {
+    MonitoringAutoOpenSidePanelItem(
+      itemID: "claude-session-1",
+      providerKind: .claude,
+      session: CLISession(id: "session-1", projectPath: "/tmp/project"),
+      state: state
+    )
+  }
+
+  private static func pendingEditState(toolUseId: String) -> SessionMonitorState {
+    SessionMonitorState(
+      pendingToolUse: PendingToolUse(
+        toolName: "Edit",
+        toolUseId: toolUseId,
+        timestamp: Date(timeIntervalSince1970: 1)
+      )
+    )
+  }
+
+  private static func planFileState(filePath: String) -> SessionMonitorState {
+    SessionMonitorState(recentActivities: planActivities(filePath: filePath))
+  }
+
+  private static func planActivities(filePath: String) -> [ActivityEntry] {
+    [
+      ActivityEntry(
+        timestamp: Date(timeIntervalSince1970: 1),
+        type: .toolUse(name: "Write"),
+        description: "plan.md",
+        toolInput: CodeChangeInput(
+          toolType: .write,
+          filePath: filePath
+        )
+      )
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Auto-open the embedded right-side panel in Single layout when pending Edits or a Plan becomes available.
- Add a testable auto-open policy that prefers Edits over Plan and suppresses repeat auto-opens for the same tool use or plan file.
- Preserve existing manual button toggles and avoid switching List/Two-column layouts automatically.

## Validation
- `xcodebuild build -project app/AgentHub.xcodeproj -scheme AgentHubCore -destination 'platform=macOS'`
- `git diff --check`

## Notes
- `swift test --package-path app/modules/AgentHubCore --filter MonitoringAutoOpenSidePanelPolicyTests` is currently blocked by an existing `CodeEditSymbols` `Bundle.module` resource issue before reaching these tests.
- Xcode test schemes for `AgentHub` and `AgentHubCore` are not configured for the test action, so the new tests were added but not executed through Xcode.