### PR TITLE
[codex] Suppress restored side panel auto-open

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringAutoOpenSidePanelPolicy.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringAutoOpenSidePanelPolicy.swift
@@ -32,14 +32,19 @@ struct MonitoringAutoOpenSidePanelKey: Equatable, Hashable, Sendable {
   static func plan(
     providerKind: SessionProviderKind,
     sessionID: String,
-    filePath: String
+    filePath: String,
+    detectedAt: Date? = nil
   ) -> MonitoringAutoOpenSidePanelKey {
     MonitoringAutoOpenSidePanelKey(
       providerRawValue: providerKind.rawValue,
       sessionID: sessionID,
       kind: .plan,
-      value: filePath
+      value: detectedAt.map { "\(filePath)#\(Self.timestampKeyValue(for: $0))" } ?? filePath
     )
+  }
+
+  private static func timestampKeyValue(for date: Date) -> Int64 {
+    Int64((date.timeIntervalSince1970 * 1000).rounded())
   }
 }
 
@@ -85,12 +90,26 @@ struct MonitoringAutoOpenSidePanelCandidate: Equatable, Sendable {
 }
 
 enum MonitoringAutoOpenSidePanelPolicy {
+  static func keys(
+    for item: MonitoringAutoOpenSidePanelItem
+  ) -> Set<MonitoringAutoOpenSidePanelKey> {
+    var keys: Set<MonitoringAutoOpenSidePanelKey> = []
+    if let editsKey = editsKey(for: item) {
+      keys.insert(editsKey)
+    }
+    if let planKey = planCandidateComponents(for: item)?.key {
+      keys.insert(planKey)
+    }
+    return keys
+  }
+
   static func candidate(
     layoutMode: HubLayoutMode,
     maximizedSessionId: String?,
     activeModuleLandingPath: String?,
     visibleItem: MonitoringAutoOpenSidePanelItem?,
-    openedKeys: Set<MonitoringAutoOpenSidePanelKey>
+    openedKeys: Set<MonitoringAutoOpenSidePanelKey>,
+    detectedAfter: Date? = nil
   ) -> MonitoringAutoOpenSidePanelCandidate? {
     guard layoutMode == .single,
           maximizedSessionId == nil,
@@ -99,13 +118,11 @@ enum MonitoringAutoOpenSidePanelPolicy {
       return nil
     }
 
-    if let pendingToolUse = visibleItem.state?.pendingToolUse,
-       pendingToolUse.isCodeChangeTool {
-      let key = MonitoringAutoOpenSidePanelKey.edits(
-        providerKind: visibleItem.providerKind,
-        sessionID: visibleItem.session.id,
-        toolUseId: pendingToolUse.toolUseId
-      )
+    if let editsCandidate = editsCandidateComponents(for: visibleItem) {
+      let key = editsCandidate.key
+      guard shouldAutoOpen(detectedAt: editsCandidate.detectedAt, detectedAfter: detectedAfter) else {
+        return nil
+      }
       guard !openedKeys.contains(key) else { return nil }
       return MonitoringAutoOpenSidePanelCandidate(
         itemID: visibleItem.itemID,
@@ -116,23 +133,89 @@ enum MonitoringAutoOpenSidePanelPolicy {
       )
     }
 
-    if let activities = visibleItem.state?.recentActivities,
-       let planState = PlanState.from(activities: activities) {
-      let key = MonitoringAutoOpenSidePanelKey.plan(
-        providerKind: visibleItem.providerKind,
-        sessionID: visibleItem.session.id,
-        filePath: planState.filePath
-      )
+    if let planCandidate = planCandidateComponents(for: visibleItem) {
+      let key = planCandidate.key
+      guard shouldAutoOpen(detectedAt: planCandidate.detectedAt, detectedAfter: detectedAfter) else {
+        return nil
+      }
       guard !openedKeys.contains(key) else { return nil }
       return MonitoringAutoOpenSidePanelCandidate(
         itemID: visibleItem.itemID,
         providerKind: visibleItem.providerKind,
         session: visibleItem.session,
-        target: .plan(planState),
+        target: .plan(planCandidate.planState),
         key: key
       )
     }
 
     return nil
+  }
+
+  private static func editsKey(
+    for item: MonitoringAutoOpenSidePanelItem
+  ) -> MonitoringAutoOpenSidePanelKey? {
+    editsCandidateComponents(for: item)?.key
+  }
+
+  private static func editsCandidateComponents(
+    for item: MonitoringAutoOpenSidePanelItem
+  ) -> (key: MonitoringAutoOpenSidePanelKey, detectedAt: Date)? {
+    guard let pendingToolUse = item.state?.pendingToolUse,
+          pendingToolUse.isCodeChangeTool else {
+      return nil
+    }
+
+    return (
+      MonitoringAutoOpenSidePanelKey.edits(
+        providerKind: item.providerKind,
+        sessionID: item.session.id,
+        toolUseId: pendingToolUse.toolUseId
+      ),
+      pendingToolUse.timestamp
+    )
+  }
+
+  private static func planCandidateComponents(
+    for item: MonitoringAutoOpenSidePanelItem
+  ) -> (key: MonitoringAutoOpenSidePanelKey, planState: PlanState, detectedAt: Date)? {
+    guard let activities = item.state?.recentActivities,
+          let planActivity = planActivity(from: activities) else {
+      return nil
+    }
+
+    return (
+      MonitoringAutoOpenSidePanelKey.plan(
+        providerKind: item.providerKind,
+        sessionID: item.session.id,
+        filePath: planActivity.planState.filePath,
+        detectedAt: planActivity.detectedAt
+      ),
+      planActivity.planState,
+      planActivity.detectedAt
+    )
+  }
+
+  private static func planActivity(
+    from activities: [ActivityEntry]
+  ) -> (planState: PlanState, detectedAt: Date)? {
+    for activity in activities.reversed() {
+      guard case .toolUse(let name) = activity.type,
+            (name == "Write" || name == "Edit"),
+            let input = activity.toolInput,
+            (input.toolType == .write || input.toolType == .edit) else {
+        continue
+      }
+
+      if input.filePath.contains("/.claude/plans/") && input.filePath.hasSuffix(".md") {
+        return (PlanState(filePath: input.filePath), activity.timestamp)
+      }
+    }
+
+    return nil
+  }
+
+  private static func shouldAutoOpen(detectedAt: Date, detectedAfter: Date?) -> Bool {
+    guard let detectedAfter else { return true }
+    return detectedAt > detectedAfter
   }
 }

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringAutoOpenSidePanelPolicy.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringAutoOpenSidePanelPolicy.swift
@@ -29,6 +29,10 @@ struct MonitoringAutoOpenSidePanelKey: Equatable, Hashable, Sendable {
     )
   }
 
+  /// Builds a dedupe key for a plan auto-open trigger.
+  ///
+  /// `detectedAt` is included when available so an update to the same plan file
+  /// is treated as a new event instead of being suppressed by a previous open.
   static func plan(
     providerKind: SessionProviderKind,
     sessionID: String,
@@ -90,6 +94,12 @@ struct MonitoringAutoOpenSidePanelCandidate: Equatable, Sendable {
 }
 
 enum MonitoringAutoOpenSidePanelPolicy {
+  /// Returns every current auto-open trigger key for an item without choosing a
+  /// presentation candidate.
+  ///
+  /// The monitoring panel uses this to mark restored launch state as already
+  /// observed, while `candidate(...)` keeps the normal edit-before-plan
+  /// precedence for actual presentation decisions.
   static func keys(
     for item: MonitoringAutoOpenSidePanelItem
   ) -> Set<MonitoringAutoOpenSidePanelKey> {

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderMonitoringPanelView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderMonitoringPanelView.swift
@@ -198,6 +198,8 @@ public struct MultiProviderMonitoringPanelView: View {
   @State private var maximizedSessionId: String?
   @State private var sidePanelPresentation = EmbeddedSidePanelPresentationState<SidePanelPayload>()
   @State private var autoOpenedSidePanelKeys: Set<MonitoringAutoOpenSidePanelKey> = []
+  @State private var autoOpenBaselineDate: Date?
+  @State private var observedAutoOpenKeysBySessionID: [String: Set<MonitoringAutoOpenSidePanelKey>] = [:]
   @State private var editorStates: [String: MonitoringEditorState] = [:]
   @State private var availableDetailWidth: CGFloat = 0
   @Binding var primarySessionId: String?
@@ -295,10 +297,13 @@ public struct MultiProviderMonitoringPanelView: View {
     .background(monitorContainerBackgroundColor)
     .cornerRadius(8)
     .onAppear {
+      if autoOpenBaselineDate == nil {
+        autoOpenBaselineDate = Date()
+      }
       onEmbeddedSidePanelVisibilityChange(wantsSidePanelPresentation)
       syncEditorStates(snapshot: snapshot)
       syncAuxiliaryShellDockState(target: auxiliaryTarget)
-      openAutoSidePanelIfNeeded(candidate: autoOpenCandidate)
+      seedObservedAutoOpenKeys(snapshot: snapshot)
     }
     .onChange(of: wantsSidePanelPresentation) { _, wantsPresentation in
       onEmbeddedSidePanelVisibilityChange(wantsPresentation)
@@ -829,7 +834,8 @@ public struct MultiProviderMonitoringPanelView: View {
       maximizedSessionId: maximizedSessionId,
       activeModuleLandingPath: activeModuleLandingPath(snapshot: snapshot),
       visibleItem: snapshot.visibleItems.first.flatMap { autoOpenSidePanelItem(for: $0) },
-      openedKeys: autoOpenedSidePanelKeys
+      openedKeys: autoOpenedSidePanelKeys,
+      detectedAfter: autoOpenBaselineDate
     )
   }
 
@@ -849,6 +855,16 @@ public struct MultiProviderMonitoringPanelView: View {
     }
   }
 
+  private func seedObservedAutoOpenKeys(
+    snapshot: MonitoringItemsSnapshot<ProviderMonitoringItem>
+  ) {
+    for item in snapshot.allItems.compactMap({ autoOpenSidePanelItem(for: $0) }) {
+      guard item.state != nil else { continue }
+      let keys = MonitoringAutoOpenSidePanelPolicy.keys(for: item)
+      observedAutoOpenKeysBySessionID[item.session.id, default: []].formUnion(keys)
+    }
+  }
+
   private func openAutoSidePanelIfNeeded(
     candidate: MonitoringAutoOpenSidePanelCandidate? = nil
   ) {
@@ -856,7 +872,15 @@ public struct MultiProviderMonitoringPanelView: View {
       return
     }
 
+    if let observedKeys = observedAutoOpenKeysBySessionID[candidate.session.id] {
+      guard !observedKeys.contains(candidate.key) else { return }
+    } else if shouldSuppressFirstObservedAutoOpenCandidate(candidate) {
+      observedAutoOpenKeysBySessionID[candidate.session.id, default: []].insert(candidate.key)
+      return
+    }
+
     autoOpenedSidePanelKeys.insert(candidate.key)
+    observedAutoOpenKeysBySessionID[candidate.session.id, default: []].insert(candidate.key)
 
     let payload = SidePanelPayload(
       itemID: candidate.itemID,
@@ -865,6 +889,13 @@ public struct MultiProviderMonitoringPanelView: View {
     )
     guard sidePanelPresentation.currentPayload != payload else { return }
     openEmbeddedSidePanel(payload)
+  }
+
+  private func shouldSuppressFirstObservedAutoOpenCandidate(
+    _ candidate: MonitoringAutoOpenSidePanelCandidate
+  ) -> Bool {
+    guard let autoOpenBaselineDate else { return true }
+    return candidate.session.lastActivityAt <= autoOpenBaselineDate
   }
 
   private func sidePanelContent(
@@ -887,6 +918,9 @@ public struct MultiProviderMonitoringPanelView: View {
     autoOpenedSidePanelKeys = Set(autoOpenedSidePanelKeys.filter {
       activeSessionIDs.contains($0.sessionID)
     })
+    observedAutoOpenKeysBySessionID = observedAutoOpenKeysBySessionID.filter { sessionID, _ in
+      activeSessionIDs.contains(sessionID)
+    }
   }
 
   /// Ensures the single-mode inline layout is active for `itemID`, then toggles the requested

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/MonitoringAutoOpenSidePanelPolicyTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/MonitoringAutoOpenSidePanelPolicyTests.swift
@@ -88,7 +88,8 @@ struct MonitoringAutoOpenSidePanelPolicyTests {
     #expect(candidate.key == .plan(
       providerKind: .claude,
       sessionID: "session-1",
-      filePath: path
+      filePath: path,
+      detectedAt: Date(timeIntervalSince1970: 1)
     ))
   }
 
@@ -157,14 +158,53 @@ struct MonitoringAutoOpenSidePanelPolicyTests {
     #expect(candidate.key.value == "edit-2")
   }
 
-  @Test("Suppresses an already-opened plan file path")
-  func suppressesSamePlanKeyAfterOpen() {
+  @Test("Suppresses restored edits detected before initial appearance")
+  func suppressesRestoredEditsBeforeInitialAppearance() {
+    let item = Self.item(state: Self.pendingEditState(
+      toolUseId: "edit-1",
+      timestamp: Date(timeIntervalSince1970: 10)
+    ))
+
+    let candidate = MonitoringAutoOpenSidePanelPolicy.candidate(
+      layoutMode: .single,
+      maximizedSessionId: nil,
+      activeModuleLandingPath: nil,
+      visibleItem: item,
+      openedKeys: [],
+      detectedAfter: Date(timeIntervalSince1970: 20)
+    )
+
+    #expect(candidate == nil)
+  }
+
+  @Test("Allows edits detected after initial appearance")
+  func allowsEditsAfterInitialAppearance() throws {
+    let item = Self.item(state: Self.pendingEditState(
+      toolUseId: "edit-1",
+      timestamp: Date(timeIntervalSince1970: 30)
+    ))
+
+    let candidate = try #require(MonitoringAutoOpenSidePanelPolicy.candidate(
+      layoutMode: .single,
+      maximizedSessionId: nil,
+      activeModuleLandingPath: nil,
+      visibleItem: item,
+      openedKeys: [],
+      detectedAfter: Date(timeIntervalSince1970: 20)
+    ))
+
+    #expect(candidate.target == .edits)
+  }
+
+  @Test("Suppresses an already-opened plan event")
+  func suppressesSamePlanEventAfterOpen() {
     let path = "/Users/test/.claude/plans/feature-plan.md"
     let item = Self.item(state: Self.planFileState(filePath: path))
     let openedKey = MonitoringAutoOpenSidePanelKey.plan(
       providerKind: .claude,
       sessionID: "session-1",
-      filePath: path
+      filePath: path,
+      detectedAt: Date(timeIntervalSince1970: 1)
     )
 
     let candidate = MonitoringAutoOpenSidePanelPolicy.candidate(
@@ -176,6 +216,36 @@ struct MonitoringAutoOpenSidePanelPolicyTests {
     )
 
     #expect(candidate == nil)
+  }
+
+  @Test("Allows same plan file when the plan event timestamp changes")
+  func allowsSamePlanFileWhenPlanEventTimestampChanges() throws {
+    let path = "/Users/test/.claude/plans/feature-plan.md"
+    let item = Self.item(state: Self.planFileState(
+      filePath: path,
+      timestamp: Date(timeIntervalSince1970: 2)
+    ))
+    let openedKey = MonitoringAutoOpenSidePanelKey.plan(
+      providerKind: .claude,
+      sessionID: "session-1",
+      filePath: path,
+      detectedAt: Date(timeIntervalSince1970: 1)
+    )
+
+    let candidate = try #require(MonitoringAutoOpenSidePanelPolicy.candidate(
+      layoutMode: .single,
+      maximizedSessionId: nil,
+      activeModuleLandingPath: nil,
+      visibleItem: item,
+      openedKeys: [openedKey]
+    ))
+
+    #expect(candidate.key == .plan(
+      providerKind: .claude,
+      sessionID: "session-1",
+      filePath: path,
+      detectedAt: Date(timeIntervalSince1970: 2)
+    ))
   }
 
   @Test("Allows a new plan candidate when the file path changes")
@@ -197,7 +267,106 @@ struct MonitoringAutoOpenSidePanelPolicyTests {
       openedKeys: [openedKey]
     ))
 
-    #expect(candidate.key.value == newPath)
+    #expect(candidate.key == .plan(
+      providerKind: .claude,
+      sessionID: "session-1",
+      filePath: newPath,
+      detectedAt: Date(timeIntervalSince1970: 1)
+    ))
+  }
+
+  @Test("Suppresses restored plans detected before initial appearance")
+  func suppressesRestoredPlansBeforeInitialAppearance() {
+    let item = Self.item(state: Self.planFileState(
+      filePath: "/Users/test/.claude/plans/feature-plan.md",
+      timestamp: Date(timeIntervalSince1970: 10)
+    ))
+
+    let candidate = MonitoringAutoOpenSidePanelPolicy.candidate(
+      layoutMode: .single,
+      maximizedSessionId: nil,
+      activeModuleLandingPath: nil,
+      visibleItem: item,
+      openedKeys: [],
+      detectedAfter: Date(timeIntervalSince1970: 20)
+    )
+
+    #expect(candidate == nil)
+  }
+
+  @Test("Allows plans detected after initial appearance")
+  func allowsPlansAfterInitialAppearance() throws {
+    let item = Self.item(state: Self.planFileState(
+      filePath: "/Users/test/.claude/plans/feature-plan.md",
+      timestamp: Date(timeIntervalSince1970: 30)
+    ))
+
+    let candidate = try #require(MonitoringAutoOpenSidePanelPolicy.candidate(
+      layoutMode: .single,
+      maximizedSessionId: nil,
+      activeModuleLandingPath: nil,
+      visibleItem: item,
+      openedKeys: [],
+      detectedAfter: Date(timeIntervalSince1970: 20)
+    ))
+
+    #expect(candidate.target == .plan(PlanState(filePath: "/Users/test/.claude/plans/feature-plan.md")))
+  }
+
+  @Test("Initial keys suppress already-present edits and plans but allow later edit changes")
+  func initialKeysSuppressAlreadyPresentTriggersButAllowLaterChanges() throws {
+    let path = "/Users/test/.claude/plans/feature-plan.md"
+    let initialItem = Self.item(state: SessionMonitorState(
+      pendingToolUse: PendingToolUse(
+        toolName: "Edit",
+        toolUseId: "edit-1",
+        timestamp: Date(timeIntervalSince1970: 1)
+      ),
+      recentActivities: Self.planActivities(filePath: path)
+    ))
+
+    let initialKeys = MonitoringAutoOpenSidePanelPolicy.keys(for: initialItem)
+
+    #expect(initialKeys.contains(.edits(
+      providerKind: .claude,
+      sessionID: "session-1",
+      toolUseId: "edit-1"
+    )))
+    #expect(initialKeys.contains(.plan(
+      providerKind: .claude,
+      sessionID: "session-1",
+      filePath: path,
+      detectedAt: Date(timeIntervalSince1970: 1)
+    )))
+    #expect(MonitoringAutoOpenSidePanelPolicy.candidate(
+      layoutMode: .single,
+      maximizedSessionId: nil,
+      activeModuleLandingPath: nil,
+      visibleItem: initialItem,
+      openedKeys: initialKeys
+    ) == nil)
+
+    let changedItem = Self.item(state: SessionMonitorState(
+      pendingToolUse: PendingToolUse(
+        toolName: "Edit",
+        toolUseId: "edit-2",
+        timestamp: Date(timeIntervalSince1970: 2)
+      ),
+      recentActivities: Self.planActivities(filePath: path)
+    ))
+    let candidate = try #require(MonitoringAutoOpenSidePanelPolicy.candidate(
+      layoutMode: .single,
+      maximizedSessionId: nil,
+      activeModuleLandingPath: nil,
+      visibleItem: changedItem,
+      openedKeys: initialKeys
+    ))
+
+    #expect(candidate.key == .edits(
+      providerKind: .claude,
+      sessionID: "session-1",
+      toolUseId: "edit-2"
+    ))
   }
 
   private static func item(
@@ -211,24 +380,33 @@ struct MonitoringAutoOpenSidePanelPolicyTests {
     )
   }
 
-  private static func pendingEditState(toolUseId: String) -> SessionMonitorState {
+  private static func pendingEditState(
+    toolUseId: String,
+    timestamp: Date = Date(timeIntervalSince1970: 1)
+  ) -> SessionMonitorState {
     SessionMonitorState(
       pendingToolUse: PendingToolUse(
         toolName: "Edit",
         toolUseId: toolUseId,
-        timestamp: Date(timeIntervalSince1970: 1)
+        timestamp: timestamp
       )
     )
   }
 
-  private static func planFileState(filePath: String) -> SessionMonitorState {
-    SessionMonitorState(recentActivities: planActivities(filePath: filePath))
+  private static func planFileState(
+    filePath: String,
+    timestamp: Date = Date(timeIntervalSince1970: 1)
+  ) -> SessionMonitorState {
+    SessionMonitorState(recentActivities: planActivities(filePath: filePath, timestamp: timestamp))
   }
 
-  private static func planActivities(filePath: String) -> [ActivityEntry] {
+  private static func planActivities(
+    filePath: String,
+    timestamp: Date = Date(timeIntervalSince1970: 1)
+  ) -> [ActivityEntry] {
     [
       ActivityEntry(
-        timestamp: Date(timeIntervalSince1970: 1),
+        timestamp: timestamp,
         type: .toolUse(name: "Write"),
         description: "plan.md",
         toolInput: CodeChangeInput(


### PR DESCRIPTION
## Summary

- Prevent the embedded side panel from auto-opening on app launch when restored monitor state already contains pending edits or a detected plan.
- Keep auto-open behavior for genuinely new edit/plan signals after app appearance.
- Make plan auto-open keys event-based so later updates to the same plan file can still open the panel.

## Root Cause

The first fix only seeded keys during `onAppear`. The session watchers can publish their initial parsed monitor state asynchronously after the view appears, which made restored edits/plans look like new changes. Some restored records can also use `Date()` as a timestamp fallback, so timestamp-only launch filtering is not sufficient.

## Regression Notes

No local regression found in the build path. The guard now tracks observed auto-open keys per session and suppresses the first hydrated trigger for sessions whose activity predates app appearance, while allowing later new keys through.

## Validation

- `swift build` from `app/modules/AgentHubCore` passed
- `xcodebuild -project app/AgentHub.xcodeproj -scheme AgentHub -configuration Debug -destination 'platform=macOS' build` passed
- `git diff --check HEAD~1 HEAD` passed
- `swift test --filter MonitoringAutoOpenSidePanelPolicyTests` is blocked by an unrelated existing compile error in `SessionWorkspaceStatePersistenceTests.swift:37` (`dbQueue.write` is async but the call is not awaited)
