### PR TITLE
[codex] Add worktree settings inventory

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/Models/WorktreeSettingsInventory.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Models/WorktreeSettingsInventory.swift
@@ -1,0 +1,162 @@
+import Foundation
+
+struct WorktreeSettingsSnapshot: Equatable {
+  let modules: [WorktreeSettingsModule]
+
+  var worktreeCount: Int {
+    modules.reduce(0) { $0 + $1.worktrees.count }
+  }
+}
+
+struct WorktreeSettingsModule: Identifiable, Equatable {
+  var id: String { path }
+
+  let name: String
+  let path: String
+  let worktrees: [WorktreeSettingsWorktree]
+}
+
+struct WorktreeSettingsWorktree: Identifiable, Equatable {
+  var id: String { path }
+
+  let branchName: String
+  let path: String
+  let worktree: WorktreeBranch
+  let parentModulePath: String
+  let providerKinds: [SessionProviderKind]
+  let deletionProviderKind: SessionProviderKind
+  let monitoredSessionCount: Int
+  let activeMonitoredSessionCount: Int
+  let historicalSessionCount: Int
+
+  var providerLabel: String {
+    providerKinds.map(\.rawValue).joined(separator: " + ")
+  }
+}
+
+enum WorktreeSettingsInventoryBuilder {
+  static func snapshot(
+    claudeRepositories: [SelectedRepository],
+    codexRepositories: [SelectedRepository],
+    claudeMonitoredSessions: [CLISession],
+    codexMonitoredSessions: [CLISession]
+  ) -> WorktreeSettingsSnapshot {
+    let mergedRepositories = WorktreeModuleResolver
+      .mergedRepositories(claudeRepositories + codexRepositories)
+      .reversed()
+
+    let modules = mergedRepositories.map { repository in
+      let modulePath = normalized(repository.path)
+      let worktrees = worktreeItems(
+        for: repository,
+        modulePath: modulePath,
+        claudeRepositories: claudeRepositories,
+        codexRepositories: codexRepositories,
+        claudeMonitoredSessions: claudeMonitoredSessions,
+        codexMonitoredSessions: codexMonitoredSessions
+      )
+
+      return WorktreeSettingsModule(
+        name: repository.name,
+        path: modulePath,
+        worktrees: worktrees
+      )
+    }
+
+    return WorktreeSettingsSnapshot(modules: modules)
+  }
+
+  private static func worktreeItems(
+    for repository: SelectedRepository,
+    modulePath: String,
+    claudeRepositories: [SelectedRepository],
+    codexRepositories: [SelectedRepository],
+    claudeMonitoredSessions: [CLISession],
+    codexMonitoredSessions: [CLISession]
+  ) -> [WorktreeSettingsWorktree] {
+    let providerRepositories = [
+      (kind: SessionProviderKind.claude, repositories: claudeRepositories),
+      (kind: SessionProviderKind.codex, repositories: codexRepositories),
+    ]
+
+    var orderedPaths: [String] = []
+    var seenPaths: Set<String> = []
+    for worktree in repository.worktrees where worktree.isWorktree {
+      appendPath(worktree.path, to: &orderedPaths, seen: &seenPaths)
+    }
+    for provider in providerRepositories {
+      guard let providerRepository = provider.repositories.first(where: { normalized($0.path) == modulePath }) else {
+        continue
+      }
+      for worktree in providerRepository.worktrees where worktree.isWorktree {
+        appendPath(worktree.path, to: &orderedPaths, seen: &seenPaths)
+      }
+    }
+
+    return orderedPaths.compactMap { worktreePath in
+      let providerMatches = providerRepositories.compactMap { provider -> (SessionProviderKind, WorktreeBranch)? in
+        guard let repository = provider.repositories.first(where: { normalized($0.path) == modulePath }),
+              let worktree = repository.worktrees.first(where: { normalized($0.path) == worktreePath && $0.isWorktree }) else {
+          return nil
+        }
+        return (provider.kind, normalizedWorktree(worktree))
+      }
+
+      guard let deletionMatch = providerMatches.first else { return nil }
+      let providerKinds = providerMatches.map(\.0)
+      let representative = deletionMatch.1
+      let monitoredSessions = providerMatches.flatMap { providerKind, _ in
+        switch providerKind {
+        case .claude:
+          return sessions(in: worktreePath, from: claudeMonitoredSessions)
+        case .codex:
+          return sessions(in: worktreePath, from: codexMonitoredSessions)
+        }
+      }
+      let historicalSessionCount = Set(providerMatches.flatMap { $0.1.sessions.map(\.id) }).count
+      let monitoredSessionsById = Dictionary(
+        monitoredSessions.map { ($0.id, $0) },
+        uniquingKeysWith: { existing, new in existing.isActive ? existing : new }
+      )
+
+      return WorktreeSettingsWorktree(
+        branchName: representative.name,
+        path: worktreePath,
+        worktree: representative,
+        parentModulePath: modulePath,
+        providerKinds: providerKinds,
+        deletionProviderKind: deletionMatch.0,
+        monitoredSessionCount: monitoredSessionsById.count,
+        activeMonitoredSessionCount: monitoredSessionsById.values.filter(\.isActive).count,
+        historicalSessionCount: historicalSessionCount
+      )
+    }
+  }
+
+  private static func sessions(in worktreePath: String, from sessions: [CLISession]) -> [CLISession] {
+    sessions.filter { session in
+      let projectPath = normalized(session.projectPath)
+      return projectPath == worktreePath || projectPath.hasPrefix(worktreePath + "/")
+    }
+  }
+
+  private static func appendPath(_ path: String, to paths: inout [String], seen: inout Set<String>) {
+    let normalizedPath = normalized(path)
+    guard seen.insert(normalizedPath).inserted else { return }
+    paths.append(normalizedPath)
+  }
+
+  private static func normalizedWorktree(_ worktree: WorktreeBranch) -> WorktreeBranch {
+    WorktreeBranch(
+      name: worktree.name,
+      path: normalized(worktree.path),
+      isWorktree: worktree.isWorktree,
+      sessions: worktree.sessions,
+      isExpanded: worktree.isExpanded
+    )
+  }
+
+  private static func normalized(_ path: String) -> String {
+    WorktreeModuleResolver.normalizedDirectoryPath(path)
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/GitWorktreeService.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/GitWorktreeService.swift
@@ -10,7 +10,14 @@ public struct LocalBranchesResult: Sendable {
   public let currentBranchName: String
 }
 
-public actor GitWorktreeService {
+public protocol GitWorktreeRemovalServiceProtocol: Sendable {
+  func removeWorktree(at worktreePath: String, force: Bool) async throws
+  func removeWorktree(at worktreePath: String, relativeTo parentRepoPath: String, force: Bool) async throws
+  func checkIfOrphaned(at worktreePath: String) -> (isOrphaned: Bool, parentRepoPath: String?)?
+  func removeOrphanedWorktree(at worktreePath: String, parentRepoPath: String) async throws
+}
+
+public actor GitWorktreeService: GitWorktreeRemovalServiceProtocol {
   private let service: WorktreeManagementService
 
   public init(service: WorktreeManagementService = WorktreeManagementService()) {

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/SimulatorService.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/SimulatorService.swift
@@ -51,12 +51,12 @@ private struct BuildSetup: Sendable {
   let derivedDataPath: String
 }
 
-private struct BuiltAppInfo: Sendable {
+struct BuiltAppInfo: Sendable {
   let appPath: String
   let bundleIdentifier: String?
 }
 
-private enum BuildPlatform {
+enum BuildPlatform {
   case macOS
   case iOSSimulator
 
@@ -66,6 +66,42 @@ private enum BuildPlatform {
       return "Debug"
     case .iOSSimulator:
       return "Debug-iphonesimulator"
+    }
+  }
+
+  func scoreProductPathComponents(_ components: [String]) -> Int? {
+    let lowercased = components.map { $0.lowercased() }
+
+    switch self {
+    case .macOS:
+      let excludedFragments = [
+        "iphoneos",
+        "iphonesimulator",
+        "appletvos",
+        "appletvsimulator",
+        "watchos",
+        "watchsimulator",
+        "xros",
+        "xrsimulator"
+      ]
+      if lowercased.contains(where: { component in
+        excludedFragments.contains(where: component.contains)
+      }) {
+        return nil
+      }
+
+      if lowercased.contains(where: { $0.contains("macosx") || $0.contains("maccatalyst") }) {
+        return 30
+      }
+      if lowercased.contains(where: { $0 == "debug" || $0 == "release" }) {
+        return 20
+      }
+      return 10
+    case .iOSSimulator:
+      guard lowercased.contains(where: { $0.contains("iphonesimulator") }) else {
+        return nil
+      }
+      return 30
     }
   }
 }
@@ -822,21 +858,61 @@ public final class SimulatorService {
     in productsDirectory: String,
     preferredAppName: String
   ) -> String? {
-    let directoryURL = URL(fileURLWithPath: productsDirectory, isDirectory: true)
+    preferredAppBundlePaths(
+      in: productsDirectory,
+      preferredAppName: preferredAppName,
+      platform: nil
+    ).first
+  }
+
+  nonisolated static func preferredAppBundlePaths(
+    in productsDirectory: String,
+    preferredAppName: String,
+    platform: BuildPlatform?
+  ) -> [String] {
+    struct Candidate {
+      let url: URL
+      let nameScore: Int
+      let platformScore: Int
+      let modified: Date
+    }
+
+    let rootURL = URL(fileURLWithPath: productsDirectory, isDirectory: true)
+      .standardizedFileURL
+    let fileManager = FileManager.default
     guard let candidates = try? FileManager.default.contentsOfDirectory(
-      at: directoryURL,
+      at: rootURL,
       includingPropertiesForKeys: [.contentModificationDateKey],
       options: [.skipsHiddenFiles]
     ) else {
-      return nil
+      return []
     }
 
-    let apps = candidates.filter { $0.pathExtension == "app" }
-    guard !apps.isEmpty else { return nil }
+    var searchURLs = candidates
+    if let enumerator = fileManager.enumerator(
+      at: rootURL,
+      includingPropertiesForKeys: [.contentModificationDateKey, .isDirectoryKey],
+      options: [.skipsHiddenFiles]
+    ) {
+      while let item = enumerator.nextObject() as? URL {
+        searchURLs.append(item)
+        if item.pathExtension == "app" {
+          enumerator.skipDescendants()
+        }
+      }
+    }
 
     let preferredBundleName = "\(preferredAppName).app".lowercased()
 
-    func rank(for url: URL) -> (Int, Date) {
+    func relativeComponents(for url: URL) -> [String] {
+      let parentURL = url.deletingLastPathComponent().standardizedFileURL
+      let rootComponents = rootURL.pathComponents
+      let parentComponents = parentURL.pathComponents
+      guard parentComponents.count >= rootComponents.count else { return [] }
+      return Array(parentComponents.dropFirst(rootComponents.count))
+    }
+
+    func scoreName(for url: URL) -> Int {
       let name = url.lastPathComponent.lowercased()
       var score = 0
 
@@ -850,21 +926,41 @@ public final class SimulatorService {
         score -= 100
       }
 
-      let modified = (try? url.resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate)
-        ?? .distantPast
-      return (score, modified)
+      return score
     }
 
-    let bestCandidate = apps.sorted { lhs, rhs in
-      let left = rank(for: lhs)
-      let right = rank(for: rhs)
-      if left.0 != right.0 {
-        return left.0 > right.0
+    let apps = searchURLs.compactMap { url -> Candidate? in
+      guard url.pathExtension == "app" else { return nil }
+      let platformScore: Int
+      if let platform {
+        guard let score = platform.scoreProductPathComponents(relativeComponents(for: url)) else {
+          return nil
+        }
+        platformScore = score
+      } else {
+        platformScore = 0
       }
-      return left.1 > right.1
-    }.first
 
-    return bestCandidate?.path
+      let modified = (try? url.resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate)
+        ?? .distantPast
+      return Candidate(
+        url: url.standardizedFileURL,
+        nameScore: scoreName(for: url),
+        platformScore: platformScore,
+        modified: modified
+      )
+    }
+
+    return apps.sorted { lhs, rhs in
+      if lhs.nameScore != rhs.nameScore {
+        return lhs.nameScore > rhs.nameScore
+      }
+      if lhs.platformScore != rhs.platformScore {
+        return lhs.platformScore > rhs.platformScore
+      }
+      return lhs.modified > rhs.modified
+    }
+    .map(\.url.path)
   }
 
   nonisolated static func bundleIdentifier(atAppPath appPath: String) -> String? {
@@ -875,27 +971,28 @@ public final class SimulatorService {
     return plist["CFBundleIdentifier"] as? String
   }
 
-  private nonisolated static func resolveBuiltApp(
+  nonisolated static func resolveBuiltApp(
     derivedDataPath: String,
     scheme: String,
     platform: BuildPlatform,
     requiresBundleIdentifier: Bool
   ) -> BuiltAppInfo? {
     let productsDirectory = (derivedDataPath as NSString)
-      .appendingPathComponent("Build/Products/\(platform.productsDirectoryName)")
-    guard let appPath = preferredAppBundlePath(
+      .appendingPathComponent("Build/Products")
+    let candidatePaths = preferredAppBundlePaths(
       in: productsDirectory,
-      preferredAppName: scheme
-    ) else {
-      return nil
+      preferredAppName: scheme,
+      platform: platform
+    )
+    for appPath in candidatePaths {
+      let bundleIdentifier = requiresBundleIdentifier ? bundleIdentifier(atAppPath: appPath) : nil
+      if requiresBundleIdentifier && bundleIdentifier == nil {
+        continue
+      }
+      return BuiltAppInfo(appPath: appPath, bundleIdentifier: bundleIdentifier)
     }
 
-    let bundleIdentifier = requiresBundleIdentifier ? bundleIdentifier(atAppPath: appPath) : nil
-    if requiresBundleIdentifier && bundleIdentifier == nil {
-      return nil
-    }
-
-    return BuiltAppInfo(appPath: appPath, bundleIdentifier: bundleIdentifier)
+    return nil
   }
 
   private nonisolated static func ensureDirectoryExists(atPath path: String) throws {

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/WorktreeInventorySection.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/WorktreeInventorySection.swift
@@ -1,0 +1,316 @@
+import SwiftUI
+
+struct WorktreeInventorySection: View {
+  @Bindable var claudeViewModel: CLISessionsViewModel
+  @Bindable var codexViewModel: CLISessionsViewModel
+
+  @State private var pendingDeletion: WorktreeSettingsWorktree?
+  @State private var isDeleteConfirmationPresented = false
+  @State private var deletionFailure: WorktreeSettingsDeletionFailure?
+  @State private var isFailureAlertPresented = false
+
+  var body: some View {
+    Section("Worktrees") {
+      let currentSnapshot = snapshot
+
+      if currentSnapshot.modules.isEmpty {
+        WorktreeInventoryEmptyView()
+      } else {
+        VStack(alignment: .leading, spacing: 14) {
+          WorktreeInventorySummaryView(snapshot: currentSnapshot)
+
+          ForEach(currentSnapshot.modules) { module in
+            WorktreeInventoryModuleView(
+              module: module,
+              isDeleting: { isDeletingWorktree(at: $0.path) },
+              onDelete: requestDelete
+            )
+          }
+        }
+        .padding(.vertical, 4)
+      }
+    }
+    .alert("Delete Worktree?", isPresented: $isDeleteConfirmationPresented, presenting: pendingDeletion) { worktree in
+      Button("Cancel", role: .cancel) {
+        pendingDeletion = nil
+      }
+      Button(worktree.monitoredSessionCount > 0 ? "Archive & Delete" : "Delete", role: .destructive) {
+        delete(worktree)
+      }
+    } message: { worktree in
+      if worktree.monitoredSessionCount > 0 {
+        Text("This worktree has \(worktree.monitoredSessionCount) monitored \(worktree.monitoredSessionCount == 1 ? "session" : "sessions"). Continuing will archive those sessions from the side panel and delete the worktree at:\n\(worktree.path)\n\nThis cannot be undone.")
+      } else {
+        Text("Delete the worktree at:\n\(worktree.path)\n\nThis cannot be undone.")
+      }
+    }
+    .alert("Failed to Delete Worktree", isPresented: $isFailureAlertPresented, presenting: deletionFailure) { failure in
+      if failure.error.isOrphaned, failure.error.parentRepoPath != nil {
+        Button("Prune & Delete", role: .destructive) {
+          pruneAndDelete(failure)
+        }
+      } else {
+        Button("Force Delete", role: .destructive) {
+          forceDelete(failure)
+        }
+      }
+      Button("Cancel", role: .cancel) {
+        clearFailure(failure)
+      }
+    } message: { failure in
+      if failure.error.isOrphaned, let parentRepoPath = failure.error.parentRepoPath {
+        Text("The worktree at:\n\(failure.error.worktree.path)\n\nhas no parent repo. You can prune and delete it from:\n\(parentRepoPath)")
+      } else {
+        Text("\(failure.error.message)\n\n\"Force Delete\" will remove the worktree even if it contains untracked files.")
+      }
+    }
+  }
+
+  private var snapshot: WorktreeSettingsSnapshot {
+    WorktreeSettingsInventoryBuilder.snapshot(
+      claudeRepositories: claudeViewModel.selectedRepositories,
+      codexRepositories: codexViewModel.selectedRepositories,
+      claudeMonitoredSessions: claudeViewModel.monitoredSessions.map(\.session),
+      codexMonitoredSessions: codexViewModel.monitoredSessions.map(\.session)
+    )
+  }
+
+  private func requestDelete(_ worktree: WorktreeSettingsWorktree) {
+    pendingDeletion = worktree
+    isDeleteConfirmationPresented = true
+  }
+
+  private func delete(_ worktree: WorktreeSettingsWorktree) {
+    pendingDeletion = nil
+    Task {
+      await delete(worktree, force: false)
+    }
+  }
+
+  private func forceDelete(_ failure: WorktreeSettingsDeletionFailure) {
+    Task {
+      await delete(failure.worktree, force: true)
+    }
+  }
+
+  private func pruneAndDelete(_ failure: WorktreeSettingsDeletionFailure) {
+    guard let parentRepoPath = failure.error.parentRepoPath else { return }
+    clearFailure(failure)
+
+    Task {
+      let viewModel = viewModel(for: failure.providerKind)
+      let succeeded = await viewModel.deleteOrphanedWorktree(
+        failure.error.worktree,
+        parentRepoPath: parentRepoPath
+      )
+
+      if succeeded {
+        completeSuccessfulDeletion(of: failure.worktree)
+      } else {
+        showFailure(from: viewModel, worktree: failure.worktree)
+      }
+    }
+  }
+
+  private func delete(_ worktree: WorktreeSettingsWorktree, force: Bool) async {
+    clearFailure(providerKind: worktree.deletionProviderKind)
+    let viewModel = viewModel(for: worktree.deletionProviderKind)
+    let succeeded = await viewModel.deleteWorktree(worktree.worktree, force: force)
+
+    if succeeded {
+      completeSuccessfulDeletion(of: worktree)
+    } else {
+      showFailure(from: viewModel, worktree: worktree)
+    }
+  }
+
+  private func completeSuccessfulDeletion(of worktree: WorktreeSettingsWorktree) {
+    claudeViewModel.archiveMonitoredSessions(inWorktreePath: worktree.path)
+    codexViewModel.archiveMonitoredSessions(inWorktreePath: worktree.path)
+    claudeViewModel.forgetOwnedWorktreePath(worktree.path)
+    codexViewModel.forgetOwnedWorktreePath(worktree.path)
+    claudeViewModel.refresh()
+    codexViewModel.refresh()
+  }
+
+  private func showFailure(from viewModel: CLISessionsViewModel, worktree: WorktreeSettingsWorktree) {
+    let error = viewModel.worktreeDeletionError ?? CLISessionsViewModel.WorktreeDeletionError(
+      worktree: worktree.worktree,
+      message: "The worktree could not be deleted."
+    )
+    deletionFailure = WorktreeSettingsDeletionFailure(
+      providerKind: viewModel.providerKind,
+      worktree: worktree,
+      error: error
+    )
+    isFailureAlertPresented = true
+  }
+
+  private func clearFailure(_ failure: WorktreeSettingsDeletionFailure) {
+    clearFailure(providerKind: failure.providerKind)
+    deletionFailure = nil
+  }
+
+  private func clearFailure(providerKind: SessionProviderKind) {
+    viewModel(for: providerKind).clearWorktreeDeletionError()
+    deletionFailure = nil
+    isFailureAlertPresented = false
+  }
+
+  private func viewModel(for providerKind: SessionProviderKind) -> CLISessionsViewModel {
+    switch providerKind {
+    case .claude:
+      return claudeViewModel
+    case .codex:
+      return codexViewModel
+    }
+  }
+
+  private func isDeletingWorktree(at path: String) -> Bool {
+    claudeViewModel.deletingWorktreePath == path || codexViewModel.deletingWorktreePath == path
+  }
+}
+
+private struct WorktreeSettingsDeletionFailure {
+  let providerKind: SessionProviderKind
+  let worktree: WorktreeSettingsWorktree
+  let error: CLISessionsViewModel.WorktreeDeletionError
+}
+
+private struct WorktreeInventorySummaryView: View {
+  let snapshot: WorktreeSettingsSnapshot
+
+  var body: some View {
+    HStack(spacing: 8) {
+      Label("\(snapshot.modules.count) \(snapshot.modules.count == 1 ? "module" : "modules")", systemImage: "folder")
+      Text("·")
+        .foregroundStyle(.secondary)
+      Text("\(snapshot.worktreeCount) \(snapshot.worktreeCount == 1 ? "worktree" : "worktrees")")
+    }
+    .font(.caption)
+    .foregroundStyle(.secondary)
+  }
+}
+
+private struct WorktreeInventoryModuleView: View {
+  let module: WorktreeSettingsModule
+  let isDeleting: (WorktreeSettingsWorktree) -> Bool
+  let onDelete: (WorktreeSettingsWorktree) -> Void
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      HStack(spacing: 8) {
+        Image(systemName: "folder.fill")
+          .foregroundStyle(.secondary)
+        VStack(alignment: .leading, spacing: 2) {
+          Text(module.name)
+            .font(.headline)
+          Text(module.path)
+            .font(.caption)
+            .foregroundStyle(.secondary)
+            .lineLimit(1)
+            .truncationMode(.middle)
+        }
+        Spacer()
+        Text("\(module.worktrees.count)")
+          .font(.caption)
+          .foregroundStyle(.secondary)
+      }
+
+      if module.worktrees.isEmpty {
+        Text("No worktrees")
+          .font(.caption)
+          .foregroundStyle(.secondary)
+          .padding(.leading, 24)
+      } else {
+        VStack(spacing: 6) {
+          ForEach(module.worktrees) { worktree in
+            WorktreeInventoryRow(
+              worktree: worktree,
+              isDeleting: isDeleting(worktree),
+              onDelete: { onDelete(worktree) }
+            )
+          }
+        }
+      }
+    }
+  }
+}
+
+private struct WorktreeInventoryRow: View {
+  let worktree: WorktreeSettingsWorktree
+  let isDeleting: Bool
+  let onDelete: () -> Void
+
+  var body: some View {
+    HStack(alignment: .center, spacing: 10) {
+      Image(systemName: "arrow.triangle.branch")
+        .foregroundStyle(.secondary)
+        .frame(width: 18)
+
+      VStack(alignment: .leading, spacing: 3) {
+        HStack(spacing: 6) {
+          Text(worktree.branchName)
+            .font(.subheadline.weight(.semibold))
+            .lineLimit(1)
+
+          Text(worktree.providerLabel)
+            .font(.caption2.weight(.medium))
+            .foregroundStyle(.secondary)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(
+              RoundedRectangle(cornerRadius: 5, style: .continuous)
+                .fill(Color.primary.opacity(0.06))
+            )
+        }
+
+        Text(worktree.path)
+          .font(.caption)
+          .foregroundStyle(.secondary)
+          .lineLimit(1)
+          .truncationMode(.middle)
+      }
+
+      Spacer(minLength: 8)
+
+      if worktree.monitoredSessionCount > 0 {
+        Label("\(worktree.monitoredSessionCount)", systemImage: worktree.activeMonitoredSessionCount > 0 ? "circle.fill" : "circle")
+          .font(.caption)
+          .foregroundStyle(worktree.activeMonitoredSessionCount > 0 ? .green : .secondary)
+          .help("\(worktree.monitoredSessionCount) monitored \(worktree.monitoredSessionCount == 1 ? "session" : "sessions")")
+      }
+
+      if isDeleting {
+        ProgressView()
+          .scaleEffect(0.7)
+          .frame(width: 28, height: 28)
+      } else {
+        Button(action: onDelete) {
+          Image(systemName: "trash")
+            .font(.system(size: 13))
+            .frame(width: 28, height: 28)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .foregroundStyle(.secondary)
+        .help("Delete worktree")
+        .accessibilityLabel("Delete worktree \(worktree.branchName)")
+      }
+    }
+    .padding(8)
+    .background(
+      RoundedRectangle(cornerRadius: 8, style: .continuous)
+        .fill(Color.primary.opacity(0.04))
+    )
+  }
+}
+
+private struct WorktreeInventoryEmptyView: View {
+  var body: some View {
+    Label("No modules added to the sessions side panel", systemImage: "folder")
+      .font(.caption)
+      .foregroundStyle(.secondary)
+      .padding(.vertical, 4)
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/WorktreeSettingsView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/WorktreeSettingsView.swift
@@ -6,6 +6,7 @@
 import SwiftUI
 
 public struct WorktreeSettingsView: View {
+  @Environment(\.agentHub) private var agentHub
   @Environment(\.colorScheme) private var colorScheme
   @Environment(\.runtimeTheme) private var runtimeTheme
   @AppStorage(AgentHubDefaults.worktreeBranchPrefix)
@@ -44,6 +45,19 @@ public struct WorktreeSettingsView: View {
             .foregroundStyle(.secondary)
 
           previewBox
+        }
+      }
+
+      if let agentHub {
+        WorktreeInventorySection(
+          claudeViewModel: agentHub.claudeSessionsViewModel,
+          codexViewModel: agentHub.codexSessionsViewModel
+        )
+      } else {
+        Section("Worktrees") {
+          Text("AgentHub provider not found")
+            .font(.caption)
+            .foregroundStyle(.secondary)
         }
       }
     }

--- a/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/CLISessionsViewModel.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/CLISessionsViewModel.swift
@@ -30,6 +30,7 @@ public final class CLISessionsViewModel {
   public let providerKind: SessionProviderKind
   private let codexDataPath: String
   private let worktreeService = GitWorktreeService()
+  private let worktreeRemovalService: any GitWorktreeRemovalServiceProtocol
   private let metadataStore: SessionMetadataStore?
   private let terminalWorkspaceStore: (any TerminalWorkspaceStoreProtocol)?
   private let sessionRelationshipStore: (any SessionRelationshipStoreProtocol)?
@@ -1318,6 +1319,7 @@ public final class CLISessionsViewModel {
     approvalClaimStore: (any ApprovalClaimStoreProtocol)? = nil,
     hookInstaller: (any ClaudeHookInstallerProtocol)? = nil,
     codexDataPath: String? = nil,
+    worktreeRemovalService: any GitWorktreeRemovalServiceProtocol = GitWorktreeService(),
     terminalSurfaceFactory: any EmbeddedTerminalSurfaceFactory = DefaultEmbeddedTerminalSurfaceFactory(),
     terminalBackend: EmbeddedTerminalBackend = .storedPreference,
     terminalWorkspaceStore: (any TerminalWorkspaceStoreProtocol)? = nil
@@ -1336,6 +1338,7 @@ public final class CLISessionsViewModel {
     self.accessorySessionDetectionService = accessorySessionDetectionService
     self.approvalClaimStore = approvalClaimStore
     self.hookInstaller = hookInstaller
+    self.worktreeRemovalService = worktreeRemovalService
     self.terminalSurfaceFactory = terminalSurfaceFactory
     self.terminalBackend = terminalBackend
     self.cliConfiguration = cliConfiguration
@@ -1604,6 +1607,11 @@ public final class CLISessionsViewModel {
     let normalizedPath = WorktreeModuleResolver.normalizedDirectoryPath(path)
     guard ownedWorktreePaths.remove(normalizedPath) != nil else { return }
     syncOwnedWorktreePathsToMonitor()
+    persistWorkspaceState()
+  }
+
+  public func forgetOwnedWorktreePath(_ path: String) {
+    removeOwnedWorktreePath(path)
   }
 
   private func filterOwnedWorktrees(in repositories: [SelectedRepository]) -> [SelectedRepository] {
@@ -2117,15 +2125,16 @@ public final class CLISessionsViewModel {
   /// - Parameters:
   ///   - worktree: The worktree to delete
   ///   - force: When true, uses double `--force` to remove worktrees with untracked files
-  public func deleteWorktree(_ worktree: WorktreeBranch, force: Bool = false) async {
+  @discardableResult
+  public func deleteWorktree(_ worktree: WorktreeBranch, force: Bool = false) async -> Bool {
     // [CLISessionsVM] deleteWorktree: \(worktree.path)")
     deletingWorktreePath = worktree.path
 
     do {
       if FileManager.default.fileExists(atPath: worktree.path) {
-        try await worktreeService.removeWorktree(at: worktree.path, force: force)
+        try await worktreeRemovalService.removeWorktree(at: worktree.path, force: force)
       } else if let parentRepoPath = findParentRepoPath(for: worktree) {
-        try await worktreeService.removeWorktree(at: worktree.path, relativeTo: parentRepoPath, force: force)
+        try await worktreeRemovalService.removeWorktree(at: worktree.path, relativeTo: parentRepoPath, force: force)
       } else {
         throw NSError(domain: "AgentHub", code: 1, userInfo: [
           NSLocalizedDescriptionKey: "Cannot find parent repository for worktree at \(worktree.path)"
@@ -2135,10 +2144,11 @@ public final class CLISessionsViewModel {
       deletingWorktreePath = nil
       clearWorktreeDeletionError()
       refresh()
+      return true
     } catch {
       // [CLISessionsVM] Failed to delete worktree: \(error.localizedDescription)")
       // Check if this is an orphaned worktree
-      if let orphanInfo = worktreeService.checkIfOrphaned(at: worktree.path),
+      if let orphanInfo = worktreeRemovalService.checkIfOrphaned(at: worktree.path),
          orphanInfo.isOrphaned {
         worktreeDeletionError = WorktreeDeletionError(
           worktree: worktree,
@@ -2153,6 +2163,7 @@ public final class CLISessionsViewModel {
         )
       }
       deletingWorktreePath = nil
+      return false
     }
   }
 
@@ -2160,21 +2171,24 @@ public final class CLISessionsViewModel {
   /// - Parameters:
   ///   - worktree: The orphaned worktree to delete
   ///   - parentRepoPath: Path to the parent git repository
-  public func deleteOrphanedWorktree(_ worktree: WorktreeBranch, parentRepoPath: String) async {
+  @discardableResult
+  public func deleteOrphanedWorktree(_ worktree: WorktreeBranch, parentRepoPath: String) async -> Bool {
     deletingWorktreePath = worktree.path
 
     do {
-      try await worktreeService.removeOrphanedWorktree(at: worktree.path, parentRepoPath: parentRepoPath)
+      try await worktreeRemovalService.removeOrphanedWorktree(at: worktree.path, parentRepoPath: parentRepoPath)
       removeOwnedWorktreePath(worktree.path)
       deletingWorktreePath = nil
       clearWorktreeDeletionError()
       refresh()
+      return true
     } catch {
       worktreeDeletionError = WorktreeDeletionError(
         worktree: worktree,
         message: "Failed to delete orphaned worktree: \(error.localizedDescription)"
       )
       deletingWorktreePath = nil
+      return false
     }
   }
 
@@ -2185,7 +2199,7 @@ public final class CLISessionsViewModel {
     deletingWorktreePath = worktree.path
     clearWorktreeDeletionError()
     Task {
-      await deleteWorktree(worktree, force: true)
+      _ = await deleteWorktree(worktree, force: true)
     }
   }
 
@@ -2194,7 +2208,7 @@ public final class CLISessionsViewModel {
     deletingWorktreePath = worktree.path
     clearWorktreeDeletionError()
     Task {
-      await deleteOrphanedWorktree(worktree, parentRepoPath: parentRepoPath)
+      _ = await deleteOrphanedWorktree(worktree, parentRepoPath: parentRepoPath)
     }
   }
 
@@ -2202,14 +2216,16 @@ public final class CLISessionsViewModel {
   /// - Parameters:
   ///   - session: The session whose worktree to delete
   ///   - force: When true, uses double `--force` to remove worktrees with untracked files
-  public func deleteWorktreeForSession(_ session: CLISession, force: Bool = false) async {
+  @discardableResult
+  public func deleteWorktreeForSession(_ session: CLISession, force: Bool = false) async -> Bool {
     deletingWorktreePath = session.projectPath
     do {
-      try await worktreeService.removeWorktree(at: session.projectPath, force: force)
+      try await worktreeRemovalService.removeWorktree(at: session.projectPath, force: force)
       removeOwnedWorktreePath(session.projectPath)
       deletingWorktreePath = nil
       stopMonitoring(session: session)
       refresh()
+      return true
     } catch {
       deletingWorktreePath = nil
       let syntheticWorktree = WorktreeBranch(
@@ -2217,7 +2233,7 @@ public final class CLISessionsViewModel {
         path: session.projectPath,
         isWorktree: true
       )
-      if let orphanInfo = worktreeService.checkIfOrphaned(at: session.projectPath),
+      if let orphanInfo = worktreeRemovalService.checkIfOrphaned(at: session.projectPath),
          orphanInfo.isOrphaned {
         worktreeDeletionError = WorktreeDeletionError(
           worktree: syntheticWorktree,
@@ -2231,6 +2247,7 @@ public final class CLISessionsViewModel {
           message: error.localizedDescription
         )
       }
+      return false
     }
   }
 
@@ -3223,6 +3240,19 @@ public final class CLISessionsViewModel {
   /// Stop monitoring a session
   public func stopMonitoring(session: CLISession) {
     stopMonitoring(sessionId: session.id)
+  }
+
+  public func monitoredSessions(inWorktreePath worktreePath: String) -> [CLISession] {
+    monitoredSessions
+      .map(\.session)
+      .filter { isProjectPath($0.projectPath, containedIn: worktreePath) }
+  }
+
+  public func archiveMonitoredSessions(inWorktreePath worktreePath: String) {
+    let sessionIds = monitoredSessions(inWorktreePath: worktreePath).map(\.id)
+    for sessionId in sessionIds {
+      stopMonitoring(sessionId: sessionId)
+    }
   }
 
   /// Stop monitoring by session ID

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/SimulatorServiceTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/SimulatorServiceTests.swift
@@ -209,15 +209,72 @@ struct BuildHelperTests {
     #expect(URL(fileURLWithPath: try #require(appPath)).standardizedFileURL.path == expectedPath)
   }
 
+  @Test func resolveBuiltMacAppSearchesProductsTree() throws {
+    let root = URL(fileURLWithPath: NSTemporaryDirectory())
+      .appendingPathComponent("SimulatorServiceTests-\(UUID().uuidString)", isDirectory: true)
+    let macProducts = root.appendingPathComponent("Build/Products/Debug-macosx", isDirectory: true)
+    let simulatorProducts = root.appendingPathComponent("Build/Products/Debug-iphonesimulator", isDirectory: true)
+    let expectedApp = macProducts.appendingPathComponent("Demo.app", isDirectory: true)
+
+    try FileManager.default.createDirectory(at: expectedApp, withIntermediateDirectories: true)
+    try FileManager.default.createDirectory(
+      at: simulatorProducts.appendingPathComponent("Demo.app", isDirectory: true),
+      withIntermediateDirectories: true
+    )
+
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    let builtApp = try #require(SimulatorService.resolveBuiltApp(
+      derivedDataPath: root.path,
+      scheme: "Demo",
+      platform: .macOS,
+      requiresBundleIdentifier: false
+    ))
+
+    #expect(URL(fileURLWithPath: builtApp.appPath).standardizedFileURL.path == expectedApp.standardizedFileURL.path)
+  }
+
+  @Test func resolveSimulatorAppSkipsCandidatesWithoutBundleIdentifier() throws {
+    let root = URL(fileURLWithPath: NSTemporaryDirectory())
+      .appendingPathComponent("SimulatorServiceTests-\(UUID().uuidString)", isDirectory: true)
+    let products = root.appendingPathComponent("Build/Products/Debug-iphonesimulator", isDirectory: true)
+    let staleApp = products.appendingPathComponent("Demo.app", isDirectory: true)
+    let launchableApp = products.appendingPathComponent("DemoPreview.app", isDirectory: true)
+
+    try FileManager.default.createDirectory(at: staleApp, withIntermediateDirectories: true)
+    try FileManager.default.createDirectory(at: launchableApp, withIntermediateDirectories: true)
+    try writeInfoPlist(bundleIdentifier: "com.agenthub.demo-preview", to: launchableApp)
+
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    let builtApp = try #require(SimulatorService.resolveBuiltApp(
+      derivedDataPath: root.path,
+      scheme: "Demo",
+      platform: .iOSSimulator,
+      requiresBundleIdentifier: true
+    ))
+
+    #expect(URL(fileURLWithPath: builtApp.appPath).standardizedFileURL.path == launchableApp.standardizedFileURL.path)
+    #expect(builtApp.bundleIdentifier == "com.agenthub.demo-preview")
+  }
+
   @Test func bundleIdentifierReadsInfoPlist() throws {
     let root = URL(fileURLWithPath: NSTemporaryDirectory())
       .appendingPathComponent("SimulatorServiceTests-\(UUID().uuidString)", isDirectory: true)
     let app = root.appendingPathComponent("Demo.app", isDirectory: true)
 
     try FileManager.default.createDirectory(at: app, withIntermediateDirectories: true)
+    try writeInfoPlist(bundleIdentifier: "com.agenthub.demo", to: app)
 
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    let bundleIdentifier = SimulatorService.bundleIdentifier(atAppPath: app.path)
+    #expect(bundleIdentifier == "com.agenthub.demo")
+  }
+
+  private func writeInfoPlist(bundleIdentifier: String, to app: URL) throws {
     let infoPlist: [String: Any] = [
-      "CFBundleIdentifier": "com.agenthub.demo"
+      "CFBundleIdentifier": bundleIdentifier
     ]
     let data = try PropertyListSerialization.data(
       fromPropertyList: infoPlist,
@@ -225,10 +282,5 @@ struct BuildHelperTests {
       options: 0
     )
     try data.write(to: app.appendingPathComponent("Info.plist"))
-
-    defer { try? FileManager.default.removeItem(at: root) }
-
-    let bundleIdentifier = SimulatorService.bundleIdentifier(atAppPath: app.path)
-    #expect(bundleIdentifier == "com.agenthub.demo")
   }
 }

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/WorktreeSettingsInventoryTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/WorktreeSettingsInventoryTests.swift
@@ -1,0 +1,228 @@
+import Combine
+import Foundation
+import Testing
+
+@testable import AgentHubCore
+
+@Suite("Worktree settings inventory")
+struct WorktreeSettingsInventoryTests {
+  @Test("Snapshot keeps side panel module order and includes modules without worktrees")
+  func snapshotKeepsModuleOrder() {
+    let agentHub = SelectedRepository(path: "/tmp/AgentHub")
+    let xcodeTrace = SelectedRepository(path: "/tmp/XcodeTraceMCP")
+    let agentHubPage = SelectedRepository(path: "/tmp/AgentHubPage")
+
+    let snapshot = WorktreeSettingsInventoryBuilder.snapshot(
+      claudeRepositories: [agentHub, xcodeTrace, agentHubPage],
+      codexRepositories: [],
+      claudeMonitoredSessions: [],
+      codexMonitoredSessions: []
+    )
+
+    #expect(snapshot.modules.map(\.name) == ["AgentHubPage", "XcodeTraceMCP", "AgentHub"])
+    #expect(snapshot.modules.map(\.worktrees.count) == [0, 0, 0])
+  }
+
+  @Test("Snapshot lists real worktrees once across providers and counts monitored sessions")
+  func snapshotDeduplicatesProviderWorktrees() throws {
+    let claudeSession = session(
+      "claude-session",
+      path: "/tmp/AgentHub-feature",
+      isActive: true
+    )
+    let codexSession = session(
+      "codex-session",
+      path: "/tmp/AgentHub-feature/app"
+    )
+    let claudeRepository = SelectedRepository(
+      path: "/tmp/AgentHub",
+      worktrees: [
+        WorktreeBranch(name: "main", path: "/tmp/AgentHub", isWorktree: false),
+        WorktreeBranch(
+          name: "feature/settings",
+          path: "/tmp/AgentHub-feature",
+          isWorktree: true,
+          sessions: [claudeSession]
+        ),
+      ]
+    )
+    let codexRepository = SelectedRepository(
+      path: "/tmp/AgentHub",
+      worktrees: [
+        WorktreeBranch(
+          name: "feature/settings",
+          path: "/tmp/AgentHub-feature/",
+          isWorktree: true,
+          sessions: [codexSession]
+        ),
+      ]
+    )
+
+    let snapshot = WorktreeSettingsInventoryBuilder.snapshot(
+      claudeRepositories: [claudeRepository],
+      codexRepositories: [codexRepository],
+      claudeMonitoredSessions: [claudeSession],
+      codexMonitoredSessions: [codexSession]
+    )
+
+    let module = try #require(snapshot.modules.first)
+    let worktree = try #require(module.worktrees.first)
+
+    #expect(module.worktrees.count == 1)
+    #expect(worktree.path == "/tmp/AgentHub-feature")
+    #expect(worktree.providerKinds == [.claude, .codex])
+    #expect(worktree.deletionProviderKind == .claude)
+    #expect(worktree.monitoredSessionCount == 2)
+    #expect(worktree.activeMonitoredSessionCount == 1)
+    #expect(worktree.historicalSessionCount == 2)
+  }
+}
+
+@Suite("Worktree settings deletion helpers")
+@MainActor
+struct WorktreeSettingsDeletionHelperTests {
+  @Test("Archive monitored sessions under worktree keeps other sessions")
+  func archiveMonitoredSessionsUnderWorktree() {
+    let viewModel = makeDeletionViewModel()
+    let worktreeSession = session("worktree-session", path: "/tmp/AgentHub-feature")
+    let nestedWorktreeSession = session("nested-session", path: "/tmp/AgentHub-feature/app")
+    let otherSession = session("other-session", path: "/tmp/AgentHub-other")
+
+    viewModel.startMonitoring(session: worktreeSession)
+    viewModel.startMonitoring(session: nestedWorktreeSession)
+    viewModel.startMonitoring(session: otherSession)
+
+    viewModel.archiveMonitoredSessions(inWorktreePath: "/tmp/AgentHub-feature")
+
+    #expect(viewModel.monitoredSessionIds == Set(["other-session"]))
+  }
+
+  @Test("Delete worktree reports success and records removal")
+  func deleteWorktreeReportsSuccess() async throws {
+    let remover = RecordingWorktreeRemovalService()
+    let viewModel = makeDeletionViewModel(remover: remover)
+    let worktreePath = try temporaryDirectory(name: "delete-success")
+    let worktree = WorktreeBranch(name: "feature", path: worktreePath, isWorktree: true)
+
+    let succeeded = await viewModel.deleteWorktree(worktree)
+
+    #expect(succeeded)
+    #expect(viewModel.worktreeDeletionError == nil)
+    #expect(viewModel.deletingWorktreePath == nil)
+    #expect(await remover.removedWorktreePaths() == [worktreePath])
+  }
+
+  @Test("Delete worktree failure keeps monitored sessions")
+  func deleteWorktreeFailureKeepsMonitoredSessions() async throws {
+    let remover = RecordingWorktreeRemovalService(error: TestDeletionError.failed)
+    let viewModel = makeDeletionViewModel(remover: remover)
+    let worktreePath = try temporaryDirectory(name: "delete-failure")
+    let worktree = WorktreeBranch(name: "feature", path: worktreePath, isWorktree: true)
+    let monitoredSession = session("session-1", path: worktreePath)
+    viewModel.startMonitoring(session: monitoredSession)
+
+    let succeeded = await viewModel.deleteWorktree(worktree)
+
+    #expect(!succeeded)
+    #expect(viewModel.worktreeDeletionError?.worktree.path == worktreePath)
+    #expect(viewModel.monitoredSessionIds == Set(["session-1"]))
+  }
+}
+
+private func session(_ id: String, path: String, isActive: Bool = false) -> CLISession {
+  CLISession(
+    id: id,
+    projectPath: path,
+    branchName: "feature",
+    isWorktree: true,
+    isActive: isActive,
+    sessionFilePath: "/tmp/\(id).jsonl"
+  )
+}
+
+@MainActor
+private func makeDeletionViewModel(
+  remover: RecordingWorktreeRemovalService = RecordingWorktreeRemovalService()
+) -> CLISessionsViewModel {
+  CLISessionsViewModel(
+    monitorService: WorktreeDeletionMonitorService(),
+    fileWatcher: WorktreeDeletionFileWatcher(),
+    searchService: nil,
+    cliConfiguration: CLICommandConfiguration(command: "claude", mode: .claude),
+    providerKind: .claude,
+    approvalNotificationService: NoOpApprovalNotificationService(),
+    worktreeRemovalService: remover
+  )
+}
+
+private final class WorktreeDeletionMonitorService: SessionMonitorServiceProtocol, @unchecked Sendable {
+  private let subject = PassthroughSubject<[SelectedRepository], Never>()
+
+  var repositoriesPublisher: AnyPublisher<[SelectedRepository], Never> {
+    subject.eraseToAnyPublisher()
+  }
+
+  func addRepository(_ path: String) async -> SelectedRepository? { nil }
+  func removeRepository(_ path: String) async {}
+  func getSelectedRepositories() async -> [SelectedRepository] { [] }
+  func setSelectedRepositories(_ repositories: [SelectedRepository]) async {}
+  func refreshSessions(skipWorktreeRedetection: Bool) async {}
+}
+
+private final class WorktreeDeletionFileWatcher: SessionFileWatcherProtocol, @unchecked Sendable {
+  private let subject = PassthroughSubject<SessionFileWatcher.StateUpdate, Never>()
+
+  var statePublisher: AnyPublisher<SessionFileWatcher.StateUpdate, Never> {
+    subject.eraseToAnyPublisher()
+  }
+
+  func startMonitoring(sessionId: String, projectPath: String, sessionFilePath: String?) async {}
+  func stopMonitoring(sessionId: String) async {}
+  func getState(sessionId: String) async -> SessionMonitorState? { nil }
+  func refreshState(sessionId: String) async {}
+  func setApprovalTimeout(_ seconds: Int) async {}
+}
+
+private actor RecordingWorktreeRemovalService: GitWorktreeRemovalServiceProtocol {
+  private let error: Error?
+  private var paths: [String] = []
+
+  init(error: Error? = nil) {
+    self.error = error
+  }
+
+  func removeWorktree(at worktreePath: String, force: Bool) async throws {
+    if let error { throw error }
+    paths.append(worktreePath)
+  }
+
+  func removeWorktree(at worktreePath: String, relativeTo parentRepoPath: String, force: Bool) async throws {
+    if let error { throw error }
+    paths.append(worktreePath)
+  }
+
+  nonisolated func checkIfOrphaned(at worktreePath: String) -> (isOrphaned: Bool, parentRepoPath: String?)? {
+    nil
+  }
+
+  func removeOrphanedWorktree(at worktreePath: String, parentRepoPath: String) async throws {
+    if let error { throw error }
+    paths.append(worktreePath)
+  }
+
+  func removedWorktreePaths() -> [String] {
+    paths
+  }
+}
+
+private enum TestDeletionError: Error {
+  case failed
+}
+
+private func temporaryDirectory(name: String) throws -> String {
+  let url = FileManager.default.temporaryDirectory
+    .appendingPathComponent("AgentHubWorktreeSettingsTests")
+    .appendingPathComponent("\(name)-\(UUID().uuidString)")
+  try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+  return url.path
+}


### PR DESCRIPTION
## Summary

Adds a Worktrees inventory to the Worktrees settings tab so users can see generated worktrees grouped by the modules currently present in the sessions side panel.

## Changes

- Build a settings snapshot from Claude and Codex selected repositories plus monitored sessions.
- Show module-grouped worktrees for side-panel modules, including per-worktree session counts and provider labels.
- Add delete flows with confirmation, archive-and-delete handling when monitored sessions exist, force-delete fallback, and orphan-prune fallback.
- Route worktree deletion through an injectable protocol so the ViewModel behavior can be tested.
- Add focused tests for snapshot ordering/deduping, monitored-session archiving, and deletion success/failure results.

## Validation

- `xcodebuild -project app/AgentHub.xcodeproj -scheme AgentHub -destination 'platform=macOS' -configuration Debug build` succeeded.
- `git diff --check` passed.
- `swift test --filter WorktreeSettings` was attempted. After fixing an ignored local SwiftPM checkout resource issue in `.build`, compilation reached the test target but stopped on an unrelated existing async error in `SessionWorkspaceStatePersistenceTests.swift` (`dbQueue.write` requires `await`).