### PR TITLE
Remove libgit2 fallback assertionFailure in GitDiffService

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHubGitDiff/Services/GitDiffService.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHubGitDiff/Services/GitDiffService.swift
@@ -389,7 +389,6 @@ public actor GitDiffService: GitDiffServiceProtocol {
       return payload
     } catch {
       Self.logger.warning("libgit2 renderPayload fallback for \(file.relativePath): \(error.localizedDescription)")
-      assertionFailure("libgit2 renderPayload fallback in \(mode.rawValue) for \(file.relativePath): \(error.localizedDescription)")
     }
 
     if try await shouldUseLimitedContext(for: file, at: repoPath, mode: mode, baseBranch: baseBranch) {


### PR DESCRIPTION
## Summary
- Drop the `assertionFailure` in `GitDiffService.renderPayload` libgit2 fallback path so debug builds no longer crash when libgit2 falls through to the shell-based diff. The warning log is retained.

## Test plan
- [ ] Trigger a libgit2 render fallback in a debug build and confirm the app no longer aborts