### PR TITLE
[codex] Add terminal pane maximize toggle

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/CommandPaletteView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/CommandPaletteView.swift
@@ -146,6 +146,20 @@ public struct CommandPaletteView: View {
   private var shortcutInfoItems: [CommandPaletteItem] {
     [
       .shortcut(
+        id: "shortcut-terminal-pane-maximize",
+        title: "Terminal Pane: Maximize or Restore",
+        subtitle: "Show the active pane by itself, then restore the split layout",
+        icon: "arrow.up.left.and.arrow.down.right",
+        shortcut: "⌘⇧M"
+      ),
+      .shortcut(
+        id: "shortcut-terminal-pane-focus",
+        title: "Terminal Pane: Focus Adjacent Pane",
+        subtitle: "Move focus left, right, up, or down between terminal panes",
+        icon: "keyboard",
+        shortcut: "⌘⌃←/→/↑/↓"
+      ),
+      .shortcut(
         id: "shortcut-web-preview-width",
         title: "Web Preview: Toggle Width",
         subtitle: "Expand or collapse the embedded preview",

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/EmbeddedTerminalView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/EmbeddedTerminalView.swift
@@ -222,6 +222,7 @@ public class TerminalContainerView: NSView, ManagedLocalProcessTerminalViewDeleg
   private var terminalPanelSession: TerminalPanelKit.Session<SafeLocalProcessTerminalView>?
   private var protectedAgentPanelID: RegularTerminalPanelID?
   private var protectedAgentTabID: RegularTerminalTabID?
+  private var maximizedPanelID: RegularTerminalPanelID?
   private var workspaceHostingView: NSHostingView<RegularTerminalWorkspaceView>?
   private var isConfigured = false
   private var hasDeliveredInitialPrompt = false
@@ -880,6 +881,7 @@ public class TerminalContainerView: NSView, ManagedLocalProcessTerminalViewDeleg
     terminalPanelSession = nil
     protectedAgentPanelID = nil
     protectedAgentTabID = nil
+    maximizedPanelID = nil
     terminalView = nil
     lastWorkspaceSnapshot = nil
   }
@@ -893,6 +895,11 @@ public class TerminalContainerView: NSView, ManagedLocalProcessTerminalViewDeleg
   }
 
   private func refreshWorkspaceRootView() {
+    maximizedPanelID = TerminalPanelKit.SplitPresentationResolver.validMaximizedPanelID(
+      maximizedPanelID,
+      panelIDs: panels.map(\.id)
+    )
+
     guard !panels.isEmpty else {
       removeMountedContent()
       return
@@ -922,6 +929,7 @@ public class TerminalContainerView: NSView, ManagedLocalProcessTerminalViewDeleg
       panels: panels,
       splitRoot: splitRoot,
       activePanelID: activePanelID,
+      maximizedPanelID: maximizedPanelID,
       canClosePanel: { [weak self] panel in
         self?.canCloseRegularPanel(panel) ?? false
       },
@@ -945,6 +953,9 @@ public class TerminalContainerView: NSView, ManagedLocalProcessTerminalViewDeleg
       },
       onSplitPanel: { [weak self] panel, axis in
         self?.openShellPane(axis: axis, anchorPanelID: panel.id)
+      },
+      onToggleMaximizedPanel: { [weak self] panel in
+        self?.toggleMaximizedPanel(panel)
       }
     )
   }
@@ -1086,6 +1097,7 @@ public class TerminalContainerView: NSView, ManagedLocalProcessTerminalViewDeleg
     guard let anchorPanel = panel(for: anchorPanelID ?? activePanelID ?? primaryPanelID) else { return }
     let tab = makeShellTab(workingDirectory: anchorPanel.activeTab?.workingDirectory)
     guard session.openPanel(with: tab, beside: anchorPanel.id, axis: axis) != nil else { return }
+    maximizedPanelID = nil
     refreshWorkspaceRootView()
     syncAppearance(
       isDark: currentIsDark,
@@ -1123,6 +1135,7 @@ public class TerminalContainerView: NSView, ManagedLocalProcessTerminalViewDeleg
     guard session.openPanel(with: tab, beside: anchorPanel.id, axis: .horizontal) != nil else {
       return nil
     }
+    maximizedPanelID = nil
     refreshWorkspaceRootView()
     syncAppearance(
       isDark: currentIsDark,
@@ -1195,6 +1208,9 @@ public class TerminalContainerView: NSView, ManagedLocalProcessTerminalViewDeleg
     guard canCloseRegularPanel(panel) else { return }
     let wasActivePanel = activePanelID == panel.id
     let closeResult = terminalPanelSession?.closePanel(panel.id) ?? .empty
+    if maximizedPanelID == panel.id {
+      maximizedPanelID = nil
+    }
     refreshWorkspaceRootView()
     notifyWorkspaceChanged()
     if wasActivePanel, let activeTab {
@@ -1207,6 +1223,9 @@ public class TerminalContainerView: NSView, ManagedLocalProcessTerminalViewDeleg
     guard canCloseRegularTab(tab, in: panel) else { return }
     let wasActiveTab = panel.activeTabID == tab.id
     let closeResult = terminalPanelSession?.closeTab(tab.id, in: panel.id) ?? .empty
+    if closeResult.closedPanelID == maximizedPanelID {
+      maximizedPanelID = nil
+    }
     refreshWorkspaceRootView()
     notifyWorkspaceChanged()
     if wasActiveTab, let replacementTab = activePanel?.activeTab {
@@ -1270,6 +1289,16 @@ public class TerminalContainerView: NSView, ManagedLocalProcessTerminalViewDeleg
     focus(tab)
   }
 
+  private func toggleMaximizedPanel(_ panel: RegularTerminalPanel) {
+    guard panels.count > 1 else { return }
+    guard terminalPanelSession?.focusPanel(panel.id) == true else { return }
+    maximizedPanelID = maximizedPanelID == panel.id ? nil : panel.id
+    refreshWorkspaceRootView()
+    if let activeTab = panel.activeTab {
+      focus(activeTab)
+    }
+  }
+
   private func handleShortcut(
     _ shortcut: RegularTerminalShortcut,
     focusedTerminal: SafeLocalProcessTerminalView
@@ -1284,6 +1313,10 @@ public class TerminalContainerView: NSView, ManagedLocalProcessTerminalViewDeleg
       openShellPane(axis: axis)
     case .closePanel:
       closeActiveOrLastAuxiliaryPanel()
+    case .toggleMaximizedPanel:
+      if let activePanel {
+        toggleMaximizedPanel(activePanel)
+      }
     case .focusPanel(let direction):
       if focusPanel(direction: direction) {
         notifyWorkspaceChanged()
@@ -1305,6 +1338,7 @@ public class TerminalContainerView: NSView, ManagedLocalProcessTerminalViewDeleg
   }
 
   private func focusPanel(direction: RegularTerminalPanelNavigationDirection) -> Bool {
+    guard maximizedPanelID == nil else { return false }
     guard terminalPanelSession?.focusPanel(direction: direction, viewportSize: bounds.size) == true else {
       return false
     }
@@ -1361,6 +1395,7 @@ public class TerminalContainerView: NSView, ManagedLocalProcessTerminalViewDeleg
   public func restoreWorkspaceSnapshot(_ snapshot: TerminalWorkspaceSnapshot) {
     guard !panels.isEmpty, !snapshot.panels.isEmpty else { return }
     isRestoringWorkspace = true
+    maximizedPanelID = nil
     defer {
       isRestoringWorkspace = false
       lastWorkspaceSnapshot = captureWorkspaceSnapshot()
@@ -1445,6 +1480,7 @@ public class TerminalContainerView: NSView, ManagedLocalProcessTerminalViewDeleg
   private func resetToPrimaryTerminal() {
     guard let session = terminalPanelSession,
           let primary = panel(for: primaryPanelID) ?? panels.first else { return }
+    maximizedPanelID = nil
     let keepTabID = protectedAgentTabID ?? primary.tabs.first?.id
     let closeResult = session.resetToPrimary(keeping: keepTabID)
     for terminal in closeResult.payloads {

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/RegularTerminalWorkspaceView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/RegularTerminalWorkspaceView.swift
@@ -54,6 +54,7 @@ struct RegularTerminalWorkspaceView: View {
   let panels: [RegularTerminalPanel]
   let splitRoot: RegularTerminalSplitNode?
   let activePanelID: RegularTerminalPanelID?
+  let maximizedPanelID: RegularTerminalPanelID?
   let canClosePanel: (RegularTerminalPanel) -> Bool
   let canCloseTab: (RegularTerminalPanel, RegularTerminalTab) -> Bool
   let onActivatePanel: (RegularTerminalPanel) -> Void
@@ -62,6 +63,7 @@ struct RegularTerminalWorkspaceView: View {
   let onCloseTab: (RegularTerminalPanel, RegularTerminalTab) -> Void
   let onOpenTab: (RegularTerminalPanel) -> Void
   let onSplitPanel: (RegularTerminalPanel, RegularTerminalSplitAxis) -> Void
+  let onToggleMaximizedPanel: (RegularTerminalPanel) -> Void
 
   var body: some View {
     if panels.isEmpty {
@@ -73,6 +75,7 @@ struct RegularTerminalWorkspaceView: View {
         node: resolvedSplitRoot,
         panels: panels,
         activePanelID: activePanelID,
+        maximizedPanelID: effectiveMaximizedPanelID,
         canClosePanel: canClosePanel,
         canCloseTab: canCloseTab,
         onActivatePanel: onActivatePanel,
@@ -80,13 +83,25 @@ struct RegularTerminalWorkspaceView: View {
         onClosePanel: onClosePanel,
         onCloseTab: onCloseTab,
         onOpenTab: onOpenTab,
-        onSplitPanel: onSplitPanel
+        onSplitPanel: onSplitPanel,
+        onToggleMaximizedPanel: onToggleMaximizedPanel
       )
     }
   }
 
   private var resolvedSplitRoot: RegularTerminalSplitNode {
-    splitRoot ?? panels.first.map { .panel($0.id) } ?? .panel(RegularTerminalPanelID())
+    TerminalPanelKit.SplitPresentationResolver.resolvedRoot(
+      splitRoot: splitRoot,
+      panelIDs: panels.map(\.id),
+      maximizedPanelID: maximizedPanelID
+    ) ?? .panel(RegularTerminalPanelID())
+  }
+
+  private var effectiveMaximizedPanelID: RegularTerminalPanelID? {
+    TerminalPanelKit.SplitPresentationResolver.validMaximizedPanelID(
+      maximizedPanelID,
+      panelIDs: panels.map(\.id)
+    )
   }
 }
 
@@ -95,6 +110,7 @@ private struct RegularTerminalSplitView: View {
   let node: RegularTerminalSplitNode
   let panels: [RegularTerminalPanel]
   let activePanelID: RegularTerminalPanelID?
+  let maximizedPanelID: RegularTerminalPanelID?
   let canClosePanel: (RegularTerminalPanel) -> Bool
   let canCloseTab: (RegularTerminalPanel, RegularTerminalTab) -> Bool
   let onActivatePanel: (RegularTerminalPanel) -> Void
@@ -103,6 +119,7 @@ private struct RegularTerminalSplitView: View {
   let onCloseTab: (RegularTerminalPanel, RegularTerminalTab) -> Void
   let onOpenTab: (RegularTerminalPanel) -> Void
   let onSplitPanel: (RegularTerminalPanel, RegularTerminalSplitAxis) -> Void
+  let onToggleMaximizedPanel: (RegularTerminalPanel) -> Void
 
   var body: some View {
     content(for: node)
@@ -116,7 +133,9 @@ private struct RegularTerminalSplitView: View {
         RegularTerminalPaneView(
           panel: panel,
           isActive: panel.id == activePanelID,
-          showsSelectionBorder: panels.count > 1,
+          isMaximized: panel.id == maximizedPanelID,
+          showsSelectionBorder: panels.count > 1 && maximizedPanelID == nil,
+          canMaximize: panels.count > 1,
           canSplit: panels.count < 4,
           canClosePanel: canClosePanel(panel),
           canCloseTab: { tab in canCloseTab(panel, tab) },
@@ -126,7 +145,8 @@ private struct RegularTerminalSplitView: View {
           onCloseTab: { tab in onCloseTab(panel, tab) },
           onOpenTab: { onOpenTab(panel) },
           onSplitRight: { onSplitPanel(panel, .horizontal) },
-          onSplitBelow: { onSplitPanel(panel, .vertical) }
+          onSplitBelow: { onSplitPanel(panel, .vertical) },
+          onToggleMaximizedPanel: { onToggleMaximizedPanel(panel) }
         )
       } else {
         EmptyView()
@@ -170,6 +190,7 @@ private struct RegularTerminalSplitView: View {
           node: child,
           panels: panels,
           activePanelID: activePanelID,
+          maximizedPanelID: maximizedPanelID,
           canClosePanel: canClosePanel,
           canCloseTab: canCloseTab,
           onActivatePanel: onActivatePanel,
@@ -177,7 +198,8 @@ private struct RegularTerminalSplitView: View {
           onClosePanel: onClosePanel,
           onCloseTab: onCloseTab,
           onOpenTab: onOpenTab,
-          onSplitPanel: onSplitPanel
+          onSplitPanel: onSplitPanel,
+          onToggleMaximizedPanel: onToggleMaximizedPanel
         )
         .frame(width: childWidth, height: size.height)
       }
@@ -202,6 +224,7 @@ private struct RegularTerminalSplitView: View {
           node: child,
           panels: panels,
           activePanelID: activePanelID,
+          maximizedPanelID: maximizedPanelID,
           canClosePanel: canClosePanel,
           canCloseTab: canCloseTab,
           onActivatePanel: onActivatePanel,
@@ -209,7 +232,8 @@ private struct RegularTerminalSplitView: View {
           onClosePanel: onClosePanel,
           onCloseTab: onCloseTab,
           onOpenTab: onOpenTab,
-          onSplitPanel: onSplitPanel
+          onSplitPanel: onSplitPanel,
+          onToggleMaximizedPanel: onToggleMaximizedPanel
         )
         .frame(width: size.width, height: childHeight)
       }
@@ -233,7 +257,9 @@ private struct RegularTerminalSplitView: View {
 private struct RegularTerminalPaneView: View {
   let panel: RegularTerminalPanel
   let isActive: Bool
+  let isMaximized: Bool
   let showsSelectionBorder: Bool
+  let canMaximize: Bool
   let canSplit: Bool
   let canClosePanel: Bool
   let canCloseTab: (RegularTerminalTab) -> Bool
@@ -244,11 +270,14 @@ private struct RegularTerminalPaneView: View {
   let onOpenTab: () -> Void
   let onSplitRight: () -> Void
   let onSplitBelow: () -> Void
+  let onToggleMaximizedPanel: () -> Void
 
   var body: some View {
     VStack(spacing: 0) {
       RegularTerminalPaneHeader(
         panel: panel,
+        isMaximized: isMaximized,
+        canMaximize: canMaximize,
         canSplit: canSplit,
         canClosePanel: canClosePanel,
         canCloseTab: canCloseTab,
@@ -257,6 +286,7 @@ private struct RegularTerminalPaneView: View {
         onOpenTab: onOpenTab,
         onSplitRight: onSplitRight,
         onSplitBelow: onSplitBelow,
+        onToggleMaximizedPanel: onToggleMaximizedPanel,
         onClosePanel: onClosePanel
       )
 
@@ -286,6 +316,8 @@ private struct RegularTerminalPaneView: View {
 @MainActor
 private struct RegularTerminalPaneHeader: View {
   let panel: RegularTerminalPanel
+  let isMaximized: Bool
+  let canMaximize: Bool
   let canSplit: Bool
   let canClosePanel: Bool
   let canCloseTab: (RegularTerminalTab) -> Bool
@@ -294,6 +326,7 @@ private struct RegularTerminalPaneHeader: View {
   let onOpenTab: () -> Void
   let onSplitRight: () -> Void
   let onSplitBelow: () -> Void
+  let onToggleMaximizedPanel: () -> Void
   let onClosePanel: () -> Void
 
   var body: some View {
@@ -340,6 +373,19 @@ private struct RegularTerminalPaneHeader: View {
               systemImage: "plus",
               help: "New terminal tab",
               action: onOpenTab
+            )
+          }
+
+          if canMaximize {
+            RegularTerminalToolbarButton(
+              title: isMaximized ? "Restore Pane" : "Maximize Pane",
+              systemImage: isMaximized
+                ? "arrow.down.right.and.arrow.up.left"
+                : "arrow.up.left.and.arrow.down.right",
+              help: isMaximized
+                ? "Restore terminal panes (Cmd+Shift+M)"
+                : "Maximize terminal pane (Cmd+Shift+M)",
+              action: onToggleMaximizedPanel
             )
           }
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/TerminalPanelKit.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/TerminalPanelKit.swift
@@ -76,6 +76,7 @@ public enum TerminalPanelKit {
     case openTab
     case openPane(axis: SplitAxis)
     case closePanel
+    case toggleMaximizedPanel
     case focusPanel(PanelNavigationDirection)
     case selectTab(TabNavigationDirection)
 
@@ -136,6 +137,7 @@ public enum TerminalPanelKit {
       if flags == [.command, .shift] {
         switch key {
         case "d": return .openPane(axis: .vertical)
+        case "m": return .toggleMaximizedPanel
         case "w": return .closePanel
         default: return nil
         }
@@ -167,6 +169,30 @@ public enum TerminalPanelKit {
       default:
         return false
       }
+    }
+  }
+
+  public enum SplitPresentationResolver {
+    public static func resolvedRoot(
+      splitRoot: SplitNode?,
+      panelIDs: [PanelID],
+      maximizedPanelID: PanelID?
+    ) -> SplitNode? {
+      if let maximizedPanelID, panelIDs.contains(maximizedPanelID) {
+        return .panel(maximizedPanelID)
+      }
+
+      return splitRoot ?? panelIDs.first.map(SplitNode.panel)
+    }
+
+    public static func validMaximizedPanelID(
+      _ maximizedPanelID: PanelID?,
+      panelIDs: [PanelID]
+    ) -> PanelID? {
+      guard let maximizedPanelID, panelIDs.contains(maximizedPanelID) else {
+        return nil
+      }
+      return maximizedPanelID
     }
   }
 

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/RegularTerminalWorkspaceTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/RegularTerminalWorkspaceTests.swift
@@ -92,6 +92,12 @@ struct RegularTerminalWorkspaceTests {
       charactersIgnoringModifiers: "w",
       modifierFlags: [.command, .shift]
     ) == .closePanel)
+
+    #expect(RegularTerminalShortcut.action(
+      keyCode: 46,
+      charactersIgnoringModifiers: "m",
+      modifierFlags: [.command, .shift]
+    ) == .toggleMaximizedPanel)
   }
 
   @Test("Terminal editing shortcuts pass through when terminal input is focused")
@@ -144,6 +150,13 @@ struct RegularTerminalWorkspaceTests {
       modifierFlags: [.command],
       terminalTextInputActive: true
     ) == .openTab)
+
+    #expect(RegularTerminalShortcut.action(
+      keyCode: 46,
+      charactersIgnoringModifiers: "m",
+      modifierFlags: [.command, .shift],
+      terminalTextInputActive: true
+    ) == .toggleMaximizedPanel)
   }
 
   @Test("Split layout builder adds and removes panels")
@@ -214,6 +227,47 @@ struct RegularTerminalWorkspaceTests {
         panelIDs: [primary, shell1, shell2]
       ) == root
     )
+  }
+
+  @Test("Split presentation resolver renders a valid maximized panel")
+  func splitPresentationResolverRendersValidMaximizedPanel() {
+    let primary = RegularTerminalPanelID(UUID(uuidString: "00000000-0000-0000-0000-000000000001")!)
+    let shell = RegularTerminalPanelID(UUID(uuidString: "00000000-0000-0000-0000-000000000002")!)
+    let root = RegularTerminalSplitNode.split(
+      axis: .horizontal,
+      children: [.panel(primary), .panel(shell)]
+    )
+
+    let resolved = TerminalPanelKit.SplitPresentationResolver.resolvedRoot(
+      splitRoot: root,
+      panelIDs: [primary, shell],
+      maximizedPanelID: shell
+    )
+
+    #expect(resolved == .panel(shell))
+  }
+
+  @Test("Split presentation resolver ignores stale maximized panels")
+  func splitPresentationResolverIgnoresStaleMaximizedPanel() {
+    let primary = RegularTerminalPanelID(UUID(uuidString: "00000000-0000-0000-0000-000000000001")!)
+    let shell = RegularTerminalPanelID(UUID(uuidString: "00000000-0000-0000-0000-000000000002")!)
+    let stale = RegularTerminalPanelID(UUID(uuidString: "00000000-0000-0000-0000-000000000003")!)
+    let root = RegularTerminalSplitNode.split(
+      axis: .horizontal,
+      children: [.panel(primary), .panel(shell)]
+    )
+
+    let resolved = TerminalPanelKit.SplitPresentationResolver.resolvedRoot(
+      splitRoot: root,
+      panelIDs: [primary, shell],
+      maximizedPanelID: stale
+    )
+
+    #expect(resolved == root)
+    #expect(TerminalPanelKit.SplitPresentationResolver.validMaximizedPanelID(
+      stale,
+      panelIDs: [primary, shell]
+    ) == nil)
   }
 
   @MainActor

--- a/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalPaneHeader.swift
+++ b/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalPaneHeader.swift
@@ -9,6 +9,8 @@ import SwiftUI
 @MainActor
 struct AgentHubGhosttyTerminalPaneHeader: View {
   let panel: TerminalPanel
+  let isMaximized: Bool
+  let canMaximize: Bool
   let canSplit: Bool
   let canClosePanel: Bool
   let canCloseTab: (TerminalTab) -> Bool
@@ -17,6 +19,7 @@ struct AgentHubGhosttyTerminalPaneHeader: View {
   let onOpenTab: () -> Void
   let onSplitRight: () -> Void
   let onSplitBelow: () -> Void
+  let onToggleMaximizedPanel: () -> Void
   let onClosePanel: () -> Void
 
   var body: some View {
@@ -45,6 +48,19 @@ struct AgentHubGhosttyTerminalPaneHeader: View {
             help: "New terminal tab",
             action: onOpenTab
           )
+
+          if canMaximize {
+            AgentHubGhosttyTerminalToolbarButton(
+              title: isMaximized ? "Restore Pane" : "Maximize Pane",
+              systemImage: isMaximized
+                ? "arrow.down.right.and.arrow.up.left"
+                : "arrow.up.left.and.arrow.down.right",
+              help: isMaximized
+                ? "Restore terminal panes (Cmd+Shift+M)"
+                : "Maximize terminal pane (Cmd+Shift+M)",
+              action: onToggleMaximizedPanel
+            )
+          }
 
           AgentHubGhosttyTerminalToolbarButton(
             title: "Split Right",

--- a/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalPaneView.swift
+++ b/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalPaneView.swift
@@ -12,6 +12,9 @@ struct AgentHubGhosttyTerminalPaneView: View {
 
   let panel: TerminalPanel
   let session: TerminalSession
+  let isMaximized: Bool
+  let showsSelectionBorder: Bool
+  let canMaximize: Bool
   let canClosePanel: (TerminalPanel) -> Bool
   let canCloseTab: (TerminalPanel, TerminalTab) -> Bool
   let onActivatePanel: (TerminalPanel) -> Void
@@ -20,12 +23,15 @@ struct AgentHubGhosttyTerminalPaneView: View {
   let onCloseTab: (TerminalPanel, TerminalTab) -> Void
   let onOpenTab: (TerminalPanel) -> Void
   let onSplitPanel: (TerminalPanel, TerminalSplitAxis) -> Void
+  let onToggleMaximizedPanel: (TerminalPanel) -> Void
   let activity: AgentHubGhosttyTerminalPaneActivity?
 
   var body: some View {
     VStack(spacing: 0) {
       AgentHubGhosttyTerminalPaneHeader(
         panel: panel,
+        isMaximized: isMaximized,
+        canMaximize: canMaximize,
         canSplit: session.canOpenPanel,
         canClosePanel: canClosePanel(panel),
         canCloseTab: { tab in canCloseTab(panel, tab) },
@@ -34,6 +40,7 @@ struct AgentHubGhosttyTerminalPaneView: View {
         onOpenTab: { onOpenTab(panel) },
         onSplitRight: { onSplitPanel(panel, .horizontal) },
         onSplitBelow: { onSplitPanel(panel, .vertical) },
+        onToggleMaximizedPanel: { onToggleMaximizedPanel(panel) },
         onClosePanel: closePanel
       )
 
@@ -56,7 +63,7 @@ struct AgentHubGhosttyTerminalPaneView: View {
     .frame(maxWidth: .infinity, maxHeight: .infinity)
     .background(Color.clear)
     .overlay {
-      if panel.id == session.activePanelID && session.visiblePanels.count > 1 {
+      if panel.id == session.activePanelID && showsSelectionBorder {
         Rectangle()
           .stroke(Color.accentColor.opacity(0.55), lineWidth: 1)
       }

--- a/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalShortcut.swift
+++ b/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalShortcut.swift
@@ -13,6 +13,7 @@ public enum AgentHubGhosttyTerminalShortcut: Equatable {
   case openTab
   case openPane(axis: TerminalSplitAxis)
   case closePanel
+  case toggleMaximizedPanel
   case focusPanel(TerminalPanelNavigationDirection)
   case selectTab(TerminalTabNavigationDirection)
 
@@ -66,6 +67,7 @@ public enum AgentHubGhosttyTerminalShortcut: Equatable {
       switch key {
       case "d": return .openPane(axis: .vertical)
       case "g": return .searchPrevious
+      case "m": return .toggleMaximizedPanel
       case "w": return .closePanel
       default: return nil
       }

--- a/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalSplitView.swift
+++ b/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalSplitView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct AgentHubGhosttyTerminalSplitView: View {
   let node: TerminalSplitLayout.Node
   let session: TerminalSession
+  let maximizedPanelID: TerminalPanelID?
   let canClosePanel: (TerminalPanel) -> Bool
   let canCloseTab: (TerminalPanel, TerminalTab) -> Bool
   let onActivatePanel: (TerminalPanel) -> Void
@@ -18,6 +19,7 @@ struct AgentHubGhosttyTerminalSplitView: View {
   let onCloseTab: (TerminalPanel, TerminalTab) -> Void
   let onOpenTab: (TerminalPanel) -> Void
   let onSplitPanel: (TerminalPanel, TerminalSplitAxis) -> Void
+  let onToggleMaximizedPanel: (TerminalPanel) -> Void
   let activityForPanel: (TerminalPanelID) -> AgentHubGhosttyTerminalPaneActivity?
 
   var body: some View {
@@ -32,6 +34,9 @@ struct AgentHubGhosttyTerminalSplitView: View {
         AgentHubGhosttyTerminalPaneView(
           panel: panel,
           session: session,
+          isMaximized: panel.id == maximizedPanelID,
+          showsSelectionBorder: session.visiblePanels.count > 1 && maximizedPanelID == nil,
+          canMaximize: session.visiblePanels.count > 1,
           canClosePanel: canClosePanel,
           canCloseTab: canCloseTab,
           onActivatePanel: onActivatePanel,
@@ -40,6 +45,7 @@ struct AgentHubGhosttyTerminalSplitView: View {
           onCloseTab: onCloseTab,
           onOpenTab: onOpenTab,
           onSplitPanel: onSplitPanel,
+          onToggleMaximizedPanel: onToggleMaximizedPanel,
           activity: activityForPanel(panel.id)
         )
       } else if let activity = activityForPanel(panelID) {
@@ -85,6 +91,7 @@ struct AgentHubGhosttyTerminalSplitView: View {
         AgentHubGhosttyTerminalSplitView(
           node: child,
           session: session,
+          maximizedPanelID: maximizedPanelID,
           canClosePanel: canClosePanel,
           canCloseTab: canCloseTab,
           onActivatePanel: onActivatePanel,
@@ -93,6 +100,7 @@ struct AgentHubGhosttyTerminalSplitView: View {
           onCloseTab: onCloseTab,
           onOpenTab: onOpenTab,
           onSplitPanel: onSplitPanel,
+          onToggleMaximizedPanel: onToggleMaximizedPanel,
           activityForPanel: activityForPanel
         )
         .frame(width: childWidth, height: size.height)
@@ -117,6 +125,7 @@ struct AgentHubGhosttyTerminalSplitView: View {
         AgentHubGhosttyTerminalSplitView(
           node: child,
           session: session,
+          maximizedPanelID: maximizedPanelID,
           canClosePanel: canClosePanel,
           canCloseTab: canCloseTab,
           onActivatePanel: onActivatePanel,
@@ -125,6 +134,7 @@ struct AgentHubGhosttyTerminalSplitView: View {
           onCloseTab: onCloseTab,
           onOpenTab: onOpenTab,
           onSplitPanel: onSplitPanel,
+          onToggleMaximizedPanel: onToggleMaximizedPanel,
           activityForPanel: activityForPanel
         )
         .frame(width: size.width, height: childHeight)

--- a/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalSurface.swift
+++ b/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalSurface.swift
@@ -26,6 +26,7 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
   private var accessoryAgentProvidersByTabID: [TerminalTabID: SessionProviderKind] = [:]
   private var linkedSessionsByTabID: [TerminalTabID: TerminalWorkspaceLinkedSessionSnapshot] = [:]
   private var splitRoot: TerminalSplitLayout.Node?
+  private var maximizedPanelID: TerminalPanelID?
   private var pendingMount: PendingMount?
   private var pendingMountTask: Task<Void, Never>?
   private var pendingWorkspaceSnapshot: TerminalWorkspaceSnapshot?
@@ -201,6 +202,7 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
     accessoryAgentProvidersByTabID.removeAll()
     linkedSessionsByTabID.removeAll()
     splitRoot = nil
+    maximizedPanelID = nil
     resetPaneActivities()
     isConfigured = false
     hasDeliveredInitialPrompt = false
@@ -355,6 +357,7 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
       configureControllerHooks(for: panel.activeTab?.controller)
       markPaneStarting(panel.id)
       splitRoot = terminalSession.splitLayout?.root ?? .panel(terminalSession.primaryPanelID)
+      maximizedPanelID = nil
       refreshWorkspaceRootView()
       notifyWorkspaceChanged()
       panel.activeTab?.controller.focusTerminal()
@@ -434,6 +437,7 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
     guard !snapshot.panels.isEmpty else { return }
 
     isRestoringWorkspace = true
+    maximizedPanelID = nil
     defer {
       isRestoringWorkspace = false
       lastWorkspaceSnapshot = captureWorkspaceSnapshot()
@@ -559,6 +563,7 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
         protectedAgentTabID = primaryTab.id
       }
       splitRoot = .panel(session.primaryPanelID)
+      maximizedPanelID = nil
       configureControllerHooks(for: session.primaryPanel.activeTab?.controller)
       mount(session)
       terminalSession = session
@@ -638,6 +643,7 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
     AgentHubGhosttyTerminalWorkspaceView(
       session: session,
       splitRoot: splitRoot,
+      maximizedPanelID: maximizedPanelID,
       canClosePanel: { [weak self] panel in
         self?.canCloseGhosttyPanel(panel) ?? false
       },
@@ -662,6 +668,9 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
       onSplitPanel: { [weak self] panel, axis in
         self?.openShellPane(axis: axis, anchorPanelID: panel.id)
       },
+      onToggleMaximizedPanel: { [weak self] panel in
+        self?.toggleMaximizedPanel(panel)
+      },
       activityForPanel: { [weak self] panelID in
         self?.paneActivityRegistry.activity(for: panelID)
       }
@@ -670,6 +679,9 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
 
   private func refreshWorkspaceRootView() {
     guard let terminalSession, let hostingView else { return }
+    if let maximizedPanelID, terminalSession.panel(for: maximizedPanelID) == nil {
+      self.maximizedPanelID = nil
+    }
     hostingView.rootView = makeWorkspaceRootView(for: terminalSession)
   }
 
@@ -900,6 +912,7 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
 
     focusProtectedAgentTab()
     splitRoot = .panel(terminalSession.primaryPanelID)
+    maximizedPanelID = nil
   }
 
   private func restoreShellTabs(
@@ -1128,8 +1141,14 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
       openShellPane(axis: axis)
     case .closePanel:
       closeActiveOrLastAuxiliaryPanel()
+    case .toggleMaximizedPanel:
+      if let terminalSession,
+         let activePanel = terminalSession.panel(for: terminalSession.activePanelID) {
+        toggleMaximizedPanel(activePanel)
+      }
     case .focusPanel(let direction):
-      if terminalSession?.focusPanel(direction: direction) == true {
+      if maximizedPanelID == nil,
+         terminalSession?.focusPanel(direction: direction) == true {
         notifyWorkspaceChanged()
       }
     case .selectTab(let direction):
@@ -1161,6 +1180,7 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
     anchorPanelID: TerminalPanelID? = nil
   ) {
     guard let terminalSession, terminalSession.canOpenPanel else { return }
+    maximizedPanelID = nil
     let resolvedAnchorPanelID = anchorPanelID ?? terminalSession.activePanelID
     let projectedPlaceholderID = TerminalPanelID()
     let projectedRoot = projectedSplitRoot(
@@ -1285,6 +1305,9 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
     requestClose(panel)
     if terminalSession.closePanel(panel.id) {
       clearPaneActivity(panel.id)
+      if maximizedPanelID == panel.id {
+        maximizedPanelID = nil
+      }
       splitRoot = projectedRoot
       refreshWorkspaceRootView()
       notifyWorkspaceChanged()
@@ -1325,6 +1348,9 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
     if terminalSession.closeTab(tab.id, in: panel.id) {
       clearPaneActivity(panel.id)
       if closesPanel {
+        if maximizedPanelID == panel.id {
+          maximizedPanelID = nil
+        }
         splitRoot = projectedRoot
       }
       refreshWorkspaceRootView()
@@ -1339,6 +1365,14 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
     for tab in panel.tabs {
       requestClose(tab)
     }
+  }
+
+  private func toggleMaximizedPanel(_ panel: TerminalPanel) {
+    guard let terminalSession, terminalSession.visiblePanels.count > 1 else { return }
+    guard terminalSession.focusPanel(panel.id) else { return }
+    maximizedPanelID = maximizedPanelID == panel.id ? nil : panel.id
+    refreshWorkspaceRootView()
+    panel.activeTab?.controller.focusTerminal()
   }
 
   private func prepareVisiblePanelsForPaneTransition(projectedRoot: TerminalSplitLayout.Node) {
@@ -1516,6 +1550,9 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
     if terminalSession.closeTab(located.tab.id, in: located.panel.id) {
       if closesPanel {
         clearPaneActivity(located.panel.id)
+        if maximizedPanelID == located.panel.id {
+          maximizedPanelID = nil
+        }
         splitRoot = projectedRoot
       }
       refreshWorkspaceRootView()

--- a/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalWorkspaceView.swift
+++ b/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalWorkspaceView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct AgentHubGhosttyTerminalWorkspaceView: View {
   let session: TerminalSession
   let splitRoot: TerminalSplitLayout.Node?
+  let maximizedPanelID: TerminalPanelID?
   let canClosePanel: (TerminalPanel) -> Bool
   let canCloseTab: (TerminalPanel, TerminalTab) -> Bool
   let onActivatePanel: (TerminalPanel) -> Void
@@ -18,6 +19,7 @@ struct AgentHubGhosttyTerminalWorkspaceView: View {
   let onCloseTab: (TerminalPanel, TerminalTab) -> Void
   let onOpenTab: (TerminalPanel) -> Void
   let onSplitPanel: (TerminalPanel, TerminalSplitAxis) -> Void
+  let onToggleMaximizedPanel: (TerminalPanel) -> Void
   let activityForPanel: (TerminalPanelID) -> AgentHubGhosttyTerminalPaneActivity?
 
   var body: some View {
@@ -29,6 +31,7 @@ struct AgentHubGhosttyTerminalWorkspaceView: View {
       AgentHubGhosttyTerminalSplitView(
         node: resolvedSplitRoot,
         session: session,
+        maximizedPanelID: effectiveMaximizedPanelID,
         canClosePanel: canClosePanel,
         canCloseTab: canCloseTab,
         onActivatePanel: onActivatePanel,
@@ -37,12 +40,23 @@ struct AgentHubGhosttyTerminalWorkspaceView: View {
         onCloseTab: onCloseTab,
         onOpenTab: onOpenTab,
         onSplitPanel: onSplitPanel,
+        onToggleMaximizedPanel: onToggleMaximizedPanel,
         activityForPanel: activityForPanel
       )
     }
   }
 
   private var resolvedSplitRoot: TerminalSplitLayout.Node {
-    splitRoot ?? session.splitLayout?.root ?? .panel(session.primaryPanelID)
+    if let effectiveMaximizedPanelID {
+      return .panel(effectiveMaximizedPanelID)
+    }
+    return splitRoot ?? session.splitLayout?.root ?? .panel(session.primaryPanelID)
+  }
+
+  private var effectiveMaximizedPanelID: TerminalPanelID? {
+    guard let maximizedPanelID, session.panel(for: maximizedPanelID) != nil else {
+      return nil
+    }
+    return maximizedPanelID
   }
 }

--- a/app/modules/Ghostty/Tests/GhosttyTests/AgentHubGhosttyTerminalShortcutTests.swift
+++ b/app/modules/Ghostty/Tests/GhosttyTests/AgentHubGhosttyTerminalShortcutTests.swift
@@ -20,6 +20,7 @@ struct AgentHubGhosttyTerminalShortcutTests {
   func shiftedCommandShortcuts() {
     expectAction(.openPane(axis: .vertical), key: "d", flags: [.command, .shift])
     expectAction(.searchPrevious, key: "g", flags: [.command, .shift])
+    expectAction(.toggleMaximizedPanel, key: "m", flags: [.command, .shift])
     expectAction(.closePanel, key: "w", flags: [.command, .shift])
   }
 


### PR DESCRIPTION
## Summary

Adds a maximize/restore affordance for terminal workspace panes across both regular and Ghostty terminal backends.

## Changes

- Add a `Cmd+Shift+M` shortcut to maximize or restore the active terminal pane.
- Add pane header toolbar controls for `Maximize Pane` and `Restore Pane`.
- Render a valid maximized pane as a single-pane split presentation without mutating the saved split layout.
- Clear stale maximize state when panes are opened, restored, reset, or closed.
- Add focused shortcut and split-presentation tests.

## Impact

Users can temporarily focus one terminal pane in a session while keeping the existing multi-pane layout intact for restore.

## Validation

- `xcodebuild -workspace app/AgentHub.xcodeproj/project.xcworkspace -scheme AgentHub build` succeeded.
- `git diff --check` succeeded.
- Focused `swift test` package runs are currently blocked before reaching these tests by the existing `CodeEditSymbols` package issue: `Bundle.module` is unavailable because `Symbols.xcassets` is not declared as a package resource.
- Xcode test attempts could not run because the `AgentHub` and `AgentHubCore` schemes are not configured for the test action.