### PR TITLE
[codex] Add expandable web preview shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ Updates are delivered automatically via [Sparkle](https://sparkle-project.org/) 
 | **Cmd+B** | Toggle sidebar |
 | **Cmd+J** | Toggle Hub auxiliary shell |
 | **Cmd+,** | Open settings |
+| **Cmd+Shift+O** | Expand/collapse the embedded web preview |
 | **Cmd+[** | Navigate to previous session |
 | **Cmd+]** | Navigate to next session |
 | **Cmd+\\** | Toggle focus mode (single ↔ previous layout) |
@@ -167,6 +168,16 @@ Updates are delivered automatically via [Sparkle](https://sparkle-project.org/) 
 | **Cmd+P** | Open quick file picker |
 | **Cmd+S** | Save current file in file editor |
 | **Escape** | Close quick file picker or file editor |
+
+### Web Preview
+
+| Shortcut | Action |
+|---|---|
+| **Cmd+Shift+O** | Expand/collapse the embedded web preview |
+| **Cmd+Shift+I** | Cycle inspect, crop, edit, and off |
+| **Cmd+R** | Reload preview |
+| **Cmd+Return** | Send queued canvas feedback or update preview |
+| **Escape** | Close preview |
 
 ### Embedded Terminal
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/CommandPaletteView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/CommandPaletteView.swift
@@ -79,6 +79,43 @@ public enum CommandPaletteAction: Identifiable {
   }
 }
 
+private struct CommandPaletteItem: Identifiable {
+  let id: String
+  let title: String
+  let subtitle: String?
+  let icon: String
+  let shortcut: String?
+  let action: CommandPaletteAction?
+
+  static func action(_ action: CommandPaletteAction) -> CommandPaletteItem {
+    CommandPaletteItem(
+      id: action.id,
+      title: action.title,
+      subtitle: action.subtitle,
+      icon: action.icon,
+      shortcut: action.shortcut,
+      action: action
+    )
+  }
+
+  static func shortcut(
+    id: String,
+    title: String,
+    subtitle: String,
+    icon: String,
+    shortcut: String
+  ) -> CommandPaletteItem {
+    CommandPaletteItem(
+      id: id,
+      title: title,
+      subtitle: subtitle,
+      icon: icon,
+      shortcut: shortcut,
+      action: nil
+    )
+  }
+}
+
 // MARK: - CommandPaletteView
 
 public struct CommandPaletteView: View {
@@ -106,8 +143,54 @@ public struct CommandPaletteView: View {
     ]
   }
 
-  private var displayedActions: [CommandPaletteAction] {
-    quickActions + filteredSessionActions
+  private var shortcutInfoItems: [CommandPaletteItem] {
+    [
+      .shortcut(
+        id: "shortcut-web-preview-width",
+        title: "Web Preview: Toggle Width",
+        subtitle: "Expand or collapse the embedded preview",
+        icon: "arrow.up.left.and.arrow.down.right",
+        shortcut: "⌘⇧O"
+      ),
+      .shortcut(
+        id: "shortcut-web-preview-inspect",
+        title: "Web Preview: Cycle Inspect Modes",
+        subtitle: "Inspect, crop, edit, then off",
+        icon: "cursorarrow.rays",
+        shortcut: "⌘⇧I"
+      ),
+      .shortcut(
+        id: "shortcut-web-preview-reload",
+        title: "Web Preview: Reload",
+        subtitle: "Reload the current preview",
+        icon: "arrow.clockwise",
+        shortcut: "⌘R"
+      ),
+      .shortcut(
+        id: "shortcut-web-preview-submit",
+        title: "Web Preview: Send or Update",
+        subtitle: "Send queued canvas feedback or update preview",
+        icon: "paperplane",
+        shortcut: "⌘↩"
+      ),
+      .shortcut(
+        id: "shortcut-web-preview-close",
+        title: "Web Preview: Close",
+        subtitle: "Close the preview",
+        icon: "xmark",
+        shortcut: "Esc"
+      ),
+    ]
+  }
+
+  private var nonSessionItemCount: Int {
+    quickActions.count + shortcutInfoItems.count
+  }
+
+  private var displayedItems: [CommandPaletteItem] {
+    quickActions.map(CommandPaletteItem.action)
+      + shortcutInfoItems
+      + filteredSessionActions.map(CommandPaletteItem.action)
   }
 
   private func performSearch() {
@@ -180,8 +263,8 @@ public struct CommandPaletteView: View {
     }
   }
 
-  private var displayedActionIDs: [String] {
-    displayedActions.map(\.id)
+  private var displayedItemIDs: [String] {
+    displayedItems.map(\.id)
   }
 
   public var body: some View {
@@ -238,16 +321,16 @@ public struct CommandPaletteView: View {
         ScrollViewReader { proxy in
           ScrollView {
             LazyVStack(spacing: 2) {
-              if displayedActions.isEmpty {
+              if displayedItems.isEmpty {
                 emptyState
               } else {
-                ForEach(Array(displayedActions.enumerated()), id: \.element.id) { index, action in
+                ForEach(Array(displayedItems.enumerated()), id: \.element.id) { index, item in
                   CommandPaletteRow(
-                    action: action,
+                    item: item,
                     isSelected: index == selectedIndex
                   )
-                  .id(action.id)
-                  .onTapGesture { executeAction(action) }
+                  .id(item.id)
+                  .onTapGesture { executeItem(item) }
                 }
               }
             }
@@ -255,10 +338,10 @@ public struct CommandPaletteView: View {
           }
           .frame(maxHeight: 400)
           .onChange(of: selectedIndex) { _, newIndex in
-            let actions = displayedActions
-            guard newIndex >= 0, newIndex < actions.count else { return }
+            let items = displayedItems
+            guard newIndex >= 0, newIndex < items.count else { return }
             withAnimation(.easeInOut(duration: 0.15)) {
-              proxy.scrollTo(actions[newIndex].id, anchor: .center)
+              proxy.scrollTo(items[newIndex].id, anchor: .center)
             }
           }
         }
@@ -285,9 +368,9 @@ public struct CommandPaletteView: View {
     .onDisappear {
       searchTask?.cancel()
     }
-    .onChange(of: displayedActionIDs) { _, _ in
+    .onChange(of: displayedItemIDs) { _, _ in
       if !normalizedQuery.isEmpty && !filteredSessionActions.isEmpty {
-        selectedIndex = quickActions.count
+        selectedIndex = nonSessionItemCount
       } else {
         clampSelectedIndex()
       }
@@ -301,31 +384,31 @@ public struct CommandPaletteView: View {
       }
 
       if !filteredSessionActions.isEmpty {
-        selectedIndex = quickActions.count
+        selectedIndex = nonSessionItemCount
       } else {
         selectedIndex = 0
       }
     }
     .onKeyPress(.upArrow) {
-      guard !displayedActions.isEmpty else { return .handled }
+      guard !displayedItems.isEmpty else { return .handled }
       if selectedIndex > 0 {
         selectedIndex -= 1
       }
       return .handled
     }
     .onKeyPress(.downArrow) {
-      guard !displayedActions.isEmpty else { return .handled }
-      if selectedIndex < displayedActions.count - 1 {
+      guard !displayedItems.isEmpty else { return .handled }
+      if selectedIndex < displayedItems.count - 1 {
         selectedIndex += 1
       }
       return .handled
     }
     .onKeyPress(.return) {
-      let actions = displayedActions
-      guard !actions.isEmpty else { return .handled }
-      let safeIndex = max(0, min(selectedIndex, actions.count - 1))
+      let items = displayedItems
+      guard !items.isEmpty else { return .handled }
+      let safeIndex = max(0, min(selectedIndex, items.count - 1))
       selectedIndex = safeIndex
-      executeAction(actions[safeIndex])
+      executeItem(items[safeIndex])
       return .handled
     }
     .onKeyPress(.escape) {
@@ -356,7 +439,7 @@ public struct CommandPaletteView: View {
   }
 
   private func clampSelectedIndex() {
-    let count = displayedActions.count
+    let count = displayedItems.count
     if count == 0 {
       selectedIndex = 0
       return
@@ -364,7 +447,9 @@ public struct CommandPaletteView: View {
     selectedIndex = max(0, min(selectedIndex, count - 1))
   }
 
-  private func executeAction(_ action: CommandPaletteAction) {
+  private func executeItem(_ item: CommandPaletteItem) {
+    guard let action = item.action else { return }
+
     isPresented = false
 
     Task { @MainActor in
@@ -384,22 +469,22 @@ private struct SessionMatch {
 // MARK: - CommandPaletteRow
 
 private struct CommandPaletteRow: View {
-  let action: CommandPaletteAction
+  let item: CommandPaletteItem
   let isSelected: Bool
 
   var body: some View {
     HStack(spacing: 12) {
-      Image(systemName: action.icon)
+      Image(systemName: item.icon)
         .font(.system(size: 16))
         .foregroundColor(isSelected ? .brandPrimary : .secondary)
         .frame(width: 20)
 
       VStack(alignment: .leading, spacing: 2) {
-        Text(action.title)
+        Text(item.title)
           .font(.geist(size: 13, weight: isSelected ? .semibold : .regular))
           .foregroundColor(.primary)
 
-        if let subtitle = action.subtitle {
+        if let subtitle = item.subtitle {
           Text(subtitle)
             .font(.secondarySmall)
             .foregroundColor(.secondary)
@@ -409,7 +494,7 @@ private struct CommandPaletteRow: View {
 
       Spacer()
 
-      if let shortcut = action.shortcut {
+      if let shortcut = item.shortcut {
         Text(shortcut)
           .font(.primarySmall)
           .foregroundColor(.secondary.opacity(0.7))

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/EmbeddedSidePanelExpansionState.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/EmbeddedSidePanelExpansionState.swift
@@ -1,0 +1,40 @@
+//
+//  EmbeddedSidePanelExpansionState.swift
+//  AgentHub
+//
+
+import SwiftUI
+
+@MainActor
+@Observable
+final class EmbeddedSidePanelExpansionState<Payload: Equatable> {
+  private(set) var expandedPayload: Payload?
+
+  func isExpanded(for payload: Payload) -> Bool {
+    expandedPayload == payload
+  }
+
+  func toggle(for payload: Payload) {
+    if expandedPayload == payload {
+      expandedPayload = nil
+    } else {
+      expandedPayload = payload
+    }
+  }
+
+  func collapse(ifExpanded payload: Payload) {
+    guard expandedPayload == payload else { return }
+    expandedPayload = nil
+  }
+
+  func collapse() {
+    expandedPayload = nil
+  }
+
+  func reconcile(currentPayload: Payload?) {
+    guard let expandedPayload else { return }
+    if currentPayload != expandedPayload {
+      self.expandedPayload = nil
+    }
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderMonitoringPanelView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderMonitoringPanelView.swift
@@ -148,6 +148,7 @@ public struct MultiProviderMonitoringPanelView: View {
 
   @State private var sessionFileSheetItem: SessionFileSheetItem?
   @State private var sidePanelPresentation = EmbeddedSidePanelPresentationState<SidePanelPayload>()
+  @State private var sidePanelExpansion = EmbeddedSidePanelExpansionState<SidePanelPayload>()
   @State private var autoOpenedSidePanelKeys: Set<MonitoringAutoOpenSidePanelKey> = []
   @State private var autoOpenBaselineDate: Date?
   @State private var observedAutoOpenKeysBySessionID: [String: Set<MonitoringAutoOpenSidePanelKey>] = [:]
@@ -179,6 +180,10 @@ public struct MultiProviderMonitoringPanelView: View {
       embeddedSidePanelMaxWidth,
       max(embeddedSidePanelMinWidth, availablePanelWidth)
     )
+  }
+
+  private var expandedEmbeddedSidePanelWidth: CGFloat {
+    max(embeddedSidePanelMinWidth, availableDetailWidth)
   }
 
   private func wantsEmbeddedSidePanelPresentation(snapshot: MonitoringItemsSnapshot<ProviderMonitoringItem>) -> Bool {
@@ -653,17 +658,33 @@ public struct MultiProviderMonitoringPanelView: View {
     @ViewBuilder content: () -> Content
   ) -> some View {
     HStack(spacing: 0) {
+      let isSidePanelExpanded = sidePanelPresentation.shellPayload.map {
+        sidePanelExpansion.isExpanded(for: $0)
+      } ?? false
+
       content()
-        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
+        .frame(width: isSidePanelExpanded ? 0 : nil)
+        .frame(
+          maxWidth: isSidePanelExpanded ? 0 : .infinity,
+          maxHeight: .infinity,
+          alignment: .leading
+        )
+        .opacity(isSidePanelExpanded ? 0 : 1)
+        .allowsHitTesting(!isSidePanelExpanded)
+        .accessibilityHidden(isSidePanelExpanded)
+        .clipped()
         .blursWhileResizing()
 
       if let shellPayload = sidePanelPresentation.shellPayload {
+        let isExpanded = sidePanelExpansion.isExpanded(for: shellPayload)
+
         ResizablePanelContainer(
           side: .trailing,
           minWidth: embeddedSidePanelMinWidth,
           maxWidth: allowedEmbeddedSidePanelWidth,
           defaultWidth: min(embeddedSidePanelDefaultWidth, allowedEmbeddedSidePanelWidth),
-          userDefaultsKey: AgentHubDefaults.sidePanelWidth
+          userDefaultsKey: AgentHubDefaults.sidePanelWidth,
+          fixedWidth: isExpanded ? expandedEmbeddedSidePanelWidth : nil
         ) {
           ZStack {
             if let mountedPayload = sidePanelPresentation.mountedPayload,
@@ -678,6 +699,7 @@ public struct MultiProviderMonitoringPanelView: View {
           .clipped()
         }
         .animation(embeddedSidePanelContentAnimation, value: sidePanelPresentation.mountedPayload)
+        .animation(embeddedSidePanelContentAnimation, value: isExpanded)
       }
     }
   }
@@ -807,13 +829,27 @@ public struct MultiProviderMonitoringPanelView: View {
   }
 
   private func openEmbeddedSidePanel(_ payload: SidePanelPayload) {
+    sidePanelExpansion.reconcile(currentPayload: payload)
     let transitionID = sidePanelPresentation.open(payload)
     completeDeferredSidePanelTransition(transitionID)
   }
 
   private func closeEmbeddedSidePanel() {
+    sidePanelExpansion.collapse()
     let transitionID = sidePanelPresentation.close()
     completeDeferredSidePanelTransition(transitionID, delay: embeddedSidePanelCloseShellDelay)
+  }
+
+  private func toggleEmbeddedSidePanelExpansion(for payload: SidePanelPayload) {
+    withAnimation(embeddedSidePanelContentAnimation) {
+      sidePanelExpansion.toggle(for: payload)
+    }
+  }
+
+  private func collapseEmbeddedSidePanelExpansion(for payload: SidePanelPayload) {
+    withAnimation(embeddedSidePanelContentAnimation) {
+      sidePanelExpansion.collapse(ifExpanded: payload)
+    }
   }
 
   private func completeDeferredSidePanelTransition(_ transitionID: UInt64, delay: Duration? = nil) {
@@ -893,6 +929,9 @@ public struct MultiProviderMonitoringPanelView: View {
         mode: mode,
         agentLocalhostURL: viewModel.monitorStates[sessionId]?.detectedLocalhostURL,
         monitorState: viewModel.monitorStates[sessionId],
+        isExpanded: sidePanelExpansion.isExpanded(for: payload),
+        onToggleExpanded: { toggleEmbeddedSidePanelExpansion(for: payload) },
+        onCollapseExpandedAfterSend: { collapseEmbeddedSidePanelExpansion(for: payload) },
         inlineEditReconciler: viewModel.agentHubProvider?.inlineEditReconciler
       )
     case .mermaid(_, let session):

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/ResizableSplitHandle.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/ResizableSplitHandle.swift
@@ -136,6 +136,7 @@ struct ResizablePanelContainer<Content: View>: View {
   let maxWidth: CGFloat
   let defaultWidth: CGFloat
   let userDefaultsKey: String
+  let fixedWidth: CGFloat?
   let content: Content
 
   @State private var width: CGFloat
@@ -146,6 +147,7 @@ struct ResizablePanelContainer<Content: View>: View {
     maxWidth: CGFloat,
     defaultWidth: CGFloat,
     userDefaultsKey: String,
+    fixedWidth: CGFloat? = nil,
     @ViewBuilder content: () -> Content
   ) {
     self.side = side
@@ -153,6 +155,7 @@ struct ResizablePanelContainer<Content: View>: View {
     self.maxWidth = maxWidth
     self.defaultWidth = defaultWidth
     self.userDefaultsKey = userDefaultsKey
+    self.fixedWidth = fixedWidth
     self.content = content()
 
     let savedWidth = UserDefaults.standard.double(forKey: userDefaultsKey)
@@ -161,18 +164,25 @@ struct ResizablePanelContainer<Content: View>: View {
   }
 
   private var resolvedWidth: CGFloat {
-    Self.clamped(width, minWidth: minWidth, maxWidth: maxWidth)
+    if let fixedWidth {
+      return max(0, fixedWidth)
+    }
+    return Self.clamped(width, minWidth: minWidth, maxWidth: maxWidth)
+  }
+
+  private var isFixedWidth: Bool {
+    fixedWidth != nil
   }
 
   var body: some View {
     HStack(spacing: 0) {
       if side == .trailing {
-        handle
+        handleSlot
           .zIndex(2)
         resizableContent
       } else {
         resizableContent
-        handle
+        handleSlot
           .zIndex(2)
       }
     }
@@ -184,6 +194,15 @@ struct ResizablePanelContainer<Content: View>: View {
     content
       .frame(width: resolvedWidth)
       .blursWhileResizing()
+  }
+
+  private var handleSlot: some View {
+    handle
+      .opacity(isFixedWidth ? 0 : 1)
+      .frame(width: isFixedWidth ? 0 : 8)
+      .clipped()
+      .allowsHitTesting(!isFixedWidth)
+      .accessibilityHidden(isFixedWidth)
   }
 
   private var handle: some View {

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/WebPreviewView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/WebPreviewView.swift
@@ -127,6 +127,9 @@ public struct WebPreviewView: View {
   /// the primary app server.
   var agentLocalhostURL: URL?
   var monitorState: SessionMonitorState?
+  let isExpanded: Bool
+  var onToggleExpanded: (() -> Void)?
+  var onCollapseExpandedAfterSend: (() -> Void)?
   /// Reachability probe used before connecting to an agent-advertised URL.
   /// Injected so tests can substitute a deterministic mock.
   var reachabilityProbe: any LocalhostReachabilityProbing = LocalhostReachabilityProbe()
@@ -190,6 +193,9 @@ public struct WebPreviewView: View {
     mode: WebPreviewMode = .app,
     agentLocalhostURL: URL? = nil,
     monitorState: SessionMonitorState? = nil,
+    isExpanded: Bool = false,
+    onToggleExpanded: (() -> Void)? = nil,
+    onCollapseExpandedAfterSend: (() -> Void)? = nil,
     reachabilityProbe: any LocalhostReachabilityProbing = LocalhostReachabilityProbe(),
     inlineEditReconciler: (any InlineEditStyleReconcilerProtocol)? = nil
   ) {
@@ -203,6 +209,9 @@ public struct WebPreviewView: View {
     self.mode = mode
     self.agentLocalhostURL = agentLocalhostURL
     self.monitorState = monitorState
+    self.isExpanded = isExpanded
+    self.onToggleExpanded = onToggleExpanded
+    self.onCollapseExpandedAfterSend = onCollapseExpandedAfterSend
     self.reachabilityProbe = reachabilityProbe
     self._inspectorViewModel = State(
       initialValue: WebPreviewInspectorViewModel(
@@ -516,8 +525,8 @@ public struct WebPreviewView: View {
       .buttonStyle(.plain)
       .help(
         inspectState.isActive
-          ? "Stop \(inspectBehavior.modeName) mode. Cmd+Shift+I cycles modes."
-          : "Start inspect mode (Cmd+Shift+I)"
+          ? "Stop \(inspectBehavior.modeName) mode. ⌘⇧I cycles modes."
+          : "Start inspect mode (⌘⇧I)"
       )
 
       if inspectState.isActive {
@@ -578,10 +587,24 @@ public struct WebPreviewView: View {
         EmptyView()
       }
 
+      if isEmbedded, let onToggleExpanded {
+        Button(action: onToggleExpanded) {
+          Image(systemName: isExpanded ? "arrow.down.right.and.arrow.up.left" : "arrow.up.left.and.arrow.down.right")
+            .font(.system(size: 13, weight: .medium))
+            .foregroundStyle(.secondary)
+            .frame(width: 24, height: 24)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(isExpanded ? "Collapse preview" : "Expand preview to full width")
+        .help(isExpanded ? "Collapse preview (⌘⇧O)" : "Expand preview to full width (⌘⇧O)")
+      }
+
       Button("Close") {
         onDismiss()
       }
       .controlSize(.small)
+      .help("Close preview (Esc)")
     }
     .overlay {
       // Hidden keyboard shortcuts — kept outside HStack layout to avoid phantom spacing
@@ -594,6 +617,10 @@ public struct WebPreviewView: View {
           Button("") { handleManualUpdate() }
             .keyboardShortcut(.return, modifiers: .command)
             .disabled(!updateState.isEnabled)
+        }
+        if isEmbedded, let onToggleExpanded {
+          Button("") { onToggleExpanded() }
+            .keyboardShortcut("o", modifiers: [.command, .shift])
         }
       }
       .hidden()
@@ -1749,11 +1776,13 @@ public struct WebPreviewView: View {
         queueSendFailureMessage = "Could not find an active terminal for this session. Keep the preview open and try again when the terminal is ready."
         return false
       }
+      onCollapseExpandedAfterSend?()
       return true
     }
 
     guard let onInspectSubmit else { return false }
     onInspectSubmit(finalPrompt, session)
+    onCollapseExpandedAfterSend?()
     return true
   }
 

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/EmbeddedSidePanelExpansionStateTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/EmbeddedSidePanelExpansionStateTests.swift
@@ -1,0 +1,61 @@
+import Testing
+
+@testable import AgentHubCore
+
+@MainActor
+@Suite("EmbeddedSidePanelExpansionState")
+struct EmbeddedSidePanelExpansionStateTests {
+  @Test("Toggle expands and collapses the same payload")
+  func toggleExpandsAndCollapsesSamePayload() {
+    let state = EmbeddedSidePanelExpansionState<String>()
+
+    state.toggle(for: "web")
+
+    #expect(state.isExpanded(for: "web"))
+    #expect(state.expandedPayload == "web")
+
+    state.toggle(for: "web")
+
+    #expect(!state.isExpanded(for: "web"))
+    #expect(state.expandedPayload == nil)
+  }
+
+  @Test("Toggling another payload transfers expansion")
+  func togglingAnotherPayloadTransfersExpansion() {
+    let state = EmbeddedSidePanelExpansionState<String>()
+
+    state.toggle(for: "web")
+    state.toggle(for: "diff")
+
+    #expect(!state.isExpanded(for: "web"))
+    #expect(state.isExpanded(for: "diff"))
+  }
+
+  @Test("Collapse if expanded only affects matching payload")
+  func collapseIfExpandedOnlyAffectsMatchingPayload() {
+    let state = EmbeddedSidePanelExpansionState<String>()
+
+    state.toggle(for: "web")
+    state.collapse(ifExpanded: "diff")
+
+    #expect(state.isExpanded(for: "web"))
+
+    state.collapse(ifExpanded: "web")
+
+    #expect(state.expandedPayload == nil)
+  }
+
+  @Test("Reconcile clears stale expansion")
+  func reconcileClearsStaleExpansion() {
+    let state = EmbeddedSidePanelExpansionState<String>()
+
+    state.toggle(for: "web")
+    state.reconcile(currentPayload: "web")
+
+    #expect(state.isExpanded(for: "web"))
+
+    state.reconcile(currentPayload: "diff")
+
+    #expect(state.expandedPayload == nil)
+  }
+}


### PR DESCRIPTION
## Summary

- Add an embedded web preview expand/collapse control and `⌘⇧O` shortcut.
- Keep the rendered preview mounted while the side panel width animates, avoiding dev-server/static-preview restarts on width changes.
- Collapse the expanded preview after successful canvas feedback send.
- Restore `⌘⇧I` as the inspect/crop/edit/off cycle and show web preview shortcuts in README plus informational `Cmd+K` palette rows.

## Validation

- `git diff --check`
- `xcodebuild -project app/AgentHub.xcodeproj -scheme AgentHub -destination 'platform=macOS' build`