### PR TITLE
[codex] Keep PR visibility resilient

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/CollapsibleSessionRow.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/CollapsibleSessionRow.swift
@@ -98,8 +98,8 @@ struct CollapsibleSessionRow: View {
         // Row 1: name + provider + status + time
         HStack(spacing: 6) {
           Text(displayName)
-            .font(.secondaryDefault)
-            .foregroundColor(.primary)
+            .font(.secondarySmall)
+            .foregroundColor(.secondary.opacity(0.7))
             .lineLimit(1)
             .layoutPriority(1)
 
@@ -128,8 +128,8 @@ struct CollapsibleSessionRow: View {
         HStack(spacing: 0) {
           if let message = session.firstMessage, !message.isEmpty {
             Text(message)
-              .font(.secondarySmall)
-              .foregroundColor(.secondary.opacity(0.7))
+              .font(.secondaryDefault)
+              .foregroundColor(.primary)
               .lineLimit(1)
           }
 

--- a/app/modules/AgentHubGitHub/Sources/AgentHubGitHub/Services/GitHubCLIService.swift
+++ b/app/modules/AgentHubGitHub/Sources/AgentHubGitHub/Services/GitHubCLIService.swift
@@ -46,6 +46,7 @@ public actor GitHubCLIService {
   private static let commandTimeout: TimeInterval = 30.0
   static let checksJSONFields = "name,state,link,bucket"
   static let noPullRequestsFoundMessageFragment = "no pull requests found"
+  static let noChecksReportedMessageFragment = "no checks reported"
 
   /// Cached gh executable path
   private var ghPath: String?
@@ -427,8 +428,20 @@ public actor GitHubCLIService {
     }
     args.append(contentsOf: ["--json", Self.checksJSONFields])
 
-    let json = try await runGH(args, at: repoPath, allowedExitCodes: [0, 8])
-    return try Self.decodeCheckRuns(json)
+    do {
+      let json = try await runGH(
+        args,
+        at: repoPath,
+        allowedExitCodes: [0, 8],
+        quietFailureMessages: [Self.noChecksReportedMessageFragment]
+      )
+      return try Self.decodeCheckRuns(json)
+    } catch let error as GitHubCLIError {
+      if case .commandFailed(let message) = error, Self.isNoChecksReportedMessage(message) {
+        return []
+      }
+      throw error
+    }
   }
 
   // MARK: - Notifications / Workflow Runs
@@ -594,6 +607,10 @@ public actor GitHubCLIService {
 
   static func isNoCurrentBranchPRMessage(_ message: String) -> Bool {
     message.localizedCaseInsensitiveContains(noPullRequestsFoundMessageFragment)
+  }
+
+  static func isNoChecksReportedMessage(_ message: String) -> Bool {
+    message.localizedCaseInsensitiveContains(noChecksReportedMessageFragment)
   }
 
   private static func shouldLogFailureQuietly(

--- a/app/modules/AgentHubGitHub/Sources/AgentHubGitHub/Services/GitHubPRObservationService.swift
+++ b/app/modules/AgentHubGitHub/Sources/AgentHubGitHub/Services/GitHubPRObservationService.swift
@@ -465,30 +465,41 @@ public actor GitHubPRObservationService: GitHubPRObservationServiceProtocol {
             lastRefreshedAt: .now
           ))
         }
-        let checks = try await service.getChecks(prNumber: pullRequest.number, at: projectPath)
+        let checksResult = await fetchChecks(prNumber: pullRequest.number, at: projectPath)
         return .success(GitHubPRObservationSnapshot(
           target: target,
           pullRequest: pullRequest,
-          checks: checks,
-          state: .ready,
+          checks: checksResult.checks,
+          state: checksResult.state,
           lastRefreshedAt: .now
         ))
 
       case .pullRequest(let projectPath, let number):
-        async let pullRequest = service.getPullRequest(number: number, at: projectPath)
-        async let checks = service.getChecks(prNumber: number, at: projectPath)
-        let (resolvedPullRequest, resolvedChecks) = try await (pullRequest, checks)
+        let resolvedPullRequest = try await service.getPullRequest(number: number, at: projectPath)
+        let checksResult = await fetchChecks(prNumber: number, at: projectPath)
         let snapshot = GitHubPRObservationSnapshot(
           target: target,
           pullRequest: resolvedPullRequest,
-          checks: resolvedChecks,
-          state: .ready,
+          checks: checksResult.checks,
+          state: checksResult.state,
           lastRefreshedAt: .now
         )
         return .success(snapshot)
       }
     } catch {
       return .failure(error)
+    }
+  }
+
+  private func fetchChecks(
+    prNumber: Int,
+    at projectPath: String
+  ) async -> (checks: [GitHubCheckRun], state: GitHubPRObservationState) {
+    do {
+      let checks = try await service.getChecks(prNumber: prNumber, at: projectPath)
+      return (checks, .ready)
+    } catch {
+      return ([], .error(error.localizedDescription))
     }
   }
 

--- a/app/modules/AgentHubGitHub/Tests/AgentHubGitHubTests/GitHubCLIServiceTests.swift
+++ b/app/modules/AgentHubGitHub/Tests/AgentHubGitHubTests/GitHubCLIServiceTests.swift
@@ -44,6 +44,14 @@ struct GitHubCLIServiceParsingTests {
     #expect(!GitHubCLIService.isNoCurrentBranchPRMessage("authentication required"))
   }
 
+  @Test("no checks reported message is recognized")
+  func noChecksReportedMessageIsRecognized() {
+    #expect(GitHubCLIService.isNoChecksReportedMessage(
+      "no checks reported on the 'drag-arrange' branch"
+    ))
+    #expect(!GitHubCLIService.isNoChecksReportedMessage("authentication required"))
+  }
+
   @Test("parsePRFiles handles slurped paginated arrays")
   func parsePRFilesHandlesSlurpedPages() throws {
     let json = """

--- a/app/modules/AgentHubGitHub/Tests/AgentHubGitHubTests/GitHubPRObservationServiceTests.swift
+++ b/app/modules/AgentHubGitHub/Tests/AgentHubGitHubTests/GitHubPRObservationServiceTests.swift
@@ -58,6 +58,18 @@ private func makeObservationConfiguration(
   )
 }
 
+private actor ObservationSnapshotCollector {
+  private var values: [GitHubPRObservationSnapshot] = []
+
+  func append(_ snapshot: GitHubPRObservationSnapshot) {
+    values.append(snapshot)
+  }
+
+  func snapshots() -> [GitHubPRObservationSnapshot] {
+    values
+  }
+}
+
 @Suite("GitHubPRObservationService")
 struct GitHubPRObservationServiceTests {
 
@@ -107,6 +119,106 @@ struct GitHubPRObservationServiceTests {
     #expect(service.getChecksCallCount == 1)
     #expect(service.getChecksPRNumber == 42)
 
+    await observer.unsubscribe(subscriptionID: subscription.id)
+  }
+
+  @Test("current branch PR publishes when no checks are reported")
+  func currentBranchPRPublishesWhenNoChecksAreReported() async {
+    let service = MockGitHubCLIService()
+    service.currentBranchPRResult = makeObservedPR(number: 88)
+    service.checksResult = []
+    let observer = GitHubPRObservationService(
+      service: service,
+      configuration: makeObservationConfiguration()
+    )
+    let target = GitHubPRObservationTarget.currentBranch(projectPath: "/tmp/repo", branchName: "feature")
+    let collector = ObservationSnapshotCollector()
+
+    let subscription = await observer.subscribe(to: target, refreshOnSubscribe: false)
+    let collectionTask = Task {
+      for await snapshot in subscription.updates {
+        await collector.append(snapshot)
+      }
+    }
+    await observer.recordActivity(for: target, at: .now)
+    try? await Task.sleep(for: .milliseconds(30))
+
+    let readySnapshot = await collector.snapshots().last { $0.state == .ready }
+    #expect(readySnapshot?.pullRequest?.number == 88)
+    #expect(readySnapshot?.checks.isEmpty == true)
+    #expect(readySnapshot?.ciSummary.total == 0)
+    #expect(service.getCurrentBranchPRCallCount == 1)
+    #expect(service.getChecksCallCount == 1)
+
+    collectionTask.cancel()
+    await observer.unsubscribe(subscriptionID: subscription.id)
+  }
+
+  @Test("current branch PR still publishes when checks fail")
+  func currentBranchPRStillPublishesWhenChecksFail() async {
+    let service = MockGitHubCLIService()
+    service.currentBranchPRResult = makeObservedPR(number: 89)
+    service.checksResults = [.failure(GitHubCLIError.timeout)]
+    let observer = GitHubPRObservationService(
+      service: service,
+      configuration: makeObservationConfiguration()
+    )
+    let target = GitHubPRObservationTarget.currentBranch(projectPath: "/tmp/repo", branchName: "feature")
+    let collector = ObservationSnapshotCollector()
+
+    let subscription = await observer.subscribe(to: target, refreshOnSubscribe: false)
+    let collectionTask = Task {
+      for await snapshot in subscription.updates {
+        await collector.append(snapshot)
+      }
+    }
+    await observer.recordActivity(for: target, at: .now)
+    try? await Task.sleep(for: .milliseconds(30))
+
+    let degradedSnapshot = await collector.snapshots().last { snapshot in
+      if case .error = snapshot.state { return true }
+      return false
+    }
+    #expect(degradedSnapshot?.pullRequest?.number == 89)
+    #expect(degradedSnapshot?.checks.isEmpty == true)
+    #expect(service.getCurrentBranchPRCallCount == 1)
+    #expect(service.getChecksCallCount == 1)
+
+    collectionTask.cancel()
+    await observer.unsubscribe(subscriptionID: subscription.id)
+  }
+
+  @Test("selected PR still publishes metadata when checks fail")
+  func selectedPRStillPublishesMetadataWhenChecksFail() async {
+    let service = MockGitHubCLIService()
+    service.pullRequestResult = makeObservedPR(number: 90)
+    service.checksResults = [.failure(GitHubCLIError.timeout)]
+    let observer = GitHubPRObservationService(
+      service: service,
+      configuration: makeObservationConfiguration()
+    )
+    let target = GitHubPRObservationTarget.pullRequest(projectPath: "/tmp/repo", number: 90)
+    let collector = ObservationSnapshotCollector()
+
+    let subscription = await observer.subscribe(to: target, refreshOnSubscribe: false)
+    let collectionTask = Task {
+      for await snapshot in subscription.updates {
+        await collector.append(snapshot)
+      }
+    }
+    await observer.recordActivity(for: target, at: .now)
+    try? await Task.sleep(for: .milliseconds(30))
+
+    let degradedSnapshot = await collector.snapshots().last { snapshot in
+      if case .error = snapshot.state { return true }
+      return false
+    }
+    #expect(degradedSnapshot?.pullRequest?.number == 90)
+    #expect(degradedSnapshot?.checks.isEmpty == true)
+    #expect(service.getPullRequestCallCount == 1)
+    #expect(service.getChecksCallCount == 1)
+
+    collectionTask.cancel()
     await observer.unsubscribe(subscriptionID: subscription.id)
   }
 


### PR DESCRIPTION
## Summary

- Keep current-branch PR metadata visible even when GitHub check retrieval fails.
- Treat `gh pr checks` "no checks reported" output as a valid empty-checks state.
- Emphasize session row first messages while making the session id/name secondary.

## Root Cause

The shared GitHub PR observation flow coupled PR discovery to CI check retrieval. When `gh pr checks` failed for a branch with no reported checks, the whole observation snapshot failed and the UI never received `currentBranchPR`.

## Validation

- `swift test --package-path app/modules/AgentHubGitHub`
- Attempted `swift test --package-path app/modules/AgentHubCore --filter CLISessionsViewModelMonitorStateModelTests`, but package compilation is still blocked by the existing `CodeEditSymbols` dependency error: `type 'Bundle' has no member 'module'`.