### PR TITLE
[codex] Improve session PR detection and create PR action

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/CodexSessionJSONLParser.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/CodexSessionJSONLParser.swift
@@ -5,6 +5,7 @@
 //  Parser for Codex session JSONL files with minimal monitoring data.
 //
 
+import AgentHubGitHub
 import Foundation
 
 public struct CodexSessionJSONLParser {
@@ -295,6 +296,9 @@ public struct CodexSessionJSONLParser {
         result.lastOutputTokens = output
       }
 
+    case "mcp_tool_call_end":
+      appendResourceLinks(extractResourceLinks(fromJSONValue: payload, timestamp: timestamp), to: &result)
+
     default:
       break
     }
@@ -323,6 +327,7 @@ public struct CodexSessionJSONLParser {
            let localhostURL = extractLocalhostURLFromText(output) {
           result.detectedLocalhostURL = localhostURL
         }
+        appendResourceLinks(extractResourceLinks(fromJSONValue: payload, timestamp: timestamp), to: &result)
       }
 
     case "custom_tool_call":
@@ -398,6 +403,23 @@ public struct CodexSessionJSONLParser {
     }
   }
 
+  private static func extractResourceLinks(fromJSONValue value: Any, timestamp: Date?) -> [ResourceLink] {
+    switch value {
+    case let string as String:
+      return prioritizedResourceLinks(from: string, timestamp: timestamp)
+    case let array as [Any]:
+      return prioritizingPullRequestLinks(
+        array.flatMap { extractResourceLinks(fromJSONValue: $0, timestamp: timestamp) }
+      )
+    case let dictionary as [String: Any]:
+      return prioritizingPullRequestLinks(
+        dictionary.values.flatMap { extractResourceLinks(fromJSONValue: $0, timestamp: timestamp) }
+      )
+    default:
+      return []
+    }
+  }
+
   private static func extractResourceLinks(from text: String, timestamp: Date?) -> [ResourceLink] {
     guard let regex = try? NSRegularExpression(
       pattern: "https?://[^\\s)\\]>\"'`]+",
@@ -417,6 +439,16 @@ public struct CodexSessionJSONLParser {
       links.append(ResourceLink(url: urlString, timestamp: timestamp ?? Date()))
     }
     return links
+  }
+
+  private static func prioritizedResourceLinks(from text: String, timestamp: Date?) -> [ResourceLink] {
+    let links = extractResourceLinks(from: text, timestamp: timestamp)
+    return prioritizingPullRequestLinks(links)
+  }
+
+  private static func prioritizingPullRequestLinks(_ links: [ResourceLink]) -> [ResourceLink] {
+    let pullRequestLinks = links.filter { GitHubPullRequestURLReference(urlString: $0.url) != nil }
+    return pullRequestLinks.isEmpty ? links : pullRequestLinks
   }
 
   // MARK: - Localhost URL Extraction

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/SessionJSONLParser.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/SessionJSONLParser.swift
@@ -5,6 +5,7 @@
 //  Created by Assistant on 1/10/26.
 //
 
+import AgentHubGitHub
 import Foundation
 
 // MARK: - SessionJSONLParser
@@ -261,8 +262,7 @@ public struct SessionJSONLParser {
             to: &result
           )
 
-          // Note: URL extraction from tool_use inputs is intentionally skipped
-          // to reduce noise — only user/assistant text links are shown
+          appendResourceLinks(extractResourceLinks(from: block.input, timestamp: timestamp), to: &result)
         }
 
       case "tool_result":
@@ -286,6 +286,7 @@ public struct SessionJSONLParser {
             AppLogger.devServer.info("[SessionJSONLParser] Detected localhost URL from tool_result: \(localhostURL.absoluteString)")
             result.detectedLocalhostURL = localhostURL
           }
+          appendResourceLinks(extractResourceLinks(from: block.content, timestamp: timestamp), to: &result)
         }
 
       case "thinking":
@@ -544,6 +545,28 @@ public struct SessionJSONLParser {
     }
   }
 
+  private static func extractResourceLinks(from content: AnyCodable?, timestamp: Date?) -> [ResourceLink] {
+    guard let content else { return [] }
+    return extractResourceLinks(fromJSONValue: content.value, timestamp: timestamp)
+  }
+
+  private static func extractResourceLinks(fromJSONValue value: Any, timestamp: Date?) -> [ResourceLink] {
+    switch value {
+    case let string as String:
+      return prioritizedResourceLinks(from: string, timestamp: timestamp)
+    case let array as [Any]:
+      return prioritizingPullRequestLinks(
+        array.flatMap { extractResourceLinks(fromJSONValue: $0, timestamp: timestamp) }
+      )
+    case let dictionary as [String: Any]:
+      return prioritizingPullRequestLinks(
+        dictionary.values.flatMap { extractResourceLinks(fromJSONValue: $0, timestamp: timestamp) }
+      )
+    default:
+      return []
+    }
+  }
+
   /// Extract URLs from text content and return as ResourceLink instances
   private static func extractResourceLinks(from text: String, timestamp: Date?) -> [ResourceLink] {
     // Match http:// and https:// URLs
@@ -567,6 +590,16 @@ public struct SessionJSONLParser {
       links.append(ResourceLink(url: urlString, timestamp: timestamp ?? Date()))
     }
     return links
+  }
+
+  private static func prioritizedResourceLinks(from text: String, timestamp: Date?) -> [ResourceLink] {
+    let links = extractResourceLinks(from: text, timestamp: timestamp)
+    return prioritizingPullRequestLinks(links)
+  }
+
+  private static func prioritizingPullRequestLinks(_ links: [ResourceLink]) -> [ResourceLink] {
+    let pullRequestLinks = links.filter { GitHubPullRequestURLReference(urlString: $0.url) != nil }
+    return pullRequestLinks.isEmpty ? links : pullRequestLinks
   }
 
   // MARK: - Localhost URL Extraction

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/CollapsibleSelectedSessionsPanel.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/CollapsibleSelectedSessionsPanel.swift
@@ -5,6 +5,7 @@
 //  Collapsible bottom panel for displaying selected/monitored sessions.
 //
 
+import AgentHubGitHub
 import SwiftUI
 
 // MARK: - CollapsibleSelectedSessionsPanel (Multi-Provider)
@@ -149,6 +150,7 @@ public struct CollapsibleSelectedSessionsPanel: View {
             isPrimary: item.id == primarySessionId,
             customName: customName(for: item),
             sessionStatus: item.sessionStatus,
+            linkedPullRequestNumber: item.linkedPullRequestNumber,
             colorScheme: colorScheme,
             isPinned: {
               switch item.providerKind {
@@ -200,6 +202,7 @@ public struct CollapsibleSelectedSessionsPanel: View {
     let timestamp: Date
     let isPending: Bool
     let sessionStatus: SessionStatus?
+    let linkedPullRequestNumber: Int?
   }
 
   private var items: [SelectedSessionItem] {
@@ -212,7 +215,8 @@ public struct CollapsibleSelectedSessionsPanel: View {
         providerKind: .claude,
         timestamp: pending.startedAt,
         isPending: true,
-        sessionStatus: nil
+        sessionStatus: nil,
+        linkedPullRequestNumber: nil
       ))
     }
 
@@ -223,7 +227,8 @@ public struct CollapsibleSelectedSessionsPanel: View {
         providerKind: .codex,
         timestamp: pending.startedAt,
         isPending: true,
-        sessionStatus: nil
+        sessionStatus: nil,
+        linkedPullRequestNumber: nil
       ))
     }
 
@@ -234,7 +239,8 @@ public struct CollapsibleSelectedSessionsPanel: View {
         providerKind: .claude,
         timestamp: item.session.lastActivityAt,
         isPending: false,
-        sessionStatus: item.state?.status
+        sessionStatus: item.state?.status,
+        linkedPullRequestNumber: Self.latestPullRequestNumber(in: item.state?.detectedResourceLinks ?? [])
       ))
     }
 
@@ -245,7 +251,8 @@ public struct CollapsibleSelectedSessionsPanel: View {
         providerKind: .codex,
         timestamp: item.session.lastActivityAt,
         isPending: false,
-        sessionStatus: item.state?.status
+        sessionStatus: item.state?.status,
+        linkedPullRequestNumber: Self.latestPullRequestNumber(in: item.state?.detectedResourceLinks ?? [])
       ))
     }
 
@@ -259,6 +266,10 @@ public struct CollapsibleSelectedSessionsPanel: View {
     case .codex:
       return codexViewModel.sessionCustomNames[item.session.id]
     }
+  }
+
+  private static func latestPullRequestNumber(in links: [ResourceLink]) -> Int? {
+    GitHubPullRequestURLReference.latestNumber(in: links.map(\.url))
   }
 
   private func ensurePrimarySelection() {
@@ -403,6 +414,7 @@ public struct SingleProviderCollapsibleSelectedSessionsPanel: View {
             isPrimary: item.id == primarySessionId,
             customName: viewModel.sessionCustomNames[item.session.id],
             sessionStatus: item.sessionStatus,
+            linkedPullRequestNumber: item.linkedPullRequestNumber,
             colorScheme: colorScheme,
             isPinned: viewModel.pinnedSessionIds.contains(item.session.id),
             onPin: {
@@ -438,6 +450,7 @@ public struct SingleProviderCollapsibleSelectedSessionsPanel: View {
     let timestamp: Date
     let isPending: Bool
     let sessionStatus: SessionStatus?
+    let linkedPullRequestNumber: Int?
   }
 
   private var items: [SelectedSessionItem] {
@@ -449,7 +462,8 @@ public struct SingleProviderCollapsibleSelectedSessionsPanel: View {
         session: pending.placeholderSession,
         timestamp: pending.startedAt,
         isPending: true,
-        sessionStatus: nil
+        sessionStatus: nil,
+        linkedPullRequestNumber: nil
       ))
     }
 
@@ -459,7 +473,8 @@ public struct SingleProviderCollapsibleSelectedSessionsPanel: View {
         session: item.session,
         timestamp: item.session.lastActivityAt,
         isPending: false,
-        sessionStatus: item.state?.status
+        sessionStatus: item.state?.status,
+        linkedPullRequestNumber: Self.latestPullRequestNumber(in: item.state?.detectedResourceLinks ?? [])
       ))
     }
 
@@ -478,5 +493,8 @@ public struct SingleProviderCollapsibleSelectedSessionsPanel: View {
 
     primarySessionId = items.first?.id
   }
-}
 
+  private static func latestPullRequestNumber(in links: [ResourceLink]) -> Int? {
+    GitHubPullRequestURLReference.latestNumber(in: links.map(\.url))
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/CollapsibleSessionRow.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/CollapsibleSessionRow.swift
@@ -11,6 +11,7 @@ struct CollapsibleSessionRow: View {
   let isPrimary: Bool
   let customName: String?
   let sessionStatus: SessionStatus?
+  var linkedPullRequestNumber: Int? = nil
   let colorScheme: ColorScheme
   let isPinned: Bool
   let onPin: (() -> Void)?
@@ -70,7 +71,8 @@ struct CollapsibleSessionRow: View {
   private var gitHubObservationTaskID: String {
     let repositoryKey = SessionGitHubQuickAccessViewModel.repositoryKey(
       projectPath: session.projectPath,
-      branchName: session.branchName
+      branchName: session.branchName,
+      linkedPullRequestNumber: linkedPullRequestNumber
     )
     return "\(repositoryKey)|\(isPending)|\(agentHub != nil)"
   }
@@ -314,15 +316,19 @@ struct CollapsibleSessionRow: View {
       return
     }
 
-    try? await Task.sleep(for: .milliseconds(observationStartupDelayMilliseconds))
-    guard !Task.isCancelled else { return }
+    if linkedPullRequestNumber == nil {
+      try? await Task.sleep(for: .milliseconds(observationStartupDelayMilliseconds))
+      guard !Task.isCancelled else { return }
+    }
 
     await sessionGitHubQuickAccessViewModel.load(
       projectPath: session.projectPath,
       branchName: session.branchName,
+      linkedPullRequestNumber: linkedPullRequestNumber,
       observationService: observationService,
       refreshOnSubscribe: false,
-      recordInitialActivity: false
+      recordInitialActivity: false,
+      forceRefreshLinkedPullRequest: linkedPullRequestNumber != nil
     )
     await sessionGitHubQuickAccessViewModel.notifySessionActivity(at: timestamp)
   }

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringCardView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringCardView.swift
@@ -186,8 +186,18 @@ public struct MonitoringCardView: View {
     state?.detectedResourceLinks ?? []
   }
 
+  private var linkedPullRequestNumber: Int? {
+    GitHubPullRequestURLReference.latestNumber(in: resourceLinks.map(\.url))
+  }
+
+  private var localDiffSummary: LocalDiffSummary? {
+    viewModel?.localDiffSummary(for: session.projectPath)
+  }
+
   private var shouldShowResourcesPanel: Bool {
-    !resourceLinks.isEmpty || sessionGitHubQuickAccessViewModel.currentBranchPR != nil
+    !resourceLinks.isEmpty
+      || sessionGitHubQuickAccessViewModel.currentBranchPR != nil
+      || (localDiffSummary?.fileCount ?? 0) > 0
   }
 
   private var gitHubQuickAccessCoordinator: (any SessionGitHubQuickAccessCoordinatorProtocol)? {
@@ -220,7 +230,9 @@ public struct MonitoringCardView: View {
       ResourceLinksPanel(
         links: resourceLinks,
         providerKind: providerKind,
-        currentPullRequest: sessionGitHubQuickAccessViewModel.currentBranchPR
+        currentPullRequest: sessionGitHubQuickAccessViewModel.currentBranchPR,
+        localDiffSummary: localDiffSummary,
+        onCreatePullRequest: createPullRequestFromSession
       ) {
         Button {
           showingActionsPopover = true
@@ -263,12 +275,18 @@ public struct MonitoringCardView: View {
     .task(id: session.projectPath) {
       await viewModel?.ensureDiffAvailability(for: session.projectPath, forceRefresh: true)
     }
-    .task(id: SessionGitHubQuickAccessViewModel.repositoryKey(projectPath: session.projectPath, branchName: session.branchName)) {
-      try? await Task.sleep(for: .seconds(2))
-      guard !Task.isCancelled else { return }
+    .task(id: session.projectPath) {
+      await viewModel?.ensureLocalDiffSummary(for: session.projectPath, forceRefresh: true)
+    }
+    .task(id: gitHubObservationTaskID) {
+      if linkedPullRequestNumber == nil {
+        try? await Task.sleep(for: .seconds(2))
+        guard !Task.isCancelled else { return }
+      }
       await sessionGitHubQuickAccessViewModel.load(
         projectPath: session.projectPath,
         branchName: session.branchName,
+        linkedPullRequestNumber: linkedPullRequestNumber,
         coordinator: gitHubQuickAccessCoordinator,
         observationService: gitHubPRObservationService
       )
@@ -285,6 +303,7 @@ public struct MonitoringCardView: View {
         await sessionGitHubQuickAccessViewModel.notifySessionActivity(at: newValue)
         await loadWebPreviewCandidateIfNeeded()
         await viewModel?.ensureDiffAvailability(for: session.projectPath, forceRefresh: true)
+        await viewModel?.ensureLocalDiffSummary(for: session.projectPath, forceRefresh: true)
       }
     }
     .onChange(of: state?.detectedLocalhostURL) { _, newValue in
@@ -547,6 +566,26 @@ public struct MonitoringCardView: View {
 
   private func presentGitHubPanel() {
     onShowGitHub?(session, session.projectPath)
+  }
+
+  private var gitHubObservationTaskID: String {
+    SessionGitHubQuickAccessViewModel.repositoryKey(
+      projectPath: session.projectPath,
+      branchName: session.branchName,
+      linkedPullRequestNumber: linkedPullRequestNumber
+    )
+  }
+
+  private static let createPullRequestPrompt = "Make a PR for the current branch. Include the local changes in this worktree and use the session context for the title, body, and validation notes."
+
+  private func createPullRequestFromSession() {
+    guard let viewModel else { return }
+    let key = terminalKey ?? session.id
+    contentMode = .terminal
+    if !viewModel.sendPromptToActiveTerminal(forKey: key, prompt: Self.createPullRequestPrompt) {
+      viewModel.showTerminalWithPrompt(for: session, prompt: Self.createPullRequestPrompt)
+    }
+    viewModel.focusTerminal(forKey: key)
   }
 
   // MARK: - Header

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
@@ -756,6 +756,7 @@ public struct MultiProviderSessionsListView: View {
     let timestamp: Date
     let isPending: Bool
     let sessionStatus: SessionStatus?
+    let linkedPullRequestNumber: Int?
   }
 
   private var selectedSessionItems: [SelectedSessionItem] {
@@ -768,7 +769,8 @@ public struct MultiProviderSessionsListView: View {
         providerKind: .claude,
         timestamp: pending.startedAt,
         isPending: true,
-        sessionStatus: nil
+        sessionStatus: nil,
+        linkedPullRequestNumber: nil
       ))
     }
 
@@ -779,7 +781,8 @@ public struct MultiProviderSessionsListView: View {
         providerKind: .codex,
         timestamp: pending.startedAt,
         isPending: true,
-        sessionStatus: nil
+        sessionStatus: nil,
+        linkedPullRequestNumber: nil
       ))
     }
 
@@ -790,7 +793,8 @@ public struct MultiProviderSessionsListView: View {
         providerKind: .claude,
         timestamp: item.session.lastActivityAt,
         isPending: false,
-        sessionStatus: item.state?.status
+        sessionStatus: item.state?.status,
+        linkedPullRequestNumber: Self.latestPullRequestNumber(in: item.state?.detectedResourceLinks ?? [])
       ))
     }
 
@@ -801,7 +805,8 @@ public struct MultiProviderSessionsListView: View {
         providerKind: .codex,
         timestamp: item.session.lastActivityAt,
         isPending: false,
-        sessionStatus: item.state?.status
+        sessionStatus: item.state?.status,
+        linkedPullRequestNumber: Self.latestPullRequestNumber(in: item.state?.detectedResourceLinks ?? [])
       ))
     }
 
@@ -1060,6 +1065,7 @@ public struct MultiProviderSessionsListView: View {
           isPrimary: item.id == primarySessionId,
           customName: selectedSessionCustomName(for: item),
           sessionStatus: item.sessionStatus,
+          linkedPullRequestNumber: item.linkedPullRequestNumber,
           colorScheme: colorScheme,
           isPinned: isPinned(item),
           onPin: item.isPending ? nil : {
@@ -1404,6 +1410,10 @@ public struct MultiProviderSessionsListView: View {
   private var gitHubPRObservationService: (any GitHubPRObservationServiceProtocol)? {
     claudeViewModel.agentHubProvider?.gitHubPRObservationService
       ?? codexViewModel.agentHubProvider?.gitHubPRObservationService
+  }
+
+  private static func latestPullRequestNumber(in links: [ResourceLink]) -> Int? {
+    GitHubPullRequestURLReference.latestNumber(in: links.map(\.url))
   }
 
   private var gitHubRefreshTargets: [GitHubPRObservationTarget] {

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/ResourceLinksPanel.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/ResourceLinksPanel.swift
@@ -5,6 +5,7 @@
 //  Created by Assistant on 3/11/26.
 //
 
+import AgentHubGitDiff
 import AgentHubGitHub
 import SwiftUI
 
@@ -16,6 +17,8 @@ struct ResourceLinksPanel<TrailingAccessory: View>: View {
   let providerKind: SessionProviderKind
   var currentPullRequest: GitHubPullRequest? = nil
   var onOpenCurrentPullRequest: ((GitHubPullRequest) -> Void)? = nil
+  var localDiffSummary: LocalDiffSummary? = nil
+  var onCreatePullRequest: (() -> Void)? = nil
   @ViewBuilder var trailingAccessory: () -> TrailingAccessory
 
   @State private var isExpanded = false
@@ -56,6 +59,13 @@ struct ResourceLinksPanel<TrailingAccessory: View>: View {
           CurrentPullRequestChip(
             pullRequest: currentPullRequest,
             action: { openCurrentPullRequest(currentPullRequest) }
+          )
+        } else if let localDiffSummary,
+                  localDiffSummary.fileCount > 0,
+                  let onCreatePullRequest {
+          CreatePullRequestChip(
+            summary: localDiffSummary,
+            action: onCreatePullRequest
           )
         }
 
@@ -173,6 +183,54 @@ private struct ResourceLinkChip: View {
     } else {
       return "globe"
     }
+  }
+}
+
+// MARK: - CreatePullRequestChip
+
+private struct CreatePullRequestChip: View {
+  let summary: LocalDiffSummary
+  let action: () -> Void
+
+  var body: some View {
+    Button(action: action) {
+      HStack(spacing: 8) {
+        Image(systemName: "arrow.triangle.pull")
+          .font(.caption2)
+          .foregroundStyle(.green)
+
+        Text("Create PR")
+          .font(.caption)
+          .bold()
+          .foregroundStyle(.primary)
+          .lineLimit(1)
+
+        Text("\(formattedCount(summary.fileCount)) files")
+          .font(.caption)
+          .foregroundStyle(.secondary)
+          .lineLimit(1)
+
+        Text("+\(formattedCount(summary.additions))")
+          .font(.caption)
+          .bold()
+          .foregroundStyle(.green)
+          .lineLimit(1)
+
+        Text("-\(formattedCount(summary.deletions))")
+          .font(.caption)
+          .bold()
+          .foregroundStyle(.red)
+          .lineLimit(1)
+      }
+      .contentShape(Rectangle())
+    }
+    .buttonStyle(.plain)
+    .help("Ask the session to create a pull request for \(summary.fileCount) changed files")
+    .accessibilityLabel("Create pull request for \(summary.fileCount) changed files")
+  }
+
+  private func formattedCount(_ value: Int) -> String {
+    value.formatted(.number.grouping(.automatic))
   }
 }
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/CLISessionsViewModel.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/CLISessionsViewModel.swift
@@ -38,6 +38,7 @@ public final class CLISessionsViewModel {
   private let webPreviewCandidateService: any WebPreviewCandidateServiceProtocol
   private let projectCapabilityService: any ProjectCapabilityServiceProtocol
   private let diffAvailabilityService: any DiffAvailabilityServiceProtocol
+  private let localDiffSummaryService: any LocalDiffSummaryServiceProtocol
   private let approvalNotificationService: any ApprovalNotificationServiceProtocol
   private let accessorySessionDetectionService: any AccessorySessionDetectionServiceProtocol
   private let approvalClaimStore: (any ApprovalClaimStoreProtocol)?
@@ -172,6 +173,10 @@ public final class CLISessionsViewModel {
     diffAvailability[DiffAvailabilityService.normalize(projectPath)]
   }
 
+  public func localDiffSummary(for projectPath: String) -> LocalDiffSummary? {
+    localDiffSummaries[LocalDiffSummaryService.normalize(projectPath)]
+  }
+
   public func ensureProjectCapabilities(
     for projectPath: String,
     forceRefresh: Bool = false
@@ -241,6 +246,29 @@ public final class CLISessionsViewModel {
     diffAvailability[normalizedProjectPath] = .checking
     let status = await diffAvailabilityService.availability(for: normalizedProjectPath)
     diffAvailability[normalizedProjectPath] = status
+  }
+
+  public func ensureLocalDiffSummary(
+    for projectPath: String,
+    forceRefresh: Bool = false
+  ) async {
+    let normalizedProjectPath = LocalDiffSummaryService.normalize(projectPath)
+
+    if forceRefresh {
+      await localDiffSummaryService.invalidate(projectPath: normalizedProjectPath)
+    } else {
+      if localDiffSummaries[normalizedProjectPath] != nil {
+        return
+      }
+
+      if let cachedSummary = await localDiffSummaryService.cachedSummary(for: normalizedProjectPath) {
+        localDiffSummaries[normalizedProjectPath] = cachedSummary
+        return
+      }
+    }
+
+    let summary = await localDiffSummaryService.summary(for: normalizedProjectPath)
+    localDiffSummaries[normalizedProjectPath] = summary
   }
 
   /// Start polling for a session
@@ -1273,6 +1301,9 @@ public final class CLISessionsViewModel {
   /// Cached project-level git diff availability keyed by normalized project path.
   public private(set) var diffAvailability: [String: DiffAvailabilityStatus] = [:]
 
+  /// Cached project-level local/branch diff summaries keyed by normalized project path.
+  public private(set) var localDiffSummaries: [String: LocalDiffSummary] = [:]
+
   /// Combine cancellables for monitoring subscriptions (keyed by session ID)
   private var monitoringCancellables: [String: AnyCancellable] = [:]
 
@@ -1314,6 +1345,7 @@ public final class CLISessionsViewModel {
     webPreviewCandidateService: any WebPreviewCandidateServiceProtocol = WebPreviewCandidateService.shared,
     projectCapabilityService: any ProjectCapabilityServiceProtocol = ProjectCapabilityService.shared,
     diffAvailabilityService: any DiffAvailabilityServiceProtocol = DiffAvailabilityService.shared,
+    localDiffSummaryService: any LocalDiffSummaryServiceProtocol = LocalDiffSummaryService.shared,
     approvalNotificationService: any ApprovalNotificationServiceProtocol = ApprovalNotificationService.shared,
     accessorySessionDetectionService: any AccessorySessionDetectionServiceProtocol = AccessorySessionDetectionService(),
     approvalClaimStore: (any ApprovalClaimStoreProtocol)? = nil,
@@ -1334,6 +1366,7 @@ public final class CLISessionsViewModel {
     self.webPreviewCandidateService = webPreviewCandidateService
     self.projectCapabilityService = projectCapabilityService
     self.diffAvailabilityService = diffAvailabilityService
+    self.localDiffSummaryService = localDiffSummaryService
     self.approvalNotificationService = approvalNotificationService
     self.accessorySessionDetectionService = accessorySessionDetectionService
     self.approvalClaimStore = approvalClaimStore

--- a/app/modules/AgentHubCore/Sources/AgentHubGitDiff/Services/LocalDiffSummaryService.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHubGitDiff/Services/LocalDiffSummaryService.swift
@@ -1,0 +1,142 @@
+//
+//  LocalDiffSummaryService.swift
+//  AgentHubGitDiff
+//
+//  Summarizes local/branch changes for compact UI entry points.
+//
+
+import Foundation
+
+public struct LocalDiffSummary: Equatable, Sendable {
+  public let fileCount: Int
+  public let additions: Int
+  public let deletions: Int
+
+  public static let empty = LocalDiffSummary(fileCount: 0, additions: 0, deletions: 0)
+
+  public init(fileCount: Int, additions: Int, deletions: Int) {
+    self.fileCount = fileCount
+    self.additions = additions
+    self.deletions = deletions
+  }
+}
+
+public protocol LocalDiffSummaryServiceProtocol: Sendable {
+  func cachedSummary(for projectPath: String) async -> LocalDiffSummary?
+  func summary(for projectPath: String) async -> LocalDiffSummary
+  func invalidate(projectPath: String) async
+}
+
+public actor LocalDiffSummaryService: LocalDiffSummaryServiceProtocol {
+  public static let shared = LocalDiffSummaryService()
+
+  typealias Evaluator = @Sendable (String) async -> LocalDiffSummary
+
+  private struct InFlightEvaluation: Sendable {
+    let id: UUID
+    let generation: Int
+    let task: Task<LocalDiffSummary, Never>
+  }
+
+  private let evaluator: Evaluator
+  private let minimumRefreshInterval: TimeInterval
+  private var cache: [String: LocalDiffSummary] = [:]
+  private var cacheGeneration: [String: Int] = [:]
+  private var inFlightTasks: [String: InFlightEvaluation] = [:]
+  private var lastEvaluationStartedAt: [String: Date] = [:]
+
+  init(
+    evaluator: Evaluator? = nil,
+    minimumRefreshInterval: TimeInterval = 1.0
+  ) {
+    self.evaluator = evaluator ?? { projectPath in
+      await Self.defaultEvaluator(projectPath: projectPath)
+    }
+    self.minimumRefreshInterval = minimumRefreshInterval
+  }
+
+  public func cachedSummary(for projectPath: String) async -> LocalDiffSummary? {
+    cache[Self.normalize(projectPath)]
+  }
+
+  public func summary(for projectPath: String) async -> LocalDiffSummary {
+    let normalizedProjectPath = Self.normalize(projectPath)
+
+    if let cached = cache[normalizedProjectPath] {
+      return cached
+    }
+    if let inFlightTask = inFlightTasks[normalizedProjectPath] {
+      return await inFlightTask.task.value
+    }
+
+    let evaluator = evaluator
+    let task = Task(priority: .utility) {
+      await evaluator(normalizedProjectPath)
+    }
+    lastEvaluationStartedAt[normalizedProjectPath] = Date.now
+    let inFlightEvaluation = InFlightEvaluation(
+      id: UUID(),
+      generation: cacheGeneration[normalizedProjectPath] ?? 0,
+      task: task
+    )
+    inFlightTasks[normalizedProjectPath] = inFlightEvaluation
+
+    let summary = await task.value
+    if inFlightTasks[normalizedProjectPath]?.id == inFlightEvaluation.id {
+      inFlightTasks.removeValue(forKey: normalizedProjectPath)
+      if (cacheGeneration[normalizedProjectPath] ?? 0) == inFlightEvaluation.generation {
+        cache[normalizedProjectPath] = summary
+      }
+    }
+    return summary
+  }
+
+  public func invalidate(projectPath: String) async {
+    let normalizedProjectPath = Self.normalize(projectPath)
+
+    if inFlightTasks[normalizedProjectPath] != nil {
+      return
+    }
+
+    if let lastEvaluationStartedAt = lastEvaluationStartedAt[normalizedProjectPath],
+       Date.now.timeIntervalSince(lastEvaluationStartedAt) < minimumRefreshInterval {
+      return
+    }
+
+    cacheGeneration[normalizedProjectPath, default: 0] += 1
+    cache.removeValue(forKey: normalizedProjectPath)
+  }
+
+  public nonisolated static func normalize(_ projectPath: String) -> String {
+    URL(fileURLWithPath: projectPath)
+      .standardizedFileURL
+      .resolvingSymlinksInPath()
+      .path
+  }
+
+  private nonisolated static func defaultEvaluator(projectPath: String) async -> LocalDiffSummary {
+    await Task.detached(priority: .utility) {
+      let service = GitDiffService()
+      var filesByPath: [String: GitDiffFileEntry] = [:]
+
+      for mode in DiffMode.allCases {
+        do {
+          let state = try await service.changedFiles(at: projectPath, mode: mode, baseBranch: nil)
+          for file in state.files where filesByPath[file.relativePath] == nil {
+            filesByPath[file.relativePath] = file
+          }
+        } catch {
+          continue
+        }
+      }
+
+      let additions = filesByPath.values.reduce(0) { $0 + $1.additions }
+      let deletions = filesByPath.values.reduce(0) { $0 + $1.deletions }
+      return LocalDiffSummary(
+        fileCount: filesByPath.count,
+        additions: additions,
+        deletions: deletions
+      )
+    }.value
+  }
+}

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/CodexSessionJSONLParserTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/CodexSessionJSONLParserTests.swift
@@ -77,6 +77,58 @@ struct CodexSessionJSONLParserTests {
     #expect(urls.first == "https://codex6.example.dev/page")
     #expect(urls.last == "https://codex55.example.dev/page")
   }
+
+  @Test("Extracts pull request URL from function call output before final text")
+  func extractsPullRequestURLFromFunctionCallOutput() {
+    let line = jsonLine([
+      "type": "response_item",
+      "timestamp": "2026-01-01T00:00:01.000Z",
+      "payload": [
+        "type": "function_call_output",
+        "call_id": "call-1",
+        "output": """
+        {"url":"https://github.com/jamesrochabrun/AgentHub/pull/322","avatar_url":"https://avatars.githubusercontent.com/u/5378604"}
+        """
+      ]
+    ])
+
+    var result = CodexSessionJSONLParser.ParseResult()
+    CodexSessionJSONLParser.parseNewLines([line], into: &result)
+
+    #expect(result.detectedResourceLinks.map(\.url) == [
+      "https://github.com/jamesrochabrun/AgentHub/pull/322"
+    ])
+  }
+
+  @Test("Extracts pull request URL from MCP tool result")
+  func extractsPullRequestURLFromMCPToolResult() {
+    let line = jsonLine([
+      "type": "event_msg",
+      "timestamp": "2026-01-01T00:00:01.000Z",
+      "payload": [
+        "type": "mcp_tool_call_end",
+        "result": [
+          "Ok": [
+            "content": [
+              [
+                "type": "text",
+                "text": """
+                {"url":"https://github.com/jamesrochabrun/AgentHub/pull/322","avatar_url":"https://avatars.githubusercontent.com/u/5378604"}
+                """
+              ]
+            ]
+          ]
+        ]
+      ]
+    ])
+
+    var result = CodexSessionJSONLParser.ParseResult()
+    CodexSessionJSONLParser.parseNewLines([line], into: &result)
+
+    #expect(result.detectedResourceLinks.map(\.url) == [
+      "https://github.com/jamesrochabrun/AgentHub/pull/322"
+    ])
+  }
 }
 
 private func jsonLine(_ object: [String: Any]) -> String {

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/DiffAvailabilityServiceTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/DiffAvailabilityServiceTests.swift
@@ -62,6 +62,38 @@ private actor MockDiffAvailabilityService: DiffAvailabilityServiceProtocol {
   }
 }
 
+private actor MockLocalDiffSummaryService: LocalDiffSummaryServiceProtocol {
+  private let summaryResult: LocalDiffSummary
+  private let cachedSummaryResult: LocalDiffSummary?
+  private(set) var invalidatedProjectPaths: [String] = []
+  private(set) var summaryCallCount = 0
+
+  init(
+    summaryResult: LocalDiffSummary = .empty,
+    cachedSummaryResult: LocalDiffSummary? = nil
+  ) {
+    self.summaryResult = summaryResult
+    self.cachedSummaryResult = cachedSummaryResult
+  }
+
+  func cachedSummary(for projectPath: String) async -> LocalDiffSummary? {
+    cachedSummaryResult
+  }
+
+  func summary(for projectPath: String) async -> LocalDiffSummary {
+    summaryCallCount += 1
+    return summaryResult
+  }
+
+  func invalidate(projectPath: String) async {
+    invalidatedProjectPaths.append(projectPath)
+  }
+
+  func recordedInvalidations() -> [String] {
+    invalidatedProjectPaths
+  }
+}
+
 private actor DiffStubMonitorService: SessionMonitorServiceProtocol {
   nonisolated var repositoriesPublisher: AnyPublisher<[SelectedRepository], Never> {
     Empty<[SelectedRepository], Never>().eraseToAnyPublisher()
@@ -72,6 +104,78 @@ private actor DiffStubMonitorService: SessionMonitorServiceProtocol {
   func getSelectedRepositories() async -> [SelectedRepository] { [] }
   func setSelectedRepositories(_ repositories: [SelectedRepository]) async {}
   func refreshSessions(skipWorktreeRedetection: Bool) async {}
+}
+
+@Suite("CLISessionsViewModel Local Diff Summary")
+struct CLISessionsViewModelLocalDiffSummaryTests {
+  @Test("ensureLocalDiffSummary stores resolved summary")
+  @MainActor
+  func ensureLocalDiffSummaryStoresResolvedSummary() async {
+    let summaryService = MockLocalDiffSummaryService(
+      summaryResult: LocalDiffSummary(fileCount: 5, additions: 10, deletions: 2)
+    )
+    let viewModel = CLISessionsViewModel(
+      monitorService: DiffStubMonitorService(),
+      fileWatcher: DiffStubFileWatcher(),
+      searchService: nil,
+      cliConfiguration: CLICommandConfiguration(command: "claude", mode: .claude),
+      providerKind: .claude,
+      localDiffSummaryService: summaryService,
+      approvalNotificationService: NoOpApprovalNotificationService()
+    )
+
+    await viewModel.ensureLocalDiffSummary(for: "/tmp/project")
+
+    #expect(viewModel.localDiffSummary(for: "/tmp/project")?.fileCount == 5)
+    #expect(await summaryService.summaryCallCount == 1)
+  }
+
+  @Test("ensureLocalDiffSummary uses cached summary")
+  @MainActor
+  func ensureLocalDiffSummaryUsesCachedSummary() async {
+    let summaryService = MockLocalDiffSummaryService(
+      summaryResult: LocalDiffSummary(fileCount: 5, additions: 10, deletions: 2),
+      cachedSummaryResult: LocalDiffSummary(fileCount: 2, additions: 3, deletions: 1)
+    )
+    let viewModel = CLISessionsViewModel(
+      monitorService: DiffStubMonitorService(),
+      fileWatcher: DiffStubFileWatcher(),
+      searchService: nil,
+      cliConfiguration: CLICommandConfiguration(command: "claude", mode: .claude),
+      providerKind: .claude,
+      localDiffSummaryService: summaryService,
+      approvalNotificationService: NoOpApprovalNotificationService()
+    )
+
+    await viewModel.ensureLocalDiffSummary(for: "/tmp/project")
+
+    #expect(viewModel.localDiffSummary(for: "/tmp/project")?.fileCount == 2)
+    #expect(await summaryService.summaryCallCount == 0)
+  }
+
+  @Test("force refresh invalidates local diff summary")
+  @MainActor
+  func forceRefreshInvalidatesLocalDiffSummary() async {
+    let summaryService = MockLocalDiffSummaryService(
+      summaryResult: LocalDiffSummary(fileCount: 5, additions: 10, deletions: 2),
+      cachedSummaryResult: LocalDiffSummary(fileCount: 2, additions: 3, deletions: 1)
+    )
+    let viewModel = CLISessionsViewModel(
+      monitorService: DiffStubMonitorService(),
+      fileWatcher: DiffStubFileWatcher(),
+      searchService: nil,
+      cliConfiguration: CLICommandConfiguration(command: "claude", mode: .claude),
+      providerKind: .claude,
+      localDiffSummaryService: summaryService,
+      approvalNotificationService: NoOpApprovalNotificationService()
+    )
+
+    await viewModel.ensureLocalDiffSummary(for: "/tmp/project")
+    await viewModel.ensureLocalDiffSummary(for: "/tmp/project", forceRefresh: true)
+
+    #expect(viewModel.localDiffSummary(for: "/tmp/project")?.fileCount == 5)
+    #expect(await summaryService.recordedInvalidations().count == 1)
+  }
 }
 
 private actor DiffStubFileWatcher: SessionFileWatcherProtocol {

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/GitDiffServiceTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/GitDiffServiceTests.swift
@@ -189,3 +189,41 @@ struct GitDiffServiceTests {
     #expect(payload.newContent == "alpha\nbeta")
   }
 }
+
+@Suite("LocalDiffSummaryService")
+struct LocalDiffSummaryServiceTests {
+
+  @Test("counts unique files across branch staged and unstaged diffs")
+  func countsUniqueFilesAcrossDiffModes() async throws {
+    let fixture = try GitRepoFixture.create()
+    defer { fixture.cleanup() }
+
+    try fixture.runGit("checkout", "-b", "feature/summary")
+    try "branch".write(toFile: fixture.repoPath + "/README.md", atomically: true, encoding: .utf8)
+    try fixture.runGit("add", "README.md")
+    try fixture.runGit("commit", "-m", "branch change")
+
+    try "unstaged".write(toFile: fixture.repoPath + "/README.md", atomically: true, encoding: .utf8)
+    try "staged".write(toFile: fixture.repoPath + "/StagedOnly.swift", atomically: true, encoding: .utf8)
+    try fixture.runGit("add", "StagedOnly.swift")
+    try "untracked".write(toFile: fixture.repoPath + "/UntrackedOnly.swift", atomically: true, encoding: .utf8)
+
+    let service = LocalDiffSummaryService(minimumRefreshInterval: 0)
+    let summary = await service.summary(for: fixture.repoPath)
+
+    #expect(summary.fileCount == 3)
+  }
+
+  @Test("returns empty summary for non git paths")
+  func returnsEmptySummaryForNonGitPaths() async throws {
+    let directory = FileManager.default.temporaryDirectory
+      .appending(path: "LocalDiffSummaryServiceTests-\(UUID().uuidString)", directoryHint: .isDirectory)
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: directory) }
+
+    let service = LocalDiffSummaryService(minimumRefreshInterval: 0)
+    let summary = await service.summary(for: directory.path)
+
+    #expect(summary == .empty)
+  }
+}

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/SessionJSONLParserURLTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/SessionJSONLParserURLTests.swift
@@ -91,6 +91,22 @@ struct SessionJSONLParserURLTests {
     #expect(count == 1)
   }
 
+  @Test("Prioritizes PR URL from tool_result JSON over incidental URLs")
+  func prioritizesPRURLFromToolResultJSON() {
+    let assistantLine = """
+      {"type":"assistant","timestamp":"2026-01-01T00:00:00Z","message":{"role":"assistant","content":[{"type":"tool_use","id":"tu1","name":"github_create_pull_request","input":{"repository_full_name":"jamesrochabrun/AgentHub"}}]}}
+      """
+    let userLine = """
+      {"type":"user","timestamp":"2026-01-01T00:00:01Z","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"tu1","content":"{\\"url\\":\\"https://github.com/jamesrochabrun/AgentHub/pull/322\\",\\"avatar_url\\":\\"https://avatars.githubusercontent.com/u/5378604\\"}"}]}}
+      """
+    var result = SessionJSONLParser.ParseResult()
+    SessionJSONLParser.parseNewLines([assistantLine, userLine], into: &result)
+
+    #expect(result.detectedResourceLinks.map(\.url) == [
+      "https://github.com/jamesrochabrun/AgentHub/pull/322"
+    ])
+  }
+
   // MARK: - URL accumulation across multiple messages
 
   @Test("Accumulates URLs across multiple incremental parse calls")

--- a/app/modules/AgentHubGitHub/Sources/AgentHubGitHub/Models/GitHubPullRequestURLReference.swift
+++ b/app/modules/AgentHubGitHub/Sources/AgentHubGitHub/Models/GitHubPullRequestURLReference.swift
@@ -1,0 +1,46 @@
+//
+//  GitHubPullRequestURLReference.swift
+//  AgentHubGitHub
+//
+//  Lightweight parser for GitHub pull request URLs detected in session output.
+//
+
+import Foundation
+
+public struct GitHubPullRequestURLReference: Equatable, Sendable {
+  public let owner: String
+  public let repository: String
+  public let number: Int
+  public let url: String
+
+  public init?(urlString: String) {
+    guard let components = URLComponents(string: urlString),
+          let host = components.host?.lowercased(),
+          host == "github.com" || host == "www.github.com" else {
+      return nil
+    }
+
+    let parts = components.path
+      .split(separator: "/", omittingEmptySubsequences: true)
+      .map(String.init)
+
+    guard parts.count >= 4,
+          parts[2] == "pull",
+          let number = Int(parts[3]) else {
+      return nil
+    }
+
+    self.owner = parts[0]
+    self.repository = parts[1]
+    self.number = number
+    self.url = urlString
+  }
+
+  public static func latest(in urls: [String]) -> GitHubPullRequestURLReference? {
+    urls.compactMap(GitHubPullRequestURLReference.init(urlString:)).last
+  }
+
+  public static func latestNumber(in urls: [String]) -> Int? {
+    latest(in: urls)?.number
+  }
+}

--- a/app/modules/AgentHubGitHub/Sources/AgentHubGitHub/ViewModels/SessionGitHubQuickAccessViewModel.swift
+++ b/app/modules/AgentHubGitHub/Sources/AgentHubGitHub/ViewModels/SessionGitHubQuickAccessViewModel.swift
@@ -29,6 +29,7 @@ public final class SessionGitHubQuickAccessViewModel {
   private var subscriptionTask: Task<Void, Never>?
   private var currentProjectPath: String?
   private var currentBranchName: String?
+  private var currentObservationTarget: GitHubPRObservationTarget?
 
   public init(
     coordinator: (any SessionGitHubQuickAccessCoordinatorProtocol)? = nil,
@@ -43,12 +44,18 @@ public final class SessionGitHubQuickAccessViewModel {
   public func load(
     projectPath: String,
     branchName: String?,
+    linkedPullRequestNumber: Int? = nil,
     coordinator: (any SessionGitHubQuickAccessCoordinatorProtocol)? = nil,
     observationService: (any GitHubPRObservationServiceProtocol)? = nil,
     refreshOnSubscribe: Bool = true,
-    recordInitialActivity: Bool = true
+    recordInitialActivity: Bool = true,
+    forceRefreshLinkedPullRequest: Bool = true
   ) async {
-    let repositoryKey = Self.repositoryKey(projectPath: projectPath, branchName: branchName)
+    let repositoryKey = Self.repositoryKey(
+      projectPath: projectPath,
+      branchName: branchName,
+      linkedPullRequestNumber: linkedPullRequestNumber
+    )
     if let coordinator {
       self.coordinator = coordinator
     }
@@ -70,10 +77,12 @@ public final class SessionGitHubQuickAccessViewModel {
     currentBranchName = branchName
 
     if let observationService = self.observationService {
-      let target = GitHubPRObservationTarget.currentBranch(
+      let target = observationTarget(
         projectPath: projectPath,
-        branchName: branchName
+        branchName: branchName,
+        linkedPullRequestNumber: linkedPullRequestNumber
       )
+      currentObservationTarget = target
       let subscription = await observationService.subscribe(to: target, refreshOnSubscribe: refreshOnSubscribe)
       observationSubscriptionID = subscription.id
       subscriptionTask = Task { [weak self] in
@@ -84,6 +93,9 @@ public final class SessionGitHubQuickAccessViewModel {
       }
       if recordInitialActivity {
         await observationService.recordActivity(for: target, at: .now)
+      }
+      if linkedPullRequestNumber != nil, forceRefreshLinkedPullRequest {
+        await observationService.refresh(target)
       }
       return
     } else if let coordinator = self.coordinator {
@@ -101,7 +113,12 @@ public final class SessionGitHubQuickAccessViewModel {
     clearState()
 
     do {
-      let pullRequest = try await service.getCurrentBranchPR(at: projectPath)
+      let pullRequest: GitHubPullRequest?
+      if let linkedPullRequestNumber {
+        pullRequest = try await service.getPullRequest(number: linkedPullRequestNumber, at: projectPath)
+      } else {
+        pullRequest = try await service.getCurrentBranchPR(at: projectPath)
+      }
       guard !Task.isCancelled, loadedRepositoryKey == repositoryKey else { return }
       currentBranchPR = pullRequest
       observationState = .ready
@@ -117,11 +134,14 @@ public final class SessionGitHubQuickAccessViewModel {
       return
     }
 
-    if let observationService {
+    if let observationService, let target = currentObservationTarget {
       await observationService.recordActivity(
-        for: .currentBranch(projectPath: projectPath, branchName: currentBranchName),
+        for: target,
         at: activityDate
       )
+      if target.pullRequestNumber != nil {
+        await observationService.refresh(target)
+      }
     } else if let coordinator {
       await coordinator.recordActivity(
         projectPath: projectPath,
@@ -200,9 +220,28 @@ public final class SessionGitHubQuickAccessViewModel {
     currentBranchChecks = []
     observationState = state
     lastRefreshedAt = nil
+    currentObservationTarget = nil
   }
 
-  public nonisolated static func repositoryKey(projectPath: String, branchName: String?) -> String {
-    "\(projectPath)|\(branchName ?? "")"
+  private nonisolated func observationTarget(
+    projectPath: String,
+    branchName: String?,
+    linkedPullRequestNumber: Int?
+  ) -> GitHubPRObservationTarget {
+    if let linkedPullRequestNumber {
+      return .pullRequest(projectPath: projectPath, number: linkedPullRequestNumber)
+    }
+    return .currentBranch(projectPath: projectPath, branchName: branchName)
+  }
+
+  public nonisolated static func repositoryKey(
+    projectPath: String,
+    branchName: String?,
+    linkedPullRequestNumber: Int? = nil
+  ) -> String {
+    if let linkedPullRequestNumber {
+      return "\(projectPath)|\(branchName ?? "")|pr:\(linkedPullRequestNumber)"
+    }
+    return "\(projectPath)|\(branchName ?? "")"
   }
 }

--- a/app/modules/AgentHubGitHub/Tests/AgentHubGitHubTests/GitHubPullRequestURLReferenceTests.swift
+++ b/app/modules/AgentHubGitHub/Tests/AgentHubGitHubTests/GitHubPullRequestURLReferenceTests.swift
@@ -1,0 +1,35 @@
+import Testing
+
+@testable import AgentHubGitHub
+
+@Suite("GitHubPullRequestURLReference")
+struct GitHubPullRequestURLReferenceTests {
+
+  @Test("Parses GitHub pull request URLs")
+  func parsesPullRequestURLs() throws {
+    let reference = try #require(GitHubPullRequestURLReference(
+      urlString: "https://github.com/jamesrochabrun/AgentHub/pull/322"
+    ))
+
+    #expect(reference.owner == "jamesrochabrun")
+    #expect(reference.repository == "AgentHub")
+    #expect(reference.number == 322)
+  }
+
+  @Test("Returns latest pull request URL from resource list")
+  func returnsLatestPullRequestURL() {
+    let number = GitHubPullRequestURLReference.latestNumber(in: [
+      "https://example.com/page",
+      "https://github.com/jamesrochabrun/AgentHub/pull/321",
+      "https://github.com/jamesrochabrun/AgentHub/pull/322"
+    ])
+
+    #expect(number == 322)
+  }
+
+  @Test("Ignores non pull request URLs")
+  func ignoresNonPullRequestURLs() {
+    #expect(GitHubPullRequestURLReference(urlString: "https://github.com/jamesrochabrun/AgentHub/issues/322") == nil)
+    #expect(GitHubPullRequestURLReference(urlString: "https://avatars.githubusercontent.com/u/5378604") == nil)
+  }
+}

--- a/app/modules/AgentHubGitHub/Tests/AgentHubGitHubTests/SessionGitHubQuickAccessViewModelTests.swift
+++ b/app/modules/AgentHubGitHub/Tests/AgentHubGitHubTests/SessionGitHubQuickAccessViewModelTests.swift
@@ -15,20 +15,22 @@ private func makeQuickAccessPR(
   title: String = "Quick Access PR",
   changedFiles: Int = 3,
   additions: Int = 10,
-  deletions: Int = 5
+  deletions: Int = 5,
+  state: String = "OPEN",
+  isDraft: Bool = false
 ) -> GitHubPullRequest {
   GitHubPullRequest(
     number: number,
     title: title,
     body: nil,
-    state: "OPEN",
+    state: state,
     url: "https://github.com/test/repo/pull/\(number)",
     headRefName: "feature-branch",
     baseRefName: "main",
     author: GitHubAuthor(login: "testuser", name: "Test User"),
     createdAt: .now,
     updatedAt: .now,
-    isDraft: false,
+    isDraft: isDraft,
     mergeable: "MERGEABLE",
     additions: additions,
     deletions: deletions,
@@ -125,6 +127,7 @@ private actor MockSessionGitHubPRObservationService: GitHubPRObservationServiceP
   private(set) var subscribedTargets: [GitHubPRObservationTarget] = []
   private(set) var unsubscribedIDs: [UUID] = []
   private(set) var recordedActivityTargets: [GitHubPRObservationTarget] = []
+  private(set) var refreshedTargets: [GitHubPRObservationTarget] = []
 
   func subscribe(
     to target: GitHubPRObservationTarget,
@@ -152,7 +155,9 @@ private actor MockSessionGitHubPRObservationService: GitHubPRObservationServiceP
     subscriptionTargets.removeValue(forKey: subscriptionID)
   }
 
-  func refresh(_ target: GitHubPRObservationTarget) async {}
+  func refresh(_ target: GitHubPRObservationTarget) async {
+    refreshedTargets.append(target)
+  }
 
   func recordActivity(for target: GitHubPRObservationTarget, at: Date) async {
     recordedActivityTargets.append(target)
@@ -241,6 +246,92 @@ struct SessionGitHubQuickAccessViewModelTests {
     #expect(viewModel.observationState == .ready)
     #expect(await observer.subscribedTargets == [target])
     #expect(await observer.recordedActivityTargets == [target])
+  }
+
+  @Test("linked pull request subscribes to explicit PR observation")
+  @MainActor
+  func linkedPullRequestSubscribesToExplicitPRObservation() async {
+    let observer = MockSessionGitHubPRObservationService()
+    let viewModel = SessionGitHubQuickAccessViewModel(observationService: observer)
+    let target = GitHubPRObservationTarget.pullRequest(projectPath: "/tmp/repo", number: 322)
+
+    await viewModel.load(
+      projectPath: "/tmp/repo",
+      branchName: "feature/github",
+      linkedPullRequestNumber: 322
+    )
+    await observer.publish(GitHubPRObservationSnapshot(
+      target: target,
+      pullRequest: makeQuickAccessPR(number: 322, isDraft: true),
+      checks: [],
+      state: .ready,
+      lastRefreshedAt: .now
+    ))
+    try? await Task.sleep(for: .milliseconds(10))
+
+    #expect(viewModel.currentBranchPR?.number == 322)
+    #expect(viewModel.currentBranchPR?.isDraft == true)
+    #expect(await observer.subscribedTargets == [target])
+    #expect(await observer.recordedActivityTargets == [target])
+    #expect(await observer.refreshedTargets == [target])
+  }
+
+  @Test("linked pull request activity force refreshes and applies state changes")
+  @MainActor
+  func linkedPullRequestActivityForceRefreshesAndAppliesStateChanges() async {
+    let observer = MockSessionGitHubPRObservationService()
+    let viewModel = SessionGitHubQuickAccessViewModel(observationService: observer)
+    let target = GitHubPRObservationTarget.pullRequest(projectPath: "/tmp/repo", number: 322)
+
+    await viewModel.load(
+      projectPath: "/tmp/repo",
+      branchName: "feature/github",
+      linkedPullRequestNumber: 322
+    )
+    await observer.publish(GitHubPRObservationSnapshot(
+      target: target,
+      pullRequest: makeQuickAccessPR(number: 322, isDraft: true),
+      checks: [],
+      state: .ready,
+      lastRefreshedAt: .now
+    ))
+    await viewModel.notifySessionActivity()
+    await observer.publish(GitHubPRObservationSnapshot(
+      target: target,
+      pullRequest: makeQuickAccessPR(number: 322, isDraft: false),
+      checks: [],
+      state: .ready,
+      lastRefreshedAt: .now
+    ))
+    try? await Task.sleep(for: .milliseconds(10))
+
+    #expect(viewModel.currentBranchPR?.isDraft == false)
+    #expect(await observer.refreshedTargets == [target, target])
+  }
+
+  @Test("linked merged pull request remains visible")
+  @MainActor
+  func linkedMergedPullRequestRemainsVisible() async {
+    let observer = MockSessionGitHubPRObservationService()
+    let viewModel = SessionGitHubQuickAccessViewModel(observationService: observer)
+    let target = GitHubPRObservationTarget.pullRequest(projectPath: "/tmp/repo", number: 322)
+
+    await viewModel.load(
+      projectPath: "/tmp/repo",
+      branchName: "feature/github",
+      linkedPullRequestNumber: 322
+    )
+    await observer.publish(GitHubPRObservationSnapshot(
+      target: target,
+      pullRequest: makeQuickAccessPR(number: 322, state: "MERGED"),
+      checks: [],
+      state: .ready,
+      lastRefreshedAt: .now
+    ))
+    try? await Task.sleep(for: .milliseconds(10))
+
+    #expect(viewModel.currentBranchPR?.number == 322)
+    #expect(viewModel.currentBranchPR?.stateKind == .merged)
   }
 
   @Test("observation service can defer initial activity for list rows")


### PR DESCRIPTION
## Summary

- Detect GitHub pull request URLs earlier from Claude and Codex session tool payloads, including Codex function outputs and MCP tool results.
- Observe explicit linked PR numbers for session rows/cards so draft, open, closed, and merged state changes refresh against the PR itself instead of relying only on current-branch lookup.
- Add a cached local diff summary service and a bottom-panel `Create PR` chip that shows changed files plus additions/deletions, then sends the make-PR prompt into the session terminal.

## Why

Draft PRs could take non-trivial time to appear in the side panel because the UI waited for branch-level GitHub observation instead of reacting as soon as a PR URL appeared in session output. Merged or state-changed PRs could also disappear or stay stale when current-branch lookup no longer represented the linked PR.

## Validation

- `git diff --check`
- `swift test --filter 'GitHubPullRequestURLReference|SessionGitHubQuickAccessViewModel|GitHubPRObservationService'`
- `swift build --target AgentHubGitDiff`
- `xcodebuild -project app/AgentHub.xcodeproj -scheme AgentHub -destination 'platform=macOS' -skipPackagePluginValidation build` (`** BUILD SUCCEEDED **`; existing SwiftLint plugin noise from CodeEdit packages remains)

Note: focused AgentHubCore SwiftPM tests could not run because the existing `CodeEditSymbols` checkout fails before tests with `Bundle.module` errors.