### PR TITLE
[codex] Add panel drag rearrangement

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/EmbeddedTerminalView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/EmbeddedTerminalView.swift
@@ -945,6 +945,9 @@ public class TerminalContainerView: NSView, ManagedLocalProcessTerminalViewDeleg
       },
       onSplitPanel: { [weak self] panel, axis in
         self?.openShellPane(axis: axis, anchorPanelID: panel.id)
+      },
+      onRearrangePanels: { [weak self] root in
+        self?.rearrangeRegularPanels(to: root)
       }
     )
   }
@@ -1224,6 +1227,12 @@ public class TerminalContainerView: NSView, ManagedLocalProcessTerminalViewDeleg
     if let auxiliary = panels.reversed().first(where: canCloseRegularPanel) {
       closeRegularPanel(auxiliary)
     }
+  }
+
+  private func rearrangeRegularPanels(to root: RegularTerminalSplitNode) {
+    guard terminalPanelSession?.rearrangePanels(to: root) == true else { return }
+    refreshWorkspaceRootView()
+    notifyWorkspaceChanged()
   }
 
   private func focus(_ tab: RegularTerminalTab) {

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/RegularTerminalWorkspaceView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/RegularTerminalWorkspaceView.swift
@@ -51,6 +51,9 @@ extension TerminalPanelKit.Tab where Payload == SafeLocalProcessTerminalView {
 
 @MainActor
 struct RegularTerminalWorkspaceView: View {
+  @State private var panelFrames: [RegularTerminalPanelID: CGRect] = [:]
+  @State private var dragState: RegularTerminalPanelDragState?
+
   let panels: [RegularTerminalPanel]
   let splitRoot: RegularTerminalSplitNode?
   let activePanelID: RegularTerminalPanelID?
@@ -62,32 +65,176 @@ struct RegularTerminalWorkspaceView: View {
   let onCloseTab: (RegularTerminalPanel, RegularTerminalTab) -> Void
   let onOpenTab: (RegularTerminalPanel) -> Void
   let onSplitPanel: (RegularTerminalPanel, RegularTerminalSplitAxis) -> Void
+  let onRearrangePanels: (RegularTerminalSplitNode) -> Void
 
   var body: some View {
-    if panels.isEmpty {
-      Text("No terminal available")
-        .foregroundStyle(.secondary)
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-    } else {
-      RegularTerminalSplitView(
-        node: resolvedSplitRoot,
-        panels: panels,
-        activePanelID: activePanelID,
-        canClosePanel: canClosePanel,
-        canCloseTab: canCloseTab,
-        onActivatePanel: onActivatePanel,
-        onSelectTab: onSelectTab,
-        onClosePanel: onClosePanel,
-        onCloseTab: onCloseTab,
-        onOpenTab: onOpenTab,
-        onSplitPanel: onSplitPanel
-      )
+    GeometryReader { proxy in
+      if panels.isEmpty {
+        Text("No terminal available")
+          .foregroundStyle(.secondary)
+          .frame(maxWidth: .infinity, maxHeight: .infinity)
+      } else {
+        RegularTerminalSplitView(
+          node: displayedSplitRoot,
+          panels: panels,
+          activePanelID: activePanelID,
+          canClosePanel: canClosePanel,
+          canCloseTab: canCloseTab,
+          onActivatePanel: onActivatePanel,
+          onSelectTab: onSelectTab,
+          onClosePanel: onClosePanel,
+          onCloseTab: onCloseTab,
+          onOpenTab: onOpenTab,
+          onSplitPanel: onSplitPanel,
+          dragVisualState: dragVisualState(for:),
+          coordinateSpaceName: Self.coordinateSpaceName,
+          onPanelDragChanged: { panel, value in
+            updatePanelDrag(panel, value: value, containerSize: proxy.size)
+          },
+          onPanelDragEnded: { _, _ in
+            finishPanelDrag()
+          }
+        )
+      }
+    }
+    .coordinateSpace(name: Self.coordinateSpaceName)
+    .onPreferenceChange(RegularTerminalPanelFramePreferenceKey.self) { frames in
+      panelFrames = frames
+    }
+    .onChange(of: panelIdentity) { _, _ in
+      dragState = nil
     }
   }
 
   private var resolvedSplitRoot: RegularTerminalSplitNode {
     splitRoot ?? panels.first.map { .panel($0.id) } ?? .panel(RegularTerminalPanelID())
   }
+
+  private var displayedSplitRoot: RegularTerminalSplitNode {
+    dragState?.proposalRoot ?? resolvedSplitRoot
+  }
+
+  private var panelIdentity: [RegularTerminalPanelID] {
+    panels.map(\.id)
+  }
+
+  private static let coordinateSpaceName = "RegularTerminalWorkspaceCoordinateSpace"
+  private static let nearestTargetDistance: CGFloat = 96
+
+  private func updatePanelDrag(
+    _ panel: RegularTerminalPanel,
+    value: DragGesture.Value,
+    containerSize: CGSize
+  ) {
+    guard panels.count > 1 else { return }
+    let sourceRoot = dragState?.sourceRoot ?? resolvedSplitRoot
+    let sourceFrames = dragState?.sourceFrames ?? usablePanelFrames(
+      containerSize: containerSize,
+      root: sourceRoot
+    )
+
+    guard let target = targetPanel(at: value.location, dragging: panel.id, frames: sourceFrames) else {
+      dragState = RegularTerminalPanelDragState(
+        draggedPanelID: panel.id,
+        sourceRoot: sourceRoot,
+        sourceFrames: sourceFrames,
+        proposalRoot: nil,
+        isInvalid: true
+      )
+      return
+    }
+
+    let placement = dropPlacement(for: value.location, in: target.frame)
+    let proposal = TerminalPanelDragLayoutEngine.proposal(
+      root: sourceRoot.terminalPanelLayoutNode,
+      dragging: panel.id,
+      over: target.id,
+      placement: placement,
+      containerSize: containerSize
+    )
+
+    dragState = RegularTerminalPanelDragState(
+      draggedPanelID: panel.id,
+      sourceRoot: sourceRoot,
+      sourceFrames: sourceFrames,
+      proposalRoot: proposal.map { RegularTerminalSplitNode(layoutNode: $0.root) },
+      isInvalid: proposal == nil
+    )
+  }
+
+  private func finishPanelDrag() {
+    defer { dragState = nil }
+    guard let proposalRoot = dragState?.proposalRoot,
+          dragState?.isInvalid == false else {
+      return
+    }
+    onRearrangePanels(proposalRoot)
+  }
+
+  private func dragVisualState(for panelID: RegularTerminalPanelID) -> TerminalPanelDragVisualState {
+    guard dragState?.draggedPanelID == panelID else { return .inactive }
+    return dragState?.isInvalid == true ? .invalid : .preview
+  }
+
+  private func targetPanel(
+    at point: CGPoint,
+    dragging draggedPanelID: RegularTerminalPanelID,
+    frames sourceFrames: [RegularTerminalPanelID: CGRect]
+  ) -> (id: RegularTerminalPanelID, frame: CGRect)? {
+    let frames = sourceFrames.filter { $0.key != draggedPanelID }
+    guard !frames.isEmpty else { return nil }
+
+    if let contained = frames.first(where: { $0.value.insetBy(dx: -12, dy: -12).contains(point) }) {
+      return (contained.key, contained.value)
+    }
+
+    guard let nearest = frames.min(by: {
+      distance(from: point, to: $0.value) < distance(from: point, to: $1.value)
+    }) else {
+      return nil
+    }
+    guard distance(from: point, to: nearest.value) <= Self.nearestTargetDistance else {
+      return nil
+    }
+    return (nearest.key, nearest.value)
+  }
+
+  private func usablePanelFrames(
+    containerSize: CGSize,
+    root: RegularTerminalSplitNode
+  ) -> [RegularTerminalPanelID: CGRect] {
+    if !panelFrames.isEmpty {
+      return panelFrames
+    }
+    return TerminalPanelDragLayoutEngine.panelFrames(
+      for: root.terminalPanelLayoutNode,
+      in: CGRect(origin: .zero, size: containerSize)
+    )
+  }
+
+  private func dropPlacement(for point: CGPoint, in frame: CGRect) -> TerminalPanelDropPlacement {
+    let distances: [(distance: CGFloat, placement: TerminalPanelDropPlacement)] = [
+      (abs(point.x - frame.minX), .leading),
+      (abs(point.x - frame.maxX), .trailing),
+      (abs(point.y - frame.minY), .above),
+      (abs(point.y - frame.maxY), .below)
+    ]
+    return distances.min(by: { $0.distance < $1.distance })?.placement ?? .trailing
+  }
+
+  private func distance(from point: CGPoint, to frame: CGRect) -> CGFloat {
+    let dx = max(frame.minX - point.x, 0, point.x - frame.maxX)
+    let dy = max(frame.minY - point.y, 0, point.y - frame.maxY)
+    return sqrt(dx * dx + dy * dy)
+  }
+}
+
+private struct RegularTerminalPanelDragState {
+  let draggedPanelID: RegularTerminalPanelID
+  let sourceRoot: RegularTerminalSplitNode
+  let sourceFrames: [RegularTerminalPanelID: CGRect]
+  let proposalRoot: RegularTerminalSplitNode?
+  let isInvalid: Bool
 }
 
 @MainActor
@@ -103,6 +250,10 @@ private struct RegularTerminalSplitView: View {
   let onCloseTab: (RegularTerminalPanel, RegularTerminalTab) -> Void
   let onOpenTab: (RegularTerminalPanel) -> Void
   let onSplitPanel: (RegularTerminalPanel, RegularTerminalSplitAxis) -> Void
+  let dragVisualState: (RegularTerminalPanelID) -> TerminalPanelDragVisualState
+  let coordinateSpaceName: String
+  let onPanelDragChanged: (RegularTerminalPanel, DragGesture.Value) -> Void
+  let onPanelDragEnded: (RegularTerminalPanel, DragGesture.Value) -> Void
 
   var body: some View {
     content(for: node)
@@ -126,7 +277,11 @@ private struct RegularTerminalSplitView: View {
           onCloseTab: { tab in onCloseTab(panel, tab) },
           onOpenTab: { onOpenTab(panel) },
           onSplitRight: { onSplitPanel(panel, .horizontal) },
-          onSplitBelow: { onSplitPanel(panel, .vertical) }
+          onSplitBelow: { onSplitPanel(panel, .vertical) },
+          dragVisualState: dragVisualState(panel.id),
+          coordinateSpaceName: coordinateSpaceName,
+          onDragChanged: { value in onPanelDragChanged(panel, value) },
+          onDragEnded: { value in onPanelDragEnded(panel, value) }
         )
       } else {
         EmptyView()
@@ -177,7 +332,11 @@ private struct RegularTerminalSplitView: View {
           onClosePanel: onClosePanel,
           onCloseTab: onCloseTab,
           onOpenTab: onOpenTab,
-          onSplitPanel: onSplitPanel
+          onSplitPanel: onSplitPanel,
+          dragVisualState: dragVisualState,
+          coordinateSpaceName: coordinateSpaceName,
+          onPanelDragChanged: onPanelDragChanged,
+          onPanelDragEnded: onPanelDragEnded
         )
         .frame(width: childWidth, height: size.height)
       }
@@ -209,7 +368,11 @@ private struct RegularTerminalSplitView: View {
           onClosePanel: onClosePanel,
           onCloseTab: onCloseTab,
           onOpenTab: onOpenTab,
-          onSplitPanel: onSplitPanel
+          onSplitPanel: onSplitPanel,
+          dragVisualState: dragVisualState,
+          coordinateSpaceName: coordinateSpaceName,
+          onPanelDragChanged: onPanelDragChanged,
+          onPanelDragEnded: onPanelDragEnded
         )
         .frame(width: size.width, height: childHeight)
       }
@@ -244,6 +407,10 @@ private struct RegularTerminalPaneView: View {
   let onOpenTab: () -> Void
   let onSplitRight: () -> Void
   let onSplitBelow: () -> Void
+  let dragVisualState: TerminalPanelDragVisualState
+  let coordinateSpaceName: String
+  let onDragChanged: (DragGesture.Value) -> Void
+  let onDragEnded: (DragGesture.Value) -> Void
 
   var body: some View {
     VStack(spacing: 0) {
@@ -259,6 +426,7 @@ private struct RegularTerminalPaneView: View {
         onSplitBelow: onSplitBelow,
         onClosePanel: onClosePanel
       )
+      .simultaneousGesture(panelDragGesture)
 
       if let activeTab = panel.activeTab {
         RegularTerminalTabRepresentable(tab: activeTab)
@@ -272,14 +440,45 @@ private struct RegularTerminalPaneView: View {
     }
     .frame(maxWidth: .infinity, maxHeight: .infinity)
     .background(Color.clear)
+    .background {
+      GeometryReader { proxy in
+        Color.clear.preference(
+          key: RegularTerminalPanelFramePreferenceKey.self,
+          value: [panel.id: proxy.frame(in: .named(coordinateSpaceName))]
+        )
+      }
+    }
     .contentShape(Rectangle())
     .onTapGesture(perform: onActivatePanel)
     .overlay {
-      if isActive && showsSelectionBorder {
+      if dragVisualState == .invalid {
+        Rectangle()
+          .stroke(Color.red.opacity(0.85), lineWidth: 2)
+      } else if dragVisualState == .preview {
+        Rectangle()
+          .stroke(Color.accentColor.opacity(0.75), lineWidth: 1)
+      } else if isActive && showsSelectionBorder {
         Rectangle()
           .stroke(Color.accentColor.opacity(0.55), lineWidth: 1)
       }
     }
+  }
+
+  private var panelDragGesture: some Gesture {
+    DragGesture(minimumDistance: 8, coordinateSpace: .named(coordinateSpaceName))
+      .onChanged(onDragChanged)
+      .onEnded(onDragEnded)
+  }
+}
+
+private struct RegularTerminalPanelFramePreferenceKey: PreferenceKey {
+  static var defaultValue: [RegularTerminalPanelID: CGRect] = [:]
+
+  static func reduce(
+    value: inout [RegularTerminalPanelID: CGRect],
+    nextValue: () -> [RegularTerminalPanelID: CGRect]
+  ) {
+    value.merge(nextValue(), uniquingKeysWith: { _, next in next })
   }
 }
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/TerminalPanelDragLayoutEngine.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/TerminalPanelDragLayoutEngine.swift
@@ -1,0 +1,392 @@
+//
+//  TerminalPanelDragLayoutEngine.swift
+//  AgentHub
+//
+
+import CoreGraphics
+import Foundation
+
+public enum TerminalPanelLayoutAxis: Codable, Equatable, Sendable {
+  case horizontal
+  case vertical
+
+  public var opposite: TerminalPanelLayoutAxis {
+    switch self {
+    case .horizontal:
+      return .vertical
+    case .vertical:
+      return .horizontal
+    }
+  }
+}
+
+public enum TerminalPanelDropPlacement: Equatable, Sendable {
+  case leading
+  case trailing
+  case above
+  case below
+
+  public var axis: TerminalPanelLayoutAxis {
+    switch self {
+    case .leading, .trailing:
+      return .horizontal
+    case .above, .below:
+      return .vertical
+    }
+  }
+
+  var order: TerminalPanelLayoutInsertionOrder {
+    switch self {
+    case .leading, .above:
+      return .before
+    case .trailing, .below:
+      return .after
+    }
+  }
+}
+
+public enum TerminalPanelDragVisualState: Equatable, Sendable {
+  case inactive
+  case preview
+  case invalid
+}
+
+public indirect enum TerminalPanelLayoutNode<PanelID: Hashable>: Equatable {
+  case panel(PanelID)
+  case split(axis: TerminalPanelLayoutAxis, children: [TerminalPanelLayoutNode<PanelID>])
+
+  public var panelIDs: [PanelID] {
+    switch self {
+    case .panel(let panelID):
+      return [panelID]
+    case .split(_, let children):
+      return children.flatMap(\.panelIDs)
+    }
+  }
+
+  public func containsPanel(_ panelID: PanelID) -> Bool {
+    switch self {
+    case .panel(let currentPanelID):
+      return currentPanelID == panelID
+    case .split(_, let children):
+      return children.contains { $0.containsPanel(panelID) }
+    }
+  }
+
+  public func removingPanel(_ panelID: PanelID) -> TerminalPanelLayoutNode<PanelID>? {
+    switch self {
+    case .panel(let currentPanelID):
+      return currentPanelID == panelID ? nil : self
+
+    case .split(let axis, let children):
+      let remainingChildren = children.compactMap { $0.removingPanel(panelID) }
+      switch remainingChildren.count {
+      case 0:
+        return nil
+      case 1:
+        return remainingChildren[0]
+      default:
+        return .split(axis: axis, children: remainingChildren)
+      }
+    }
+  }
+
+  public func insertingPanel(
+    _ panelID: PanelID,
+    beside targetPanelID: PanelID,
+    axis insertionAxis: TerminalPanelLayoutAxis,
+    order: TerminalPanelLayoutInsertionOrder
+  ) -> TerminalPanelLayoutNode<PanelID> {
+    switch self {
+    case .panel(let currentPanelID):
+      guard currentPanelID == targetPanelID else { return self }
+      return Self.split(
+        axis: insertionAxis,
+        children: order.ordered(panelID, targetPanelID).map(Self.panel)
+      )
+
+    case .split(let axis, let children):
+      if axis == insertionAxis,
+         let directTargetIndex = children.firstIndex(where: { $0.directPanelID == targetPanelID }) {
+        var updatedChildren = children
+        let insertionIndex = order == .before ? directTargetIndex : directTargetIndex + 1
+        updatedChildren.insert(.panel(panelID), at: insertionIndex)
+        return .split(axis: axis, children: updatedChildren)
+      }
+
+      return .split(
+        axis: axis,
+        children: children.map { child in
+          guard child.containsPanel(targetPanelID) else { return child }
+          return child.insertingPanel(
+            panelID,
+            beside: targetPanelID,
+            axis: insertionAxis,
+            order: order
+          )
+        }
+      )
+    }
+  }
+
+  var directPanelID: PanelID? {
+    switch self {
+    case .panel(let panelID):
+      return panelID
+    case .split:
+      return nil
+    }
+  }
+}
+
+public enum TerminalPanelLayoutInsertionOrder: Equatable, Sendable {
+  case before
+  case after
+
+  func ordered<PanelID>(_ panelID: PanelID, _ targetPanelID: PanelID) -> [PanelID] {
+    switch self {
+    case .before:
+      return [panelID, targetPanelID]
+    case .after:
+      return [targetPanelID, panelID]
+    }
+  }
+}
+
+public struct TerminalPanelLayoutProposal<PanelID: Hashable>: Equatable {
+  public let root: TerminalPanelLayoutNode<PanelID>
+  public let frames: [PanelID: CGRect]
+  public let switchedAxis: Bool
+
+  public init(
+    root: TerminalPanelLayoutNode<PanelID>,
+    frames: [PanelID: CGRect],
+    switchedAxis: Bool
+  ) {
+    self.root = root
+    self.frames = frames
+    self.switchedAxis = switchedAxis
+  }
+}
+
+public enum TerminalPanelDragLayoutEngine {
+  public static let defaultMinimumPanelSize = CGSize(width: 260, height: 160)
+  public static let defaultDividerSize: CGFloat = 1
+
+  public static func proposal<PanelID: Hashable>(
+    root: TerminalPanelLayoutNode<PanelID>,
+    dragging draggedPanelID: PanelID,
+    over targetPanelID: PanelID,
+    placement: TerminalPanelDropPlacement,
+    containerSize: CGSize,
+    minimumPanelSize: CGSize = defaultMinimumPanelSize,
+    dividerSize: CGFloat = defaultDividerSize
+  ) -> TerminalPanelLayoutProposal<PanelID>? {
+    guard draggedPanelID != targetPanelID,
+          containerSize.width > 0,
+          containerSize.height > 0,
+          root.containsPanel(draggedPanelID),
+          root.containsPanel(targetPanelID),
+          let rootWithoutDragged = root.removingPanel(draggedPanelID),
+          rootWithoutDragged.containsPanel(targetPanelID) else {
+      return nil
+    }
+
+    let expectedPanelIDs = root.panelIDs
+    let candidates = proposalCandidates(
+      rootWithoutDragged: rootWithoutDragged,
+      draggedPanelID: draggedPanelID,
+      targetPanelID: targetPanelID,
+      placement: placement
+    )
+
+    for candidate in candidates {
+      guard exactPanelSet(candidate.root, matches: expectedPanelIDs) else { continue }
+      let frames = panelFrames(
+        for: candidate.root,
+        in: CGRect(origin: .zero, size: containerSize),
+        dividerSize: dividerSize
+      )
+      guard framesSatisfyMinimum(
+        frames,
+        panelIDs: expectedPanelIDs,
+        minimumPanelSize: minimumPanelSize
+      ) else {
+        continue
+      }
+      return TerminalPanelLayoutProposal(
+        root: candidate.root,
+        frames: frames,
+        switchedAxis: candidate.switchedAxis
+      )
+    }
+
+    return nil
+  }
+
+  public static func panelFrames<PanelID: Hashable>(
+    for node: TerminalPanelLayoutNode<PanelID>,
+    in rect: CGRect,
+    dividerSize: CGFloat = defaultDividerSize
+  ) -> [PanelID: CGRect] {
+    switch node {
+    case .panel(let panelID):
+      return [panelID: rect]
+    case .split(let axis, let children):
+      return splitPanelFrames(axis: axis, children: children, in: rect, dividerSize: dividerSize)
+    }
+  }
+
+  private static func proposalCandidates<PanelID: Hashable>(
+    rootWithoutDragged: TerminalPanelLayoutNode<PanelID>,
+    draggedPanelID: PanelID,
+    targetPanelID: PanelID,
+    placement: TerminalPanelDropPlacement
+  ) -> [(root: TerminalPanelLayoutNode<PanelID>, switchedAxis: Bool)] {
+    var candidates: [(root: TerminalPanelLayoutNode<PanelID>, switchedAxis: Bool)] = []
+
+    if let flatRoot = flatRootCandidate(
+      rootWithoutDragged: rootWithoutDragged,
+      draggedPanelID: draggedPanelID,
+      targetPanelID: targetPanelID,
+      placement: placement,
+      switchedAxis: false
+    ) {
+      append((root: flatRoot.root, switchedAxis: flatRoot.switchedAxis), to: &candidates)
+      let reflowedRoot = TerminalPanelLayoutNode.split(
+        axis: flatRoot.rootAxis.opposite,
+        children: flatRoot.children
+      )
+      append((root: reflowedRoot, switchedAxis: true), to: &candidates)
+    }
+
+    let edgeCandidate = rootWithoutDragged.insertingPanel(
+      draggedPanelID,
+      beside: targetPanelID,
+      axis: placement.axis,
+      order: placement.order
+    )
+    append((root: edgeCandidate, switchedAxis: false), to: &candidates)
+
+    return candidates
+  }
+
+  private static func flatRootCandidate<PanelID: Hashable>(
+    rootWithoutDragged: TerminalPanelLayoutNode<PanelID>,
+    draggedPanelID: PanelID,
+    targetPanelID: PanelID,
+    placement: TerminalPanelDropPlacement,
+    switchedAxis: Bool
+  ) -> (root: TerminalPanelLayoutNode<PanelID>, rootAxis: TerminalPanelLayoutAxis, children: [TerminalPanelLayoutNode<PanelID>], switchedAxis: Bool)? {
+    switch rootWithoutDragged {
+    case .panel(let panelID):
+      guard panelID == targetPanelID else { return nil }
+      let children = placement.order.ordered(draggedPanelID, targetPanelID).map(TerminalPanelLayoutNode.panel)
+      return (
+        root: .split(axis: placement.axis, children: children),
+        rootAxis: placement.axis,
+        children: children,
+        switchedAxis: switchedAxis
+      )
+
+    case .split(let axis, let children):
+      guard children.allSatisfy({ $0.directPanelID != nil }),
+            children.contains(where: { $0.directPanelID == targetPanelID }) else {
+        return nil
+      }
+      var updatedChildren = children
+      guard let targetIndex = updatedChildren.firstIndex(where: { $0.directPanelID == targetPanelID }) else {
+        return nil
+      }
+      let insertionIndex = placement.order == .before ? targetIndex : targetIndex + 1
+      updatedChildren.insert(.panel(draggedPanelID), at: insertionIndex)
+      return (
+        root: .split(axis: axis, children: updatedChildren),
+        rootAxis: axis,
+        children: updatedChildren,
+        switchedAxis: switchedAxis
+      )
+    }
+  }
+
+  private static func append<PanelID: Hashable>(
+    _ candidate: (root: TerminalPanelLayoutNode<PanelID>, switchedAxis: Bool),
+    to candidates: inout [(root: TerminalPanelLayoutNode<PanelID>, switchedAxis: Bool)]
+  ) {
+    guard !candidates.contains(where: { $0.root == candidate.root }) else { return }
+    candidates.append(candidate)
+  }
+
+  private static func splitPanelFrames<PanelID: Hashable>(
+    axis: TerminalPanelLayoutAxis,
+    children: [TerminalPanelLayoutNode<PanelID>],
+    in rect: CGRect,
+    dividerSize: CGFloat
+  ) -> [PanelID: CGRect] {
+    guard !children.isEmpty else { return [:] }
+
+    var result: [PanelID: CGRect] = [:]
+    let childCount = CGFloat(children.count)
+
+    switch axis {
+    case .horizontal:
+      let totalDividerWidth = dividerSize * CGFloat(max(children.count - 1, 0))
+      let childWidth = max(0, rect.width - totalDividerWidth) / childCount
+      var nextX = rect.minX
+
+      for (index, child) in children.enumerated() {
+        if index > 0 {
+          nextX += dividerSize
+        }
+        let childRect = CGRect(x: nextX, y: rect.minY, width: childWidth, height: rect.height)
+        result.merge(
+          panelFrames(for: child, in: childRect, dividerSize: dividerSize),
+          uniquingKeysWith: { current, _ in current }
+        )
+        nextX += childWidth
+      }
+
+    case .vertical:
+      let totalDividerHeight = dividerSize * CGFloat(max(children.count - 1, 0))
+      let childHeight = max(0, rect.height - totalDividerHeight) / childCount
+      var nextY = rect.minY
+
+      for (index, child) in children.enumerated() {
+        if index > 0 {
+          nextY += dividerSize
+        }
+        let childRect = CGRect(x: rect.minX, y: nextY, width: rect.width, height: childHeight)
+        result.merge(
+          panelFrames(for: child, in: childRect, dividerSize: dividerSize),
+          uniquingKeysWith: { current, _ in current }
+        )
+        nextY += childHeight
+      }
+    }
+
+    return result
+  }
+
+  private static func framesSatisfyMinimum<PanelID: Hashable>(
+    _ frames: [PanelID: CGRect],
+    panelIDs: [PanelID],
+    minimumPanelSize: CGSize
+  ) -> Bool {
+    for panelID in panelIDs {
+      guard let frame = frames[panelID],
+            frame.width >= minimumPanelSize.width,
+            frame.height >= minimumPanelSize.height else {
+        return false
+      }
+    }
+    return true
+  }
+
+  private static func exactPanelSet<PanelID: Hashable>(
+    _ node: TerminalPanelLayoutNode<PanelID>,
+    matches panelIDs: [PanelID]
+  ) -> Bool {
+    let nodePanelIDs = node.panelIDs
+    return nodePanelIDs.count == panelIDs.count && Set(nodePanelIDs) == Set(panelIDs)
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/TerminalPanelKit.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/TerminalPanelKit.swift
@@ -512,6 +512,18 @@ public enum TerminalPanelKit {
     }
 
     @discardableResult
+    public func rearrangePanels(to root: SplitNode) -> Bool {
+      let currentPanelIDs = panels.map(\.id)
+      let proposedPanelIDs = root.panelIDs
+      guard proposedPanelIDs.count == currentPanelIDs.count,
+            Set(proposedPanelIDs) == Set(currentPanelIDs) else {
+        return false
+      }
+      splitRoot = root
+      return true
+    }
+
+    @discardableResult
     public func focusPanel(
       direction: PanelNavigationDirection,
       viewportSize: CGSize
@@ -751,6 +763,52 @@ public enum TerminalPanelKit {
           }
         )
       }
+    }
+  }
+}
+
+public extension TerminalPanelKit.SplitAxis {
+  init(_ axis: TerminalPanelLayoutAxis) {
+    switch axis {
+    case .horizontal:
+      self = .horizontal
+    case .vertical:
+      self = .vertical
+    }
+  }
+
+  var terminalPanelLayoutAxis: TerminalPanelLayoutAxis {
+    switch self {
+    case .horizontal:
+      return .horizontal
+    case .vertical:
+      return .vertical
+    }
+  }
+}
+
+public extension TerminalPanelKit.SplitNode {
+  init(layoutNode: TerminalPanelLayoutNode<TerminalPanelKit.PanelID>) {
+    switch layoutNode {
+    case .panel(let panelID):
+      self = .panel(panelID)
+    case .split(let axis, let children):
+      self = .split(
+        axis: TerminalPanelKit.SplitAxis(axis),
+        children: children.map(TerminalPanelKit.SplitNode.init(layoutNode:))
+      )
+    }
+  }
+
+  var terminalPanelLayoutNode: TerminalPanelLayoutNode<TerminalPanelKit.PanelID> {
+    switch self {
+    case .panel(let panelID):
+      return .panel(panelID)
+    case .split(let axis, let children):
+      return .split(
+        axis: axis.terminalPanelLayoutAxis,
+        children: children.map(\.terminalPanelLayoutNode)
+      )
     }
   }
 }

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/RegularTerminalWorkspaceTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/RegularTerminalWorkspaceTests.swift
@@ -119,6 +119,107 @@ struct RegularTerminalWorkspaceTests {
     #expect(RegularTerminalSplitLayoutBuilder.removingPanel(shell, from: split) == .panel(primary))
   }
 
+  @Test("Drag layout proposal switches a flat stack when current orientation is too small")
+  func dragLayoutProposalSwitchesFlatStackWhenCurrentOrientationIsTooSmall() {
+    let primary = RegularTerminalPanelID(UUID(uuidString: "00000000-0000-0000-0000-000000000001")!)
+    let shell1 = RegularTerminalPanelID(UUID(uuidString: "00000000-0000-0000-0000-000000000002")!)
+    let shell2 = RegularTerminalPanelID(UUID(uuidString: "00000000-0000-0000-0000-000000000003")!)
+    let root = RegularTerminalSplitNode.split(
+      axis: .vertical,
+      children: [.panel(primary), .panel(shell1), .panel(shell2)]
+    )
+
+    let proposal = TerminalPanelDragLayoutEngine.proposal(
+      root: root.terminalPanelLayoutNode,
+      dragging: shell2,
+      over: shell1,
+      placement: .below,
+      containerSize: CGSize(width: 900, height: 420),
+      minimumPanelSize: CGSize(width: 260, height: 180)
+    )
+
+    #expect(proposal?.switchedAxis == true)
+    #expect(
+      proposal?.root == TerminalPanelLayoutNode.split(
+        axis: .horizontal,
+        children: [.panel(primary), .panel(shell1), .panel(shell2)]
+      )
+    )
+  }
+
+  @Test("Drag layout proposal rejects drops that cannot fit after reflow")
+  func dragLayoutProposalRejectsDropsThatCannotFitAfterReflow() {
+    let primary = RegularTerminalPanelID(UUID(uuidString: "00000000-0000-0000-0000-000000000001")!)
+    let shell1 = RegularTerminalPanelID(UUID(uuidString: "00000000-0000-0000-0000-000000000002")!)
+    let shell2 = RegularTerminalPanelID(UUID(uuidString: "00000000-0000-0000-0000-000000000003")!)
+    let root = RegularTerminalSplitNode.split(
+      axis: .vertical,
+      children: [.panel(primary), .panel(shell1), .panel(shell2)]
+    )
+
+    let proposal = TerminalPanelDragLayoutEngine.proposal(
+      root: root.terminalPanelLayoutNode,
+      dragging: shell2,
+      over: shell1,
+      placement: .below,
+      containerSize: CGSize(width: 600, height: 420),
+      minimumPanelSize: CGSize(width: 260, height: 180)
+    )
+
+    #expect(proposal == nil)
+  }
+
+  @Test("Drag layout proposal does not reflow nested target stacks")
+  func dragLayoutProposalDoesNotReflowNestedTargetStacks() {
+    let primary = RegularTerminalPanelID(UUID(uuidString: "00000000-0000-0000-0000-000000000001")!)
+    let shell1 = RegularTerminalPanelID(UUID(uuidString: "00000000-0000-0000-0000-000000000002")!)
+    let shell2 = RegularTerminalPanelID(UUID(uuidString: "00000000-0000-0000-0000-000000000003")!)
+    let shell3 = RegularTerminalPanelID(UUID(uuidString: "00000000-0000-0000-0000-000000000004")!)
+    let root = RegularTerminalSplitNode.split(
+      axis: .horizontal,
+      children: [
+        .panel(primary),
+        .split(axis: .vertical, children: [.panel(shell1), .panel(shell2)]),
+        .panel(shell3)
+      ]
+    )
+
+    let proposal = TerminalPanelDragLayoutEngine.proposal(
+      root: root.terminalPanelLayoutNode,
+      dragging: shell3,
+      over: shell1,
+      placement: .below,
+      containerSize: CGSize(width: 1_000, height: 420),
+      minimumPanelSize: CGSize(width: 240, height: 180)
+    )
+
+    #expect(proposal == nil)
+  }
+
+  @MainActor
+  @Test("Panel kit commits a validated panel rearrangement")
+  func panelKitCommitsValidatedPanelRearrangement() {
+    let agent = TerminalPanelKit.Tab(role: .agent, payload: "agent")
+    let session = TerminalPanelKit.Session(primaryTab: agent)
+    let shell1 = TerminalPanelKit.Tab(role: .shell, payload: "shell1")
+    let shell2 = TerminalPanelKit.Tab(role: .shell, payload: "shell2")
+    let firstPanel = session.openPanel(with: shell1, beside: session.primaryPanelID, axis: .horizontal)
+    let secondPanel = session.openPanel(with: shell2, beside: firstPanel!.id, axis: .horizontal)
+
+    let rearrangedRoot = RegularTerminalSplitNode.split(
+      axis: .vertical,
+      children: [
+        .panel(session.primaryPanelID),
+        .panel(secondPanel!.id),
+        .panel(firstPanel!.id)
+      ]
+    )
+
+    #expect(session.rearrangePanels(to: rearrangedRoot))
+    #expect(session.splitRoot == rearrangedRoot)
+    #expect(session.rearrangePanels(to: .panel(RegularTerminalPanelID())) == false)
+  }
+
   @Test("Removing a nested split panel collapses the empty branch")
   func removingNestedPanelCollapsesSplitBranch() {
     let primary = RegularTerminalPanelID(UUID(uuidString: "00000000-0000-0000-0000-000000000001")!)

--- a/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttySplitLayoutBuilder.swift
+++ b/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttySplitLayoutBuilder.swift
@@ -3,6 +3,8 @@
 //  AgentHub
 //
 
+import AgentHubCore
+import CoreGraphics
 import GhosttySwift
 
 enum AgentHubGhosttySplitLayoutBuilder {
@@ -19,7 +21,7 @@ enum AgentHubGhosttySplitLayoutBuilder {
 
     case .split(let splitAxis, let children):
       let updatedChildren = children.map { child in
-        guard child.containsPanel(anchorPanelID) else { return child }
+        guard child.agentHubContainsPanel(anchorPanelID) else { return child }
         return addingPanel(newPanelID, to: child, beside: anchorPanelID, axis: axis)
       }
       return .split(axis: splitAxis, children: updatedChildren)
@@ -65,15 +67,86 @@ enum AgentHubGhosttySplitLayoutBuilder {
       )
     }
   }
+
+  static func rearrangementProposal(
+    root: TerminalSplitLayout.Node,
+    dragging draggedPanelID: TerminalPanelID,
+    over targetPanelID: TerminalPanelID,
+    placement: TerminalPanelDropPlacement,
+    containerSize: CGSize,
+    minimumPanelSize: CGSize = TerminalPanelDragLayoutEngine.defaultMinimumPanelSize
+  ) -> TerminalSplitLayout.Node? {
+    TerminalPanelDragLayoutEngine.proposal(
+      root: root.terminalPanelLayoutNode,
+      dragging: draggedPanelID,
+      over: targetPanelID,
+      placement: placement,
+      containerSize: containerSize,
+      minimumPanelSize: minimumPanelSize
+    ).map { TerminalSplitLayout.Node(layoutNode: $0.root) }
+  }
 }
 
-private extension TerminalSplitLayout.Node {
-  func containsPanel(_ panelID: TerminalPanelID) -> Bool {
+extension TerminalSplitLayout.Node {
+  var agentHubPanelIDs: [TerminalPanelID] {
+    switch self {
+    case .panel(let panelID):
+      return [panelID]
+    case .split(_, let children):
+      return children.flatMap(\.agentHubPanelIDs)
+    }
+  }
+
+  func agentHubContainsPanel(_ panelID: TerminalPanelID) -> Bool {
     switch self {
     case .panel(let currentPanelID):
       return currentPanelID == panelID
     case .split(_, let children):
-      return children.contains { $0.containsPanel(panelID) }
+      return children.contains { $0.agentHubContainsPanel(panelID) }
+    }
+  }
+
+  init(layoutNode: TerminalPanelLayoutNode<TerminalPanelID>) {
+    switch layoutNode {
+    case .panel(let panelID):
+      self = .panel(panelID)
+    case .split(let axis, let children):
+      self = .split(
+        axis: TerminalSplitAxis(axis),
+        children: children.map(TerminalSplitLayout.Node.init(layoutNode:))
+      )
+    }
+  }
+
+  var terminalPanelLayoutNode: TerminalPanelLayoutNode<TerminalPanelID> {
+    switch self {
+    case .panel(let panelID):
+      return .panel(panelID)
+    case .split(let axis, let children):
+      return .split(
+        axis: axis.terminalPanelLayoutAxis,
+        children: children.map(\.terminalPanelLayoutNode)
+      )
+    }
+  }
+}
+
+extension TerminalSplitAxis {
+  init(_ axis: TerminalPanelLayoutAxis) {
+    switch axis {
+    case .horizontal:
+      self = .horizontal
+    case .vertical:
+      self = .vertical
+    }
+  }
+
+  var terminalPanelLayoutAxis: TerminalPanelLayoutAxis {
+    switch self {
+    case .horizontal:
+      return .horizontal
+    case .vertical:
+      return .vertical
     }
   }
 }

--- a/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalPaneView.swift
+++ b/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalPaneView.swift
@@ -3,6 +3,7 @@
 //  AgentHub
 //
 
+import AgentHubCore
 import GhosttySwift
 import SwiftUI
 
@@ -20,6 +21,10 @@ struct AgentHubGhosttyTerminalPaneView: View {
   let onCloseTab: (TerminalPanel, TerminalTab) -> Void
   let onOpenTab: (TerminalPanel) -> Void
   let onSplitPanel: (TerminalPanel, TerminalSplitAxis) -> Void
+  let dragVisualState: TerminalPanelDragVisualState
+  let coordinateSpaceName: String
+  let onDragChanged: (DragGesture.Value) -> Void
+  let onDragEnded: (DragGesture.Value) -> Void
   let activity: AgentHubGhosttyTerminalPaneActivity?
 
   var body: some View {
@@ -36,6 +41,7 @@ struct AgentHubGhosttyTerminalPaneView: View {
         onSplitBelow: { onSplitPanel(panel, .vertical) },
         onClosePanel: closePanel
       )
+      .simultaneousGesture(panelDragGesture)
 
       if let activeTab = panel.activeTab {
         ZStack {
@@ -55,8 +61,22 @@ struct AgentHubGhosttyTerminalPaneView: View {
     }
     .frame(maxWidth: .infinity, maxHeight: .infinity)
     .background(Color.clear)
+    .background {
+      GeometryReader { proxy in
+        Color.clear.preference(
+          key: AgentHubGhosttyPanelFramePreferenceKey.self,
+          value: [panel.id: proxy.frame(in: .named(coordinateSpaceName))]
+        )
+      }
+    }
     .overlay {
-      if panel.id == session.activePanelID && session.visiblePanels.count > 1 {
+      if dragVisualState == .invalid {
+        Rectangle()
+          .stroke(Color.red.opacity(0.85), lineWidth: 2)
+      } else if dragVisualState == .preview {
+        Rectangle()
+          .stroke(Color.accentColor.opacity(0.75), lineWidth: 1)
+      } else if panel.id == session.activePanelID && session.visiblePanels.count > 1 {
         Rectangle()
           .stroke(Color.accentColor.opacity(0.55), lineWidth: 1)
       }
@@ -70,6 +90,12 @@ struct AgentHubGhosttyTerminalPaneView: View {
 
   private var visibleActivity: AgentHubGhosttyTerminalPaneActivity? {
     immediateActivity ?? activity
+  }
+
+  private var panelDragGesture: some Gesture {
+    DragGesture(minimumDistance: 8, coordinateSpace: .named(coordinateSpaceName))
+      .onChanged(onDragChanged)
+      .onEnded(onDragEnded)
   }
 
   private func closePanel() {

--- a/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalSplitView.swift
+++ b/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalSplitView.swift
@@ -3,6 +3,7 @@
 //  AgentHub
 //
 
+import AgentHubCore
 import GhosttySwift
 import SwiftUI
 
@@ -18,6 +19,10 @@ struct AgentHubGhosttyTerminalSplitView: View {
   let onCloseTab: (TerminalPanel, TerminalTab) -> Void
   let onOpenTab: (TerminalPanel) -> Void
   let onSplitPanel: (TerminalPanel, TerminalSplitAxis) -> Void
+  let dragVisualState: (TerminalPanelID) -> TerminalPanelDragVisualState
+  let coordinateSpaceName: String
+  let onPanelDragChanged: (TerminalPanel, DragGesture.Value) -> Void
+  let onPanelDragEnded: (TerminalPanel, DragGesture.Value) -> Void
   let activityForPanel: (TerminalPanelID) -> AgentHubGhosttyTerminalPaneActivity?
 
   var body: some View {
@@ -40,6 +45,10 @@ struct AgentHubGhosttyTerminalSplitView: View {
           onCloseTab: onCloseTab,
           onOpenTab: onOpenTab,
           onSplitPanel: onSplitPanel,
+          dragVisualState: dragVisualState(panel.id),
+          coordinateSpaceName: coordinateSpaceName,
+          onDragChanged: { value in onPanelDragChanged(panel, value) },
+          onDragEnded: { value in onPanelDragEnded(panel, value) },
           activity: activityForPanel(panel.id)
         )
       } else if let activity = activityForPanel(panelID) {
@@ -93,6 +102,10 @@ struct AgentHubGhosttyTerminalSplitView: View {
           onCloseTab: onCloseTab,
           onOpenTab: onOpenTab,
           onSplitPanel: onSplitPanel,
+          dragVisualState: dragVisualState,
+          coordinateSpaceName: coordinateSpaceName,
+          onPanelDragChanged: onPanelDragChanged,
+          onPanelDragEnded: onPanelDragEnded,
           activityForPanel: activityForPanel
         )
         .frame(width: childWidth, height: size.height)
@@ -125,6 +138,10 @@ struct AgentHubGhosttyTerminalSplitView: View {
           onCloseTab: onCloseTab,
           onOpenTab: onOpenTab,
           onSplitPanel: onSplitPanel,
+          dragVisualState: dragVisualState,
+          coordinateSpaceName: coordinateSpaceName,
+          onPanelDragChanged: onPanelDragChanged,
+          onPanelDragEnded: onPanelDragEnded,
           activityForPanel: activityForPanel
         )
         .frame(width: size.width, height: childHeight)

--- a/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalSurface.swift
+++ b/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalSurface.swift
@@ -637,6 +637,9 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
       onSplitPanel: { [weak self] panel, axis in
         self?.openShellPane(axis: axis, anchorPanelID: panel.id)
       },
+      onRearrangePanels: { [weak self] root in
+        self?.rearrangeGhosttyPanels(to: root)
+      },
       activityForPanel: { [weak self] panelID in
         self?.paneActivityRegistry.activity(for: panelID)
       }
@@ -1200,6 +1203,20 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
 
     guard let targetPanel, targetPanel.id != terminalSession.primaryPanelID else { return }
     closeGhosttyPanel(targetPanel)
+  }
+
+  private func rearrangeGhosttyPanels(to root: TerminalSplitLayout.Node) {
+    guard let terminalSession else { return }
+    let currentPanelIDs = terminalSession.visiblePanels.map(\.id)
+    let proposedPanelIDs = root.agentHubPanelIDs
+    guard proposedPanelIDs.count == currentPanelIDs.count,
+          Set(proposedPanelIDs) == Set(currentPanelIDs) else {
+      return
+    }
+    prepareVisiblePanelsForPaneTransition(projectedRoot: root)
+    splitRoot = root
+    refreshWorkspaceRootView()
+    notifyWorkspaceChanged()
   }
 
   private func canCloseGhosttyPanel(_ panel: TerminalPanel) -> Bool {

--- a/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalWorkspaceView.swift
+++ b/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalWorkspaceView.swift
@@ -3,11 +3,15 @@
 //  AgentHub
 //
 
+import AgentHubCore
 import GhosttySwift
 import SwiftUI
 
 @MainActor
 struct AgentHubGhosttyTerminalWorkspaceView: View {
+  @State private var panelFrames: [TerminalPanelID: CGRect] = [:]
+  @State private var dragState: AgentHubGhosttyPanelDragState?
+
   let session: TerminalSession
   let splitRoot: TerminalSplitLayout.Node?
   let canClosePanel: (TerminalPanel) -> Bool
@@ -18,31 +22,186 @@ struct AgentHubGhosttyTerminalWorkspaceView: View {
   let onCloseTab: (TerminalPanel, TerminalTab) -> Void
   let onOpenTab: (TerminalPanel) -> Void
   let onSplitPanel: (TerminalPanel, TerminalSplitAxis) -> Void
+  let onRearrangePanels: (TerminalSplitLayout.Node) -> Void
   let activityForPanel: (TerminalPanelID) -> AgentHubGhosttyTerminalPaneActivity?
 
   var body: some View {
-    if session.visiblePanels.isEmpty {
-      Text("No terminal available")
-        .foregroundStyle(.secondary)
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-    } else {
-      AgentHubGhosttyTerminalSplitView(
-        node: resolvedSplitRoot,
-        session: session,
-        canClosePanel: canClosePanel,
-        canCloseTab: canCloseTab,
-        onActivatePanel: onActivatePanel,
-        onSelectTab: onSelectTab,
-        onClosePanel: onClosePanel,
-        onCloseTab: onCloseTab,
-        onOpenTab: onOpenTab,
-        onSplitPanel: onSplitPanel,
-        activityForPanel: activityForPanel
-      )
+    GeometryReader { proxy in
+      if session.visiblePanels.isEmpty {
+        Text("No terminal available")
+          .foregroundStyle(.secondary)
+          .frame(maxWidth: .infinity, maxHeight: .infinity)
+      } else {
+        AgentHubGhosttyTerminalSplitView(
+          node: displayedSplitRoot,
+          session: session,
+          canClosePanel: canClosePanel,
+          canCloseTab: canCloseTab,
+          onActivatePanel: onActivatePanel,
+          onSelectTab: onSelectTab,
+          onClosePanel: onClosePanel,
+          onCloseTab: onCloseTab,
+          onOpenTab: onOpenTab,
+          onSplitPanel: onSplitPanel,
+          dragVisualState: dragVisualState(for:),
+          coordinateSpaceName: Self.coordinateSpaceName,
+          onPanelDragChanged: { panel, value in
+            updatePanelDrag(panel, value: value, containerSize: proxy.size)
+          },
+          onPanelDragEnded: { _, _ in
+            finishPanelDrag()
+          },
+          activityForPanel: activityForPanel
+        )
+      }
+    }
+    .coordinateSpace(name: Self.coordinateSpaceName)
+    .onPreferenceChange(AgentHubGhosttyPanelFramePreferenceKey.self) { frames in
+      panelFrames = frames
+    }
+    .onChange(of: panelIdentity) { _, _ in
+      dragState = nil
     }
   }
 
   private var resolvedSplitRoot: TerminalSplitLayout.Node {
     splitRoot ?? session.splitLayout?.root ?? .panel(session.primaryPanelID)
+  }
+
+  private var displayedSplitRoot: TerminalSplitLayout.Node {
+    dragState?.proposalRoot ?? resolvedSplitRoot
+  }
+
+  private var panelIdentity: [TerminalPanelID] {
+    session.visiblePanels.map(\.id)
+  }
+
+  private static let coordinateSpaceName = "AgentHubGhosttyWorkspaceCoordinateSpace"
+  private static let nearestTargetDistance: CGFloat = 96
+
+  private func updatePanelDrag(
+    _ panel: TerminalPanel,
+    value: DragGesture.Value,
+    containerSize: CGSize
+  ) {
+    guard session.visiblePanels.count > 1 else { return }
+    let sourceRoot = dragState?.sourceRoot ?? resolvedSplitRoot
+    let sourceFrames = dragState?.sourceFrames ?? usablePanelFrames(
+      containerSize: containerSize,
+      root: sourceRoot
+    )
+
+    guard let target = targetPanel(at: value.location, dragging: panel.id, frames: sourceFrames) else {
+      dragState = AgentHubGhosttyPanelDragState(
+        draggedPanelID: panel.id,
+        sourceRoot: sourceRoot,
+        sourceFrames: sourceFrames,
+        proposalRoot: nil,
+        isInvalid: true
+      )
+      return
+    }
+
+    let placement = dropPlacement(for: value.location, in: target.frame)
+    let proposalRoot = AgentHubGhosttySplitLayoutBuilder.rearrangementProposal(
+      root: sourceRoot,
+      dragging: panel.id,
+      over: target.id,
+      placement: placement,
+      containerSize: containerSize
+    )
+
+    dragState = AgentHubGhosttyPanelDragState(
+      draggedPanelID: panel.id,
+      sourceRoot: sourceRoot,
+      sourceFrames: sourceFrames,
+      proposalRoot: proposalRoot,
+      isInvalid: proposalRoot == nil
+    )
+  }
+
+  private func finishPanelDrag() {
+    defer { dragState = nil }
+    guard let proposalRoot = dragState?.proposalRoot,
+          dragState?.isInvalid == false else {
+      return
+    }
+    onRearrangePanels(proposalRoot)
+  }
+
+  private func dragVisualState(for panelID: TerminalPanelID) -> TerminalPanelDragVisualState {
+    guard dragState?.draggedPanelID == panelID else { return .inactive }
+    return dragState?.isInvalid == true ? .invalid : .preview
+  }
+
+  private func targetPanel(
+    at point: CGPoint,
+    dragging draggedPanelID: TerminalPanelID,
+    frames sourceFrames: [TerminalPanelID: CGRect]
+  ) -> (id: TerminalPanelID, frame: CGRect)? {
+    let frames = sourceFrames.filter { $0.key != draggedPanelID }
+    guard !frames.isEmpty else { return nil }
+
+    if let contained = frames.first(where: { $0.value.insetBy(dx: -12, dy: -12).contains(point) }) {
+      return (contained.key, contained.value)
+    }
+
+    guard let nearest = frames.min(by: {
+      distance(from: point, to: $0.value) < distance(from: point, to: $1.value)
+    }) else {
+      return nil
+    }
+    guard distance(from: point, to: nearest.value) <= Self.nearestTargetDistance else {
+      return nil
+    }
+    return (nearest.key, nearest.value)
+  }
+
+  private func usablePanelFrames(
+    containerSize: CGSize,
+    root: TerminalSplitLayout.Node
+  ) -> [TerminalPanelID: CGRect] {
+    if !panelFrames.isEmpty {
+      return panelFrames
+    }
+    return TerminalPanelDragLayoutEngine.panelFrames(
+      for: root.terminalPanelLayoutNode,
+      in: CGRect(origin: .zero, size: containerSize)
+    )
+  }
+
+  private func dropPlacement(for point: CGPoint, in frame: CGRect) -> TerminalPanelDropPlacement {
+    let distances: [(distance: CGFloat, placement: TerminalPanelDropPlacement)] = [
+      (abs(point.x - frame.minX), .leading),
+      (abs(point.x - frame.maxX), .trailing),
+      (abs(point.y - frame.minY), .above),
+      (abs(point.y - frame.maxY), .below)
+    ]
+    return distances.min(by: { $0.distance < $1.distance })?.placement ?? .trailing
+  }
+
+  private func distance(from point: CGPoint, to frame: CGRect) -> CGFloat {
+    let dx = max(frame.minX - point.x, 0, point.x - frame.maxX)
+    let dy = max(frame.minY - point.y, 0, point.y - frame.maxY)
+    return sqrt(dx * dx + dy * dy)
+  }
+}
+
+private struct AgentHubGhosttyPanelDragState {
+  let draggedPanelID: TerminalPanelID
+  let sourceRoot: TerminalSplitLayout.Node
+  let sourceFrames: [TerminalPanelID: CGRect]
+  let proposalRoot: TerminalSplitLayout.Node?
+  let isInvalid: Bool
+}
+
+struct AgentHubGhosttyPanelFramePreferenceKey: PreferenceKey {
+  static var defaultValue: [TerminalPanelID: CGRect] = [:]
+
+  static func reduce(
+    value: inout [TerminalPanelID: CGRect],
+    nextValue: () -> [TerminalPanelID: CGRect]
+  ) {
+    value.merge(nextValue(), uniquingKeysWith: { _, next in next })
   }
 }

--- a/app/modules/Ghostty/Tests/GhosttyTests/AgentHubGhosttySplitLayoutBuilderTests.swift
+++ b/app/modules/Ghostty/Tests/GhosttyTests/AgentHubGhosttySplitLayoutBuilderTests.swift
@@ -1,3 +1,5 @@
+import AgentHubCore
+import CoreGraphics
 import Foundation
 import GhosttySwift
 import Testing
@@ -86,5 +88,27 @@ struct AgentHubGhosttySplitLayoutBuilderTests {
     )
 
     #expect(result == .split(axis: .vertical, children: [.panel(primary), .panel(shell)]))
+  }
+
+  @Test("Drag proposal switches a flat stack when the current orientation is too small")
+  func dragProposalSwitchesFlatStackWhenCurrentOrientationIsTooSmall() {
+    let primary = TerminalPanelID(UUID(uuidString: "00000000-0000-0000-0000-000000000001")!)
+    let shell1 = TerminalPanelID(UUID(uuidString: "00000000-0000-0000-0000-000000000002")!)
+    let shell2 = TerminalPanelID(UUID(uuidString: "00000000-0000-0000-0000-000000000003")!)
+    let root = TerminalSplitLayout.Node.split(
+      axis: .vertical,
+      children: [.panel(primary), .panel(shell1), .panel(shell2)]
+    )
+
+    let result = AgentHubGhosttySplitLayoutBuilder.rearrangementProposal(
+      root: root,
+      dragging: shell2,
+      over: shell1,
+      placement: .below,
+      containerSize: CGSize(width: 900, height: 420),
+      minimumPanelSize: CGSize(width: 260, height: 180)
+    )
+
+    #expect(result == .split(axis: .horizontal, children: [.panel(primary), .panel(shell1), .panel(shell2)]))
   }
 }


### PR DESCRIPTION
## Summary

Adds drag-and-drop rearrangement for terminal panels across both the regular SwiftTerm workspace and the Ghostty-backed workspace.

## Changes

- Added a shared panel drag layout engine that validates proposed drops, calculates preview frames, and reflows flat stacks when the current axis cannot fit the layout.
- Wired pane-header dragging into the regular and Ghostty terminal views so valid drops preview the proposed layout before release.
- Added invalid-drop red borders on the dragged panel and commit handling that updates the split root on release.
- Added focused coverage for reflow proposals, invalid no-fit drops, nested-stack rejection, and split-root commit validation.

## Validation

- `swiftc -typecheck app/modules/AgentHubCore/Sources/AgentHub/UI/TerminalPanelDragLayoutEngine.swift`
- Isolated type-check of the regular terminal workspace with local stubs
- Parse check for modified Ghostty Swift files
- Local engine behavior check for vertical-to-horizontal reflow and invalid no-fit cases
- `git diff --check`

Focused SwiftPM tests were attempted, but package compilation is currently blocked by the existing `CodeEditSymbols` dependency error: `type 'Bundle' has no member 'module'`.