### PR TITLE
[codex] Fix sidebar session shortcut ordering

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
@@ -99,38 +99,13 @@ private struct RemoveConfirmationAlert: ViewModifier {
   }
 }
 
-// MARK: - SidebarGroupMode
-
-private enum SidebarGroupMode: String, CaseIterable {
-  case repo = "Repo"
-  case status = "Status"
-}
-
-// MARK: - StatusGroupCategory
-
-private enum StatusGroupCategory: String, CaseIterable, Identifiable {
-  case needsAttention = "Needs Attention"
-  case working = "Working"
-  case ready = "Ready"
-  case idle = "Idle"
-
-  var id: String { rawValue }
-
+private extension StatusGroupCategory {
   var color: Color {
     switch self {
     case .needsAttention: return .yellow
     case .working: return .blue
     case .ready: return .green
     case .idle: return .gray
-    }
-  }
-
-  static func category(for status: SessionStatus?) -> StatusGroupCategory {
-    switch status {
-    case .thinking, .executingTool: return .working
-    case .waitingForUser: return .ready
-    case .awaitingApproval: return .needsAttention
-    case .idle, .none: return .idle
     }
   }
 }
@@ -842,12 +817,6 @@ public struct MultiProviderSessionsListView: View {
 
   // MARK: - Project Grouping
 
-  private struct SessionGroup: Identifiable {
-    let id: String            // repoPath
-    let displayName: String
-    let items: [SelectedSessionItem]
-  }
-
   /// Deduplicated tracked repos from both providers, preserving insertion order,
   /// newest-first. Claude's repos are walked first, then Codex-only repos.
   private var orderedTrackedRepos: [SelectedRepository] {
@@ -860,14 +829,6 @@ public struct MultiProviderSessionsListView: View {
 
   private var worktreeDisplayMode: WorktreeDisplayMode {
     WorktreeDisplayMode(rawValue: worktreeDisplayModeRawValue) ?? .parent
-  }
-
-  private func findModulePath(for itemPath: String) -> String {
-    WorktreeModuleResolver.modulePath(
-      for: itemPath,
-      repositories: orderedTrackedRepos,
-      mode: worktreeDisplayMode
-    )
   }
 
   private var pinnedSessionSnapshot: ProviderScopedPinnedSessions {
@@ -885,59 +846,54 @@ public struct MultiProviderSessionsListView: View {
   }
 
   private var pinnedSessionItems: [SelectedSessionItem] {
-    return selectedSessionItems
-      .filter { isPinned($0) }
-      .sorted { $0.timestamp > $1.timestamp }
+    SidebarSessionOrdering.pinnedItems(
+      from: selectedSessionItems,
+      isPinned: isPinned,
+      timestamp: { $0.timestamp },
+      id: { $0.id }
+    )
   }
 
   /// Groups built from tracked repos first (even empty), then an orphan bucket
   /// for sessions whose path doesn't belong to any tracked repo.
-  private var groupedSelectedSessions: [SessionGroup] {
-    let allItems = selectedSessionItems.filter { !isPinned($0) }
-    var byRepo: [String: [SelectedSessionItem]] = [:]
-    for item in allItems {
-      let key = findModulePath(for: item.session.projectPath)
-      byRepo[key, default: []].append(item)
-    }
-
-    var groups: [SessionGroup] = []
-    var handledKeys: Set<String> = []
-
-    // Tracked modules — always emit a header, even if empty.
-    for modulePath in WorktreeModuleResolver.modulePaths(for: Array(orderedTrackedRepos), mode: worktreeDisplayMode) {
-      let items = (byRepo[modulePath] ?? []).sorted { $0.timestamp > $1.timestamp }
-      groups.append(SessionGroup(
-        id: modulePath,
-        displayName: URL(fileURLWithPath: modulePath).lastPathComponent,
-        items: items
-      ))
-      handledKeys.insert(modulePath)
-    }
-
-    // Orphan sessions (repo not tracked yet — e.g. a brand-new pending one).
-    for (key, items) in byRepo where !handledKeys.contains(key) {
-      groups.append(SessionGroup(
-        id: key,
-        displayName: URL(fileURLWithPath: key).lastPathComponent,
-        items: items.sorted { $0.timestamp > $1.timestamp }
-      ))
-    }
-
-    return groups
+  private var groupedSelectedSessions: [SidebarSessionGroup<SelectedSessionItem>] {
+    SidebarSessionOrdering.moduleGroups(
+      from: selectedSessionItems,
+      repositories: Array(orderedTrackedRepos),
+      worktreeDisplayMode: worktreeDisplayMode,
+      isPinned: isPinned,
+      projectPath: { $0.session.projectPath },
+      timestamp: { $0.timestamp },
+      id: { $0.id }
+    )
   }
 
   /// Sessions grouped by status category (Working / Needs Attention / Idle).
   private var statusGroupedSessions: [StatusGroupCategory: [SelectedSessionItem]] {
-    var result: [StatusGroupCategory: [SelectedSessionItem]] = [:]
-    for item in selectedSessionItems where !isPinned(item) {
-      let category = StatusGroupCategory.category(for: item.sessionStatus)
-      result[category, default: []].append(item)
-    }
-    // Sort each group by timestamp descending.
-    for key in result.keys {
-      result[key]?.sort { $0.timestamp > $1.timestamp }
-    }
-    return result
+    SidebarSessionOrdering.statusGroups(
+      from: selectedSessionItems,
+      isPinned: isPinned,
+      status: { $0.sessionStatus },
+      timestamp: { $0.timestamp },
+      id: { $0.id }
+    )
+  }
+
+  private var navigableSessionItems: [SelectedSessionItem] {
+    SidebarSessionOrdering.flattenedItems(
+      from: selectedSessionItems,
+      repositories: Array(orderedTrackedRepos),
+      groupMode: sidebarGroupMode,
+      worktreeDisplayMode: worktreeDisplayMode,
+      collapsedProjectGroups: collapsedProjectGroups,
+      collapsedStatusGroups: collapsedStatusGroups,
+      isPinnedSectionCollapsed: isPinnedSectionCollapsed,
+      isPinned: isPinned,
+      projectPath: { $0.session.projectPath },
+      status: { $0.sessionStatus },
+      timestamp: { $0.timestamp },
+      id: { $0.id }
+    )
   }
 
   @ViewBuilder
@@ -1766,31 +1722,19 @@ public struct MultiProviderSessionsListView: View {
     accessibilityReduceMotion ? .easeInOut(duration: 0.12) : .spring(response: 0.28, dampingFraction: 0.9)
   }
 
-  private enum NavigationDirection {
-    case forward, backward
-  }
-
-  private func navigateSessionHistory(direction: NavigationDirection) {
-    let items = selectedSessionItems
-    guard !items.isEmpty else { return }
-
-    if let currentId = primarySessionId,
-       let currentIndex = items.firstIndex(where: { $0.id == currentId }) {
-      let newIndex: Int
-      switch direction {
-      case .forward:
-        newIndex = min(currentIndex + 1, items.count - 1)
-      case .backward:
-        newIndex = max(currentIndex - 1, 0)
-      }
-      selectedModuleLandingPath = nil
-      primarySessionId = items[newIndex].id
-      scrollToSessionId = items[newIndex].id
-    } else {
-      selectedModuleLandingPath = nil
-      primarySessionId = items.first?.id
-      scrollToSessionId = items.first?.id
+  private func navigateSessionHistory(direction: SidebarSessionNavigationDirection) {
+    let orderedIDs = navigableSessionItems.map(\.id)
+    guard let nextID = SidebarSessionOrdering.nextID(
+      in: orderedIDs,
+      currentID: primarySessionId,
+      direction: direction
+    ) else {
+      return
     }
+
+    selectedModuleLandingPath = nil
+    primarySessionId = nextID
+    scrollToSessionId = nextID
   }
 }
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/SidebarSessionOrdering.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/SidebarSessionOrdering.swift
@@ -1,0 +1,227 @@
+//
+//  SidebarSessionOrdering.swift
+//  AgentHub
+//
+
+import Foundation
+
+enum SidebarGroupMode: String, CaseIterable {
+  case repo = "Repo"
+  case status = "Status"
+}
+
+enum StatusGroupCategory: String, CaseIterable, Identifiable {
+  case needsAttention = "Needs Attention"
+  case working = "Working"
+  case ready = "Ready"
+  case idle = "Idle"
+
+  var id: String { rawValue }
+
+  static func category(for status: SessionStatus?) -> StatusGroupCategory {
+    switch status {
+    case .thinking, .executingTool:
+      return .working
+    case .waitingForUser:
+      return .ready
+    case .awaitingApproval:
+      return .needsAttention
+    case .idle, .none:
+      return .idle
+    }
+  }
+}
+
+enum SidebarSessionNavigationDirection {
+  case forward
+  case backward
+}
+
+struct SidebarSessionGroup<Item>: Identifiable {
+  let id: String
+  let displayName: String
+  let items: [Item]
+}
+
+enum SidebarSessionOrdering {
+  static func pinnedItems<Item>(
+    from items: [Item],
+    isPinned: (Item) -> Bool,
+    timestamp: (Item) -> Date,
+    id: (Item) -> String
+  ) -> [Item] {
+    items
+      .filter(isPinned)
+      .sorted { orderedByActivity($0, $1, timestamp: timestamp, id: id) }
+  }
+
+  static func moduleGroups<Item>(
+    from items: [Item],
+    repositories: [SelectedRepository],
+    worktreeDisplayMode: WorktreeDisplayMode,
+    isPinned: (Item) -> Bool,
+    projectPath: (Item) -> String,
+    timestamp: (Item) -> Date,
+    id: (Item) -> String
+  ) -> [SidebarSessionGroup<Item>] {
+    let unpinnedItems = items.filter { !isPinned($0) }
+    var itemsByModule: [String: [Item]] = [:]
+
+    for item in unpinnedItems {
+      let key = WorktreeModuleResolver.modulePath(
+        for: projectPath(item),
+        repositories: repositories,
+        mode: worktreeDisplayMode
+      )
+      itemsByModule[key, default: []].append(item)
+    }
+
+    var groups: [SidebarSessionGroup<Item>] = []
+    var handledKeys: Set<String> = []
+
+    for modulePath in WorktreeModuleResolver.modulePaths(for: repositories, mode: worktreeDisplayMode) {
+      groups.append(SidebarSessionGroup(
+        id: modulePath,
+        displayName: URL(fileURLWithPath: modulePath).lastPathComponent,
+        items: sortedByActivity(itemsByModule[modulePath] ?? [], timestamp: timestamp, id: id)
+      ))
+      handledKeys.insert(modulePath)
+    }
+
+    let orphanKeys = itemsByModule.keys
+      .filter { !handledKeys.contains($0) }
+      .sorted()
+
+    for key in orphanKeys {
+      groups.append(SidebarSessionGroup(
+        id: key,
+        displayName: URL(fileURLWithPath: key).lastPathComponent,
+        items: sortedByActivity(itemsByModule[key] ?? [], timestamp: timestamp, id: id)
+      ))
+    }
+
+    return groups
+  }
+
+  static func statusGroups<Item>(
+    from items: [Item],
+    isPinned: (Item) -> Bool,
+    status: (Item) -> SessionStatus?,
+    timestamp: (Item) -> Date,
+    id: (Item) -> String
+  ) -> [StatusGroupCategory: [Item]] {
+    var result: [StatusGroupCategory: [Item]] = [:]
+
+    for item in items where !isPinned(item) {
+      let category = StatusGroupCategory.category(for: status(item))
+      result[category, default: []].append(item)
+    }
+
+    for key in result.keys {
+      result[key] = sortedByActivity(result[key] ?? [], timestamp: timestamp, id: id)
+    }
+
+    return result
+  }
+
+  static func flattenedItems<Item>(
+    from items: [Item],
+    repositories: [SelectedRepository],
+    groupMode: SidebarGroupMode,
+    worktreeDisplayMode: WorktreeDisplayMode,
+    collapsedProjectGroups: Set<String>,
+    collapsedStatusGroups: Set<StatusGroupCategory>,
+    isPinnedSectionCollapsed: Bool,
+    isPinned: (Item) -> Bool,
+    projectPath: (Item) -> String,
+    status: (Item) -> SessionStatus?,
+    timestamp: (Item) -> Date,
+    id: (Item) -> String
+  ) -> [Item] {
+    var result: [Item] = []
+
+    if !isPinnedSectionCollapsed {
+      result.append(contentsOf: pinnedItems(
+        from: items,
+        isPinned: isPinned,
+        timestamp: timestamp,
+        id: id
+      ))
+    }
+
+    switch groupMode {
+    case .repo:
+      let groups = moduleGroups(
+        from: items,
+        repositories: repositories,
+        worktreeDisplayMode: worktreeDisplayMode,
+        isPinned: isPinned,
+        projectPath: projectPath,
+        timestamp: timestamp,
+        id: id
+      )
+
+      for group in groups where !collapsedProjectGroups.contains(group.id) {
+        result.append(contentsOf: group.items)
+      }
+
+    case .status:
+      let groups = statusGroups(
+        from: items,
+        isPinned: isPinned,
+        status: status,
+        timestamp: timestamp,
+        id: id
+      )
+
+      for category in StatusGroupCategory.allCases where !collapsedStatusGroups.contains(category) {
+        result.append(contentsOf: groups[category] ?? [])
+      }
+    }
+
+    return result
+  }
+
+  static func nextID(
+    in orderedIDs: [String],
+    currentID: String?,
+    direction: SidebarSessionNavigationDirection
+  ) -> String? {
+    guard !orderedIDs.isEmpty else { return nil }
+    guard let currentID,
+          let currentIndex = orderedIDs.firstIndex(of: currentID) else {
+      return orderedIDs.first
+    }
+
+    let newIndex: Int
+    switch direction {
+    case .forward:
+      newIndex = min(currentIndex + 1, orderedIDs.count - 1)
+    case .backward:
+      newIndex = max(currentIndex - 1, 0)
+    }
+    return orderedIDs[newIndex]
+  }
+
+  private static func sortedByActivity<Item>(
+    _ items: [Item],
+    timestamp: (Item) -> Date,
+    id: (Item) -> String
+  ) -> [Item] {
+    items.sorted { orderedByActivity($0, $1, timestamp: timestamp, id: id) }
+  }
+
+  private static func orderedByActivity<Item>(
+    _ lhs: Item,
+    _ rhs: Item,
+    timestamp: (Item) -> Date,
+    id: (Item) -> String
+  ) -> Bool {
+    let lhsTimestamp = timestamp(lhs)
+    let rhsTimestamp = timestamp(rhs)
+    if lhsTimestamp != rhsTimestamp {
+      return lhsTimestamp > rhsTimestamp
+    }
+    return id(lhs) < id(rhs)
+  }
+}

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/SidebarSessionOrderingTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/SidebarSessionOrderingTests.swift
@@ -1,0 +1,170 @@
+import Foundation
+import Testing
+
+@testable import AgentHubCore
+
+@Suite("Sidebar session ordering")
+struct SidebarSessionOrderingTests {
+  @Test("Repo grouping flattens by module order instead of global timestamp")
+  func repoGroupingFlattensByModuleOrder() {
+    let repoA = SelectedRepository(
+      path: "/tmp/RepoA",
+      worktrees: [
+        WorktreeBranch(name: "main", path: "/tmp/RepoA", isWorktree: false),
+        WorktreeBranch(name: "feature", path: "/tmp/RepoA-feature", isWorktree: true)
+      ]
+    )
+    let repoB = SelectedRepository(path: "/tmp/RepoB")
+
+    let items = [
+      item("b-newest", projectPath: "/tmp/RepoB", timestamp: 400),
+      item("a-worktree", projectPath: "/tmp/RepoA-feature", timestamp: 300),
+      item("a-main", projectPath: "/tmp/RepoA", timestamp: 100)
+    ]
+
+    let ids = flattenedIDs(
+      items,
+      repositories: [repoA, repoB],
+      groupMode: .repo,
+      worktreeDisplayMode: .parent
+    )
+
+    #expect(ids == ["a-worktree", "a-main", "b-newest"])
+  }
+
+  @Test("Separate worktree module mode flattens worktree sections independently")
+  func separateWorktreeModeFlattensWorktreeSections() {
+    let repoA = SelectedRepository(
+      path: "/tmp/RepoA",
+      worktrees: [
+        WorktreeBranch(name: "main", path: "/tmp/RepoA", isWorktree: false),
+        WorktreeBranch(name: "feature", path: "/tmp/RepoA-feature", isWorktree: true)
+      ]
+    )
+    let repoB = SelectedRepository(path: "/tmp/RepoB")
+
+    let items = [
+      item("b-newest", projectPath: "/tmp/RepoB", timestamp: 400),
+      item("a-worktree", projectPath: "/tmp/RepoA-feature", timestamp: 300),
+      item("a-main", projectPath: "/tmp/RepoA", timestamp: 100)
+    ]
+
+    let ids = flattenedIDs(
+      items,
+      repositories: [repoA, repoB],
+      groupMode: .repo,
+      worktreeDisplayMode: .separateModules
+    )
+
+    #expect(ids == ["a-main", "a-worktree", "b-newest"])
+  }
+
+  @Test("Status grouping flattens by status section order")
+  func statusGroupingFlattensByStatusOrder() {
+    let items = [
+      item("idle-newest", timestamp: 500, status: .idle),
+      item("ready", timestamp: 400, status: .waitingForUser),
+      item("working", timestamp: 300, status: .thinking),
+      item("approval", timestamp: 200, status: .awaitingApproval(tool: "Edit"))
+    ]
+
+    let ids = flattenedIDs(items, groupMode: .status)
+
+    #expect(ids == ["approval", "working", "ready", "idle-newest"])
+  }
+
+  @Test("Pinned sessions stay first before the active grouping")
+  func pinnedSessionsStayFirst() {
+    let items = [
+      item("repo-item", projectPath: "/tmp/Repo", timestamp: 500),
+      item("pinned-old", projectPath: "/tmp/Repo", timestamp: 100, isPinned: true)
+    ]
+
+    let ids = flattenedIDs(
+      items,
+      repositories: [SelectedRepository(path: "/tmp/Repo")],
+      groupMode: .repo
+    )
+
+    #expect(ids == ["pinned-old", "repo-item"])
+  }
+
+  @Test("Collapsed sidebar groups are skipped by keyboard navigation order")
+  func collapsedGroupsAreSkipped() {
+    let repoA = SelectedRepository(path: "/tmp/RepoA")
+    let repoB = SelectedRepository(path: "/tmp/RepoB")
+    let items = [
+      item("a", projectPath: "/tmp/RepoA", timestamp: 200),
+      item("b", projectPath: "/tmp/RepoB", timestamp: 100)
+    ]
+
+    let ids = flattenedIDs(
+      items,
+      repositories: [repoA, repoB],
+      groupMode: .repo,
+      collapsedProjectGroups: ["/tmp/RepoA"]
+    )
+
+    #expect(ids == ["b"])
+  }
+
+  @Test("Next ID indexes through the flattened order without wrapping")
+  func nextIDIndexesThroughFlattenedOrder() {
+    let ids = ["first", "second", "third"]
+
+    #expect(SidebarSessionOrdering.nextID(in: ids, currentID: nil, direction: .forward) == "first")
+    #expect(SidebarSessionOrdering.nextID(in: ids, currentID: "first", direction: .forward) == "second")
+    #expect(SidebarSessionOrdering.nextID(in: ids, currentID: "third", direction: .forward) == "third")
+    #expect(SidebarSessionOrdering.nextID(in: ids, currentID: "third", direction: .backward) == "second")
+  }
+}
+
+private struct SidebarTestItem {
+  let id: String
+  let projectPath: String
+  let timestamp: Date
+  let status: SessionStatus?
+  let isPinned: Bool
+}
+
+private func item(
+  _ id: String,
+  projectPath: String = "/tmp/Repo",
+  timestamp: TimeInterval,
+  status: SessionStatus? = nil,
+  isPinned: Bool = false
+) -> SidebarTestItem {
+  SidebarTestItem(
+    id: id,
+    projectPath: projectPath,
+    timestamp: Date(timeIntervalSince1970: timestamp),
+    status: status,
+    isPinned: isPinned
+  )
+}
+
+private func flattenedIDs(
+  _ items: [SidebarTestItem],
+  repositories: [SelectedRepository] = [SelectedRepository(path: "/tmp/Repo")],
+  groupMode: SidebarGroupMode,
+  worktreeDisplayMode: WorktreeDisplayMode = .parent,
+  collapsedProjectGroups: Set<String> = [],
+  collapsedStatusGroups: Set<StatusGroupCategory> = [],
+  isPinnedSectionCollapsed: Bool = false
+) -> [String] {
+  SidebarSessionOrdering.flattenedItems(
+    from: items,
+    repositories: repositories,
+    groupMode: groupMode,
+    worktreeDisplayMode: worktreeDisplayMode,
+    collapsedProjectGroups: collapsedProjectGroups,
+    collapsedStatusGroups: collapsedStatusGroups,
+    isPinnedSectionCollapsed: isPinnedSectionCollapsed,
+    isPinned: { $0.isPinned },
+    projectPath: { $0.projectPath },
+    status: { $0.status },
+    timestamp: { $0.timestamp },
+    id: { $0.id }
+  )
+  .map(\.id)
+}


### PR DESCRIPTION
## Summary

- Extract sidebar session ordering into a shared helper used by both rendering and keyboard navigation.
- Make Cmd+[ and Cmd+] navigate through the flattened visible sidebar order instead of the global timestamp-sorted session list.
- Add focused ordering coverage for repo grouping, worktree-as-module mode, status grouping, pinned rows, collapsed groups, and next/previous indexing.

## Root Cause

The shortcut handler indexed into `selectedSessionItems`, which is sorted only by timestamp. The sidebar can render a different order when sessions are pinned, grouped by repo, grouped by status, displayed with worktrees as parent modules or separate modules, or collapsed. That mismatch made keyboard navigation appear to jump incorrectly.

## Validation

- `xcodebuild build -project app/AgentHub.xcodeproj -scheme AgentHub -destination 'platform=macOS'`

Note: `swift test --package-path app/modules/AgentHubCore --filter SidebarSessionOrderingTests` is blocked before AgentHub tests run by the existing third-party `CodeEditSymbols` SwiftPM resource issue: `Bundle.module` is unavailable because `Symbols.xcassets` is not declared as a resource.