### PR TITLE
[codex] Fix GitHub badge layout wrapping

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/GitHubComponents.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/GitHubComponents.swift
@@ -103,6 +103,7 @@ struct AdditionsDeletionsBadge: View {
     HStack(spacing: 3) {
       Text("+\(additions)")
         .font(GitHubTypography.monoCaption)
+        .lineLimit(1)
         .foregroundStyle(GitHubPalette.addition)
         .padding(.horizontal, 4)
         .padding(.vertical, 1)
@@ -111,12 +112,14 @@ struct AdditionsDeletionsBadge: View {
 
       Text("-\(deletions)")
         .font(GitHubTypography.monoCaption)
+        .lineLimit(1)
         .foregroundStyle(GitHubPalette.deletion)
         .padding(.horizontal, 4)
         .padding(.vertical, 1)
         .background(GitHubPalette.deletion.opacity(0.1))
         .clipShape(RoundedRectangle(cornerRadius: 3))
     }
+    .fixedSize(horizontal: true, vertical: false)
   }
 }
 
@@ -132,6 +135,7 @@ struct BranchBadge: View {
       Text(name)
         .font(GitHubTypography.monoCaption)
         .lineLimit(1)
+        .truncationMode(.middle)
     }
     .padding(.horizontal, 6)
     .padding(.vertical, 2)
@@ -154,11 +158,14 @@ struct GitHubLabelPill: View {
   var body: some View {
     Text(label.name)
       .font(GitHubTypography.badge)
+      .lineLimit(1)
+      .truncationMode(.tail)
       .padding(.horizontal, 6)
       .padding(.vertical, 2)
       .background(pillColor.opacity(0.15))
       .foregroundStyle(pillColor)
       .clipShape(Capsule())
+      .fixedSize(horizontal: true, vertical: false)
   }
 }
 
@@ -173,12 +180,14 @@ struct CIStatusBadge: View {
         .font(.system(size: 9))
       Text(status.rawValue.capitalized)
         .font(GitHubTypography.badge)
+        .lineLimit(1)
     }
     .padding(.horizontal, 6)
     .padding(.vertical, 2)
     .background(statusColor.opacity(0.15))
     .foregroundStyle(statusColor)
     .clipShape(Capsule())
+    .fixedSize(horizontal: true, vertical: false)
   }
 
   private var statusColor: Color {
@@ -233,12 +242,14 @@ struct ReviewDecisionBadge: View {
         .font(.system(size: 10))
       Text(label)
         .font(GitHubTypography.badge)
+        .lineLimit(1)
     }
     .padding(.horizontal, 6)
     .padding(.vertical, 2)
     .background(color.opacity(0.15))
     .foregroundStyle(color)
     .clipShape(Capsule())
+    .fixedSize(horizontal: true, vertical: false)
   }
 }
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/GitHubPRDetailView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/GitHubPRDetailView.swift
@@ -221,47 +221,93 @@ struct GitHubPRDetailView: View {
         .font(GitHubTypography.sectionTitle)
         .fixedSize(horizontal: false, vertical: true)
 
-      // Metadata row
-      HStack(spacing: DesignTokens.Spacing.md) {
-        if let author = pr.author {
-          HStack(spacing: DesignTokens.Spacing.xs) {
-            AuthorAvatarView(login: author.login, size: 18)
-            Text(author.login)
-              .font(GitHubTypography.bodySmall)
-          }
-          .foregroundStyle(.secondary)
-        }
-
-        HStack(spacing: DesignTokens.Spacing.xs) {
-          BranchBadge(name: pr.headRefName)
-          Image(systemName: "arrow.right")
-            .font(.system(size: 8))
-            .foregroundStyle(.tertiary)
-          BranchBadge(name: pr.baseRefName)
-        }
-
-        AdditionsDeletionsBadge(additions: pr.additions, deletions: pr.deletions)
-
-        Text("\(pr.changedFiles) files")
-          .font(GitHubTypography.bodySmall)
-          .foregroundStyle(.secondary)
-
-        if let decision = pr.reviewDecision {
-          ReviewDecisionBadge(decision: decision)
-        }
-      }
+      prMetadataRows
 
       if let labels = pr.labels, !labels.isEmpty {
-        HStack(spacing: DesignTokens.Spacing.xs) {
-          ForEach(labels) { label in
-            GitHubLabelPill(label: label)
-          }
-        }
+        prLabelRows(labels)
       }
     }
     .frame(maxWidth: .infinity, alignment: .leading)
     .padding(.horizontal, DesignTokens.Spacing.md)
     .padding(.vertical, DesignTokens.Spacing.sm)
+  }
+
+  private var prMetadataRows: some View {
+    ViewThatFits(in: .horizontal) {
+      HStack(spacing: DesignTokens.Spacing.md) {
+        prAuthorMetadata
+        prBranchMetadata
+        prChangeMetadata
+      }
+      .fixedSize(horizontal: true, vertical: false)
+
+      VStack(alignment: .leading, spacing: 6) {
+        HStack(spacing: DesignTokens.Spacing.md) {
+          prAuthorMetadata
+          prBranchMetadata
+        }
+
+        prChangeMetadata
+      }
+    }
+  }
+
+  @ViewBuilder
+  private var prAuthorMetadata: some View {
+    if let author = pr.author {
+      HStack(spacing: DesignTokens.Spacing.xs) {
+        AuthorAvatarView(login: author.login, size: 18)
+        Text(author.login)
+          .font(GitHubTypography.bodySmall)
+          .lineLimit(1)
+          .truncationMode(.middle)
+          .frame(maxWidth: 140, alignment: .leading)
+      }
+      .foregroundStyle(.secondary)
+    }
+  }
+
+  private var prBranchMetadata: some View {
+    HStack(spacing: DesignTokens.Spacing.xs) {
+      BranchBadge(name: pr.headRefName)
+      Image(systemName: "arrow.right")
+        .font(.system(size: 8))
+        .foregroundStyle(.tertiary)
+      BranchBadge(name: pr.baseRefName)
+    }
+  }
+
+  private var prChangeMetadata: some View {
+    HStack(spacing: DesignTokens.Spacing.md) {
+      AdditionsDeletionsBadge(additions: pr.additions, deletions: pr.deletions)
+
+      Text("\(pr.changedFiles) files")
+        .font(GitHubTypography.bodySmall)
+        .foregroundStyle(.secondary)
+        .lineLimit(1)
+        .fixedSize(horizontal: true, vertical: false)
+
+      if let decision = pr.reviewDecision {
+        ReviewDecisionBadge(decision: decision)
+      }
+    }
+    .fixedSize(horizontal: true, vertical: false)
+  }
+
+  private func prLabelRows(_ labels: [GitHubLabel]) -> some View {
+    ViewThatFits(in: .horizontal) {
+      HStack(spacing: DesignTokens.Spacing.xs) {
+        ForEach(labels) { label in
+          GitHubLabelPill(label: label)
+        }
+      }
+
+      VStack(alignment: .leading, spacing: 4) {
+        ForEach(labels) { label in
+          GitHubLabelPill(label: label)
+        }
+      }
+    }
   }
 
   private var prStateColor: Color {

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/GitHubPanelView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/GitHubPanelView.swift
@@ -654,37 +654,61 @@ struct FilterChipWithCount: View {
 
   var body: some View {
     Button(action: action) {
-      HStack(spacing: 5) {
-        Text(title)
-          .font(GitHubTypography.button)
-          .foregroundStyle(isActive ? accent : .secondary)
-        if count > 0 {
-          Text("\(count)")
-            .font(GitHubTypography.monoCaption)
-            .foregroundStyle(isActive ? accent : .secondary)
-            .padding(.horizontal, 5)
-            .padding(.vertical, 1)
-            .background(
-              (isActive ? accent : Color.secondary).opacity(colorScheme == .dark ? 0.18 : 0.14)
+      chipContent
+        .padding(.horizontal, 10)
+        .padding(.vertical, 4)
+        .background(
+          RoundedRectangle(cornerRadius: AgentHubLayout.chipCornerRadius, style: .continuous)
+            .fill(isActive ? accent.opacity(colorScheme == .dark ? 0.15 : 0.12) : .clear)
+        )
+        .overlay(
+          RoundedRectangle(cornerRadius: AgentHubLayout.chipCornerRadius, style: .continuous)
+            .stroke(
+              isActive ? accent.opacity(0.35) : Color.secondary.opacity(0.18),
+              lineWidth: 1
             )
-            .clipShape(Capsule())
-        }
-      }
-      .padding(.horizontal, 10)
-      .padding(.vertical, 4)
-      .background(
-        RoundedRectangle(cornerRadius: AgentHubLayout.chipCornerRadius, style: .continuous)
-          .fill(isActive ? accent.opacity(colorScheme == .dark ? 0.15 : 0.12) : .clear)
-      )
-      .overlay(
-        RoundedRectangle(cornerRadius: AgentHubLayout.chipCornerRadius, style: .continuous)
-          .stroke(
-            isActive ? accent.opacity(0.35) : Color.secondary.opacity(0.18),
-            lineWidth: 1
-          )
-      )
+        )
     }
     .buttonStyle(.plain)
+  }
+
+  private var chipContent: some View {
+    ViewThatFits(in: .horizontal) {
+      HStack(spacing: 5) {
+        titleLabel
+        countBadge
+      }
+
+      VStack(spacing: 2) {
+        titleLabel
+        countBadge
+      }
+    }
+  }
+
+  private var titleLabel: some View {
+    Text(title)
+      .font(GitHubTypography.button)
+      .foregroundStyle(isActive ? accent : .secondary)
+      .lineLimit(1)
+      .fixedSize(horizontal: true, vertical: false)
+  }
+
+  @ViewBuilder
+  private var countBadge: some View {
+    if count > 0 {
+      Text("\(count)")
+        .font(GitHubTypography.monoCaption)
+        .foregroundStyle(isActive ? accent : .secondary)
+        .lineLimit(1)
+        .padding(.horizontal, 5)
+        .padding(.vertical, 1)
+        .background(
+          (isActive ? accent : Color.secondary).opacity(colorScheme == .dark ? 0.18 : 0.14)
+        )
+        .clipShape(Capsule())
+        .fixedSize(horizontal: true, vertical: false)
+    }
   }
 }
 
@@ -695,75 +719,21 @@ struct GitHubPRRow: View {
   var isCurrentBranch: Bool = false
   let onSelect: () -> Void
 
-  @Environment(\.runtimeTheme) private var runtimeTheme
-
   var body: some View {
     Button(action: onSelect) {
-      HStack(spacing: DesignTokens.Spacing.sm) {
+      HStack(alignment: .top, spacing: DesignTokens.Spacing.sm) {
         PRStatusDot(state: pr.stateKind, isDraft: pr.isDraft)
+          .padding(.top, 9)
 
         if let author = pr.author {
           AuthorAvatarView(login: author.login, size: 26)
         }
 
-        VStack(alignment: .leading, spacing: 2) {
-          HStack(spacing: DesignTokens.Spacing.xs) {
-            Text(pr.title)
-              .font(.geist(size: 13, weight: .semibold))
-              .foregroundStyle(.primary)
-              .lineLimit(1)
-
-            if pr.isDraft {
-              Text("Draft")
-                .font(GitHubTypography.badge)
-                .padding(.horizontal, 5)
-                .padding(.vertical, 1)
-                .background(Color.secondary.opacity(0.15))
-                .foregroundStyle(.secondary)
-                .clipShape(Capsule())
-            }
-          }
-
-          HStack(spacing: DesignTokens.Spacing.sm) {
-            Text("#\(pr.number)")
-              .font(GitHubTypography.monoCaption)
-              .foregroundStyle(.tertiary)
-
-            if let author = pr.author {
-              Text("@\(author.login)")
-                .font(GitHubTypography.caption)
-                .foregroundStyle(.tertiary)
-            }
-
-            AdditionsDeletionsBadge(
-              additions: pr.additions,
-              deletions: pr.deletions
-            )
-
-            if let labels = pr.labels, !labels.isEmpty {
-              ForEach(labels.prefix(1)) { label in
-                GitHubLabelPill(label: label)
-              }
-            }
-          }
+        VStack(alignment: .leading, spacing: 5) {
+          titleRow
+          detailRows
         }
-
-        Spacer()
-
-        HStack(spacing: DesignTokens.Spacing.sm) {
-          if let decision = pr.reviewDecision {
-            ReviewDecisionBadge(decision: decision)
-          }
-
-          ciIcon(pr.ciStatus)
-
-          if let updated = pr.updatedAt {
-            Text(relativeTime(updated))
-              .font(GitHubTypography.caption)
-              .foregroundStyle(.tertiary)
-              .monospacedDigit()
-          }
-        }
+        .frame(maxWidth: .infinity, alignment: .leading)
       }
       .padding(.horizontal, DesignTokens.Spacing.md)
       .padding(.vertical, DesignTokens.Spacing.sm)
@@ -783,6 +753,105 @@ struct GitHubPRRow: View {
         Label("Open in Browser", systemImage: "safari")
       }
     }
+  }
+
+  private var titleRow: some View {
+    HStack(spacing: DesignTokens.Spacing.xs) {
+      Text(pr.title)
+        .font(.geist(size: 13, weight: .semibold))
+        .foregroundStyle(.primary)
+        .lineLimit(1)
+        .truncationMode(.tail)
+
+      if pr.isDraft {
+        Text("Draft")
+          .font(GitHubTypography.badge)
+          .lineLimit(1)
+          .padding(.horizontal, 5)
+          .padding(.vertical, 1)
+          .background(Color.secondary.opacity(0.15))
+          .foregroundStyle(.secondary)
+          .clipShape(Capsule())
+          .fixedSize(horizontal: true, vertical: false)
+      }
+    }
+  }
+
+  @ViewBuilder
+  private var detailRows: some View {
+    if hasTrailingMetadata {
+      ViewThatFits(in: .horizontal) {
+        HStack(alignment: .center, spacing: DesignTokens.Spacing.sm) {
+          metadataRow
+
+          Spacer(minLength: DesignTokens.Spacing.sm)
+
+          trailingMetadataRow
+        }
+
+        VStack(alignment: .leading, spacing: 4) {
+          metadataRow
+          trailingMetadataRow
+        }
+      }
+    } else {
+      metadataRow
+    }
+  }
+
+  private var hasTrailingMetadata: Bool {
+    pr.reviewDecision != nil || pr.ciStatus != .none || pr.updatedAt != nil
+  }
+
+  private var metadataRow: some View {
+    HStack(spacing: DesignTokens.Spacing.sm) {
+      Text("#\(pr.number)")
+        .font(GitHubTypography.monoCaption)
+        .foregroundStyle(.tertiary)
+        .lineLimit(1)
+        .fixedSize(horizontal: true, vertical: false)
+
+      if let author = pr.author {
+        Text("@\(author.login)")
+          .font(GitHubTypography.caption)
+          .foregroundStyle(.tertiary)
+          .lineLimit(1)
+          .truncationMode(.middle)
+          .frame(maxWidth: 120, alignment: .leading)
+      }
+
+      AdditionsDeletionsBadge(
+        additions: pr.additions,
+        deletions: pr.deletions
+      )
+
+      if let labels = pr.labels, !labels.isEmpty {
+        ForEach(labels.prefix(1)) { label in
+          GitHubLabelPill(label: label)
+        }
+      }
+    }
+    .fixedSize(horizontal: true, vertical: false)
+  }
+
+  private var trailingMetadataRow: some View {
+    HStack(spacing: DesignTokens.Spacing.sm) {
+      if let decision = pr.reviewDecision {
+        ReviewDecisionBadge(decision: decision)
+      }
+
+      ciIcon(pr.ciStatus)
+
+      if let updated = pr.updatedAt {
+        Text(relativeTime(updated))
+          .font(GitHubTypography.caption)
+          .foregroundStyle(.tertiary)
+          .monospacedDigit()
+          .lineLimit(1)
+          .fixedSize(horizontal: true, vertical: false)
+      }
+    }
+    .fixedSize(horizontal: true, vertical: false)
   }
 
   @ViewBuilder


### PR DESCRIPTION
## Summary

- Keep GitHub status/count badges on one line so labels like `Review Required` and `needs-review` do not collapse into stacked text.
- Make PR rows and PR detail metadata adapt vertically when the panel is narrow instead of compressing badge text.
- Update PR filter chips so the count badge moves below the title when needed while the title stays on one line.

## Why

The GitHub panel was allowing badge text to compress before the surrounding row layout adapted, which produced broken wrapping such as `Open` splitting across lines and review/label badges becoming unreadable.

## Validation

- `git diff --check`
- `xcodebuild -project app/AgentHub.xcodeproj -scheme AgentHub -configuration Debug -destination 'platform=macOS' build`

The package-level Swift test listing was not used for validation because `swift test --package-path app/modules/AgentHubCore --list-tests` fails before project code in the existing `CodeEditSymbols` checkout due to `Bundle.module`.