### PR TITLE
Enable code editor minimap by default

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/SettingsView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/SettingsView.swift
@@ -36,7 +36,7 @@ public struct SettingsView: View {
   private var terminalGhosttyConfigPath: String = ""
 
   @AppStorage(AgentHubDefaults.sourceEditorMinimapEnabled)
-  private var sourceEditorMinimapEnabled: Bool = false
+  private var sourceEditorMinimapEnabled: Bool = true
 
   @AppStorage(AgentHubDefaults.sourceEditorWrapLinesEnabled)
   private var sourceEditorWrapLinesEnabled: Bool = true

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/SourceCodeEditorView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/SourceCodeEditorView.swift
@@ -88,7 +88,7 @@ private struct SourceCodeEditorHost: View {
   let onIdleTextSnapshot: (String) -> Void
 
   @AppStorage(AgentHubDefaults.sourceEditorMinimapEnabled)
-  private var sourceEditorMinimapEnabled: Bool = false
+  private var sourceEditorMinimapEnabled: Bool = true
   @AppStorage(AgentHubDefaults.sourceEditorWrapLinesEnabled)
   private var sourceEditorWrapLinesEnabled: Bool = true
   @Environment(\.colorScheme) private var colorScheme


### PR DESCRIPTION
## Summary
- Flip the `@AppStorage` default for `sourceEditorMinimapEnabled` from `false` to `true` so new users see the CodeEdit minimap in the session editor and web preview source editors out of the box.
- Existing users who explicitly toggled the setting keep their stored choice; only users with no stored value are affected.

## Test plan
- [ ] Launch app with a fresh `defaults` domain — confirm minimap renders in source editors.
- [ ] Toggle the setting off in Settings, relaunch — minimap stays off.
- [ ] Toggle back on — minimap returns.