### PR TITLE
[codex] Add macOS terminal editing shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,11 +170,21 @@ Updates are delivered automatically via [Sparkle](https://sparkle-project.org/) 
 
 ### Embedded Terminal
 
+When the embedded Claude or Codex terminal is focused, text editing shortcuts follow macOS Terminal-style line editing.
+
 | Shortcut | Action |
 |---|---|
 | **Cmd+C** | Copy selected text |
 | **Cmd+V** | Paste |
 | **Cmd+A** | Select all |
+| **Cmd+Left / Cmd+Up** | Move to beginning of line |
+| **Cmd+Right / Cmd+Down** | Move to end of line |
+| **Cmd+Backspace** | Delete to beginning of line |
+| **Cmd+Forward Delete** | Delete to end of line |
+| **Option+Left** | Move back one word |
+| **Option+Right** | Move forward one word |
+| **Option+Backspace** | Delete previous word |
+| **Option+Forward Delete** | Delete next word |
 | **⌥↩ / ⌘↩ / ⇧↩** | Insert newline (configurable in Settings → Terminal) |
 
 ### Command Palette

--- a/app/AgentHub.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/app/AgentHub.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -177,8 +177,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/jamesrochabrun/SwiftTerm",
       "state" : {
-        "revision" : "287a410162ca653e43b1c571faefc0320ae2f51b",
-        "version" : "1.13.0-agenthub.1"
+        "revision" : "46d4c1a9b5bf981b9d9e376447be7f81f456837a",
+        "version" : "1.13.0-agenthub.5"
       }
     },
     {

--- a/app/modules/AgentHubCore/Package.resolved
+++ b/app/modules/AgentHubCore/Package.resolved
@@ -159,8 +159,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/jamesrochabrun/SwiftTerm",
       "state" : {
-        "revision" : "287a410162ca653e43b1c571faefc0320ae2f51b",
-        "version" : "1.13.0-agenthub.1"
+        "revision" : "46d4c1a9b5bf981b9d9e376447be7f81f456837a",
+        "version" : "1.13.0-agenthub.5"
       }
     },
     {

--- a/app/modules/AgentHubCore/Package.swift
+++ b/app/modules/AgentHubCore/Package.swift
@@ -35,7 +35,7 @@ let package = Package(
     .package(path: "../Storybook"),
     .package(url: "https://github.com/jamesrochabrun/Canvas", from: "1.2.0"),
     .package(url: "https://github.com/jamesrochabrun/PierreDiffsSwift", exact: "1.1.7"),
-    .package(url: "https://github.com/jamesrochabrun/SwiftTerm", exact: "1.13.0-agenthub.1"),
+    .package(url: "https://github.com/jamesrochabrun/SwiftTerm", exact: "1.13.0-agenthub.5"),
     .package(url: "https://github.com/gonzalezreal/swift-markdown-ui", from: "2.0.0"),
     .package(url: "https://github.com/groue/GRDB.swift", from: "6.24.0"),
     .package(url: "https://github.com/appstefan/HighlightSwift", from: "1.1.0"),

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/EmbeddedTerminalView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/EmbeddedTerminalView.swift
@@ -579,15 +579,19 @@ public class TerminalContainerView: NSView, ManagedLocalProcessTerminalViewDeleg
 
         let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
         let isTerminalVisible = terminal.superview != nil && !terminal.isHidden && terminal.alphaValue > 0
+        let terminalTextInputActive = isTerminalVisible
+          && self.isTerminalResponderActive(window: window, terminal: terminal)
 
-        if let shortcut = RegularTerminalShortcut.action(for: event) {
+        if let shortcut = RegularTerminalShortcut.action(
+          for: event,
+          terminalTextInputActive: terminalTextInputActive
+        ) {
           self.handleShortcut(shortcut, focusedTerminal: terminal)
           self.onUserInteraction?()
           return nil
         }
 
-        if isTerminalVisible,
-           self.isTerminalResponderActive(window: window, terminal: terminal),
+        if terminalTextInputActive,
            flags == .control,
            event.keyCode == 50,
            self.onRequestShowEditor != nil {
@@ -597,7 +601,7 @@ public class TerminalContainerView: NSView, ManagedLocalProcessTerminalViewDeleg
         }
 
         // Typing shortcuts (require terminal to be first responder)
-        guard isTerminalResponderActive(window: window, terminal: terminal) else { break }
+        guard terminalTextInputActive else { break }
         guard isProtectedAgentTab(focusedTab) else {
           self.onUserInteraction?()
           break

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/TerminalPanelKit.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/TerminalPanelKit.swift
@@ -79,21 +79,30 @@ public enum TerminalPanelKit {
     case focusPanel(PanelNavigationDirection)
     case selectTab(TabNavigationDirection)
 
-    public static func action(for event: NSEvent) -> Shortcut? {
+    public static func action(
+      for event: NSEvent,
+      terminalTextInputActive: Bool = false
+    ) -> Shortcut? {
       action(
         keyCode: event.keyCode,
         charactersIgnoringModifiers: event.charactersIgnoringModifiers,
-        modifierFlags: event.modifierFlags
+        modifierFlags: event.modifierFlags,
+        terminalTextInputActive: terminalTextInputActive
       )
     }
 
     public static func action(
       keyCode: UInt16,
       charactersIgnoringModifiers: String?,
-      modifierFlags: NSEvent.ModifierFlags
+      modifierFlags: NSEvent.ModifierFlags,
+      terminalTextInputActive: Bool = false
     ) -> Shortcut? {
       let flags = normalizedModifierFlags(modifierFlags)
       let key = charactersIgnoringModifiers?.lowercased()
+
+      if terminalTextInputActive && isTerminalEditingShortcut(keyCode: keyCode, flags: flags) {
+        return nil
+      }
 
       if flags == [.command] {
         switch keyCode {
@@ -137,6 +146,23 @@ public enum TerminalPanelKit {
       flags
         .intersection(.deviceIndependentFlagsMask)
         .subtracting([.numericPad, .function, .capsLock])
+    }
+
+    private static func isTerminalEditingShortcut(
+      keyCode: UInt16,
+      flags: NSEvent.ModifierFlags
+    ) -> Bool {
+      guard !flags.contains(.control),
+            flags.contains(.command) || flags.contains(.option) else {
+        return false
+      }
+
+      switch keyCode {
+      case 51, 117, 123, 124, 125, 126:
+        return true
+      default:
+        return false
+      }
     }
   }
 

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/RegularTerminalWorkspaceTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/RegularTerminalWorkspaceTests.swift
@@ -64,6 +64,44 @@ struct RegularTerminalWorkspaceTests {
     ) == .closePanel)
   }
 
+  @Test("Terminal editing shortcuts pass through when terminal input is focused")
+  func terminalEditingShortcutsPassThroughWhenTerminalInputIsFocused() {
+    #expect(RegularTerminalShortcut.action(
+      keyCode: 123,
+      charactersIgnoringModifiers: nil,
+      modifierFlags: [.command, .numericPad],
+      terminalTextInputActive: true
+    ) == nil)
+
+    #expect(RegularTerminalShortcut.action(
+      keyCode: 124,
+      charactersIgnoringModifiers: nil,
+      modifierFlags: [.command, .shift, .numericPad],
+      terminalTextInputActive: true
+    ) == nil)
+
+    #expect(RegularTerminalShortcut.action(
+      keyCode: 51,
+      charactersIgnoringModifiers: "\u{7f}",
+      modifierFlags: [.command],
+      terminalTextInputActive: true
+    ) == nil)
+
+    #expect(RegularTerminalShortcut.action(
+      keyCode: 3,
+      charactersIgnoringModifiers: "f",
+      modifierFlags: [.command],
+      terminalTextInputActive: true
+    ) == .startSearch)
+
+    #expect(RegularTerminalShortcut.action(
+      keyCode: 17,
+      charactersIgnoringModifiers: "t",
+      modifierFlags: [.command],
+      terminalTextInputActive: true
+    ) == .openTab)
+  }
+
   @Test("Split layout builder adds and removes panels")
   func splitLayoutBuilderAddsAndRemovesPanels() {
     let primary = RegularTerminalPanelID(UUID(uuidString: "00000000-0000-0000-0000-000000000001")!)


### PR DESCRIPTION
## Summary

Make AgentHub's embedded Claude and Codex terminals behave more like macOS Terminal for prompt editing.

- updates SwiftTerm to `1.13.0-agenthub.5`
- lets terminal editing shortcuts pass through when SwiftTerm is the active responder
- preserves AgentHub shortcuts such as search, tabs, settings, and configured newline handling
- documents the embedded terminal shortcut matrix in the README

## Dependency

Depends on `jamesrochabrun/SwiftTerm#4`, which provides tag `1.13.0-agenthub.5` at `46d4c1a`.

## Validation

- `swift package resolve`
- `xcodebuild build -project app/AgentHub.xcodeproj -scheme AgentHubCore -destination 'platform=macOS'`
- SwiftPM tests were attempted, but the package test build is blocked before AgentHub tests run by the existing `CodeEditSymbols` `Bundle.module` resource issue.
- Xcode test actions were attempted for `AgentHubCore` and `AgentHub`, but those schemes are not configured for test action.