### PR TITLE
[codex] Fix terminal pane shortcuts and layout restore

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,8 @@ When the embedded Claude or Codex terminal is focused, text editing shortcuts fo
 | **Option+Right** | Move forward one word |
 | **Option+Backspace** | Delete previous word |
 | **Option+Forward Delete** | Delete next word |
+| **Cmd+Ctrl+Arrow** | Focus adjacent terminal pane |
+| **Cmd+Ctrl+Shift+Left / Right** | Select previous / next terminal tab |
 | **⌥↩ / ⌘↩ / ⇧↩** | Insert newline (configurable in Settings → Terminal) |
 
 ### Command Palette

--- a/app/modules/AgentHubCore/Sources/AgentHub/Models/TerminalWorkspaceSnapshot.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Models/TerminalWorkspaceSnapshot.swift
@@ -11,15 +11,100 @@ public struct TerminalWorkspaceSnapshot: Codable, Equatable, Sendable {
   public var schemaVersion: Int
   public var panels: [TerminalWorkspacePanelSnapshot]
   public var activePanelIndex: Int
+  public var splitLayout: TerminalWorkspaceSplitNode?
 
   public init(
-    schemaVersion: Int = 2,
+    schemaVersion: Int = 3,
     panels: [TerminalWorkspacePanelSnapshot],
-    activePanelIndex: Int = 0
+    activePanelIndex: Int = 0,
+    splitLayout: TerminalWorkspaceSplitNode? = nil
   ) {
     self.schemaVersion = schemaVersion
     self.panels = panels
     self.activePanelIndex = activePanelIndex
+    self.splitLayout = splitLayout
+  }
+}
+
+public enum TerminalWorkspaceSplitAxis: String, Codable, Equatable, Sendable {
+  case horizontal
+  case vertical
+}
+
+public indirect enum TerminalWorkspaceSplitNode: Equatable, Sendable {
+  case panel(index: Int)
+  case split(axis: TerminalWorkspaceSplitAxis, children: [TerminalWorkspaceSplitNode])
+
+  public var panelIndexes: [Int] {
+    switch self {
+    case .panel(let index):
+      return [index]
+    case .split(_, let children):
+      return children.flatMap(\.panelIndexes)
+    }
+  }
+
+  public func remappingPanelIndexes(
+    _ normalizedIndexByOriginalIndex: [Int: Int]
+  ) -> TerminalWorkspaceSplitNode? {
+    switch self {
+    case .panel(let index):
+      guard let normalizedIndex = normalizedIndexByOriginalIndex[index] else {
+        return nil
+      }
+      return .panel(index: normalizedIndex)
+
+    case .split(let axis, let children):
+      let remappedChildren = children.compactMap {
+        $0.remappingPanelIndexes(normalizedIndexByOriginalIndex)
+      }
+      guard !remappedChildren.isEmpty else { return nil }
+      return .split(axis: axis, children: remappedChildren)
+    }
+  }
+}
+
+extension TerminalWorkspaceSplitNode: Codable {
+  private enum CodingKeys: String, CodingKey {
+    case type
+    case index
+    case axis
+    case children
+  }
+
+  private enum NodeType: String, Codable {
+    case panel
+    case split
+  }
+
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    let type = try container.decode(NodeType.self, forKey: .type)
+
+    switch type {
+    case .panel:
+      self = .panel(index: try container.decode(Int.self, forKey: .index))
+    case .split:
+      self = .split(
+        axis: try container.decode(TerminalWorkspaceSplitAxis.self, forKey: .axis),
+        children: try container.decode([TerminalWorkspaceSplitNode].self, forKey: .children)
+      )
+    }
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+
+    switch self {
+    case .panel(let index):
+      try container.encode(NodeType.panel, forKey: .type)
+      try container.encode(index, forKey: .index)
+
+    case .split(let axis, let children):
+      try container.encode(NodeType.split, forKey: .type)
+      try container.encode(axis, forKey: .axis)
+      try container.encode(children, forKey: .children)
+    }
   }
 }
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/EmbeddedTerminalView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/EmbeddedTerminalView.swift
@@ -1348,7 +1348,13 @@ public class TerminalContainerView: NSView, ManagedLocalProcessTerminalViewDeleg
 
     return TerminalWorkspaceSnapshot(
       panels: panelSnapshots,
-      activePanelIndex: panels.firstIndex { $0.id == activePanelID } ?? 0
+      activePanelIndex: panels.firstIndex { $0.id == activePanelID } ?? 0,
+      splitLayout: terminalPanelSession.flatMap {
+        RegularTerminalSplitLayoutBuilder.snapshotNode(
+          from: $0.currentSplitRoot(),
+          panelIDs: panels.map(\.id)
+        )
+      }
     )
   }
 
@@ -1361,12 +1367,21 @@ public class TerminalContainerView: NSView, ManagedLocalProcessTerminalViewDeleg
     }
 
     resetToPrimaryTerminal()
-    let panelSnapshots = normalizedPanelSnapshots(snapshot.panels)
+    let panelSnapshotEntries = normalizedPanelSnapshotEntries(snapshot.panels)
+    let panelSnapshots = panelSnapshotEntries.map(\.snapshot)
+    let normalizedIndexByOriginalIndex = Dictionary(
+      uniqueKeysWithValues: panelSnapshotEntries.enumerated().map { normalizedIndex, entry in
+        (entry.originalIndex, normalizedIndex)
+      }
+    )
+    let restoredSplitLayout = snapshot.splitLayout?.remappingPanelIndexes(normalizedIndexByOriginalIndex)
     var restoredPanelIDs: [RegularTerminalPanelID] = []
+    var restoredPanelIDByIndex: [Int: RegularTerminalPanelID] = [:]
     var restoredTabIDs: [[RegularTerminalTabID]] = []
 
     if let primary = panel(for: primaryPanelID) {
       restoredPanelIDs.append(primary.id)
+      restoredPanelIDByIndex[0] = primary.id
       var primaryTabIDs = primary.tabs.map(\.id)
       if let primarySnapshot = panelSnapshots.first {
         primaryTabIDs = restoreShellTabs(
@@ -1378,7 +1393,7 @@ public class TerminalContainerView: NSView, ManagedLocalProcessTerminalViewDeleg
       restoredTabIDs.append(primaryTabIDs)
     }
 
-    for panelSnapshot in panelSnapshots.dropFirst() {
+    for (panelIndex, panelSnapshot) in panelSnapshots.enumerated().dropFirst() {
       guard let session = terminalPanelSession, session.canOpenPanel else { break }
       guard let firstAccessoryTab = firstRestorableAccessoryTab(in: panelSnapshot) else { continue }
       let tab = makeRestoredAccessoryTab(firstAccessoryTab)
@@ -1401,7 +1416,16 @@ public class TerminalContainerView: NSView, ManagedLocalProcessTerminalViewDeleg
         )
       }
       restoredPanelIDs.append(panel.id)
+      restoredPanelIDByIndex[panelIndex] = panel.id
       restoredTabIDs.append(tabIDs)
+    }
+
+    if let restoredSplitLayout,
+       let splitRoot = RegularTerminalSplitLayoutBuilder.splitNode(
+         from: restoredSplitLayout,
+         panelIDByIndex: restoredPanelIDByIndex
+       ) {
+      _ = terminalPanelSession?.restoreSplitRoot(splitRoot)
     }
 
     restoreActiveSelection(
@@ -1511,12 +1535,18 @@ public class TerminalContainerView: NSView, ManagedLocalProcessTerminalViewDeleg
     _ = terminalPanelSession?.selectTab(panelTabIDs[tabIndex], in: panel.id)
   }
 
-  private func normalizedPanelSnapshots(
+  private func normalizedPanelSnapshotEntries(
     _ panels: [TerminalWorkspacePanelSnapshot]
-  ) -> [TerminalWorkspacePanelSnapshot] {
+  ) -> [(originalIndex: Int, snapshot: TerminalWorkspacePanelSnapshot)] {
     let primary = panels.first { $0.role == .primary } ?? panels.first
-    let auxiliaries = panels.filter { $0.role == .auxiliary }
-    return ([primary].compactMap { $0 } + auxiliaries).prefix(4).map { $0 }
+    let primaryIndex = primary.flatMap { primary in
+      panels.firstIndex { $0 == primary }
+    }
+    let primaryEntry = primaryIndex.map { (originalIndex: $0, snapshot: panels[$0]) }
+    let auxiliaries = panels.enumerated()
+      .filter { $0.element.role == .auxiliary && $0.offset != primaryIndex }
+      .map { (originalIndex: $0.offset, snapshot: $0.element) }
+    return Array(([primaryEntry].compactMap { $0 } + auxiliaries).prefix(4))
   }
 
   private func restoredTabName(for tab: TerminalWorkspaceTabSnapshot) -> String? {

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/TerminalPanelKit.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/TerminalPanelKit.swift
@@ -516,6 +516,18 @@ public enum TerminalPanelKit {
     }
 
     @discardableResult
+    public func restoreSplitRoot(_ root: SplitNode) -> Bool {
+      let visiblePanelIDs = root.panelIDs
+      let availablePanelIDs = panels.map(\.id)
+      guard Set(visiblePanelIDs) == Set(availablePanelIDs),
+            Set(visiblePanelIDs).count == visiblePanelIDs.count else {
+        return false
+      }
+      splitRoot = root
+      return true
+    }
+
+    @discardableResult
     public func focusPanel(
       direction: PanelNavigationDirection,
       viewportSize: CGSize
@@ -695,6 +707,50 @@ public enum TerminalPanelKit {
   }
 
   public enum SplitLayoutBuilder {
+    public static func snapshotNode(
+      from root: SplitNode,
+      panelIDs: [PanelID]
+    ) -> TerminalWorkspaceSplitNode? {
+      let indexByPanelID = Dictionary(
+        uniqueKeysWithValues: panelIDs.enumerated().map { index, panelID in
+          (panelID, index)
+        }
+      )
+      return snapshotNode(from: root, indexByPanelID: indexByPanelID)
+    }
+
+    public static func splitNode(
+      from snapshotNode: TerminalWorkspaceSplitNode,
+      panelIDs: [PanelID]
+    ) -> SplitNode? {
+      splitNode(
+        from: snapshotNode,
+        panelIDByIndex: Dictionary(
+          uniqueKeysWithValues: panelIDs.enumerated().map { index, panelID in
+            (index, panelID)
+          }
+        )
+      )
+    }
+
+    public static func splitNode(
+      from snapshotNode: TerminalWorkspaceSplitNode,
+      panelIDByIndex: [Int: PanelID]
+    ) -> SplitNode? {
+      switch snapshotNode {
+      case .panel(let index):
+        guard let panelID = panelIDByIndex[index] else { return nil }
+        return .panel(panelID)
+
+      case .split(let axis, let children):
+        let restoredChildren = children.compactMap {
+          splitNode(from: $0, panelIDByIndex: panelIDByIndex)
+        }
+        guard !restoredChildren.isEmpty else { return nil }
+        return .split(axis: SplitAxis(axis), children: restoredChildren)
+      }
+    }
+
     public static func addingPanel(
       _ newPanelID: PanelID,
       to root: SplitNode,
@@ -755,6 +811,46 @@ public enum TerminalPanelKit {
           }
         )
       }
+    }
+
+    private static func snapshotNode(
+      from root: SplitNode,
+      indexByPanelID: [PanelID: Int]
+    ) -> TerminalWorkspaceSplitNode? {
+      switch root {
+      case .panel(let panelID):
+        guard let index = indexByPanelID[panelID] else { return nil }
+        return .panel(index: index)
+
+      case .split(let axis, let children):
+        let snapshotChildren = children.compactMap {
+          snapshotNode(from: $0, indexByPanelID: indexByPanelID)
+        }
+        guard !snapshotChildren.isEmpty else { return nil }
+        return .split(axis: TerminalWorkspaceSplitAxis(axis), children: snapshotChildren)
+      }
+    }
+  }
+}
+
+private extension TerminalWorkspaceSplitAxis {
+  init(_ axis: TerminalPanelKit.SplitAxis) {
+    switch axis {
+    case .horizontal:
+      self = .horizontal
+    case .vertical:
+      self = .vertical
+    }
+  }
+}
+
+private extension TerminalPanelKit.SplitAxis {
+  init(_ axis: TerminalWorkspaceSplitAxis) {
+    switch axis {
+    case .horizontal:
+      self = .horizontal
+    case .vertical:
+      self = .vertical
     }
   }
 }

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/TerminalPanelKit.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/TerminalPanelKit.swift
@@ -104,16 +104,18 @@ public enum TerminalPanelKit {
         return nil
       }
 
-      if flags == [.command] {
+      if flags == [.command, .control] {
         switch keyCode {
         case 123: return .focusPanel(.left)
         case 124: return .focusPanel(.right)
         case 125: return .focusPanel(.down)
         case 126: return .focusPanel(.up)
         default:
-          break
+          return nil
         }
+      }
 
+      if flags == [.command] {
         switch key {
         case "f": return .startSearch
         case "t": return .openTab
@@ -122,14 +124,16 @@ public enum TerminalPanelKit {
         }
       }
 
-      if flags == [.command, .shift] {
+      if flags == [.command, .control, .shift] {
         switch keyCode {
         case 123: return .selectTab(.previous)
         case 124: return .selectTab(.next)
         default:
-          break
+          return nil
         }
+      }
 
+      if flags == [.command, .shift] {
         switch key {
         case "d": return .openPane(axis: .vertical)
         case "w": return .closePanel

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/RegularTerminalWorkspaceTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/RegularTerminalWorkspaceTests.swift
@@ -181,6 +181,41 @@ struct RegularTerminalWorkspaceTests {
     #expect(result == .split(axis: .horizontal, children: [.panel(primary), .panel(shell2)]))
   }
 
+  @Test("Split layouts convert to persisted panel indexes")
+  func splitLayoutsConvertToPersistedPanelIndexes() {
+    let primary = RegularTerminalPanelID(UUID(uuidString: "00000000-0000-0000-0000-000000000001")!)
+    let shell1 = RegularTerminalPanelID(UUID(uuidString: "00000000-0000-0000-0000-000000000002")!)
+    let shell2 = RegularTerminalPanelID(UUID(uuidString: "00000000-0000-0000-0000-000000000003")!)
+    let root = RegularTerminalSplitNode.split(
+      axis: .horizontal,
+      children: [
+        .panel(primary),
+        .split(axis: .vertical, children: [.panel(shell1), .panel(shell2)])
+      ]
+    )
+
+    let snapshotNode = RegularTerminalSplitLayoutBuilder.snapshotNode(
+      from: root,
+      panelIDs: [primary, shell1, shell2]
+    )
+
+    #expect(
+      snapshotNode == .split(
+        axis: .horizontal,
+        children: [
+          .panel(index: 0),
+          .split(axis: .vertical, children: [.panel(index: 1), .panel(index: 2)])
+        ]
+      )
+    )
+    #expect(
+      RegularTerminalSplitLayoutBuilder.splitNode(
+        from: snapshotNode!,
+        panelIDs: [primary, shell1, shell2]
+      ) == root
+    )
+  }
+
   @MainActor
   @Test("Panel kit opens tabs and panels without replacing existing payloads")
   func panelKitOpensTabsAndPanels() {
@@ -201,6 +236,33 @@ struct RegularTerminalWorkspaceTests {
     #expect(session.primaryPanel?.tabs.map(\.payload) == ["agent", "shell-tab"])
     #expect(shellPanel?.activeTab?.payload == "shell-panel")
     #expect(session.activePanelID == shellPanel?.id)
+  }
+
+  @MainActor
+  @Test("Panel kit restores a persisted split root")
+  func panelKitRestoresPersistedSplitRoot() {
+    let agent = TerminalPanelKit.Tab(role: .agent, payload: "agent")
+    let session = TerminalPanelKit.Session(primaryTab: agent)
+    let shell1 = TerminalPanelKit.Tab(role: .shell, payload: "shell-1")
+    let panel1 = session.openPanel(with: shell1, beside: session.primaryPanelID, axis: .horizontal)
+    let shell2 = TerminalPanelKit.Tab(role: .shell, payload: "shell-2")
+    let panel2 = session.openPanel(with: shell2, beside: session.primaryPanelID, axis: .horizontal)
+
+    guard let panel1, let panel2 else {
+      Issue.record("Expected panels to open")
+      return
+    }
+
+    let root = RegularTerminalSplitNode.split(
+      axis: .horizontal,
+      children: [
+        .panel(session.primaryPanelID),
+        .split(axis: .vertical, children: [.panel(panel1.id), .panel(panel2.id)])
+      ]
+    )
+
+    #expect(session.restoreSplitRoot(root))
+    #expect(session.currentSplitRoot() == root)
   }
 
   @MainActor

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/RegularTerminalWorkspaceTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/RegularTerminalWorkspaceTests.swift
@@ -49,12 +49,42 @@ struct RegularTerminalWorkspaceTests {
       keyCode: 123,
       charactersIgnoringModifiers: nil,
       modifierFlags: [.command, .numericPad]
+    ) == nil)
+
+    #expect(RegularTerminalShortcut.action(
+      keyCode: 123,
+      charactersIgnoringModifiers: nil,
+      modifierFlags: [.command, .control, .numericPad]
     ) == .focusPanel(.left))
 
     #expect(RegularTerminalShortcut.action(
       keyCode: 124,
       charactersIgnoringModifiers: nil,
+      modifierFlags: [.command, .control, .numericPad]
+    ) == .focusPanel(.right))
+
+    #expect(RegularTerminalShortcut.action(
+      keyCode: 125,
+      charactersIgnoringModifiers: nil,
+      modifierFlags: [.command, .control, .numericPad]
+    ) == .focusPanel(.down))
+
+    #expect(RegularTerminalShortcut.action(
+      keyCode: 126,
+      charactersIgnoringModifiers: nil,
+      modifierFlags: [.command, .control, .numericPad]
+    ) == .focusPanel(.up))
+
+    #expect(RegularTerminalShortcut.action(
+      keyCode: 124,
+      charactersIgnoringModifiers: nil,
       modifierFlags: [.command, .shift, .numericPad]
+    ) == nil)
+
+    #expect(RegularTerminalShortcut.action(
+      keyCode: 124,
+      charactersIgnoringModifiers: nil,
+      modifierFlags: [.command, .control, .shift, .numericPad]
     ) == .selectTab(.next))
 
     #expect(RegularTerminalShortcut.action(
@@ -79,6 +109,20 @@ struct RegularTerminalWorkspaceTests {
       modifierFlags: [.command, .shift, .numericPad],
       terminalTextInputActive: true
     ) == nil)
+
+    #expect(RegularTerminalShortcut.action(
+      keyCode: 123,
+      charactersIgnoringModifiers: nil,
+      modifierFlags: [.command, .control, .numericPad],
+      terminalTextInputActive: true
+    ) == .focusPanel(.left))
+
+    #expect(RegularTerminalShortcut.action(
+      keyCode: 124,
+      charactersIgnoringModifiers: nil,
+      modifierFlags: [.command, .control, .shift, .numericPad],
+      terminalTextInputActive: true
+    ) == .selectTab(.next))
 
     #expect(RegularTerminalShortcut.action(
       keyCode: 51,

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/TerminalWorkspaceLinkedSessionSnapshotTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/TerminalWorkspaceLinkedSessionSnapshotTests.swift
@@ -34,12 +34,23 @@ struct TerminalWorkspaceLinkedSessionSnapshotTests {
 
     #expect(snapshot.schemaVersion == 1)
     #expect(snapshot.panels.first?.tabs.first?.linkedSession == nil)
+    #expect(snapshot.splitLayout == nil)
   }
 
-  @Test("Linked child session metadata round-trips")
-  func linkedSessionRoundTrip() throws {
+  @Test("Linked child session metadata and split layout round-trip")
+  func linkedSessionAndSplitLayoutRoundTrip() throws {
     let snapshot = TerminalWorkspaceSnapshot(
       panels: [
+        TerminalWorkspacePanelSnapshot(
+          role: .primary,
+          tabs: [
+            TerminalWorkspaceTabSnapshot(
+              role: .agent,
+              name: "Claude",
+              workingDirectory: "/tmp/project"
+            )
+          ]
+        ),
         TerminalWorkspacePanelSnapshot(
           role: .auxiliary,
           tabs: [
@@ -54,13 +65,20 @@ struct TerminalWorkspaceLinkedSessionSnapshotTests {
             )
           ]
         )
-      ]
+      ],
+      splitLayout: .split(
+        axis: .horizontal,
+        children: [
+          .panel(index: 0),
+          .split(axis: .vertical, children: [.panel(index: 1)])
+        ]
+      )
     )
 
     let data = try JSONEncoder().encode(snapshot)
     let decoded = try JSONDecoder().decode(TerminalWorkspaceSnapshot.self, from: data)
 
     #expect(decoded == snapshot)
-    #expect(decoded.schemaVersion == 2)
+    #expect(decoded.schemaVersion == 3)
   }
 }

--- a/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttySplitLayoutBuilder.swift
+++ b/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttySplitLayoutBuilder.swift
@@ -3,9 +3,40 @@
 //  AgentHub
 //
 
+import AgentHubCore
 import GhosttySwift
 
 enum AgentHubGhosttySplitLayoutBuilder {
+  static func snapshotNode(
+    from root: TerminalSplitLayout.Node,
+    panelIDs: [TerminalPanelID]
+  ) -> TerminalWorkspaceSplitNode? {
+    let indexByPanelID = Dictionary(
+      uniqueKeysWithValues: panelIDs.enumerated().map { index, panelID in
+        (panelID, index)
+      }
+    )
+    return snapshotNode(from: root, indexByPanelID: indexByPanelID)
+  }
+
+  static func terminalNode(
+    from snapshotNode: TerminalWorkspaceSplitNode,
+    panelIDByIndex: [Int: TerminalPanelID]
+  ) -> TerminalSplitLayout.Node? {
+    switch snapshotNode {
+    case .panel(let index):
+      guard let panelID = panelIDByIndex[index] else { return nil }
+      return .panel(panelID)
+
+    case .split(let axis, let children):
+      let restoredChildren = children.compactMap {
+        terminalNode(from: $0, panelIDByIndex: panelIDByIndex)
+      }
+      guard !restoredChildren.isEmpty else { return nil }
+      return .split(axis: TerminalSplitAxis(axis), children: restoredChildren)
+    }
+  }
+
   static func addingPanel(
     _ newPanelID: TerminalPanelID,
     to root: TerminalSplitLayout.Node,
@@ -63,6 +94,46 @@ enum AgentHubGhosttySplitLayoutBuilder {
           replacingPanel(currentPanelID, with: replacementPanelID, in: $0)
         }
       )
+    }
+  }
+
+  private static func snapshotNode(
+    from root: TerminalSplitLayout.Node,
+    indexByPanelID: [TerminalPanelID: Int]
+  ) -> TerminalWorkspaceSplitNode? {
+    switch root {
+    case .panel(let panelID):
+      guard let index = indexByPanelID[panelID] else { return nil }
+      return .panel(index: index)
+
+    case .split(let axis, let children):
+      let snapshotChildren = children.compactMap {
+        snapshotNode(from: $0, indexByPanelID: indexByPanelID)
+      }
+      guard !snapshotChildren.isEmpty else { return nil }
+      return .split(axis: TerminalWorkspaceSplitAxis(axis), children: snapshotChildren)
+    }
+  }
+}
+
+private extension TerminalWorkspaceSplitAxis {
+  init(_ axis: TerminalSplitAxis) {
+    switch axis {
+    case .horizontal:
+      self = .horizontal
+    case .vertical:
+      self = .vertical
+    }
+  }
+}
+
+private extension TerminalSplitAxis {
+  init(_ axis: TerminalWorkspaceSplitAxis) {
+    switch axis {
+    case .horizontal:
+      self = .horizontal
+    case .vertical:
+      self = .vertical
     }
   }
 }

--- a/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalShortcut.swift
+++ b/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalShortcut.swift
@@ -32,16 +32,18 @@ public enum AgentHubGhosttyTerminalShortcut: Equatable {
     let flags = normalizedModifierFlags(modifierFlags)
     let key = charactersIgnoringModifiers?.lowercased()
 
-    if flags == [.command] {
+    if flags == [.command, .control] {
       switch keyCode {
       case 123: return .focusPanel(.left)
       case 124: return .focusPanel(.right)
       case 125: return .focusPanel(.down)
       case 126: return .focusPanel(.up)
       default:
-        break
+        return nil
       }
+    }
 
+    if flags == [.command] {
       switch key {
       case "f": return .startSearch
       case "g": return .searchNext
@@ -51,14 +53,16 @@ public enum AgentHubGhosttyTerminalShortcut: Equatable {
       }
     }
 
-    if flags == [.command, .shift] {
+    if flags == [.command, .control, .shift] {
       switch keyCode {
       case 123: return .selectTab(.previous)
       case 124: return .selectTab(.next)
       default:
-        break
+        return nil
       }
+    }
 
+    if flags == [.command, .shift] {
       switch key {
       case "d": return .openPane(axis: .vertical)
       case "g": return .searchPrevious

--- a/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalSurface.swift
+++ b/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalSurface.swift
@@ -416,7 +416,13 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
 
     return TerminalWorkspaceSnapshot(
       panels: panels,
-      activePanelIndex: terminalSession.panels.firstIndex { $0.id == terminalSession.activePanelID } ?? 0
+      activePanelIndex: terminalSession.panels.firstIndex { $0.id == terminalSession.activePanelID } ?? 0,
+      splitLayout: currentSplitRoot().flatMap {
+        AgentHubGhosttySplitLayoutBuilder.snapshotNode(
+          from: $0,
+          panelIDs: terminalSession.panels.map(\.id)
+        )
+      }
     )
   }
 
@@ -435,8 +441,16 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
 
     resetToPrimaryAgentTab(in: terminalSession)
 
-    let panelSnapshots = normalizedPanelSnapshots(snapshot.panels)
+    let panelSnapshotEntries = normalizedPanelSnapshotEntries(snapshot.panels)
+    let panelSnapshots = panelSnapshotEntries.map(\.snapshot)
+    let normalizedIndexByOriginalIndex = Dictionary(
+      uniqueKeysWithValues: panelSnapshotEntries.enumerated().map { normalizedIndex, entry in
+        (entry.originalIndex, normalizedIndex)
+      }
+    )
+    let restoredSplitLayout = snapshot.splitLayout?.remappingPanelIndexes(normalizedIndexByOriginalIndex)
     var restoredPanelIDs: [TerminalPanelID] = [terminalSession.primaryPanelID]
+    var restoredPanelIDByIndex: [Int: TerminalPanelID] = [0: terminalSession.primaryPanelID]
     var restoredTabIDs: [[TerminalTabID]] = [[protectedAgentTabID ?? terminalSession.primaryPanel.activeTabID]]
 
     if let primarySnapshot = panelSnapshots.first {
@@ -447,7 +461,7 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
       )
     }
 
-    for panelSnapshot in panelSnapshots.dropFirst() {
+    for (panelIndex, panelSnapshot) in panelSnapshots.enumerated().dropFirst() {
       guard terminalSession.canOpenPanel else { break }
       guard let firstAccessoryTab = firstRestorableAccessoryTab(in: panelSnapshot) else { continue }
       guard let configuration = configurationForRestoredAccessoryTab(firstAccessoryTab) else { continue }
@@ -464,6 +478,7 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
         }
         configureControllerHooks(for: panel.activeTab?.controller)
         restoredPanelIDs.append(panel.id)
+        restoredPanelIDByIndex[panelIndex] = panel.id
 
         var tabIDs = panel.activeTab.map { [$0.id] } ?? []
         tabIDs = restoreShellTabs(
@@ -479,7 +494,17 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
     }
 
     terminalSession.showPrimaryAndAuxiliaries()
-    splitRoot = terminalSession.splitLayout?.root ?? .panel(terminalSession.primaryPanelID)
+    if let restoredSplitLayout,
+       let restoredRoot = AgentHubGhosttySplitLayoutBuilder.terminalNode(
+         from: restoredSplitLayout,
+         panelIDByIndex: restoredPanelIDByIndex
+       ),
+       Set(restoredRoot.panelIDs) == Set(restoredPanelIDs),
+       Set(restoredRoot.panelIDs).count == restoredRoot.panelIDs.count {
+      splitRoot = restoredRoot
+    } else {
+      splitRoot = terminalSession.splitLayout?.root ?? .panel(terminalSession.primaryPanelID)
+    }
     refreshWorkspaceRootView()
     restoreActiveSelection(
       from: snapshot,
@@ -848,12 +873,18 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
     return expandedPath
   }
 
-  private func normalizedPanelSnapshots(
+  private func normalizedPanelSnapshotEntries(
     _ panels: [TerminalWorkspacePanelSnapshot]
-  ) -> [TerminalWorkspacePanelSnapshot] {
+  ) -> [(originalIndex: Int, snapshot: TerminalWorkspacePanelSnapshot)] {
     let primary = panels.first { $0.role == .primary } ?? panels.first
-    let auxiliaries = panels.filter { $0.role == .auxiliary }
-    return ([primary].compactMap { $0 } + auxiliaries).prefix(4).map { $0 }
+    let primaryIndex = primary.flatMap { primary in
+      panels.firstIndex { $0 == primary }
+    }
+    let primaryEntry = primaryIndex.map { (originalIndex: $0, snapshot: panels[$0]) }
+    let auxiliaries = panels.enumerated()
+      .filter { $0.element.role == .auxiliary && $0.offset != primaryIndex }
+      .map { (originalIndex: $0.offset, snapshot: $0.element) }
+    return Array(([primaryEntry].compactMap { $0 } + auxiliaries).prefix(4))
   }
 
   private func resetToPrimaryAgentTab(in terminalSession: TerminalSession) {

--- a/app/modules/Ghostty/Tests/GhosttyTests/AgentHubGhosttySplitLayoutBuilderTests.swift
+++ b/app/modules/Ghostty/Tests/GhosttyTests/AgentHubGhosttySplitLayoutBuilderTests.swift
@@ -87,4 +87,39 @@ struct AgentHubGhosttySplitLayoutBuilderTests {
 
     #expect(result == .split(axis: .vertical, children: [.panel(primary), .panel(shell)]))
   }
+
+  @Test("Split layouts convert to persisted panel indexes")
+  func splitLayoutsConvertToPersistedPanelIndexes() {
+    let primary = TerminalPanelID(UUID(uuidString: "00000000-0000-0000-0000-000000000001")!)
+    let shell1 = TerminalPanelID(UUID(uuidString: "00000000-0000-0000-0000-000000000002")!)
+    let shell2 = TerminalPanelID(UUID(uuidString: "00000000-0000-0000-0000-000000000003")!)
+    let root = TerminalSplitLayout.Node.split(
+      axis: .horizontal,
+      children: [
+        .panel(primary),
+        .split(axis: .vertical, children: [.panel(shell1), .panel(shell2)])
+      ]
+    )
+
+    let snapshotNode = AgentHubGhosttySplitLayoutBuilder.snapshotNode(
+      from: root,
+      panelIDs: [primary, shell1, shell2]
+    )
+
+    #expect(
+      snapshotNode == .split(
+        axis: .horizontal,
+        children: [
+          .panel(index: 0),
+          .split(axis: .vertical, children: [.panel(index: 1), .panel(index: 2)])
+        ]
+      )
+    )
+    #expect(
+      AgentHubGhosttySplitLayoutBuilder.terminalNode(
+        from: snapshotNode!,
+        panelIDByIndex: [0: primary, 1: shell1, 2: shell2]
+      ) == root
+    )
+  }
 }

--- a/app/modules/Ghostty/Tests/GhosttyTests/AgentHubGhosttyTerminalShortcutTests.swift
+++ b/app/modules/Ghostty/Tests/GhosttyTests/AgentHubGhosttyTerminalShortcutTests.swift
@@ -23,18 +23,20 @@ struct AgentHubGhosttyTerminalShortcutTests {
     expectAction(.closePanel, key: "w", flags: [.command, .shift])
   }
 
-  @Test("Command arrow shortcuts focus panes")
+  @Test("Control-command arrow shortcuts focus panes")
   func paneFocusShortcuts() {
-    expectFocusPanel(.left, keyCode: 123, flags: [.command, .numericPad])
-    expectFocusPanel(.right, keyCode: 124, flags: [.command, .numericPad])
-    expectFocusPanel(.down, keyCode: 125, flags: [.command, .numericPad])
-    expectFocusPanel(.up, keyCode: 126, flags: [.command, .numericPad])
+    expectNoAction(keyCode: 123, flags: [.command, .numericPad])
+    expectFocusPanel(.left, keyCode: 123, flags: [.command, .control, .numericPad])
+    expectFocusPanel(.right, keyCode: 124, flags: [.command, .control, .numericPad])
+    expectFocusPanel(.down, keyCode: 125, flags: [.command, .control, .numericPad])
+    expectFocusPanel(.up, keyCode: 126, flags: [.command, .control, .numericPad])
   }
 
-  @Test("Shift-command arrow shortcuts select tabs")
+  @Test("Control-shift-command arrow shortcuts select tabs")
   func tabSelectionShortcuts() {
-    expectSelectTab(.previous, keyCode: 123, flags: [.command, .shift, .numericPad])
-    expectSelectTab(.next, keyCode: 124, flags: [.command, .shift, .numericPad])
+    expectNoAction(keyCode: 123, flags: [.command, .shift, .numericPad])
+    expectSelectTab(.previous, keyCode: 123, flags: [.command, .control, .shift, .numericPad])
+    expectSelectTab(.next, keyCode: 124, flags: [.command, .control, .shift, .numericPad])
   }
 }
 
@@ -60,6 +62,19 @@ private func expectNoAction(
   let action = AgentHubGhosttyTerminalShortcut.action(
     keyCode: 0,
     charactersIgnoringModifiers: key,
+    modifierFlags: flags
+  )
+  #expect(action == nil, sourceLocation: sourceLocation)
+}
+
+private func expectNoAction(
+  keyCode: UInt16,
+  flags: NSEvent.ModifierFlags,
+  sourceLocation: SourceLocation = #_sourceLocation
+) {
+  let action = AgentHubGhosttyTerminalShortcut.action(
+    keyCode: keyCode,
+    charactersIgnoringModifiers: nil,
     modifierFlags: flags
   )
   #expect(action == nil, sourceLocation: sourceLocation)


### PR DESCRIPTION
## Summary
- Move terminal pane focus to `Cmd+Ctrl+Arrow` so `Cmd+Arrow` can remain macOS-style terminal text editing.
- Persist terminal workspace split layout trees so mixed horizontal/vertical pane arrangements restore after relaunch.
- Add focused coverage for shortcut mapping, split layout serialization, and split layout conversion for regular and Ghostty terminals.

## Root Cause
Terminal workspace snapshots only stored a flat panel list and active indexes. On restore, AgentHub recreated panes with a default/canonical layout, losing the user's mixed split structure.

## Validation
- `git diff --check`
- `xcodebuild -project app/AgentHub.xcodeproj -scheme AgentHubCore -destination 'platform=macOS' build`
- `xcodebuild -project app/AgentHub.xcodeproj -scheme Ghostty -destination 'platform=macOS' build`

## Notes
- SwiftPM focused tests are currently blocked before reaching AgentHub tests by the existing `CodeEditSymbols` `Bundle.module` resource issue.
- Xcode package schemes build, but the `AgentHubCore` and `AgentHub` schemes are not configured for the test action.