### PR TITLE
Remove libgit2 fallback assertionFailure in GitDiffService

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHubGitDiff/Services/GitDiffService.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHubGitDiff/Services/GitDiffService.swift
@@ -101,7 +101,6 @@ public actor GitDiffService: GitDiffServiceProtocol {
       return state
     } catch {
       Self.logger.warning("libgit2 changedFiles fallback: \(error.localizedDescription)")
-      assertionFailure("libgit2 changedFiles fallback in \(mode.rawValue): \(error.localizedDescription)")
     }
 
     switch mode {


### PR DESCRIPTION
## Summary
- Drop the `assertionFailure` in `GitDiffService.changedFiles` libgit2 fallback path. The warning log is retained, but the assertion was firing on expected fallback conditions in debug builds.

## Test plan
- [ ] Trigger a libgit2 fallback in a debug build and confirm no assertion fires
- [ ] Verify the warning log still appears