### PR TITLE
[codex] Improve file search progress feedback

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/Models/FileTreeNode.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Models/FileTreeNode.swift
@@ -42,7 +42,7 @@ public struct FileTreeNode: Identifiable, Equatable, Sendable {
 
 // MARK: - FileSearchResult
 
-public struct FileSearchResult: Identifiable, Sendable {
+public struct FileSearchResult: Identifiable, Equatable, Sendable {
   public let id: String           // absolute path
   public let name: String
   public let relativePath: String // path relative to projectPath

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/FileIndexService.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/FileIndexService.swift
@@ -10,10 +10,43 @@ import Foundation
 
 // MARK: - FileIndexService
 
-public enum FileSearchIndexStatus: Sendable {
+public enum FileSearchIndexStatus: Sendable, Equatable {
   case idle
   case building
   case ready
+}
+
+public enum FileSearchResultSource: Sendable, Equatable {
+  case spotlight
+  case localIndex
+}
+
+public struct FileSearchDiagnostics: Sendable, Equatable {
+  public let results: [FileSearchResult]
+  public let source: FileSearchResultSource
+  public let spotlightCandidateCount: Int
+  public let spotlightElapsedSeconds: TimeInterval
+  public let localIndexStatusBeforeFallback: FileSearchIndexStatus
+  public let localIndexedFileCount: Int
+  public let localIndexElapsedSeconds: TimeInterval?
+
+  public init(
+    results: [FileSearchResult],
+    source: FileSearchResultSource,
+    spotlightCandidateCount: Int,
+    spotlightElapsedSeconds: TimeInterval,
+    localIndexStatusBeforeFallback: FileSearchIndexStatus,
+    localIndexedFileCount: Int,
+    localIndexElapsedSeconds: TimeInterval?
+  ) {
+    self.results = results
+    self.source = source
+    self.spotlightCandidateCount = spotlightCandidateCount
+    self.spotlightElapsedSeconds = spotlightElapsedSeconds
+    self.localIndexStatusBeforeFallback = localIndexStatusBeforeFallback
+    self.localIndexedFileCount = localIndexedFileCount
+    self.localIndexElapsedSeconds = localIndexElapsedSeconds
+  }
 }
 
 /// Scans project directories, respects .gitignore, caches tree nodes, and provides project file search.
@@ -155,10 +188,7 @@ public actor FileIndexService {
 
   public func searchIndexStatus(projectPath: String) async -> FileSearchIndexStatus {
     let resolvedProjectPath = Self.resolvedURL(for: projectPath).path
-    if searchBuildTasks[resolvedProjectPath] != nil {
-      return .building
-    }
-    return .ready
+    return searchIndexStatus(resolvedProjectPath: resolvedProjectPath)
   }
 
   /// Searches files using Spotlight first, then falls back to the legacy in-process index if
@@ -168,14 +198,29 @@ public actor FileIndexService {
   /// 3. Path contains query as substring → medium score
   /// All matching is case-insensitive substring, no fuzzy.
   public func search(query: String, in projectPath: String) async -> [FileSearchResult] {
-    guard !query.isEmpty, query.count < 200 else { return [] }
+    await searchWithDiagnostics(query: query, in: projectPath).results
+  }
+
+  public func searchWithDiagnostics(query: String, in projectPath: String) async -> FileSearchDiagnostics {
+    guard !query.isEmpty, query.count < 200 else {
+      return FileSearchDiagnostics(
+        results: [],
+        source: .localIndex,
+        spotlightCandidateCount: 0,
+        spotlightElapsedSeconds: 0,
+        localIndexStatusBeforeFallback: .idle,
+        localIndexedFileCount: 0,
+        localIndexElapsedSeconds: nil
+      )
+    }
+
     let resolvedProjectPath = Self.resolvedURL(for: projectPath).path
-    let spotlightResults = await projectFileSearchService.search(
+    let spotlightResponse = await projectFileSearchService.searchWithDiagnostics(
       query: query,
       in: resolvedProjectPath,
       limit: Self.maxSearchResults * 10
     )
-    let filteredSpotlightResults = spotlightResults
+    let filteredSpotlightResults = spotlightResponse.results
       .compactMap { spotlightResult -> FileSearchResult? in
         let absolutePath = Self.resolvedURL(for: spotlightResult.absolutePath).path
         guard Self.shouldIncludeSearchResult(at: absolutePath, rootPath: resolvedProjectPath),
@@ -195,50 +240,33 @@ public actor FileIndexService {
       .sortedBySearchScore()
 
     if !filteredSpotlightResults.isEmpty {
-      return Array(filteredSpotlightResults.prefix(Self.maxSearchResults))
+      return FileSearchDiagnostics(
+        results: Array(filteredSpotlightResults.prefix(Self.maxSearchResults)),
+        source: .spotlight,
+        spotlightCandidateCount: spotlightResponse.candidateCount,
+        spotlightElapsedSeconds: spotlightResponse.elapsedSeconds,
+        localIndexStatusBeforeFallback: searchIndexStatus(resolvedProjectPath: resolvedProjectPath),
+        localIndexedFileCount: searchCache[resolvedProjectPath]?.files.count ?? 0,
+        localIndexElapsedSeconds: nil
+      )
     }
 
+    let localStatusBeforeFallback = searchIndexStatus(resolvedProjectPath: resolvedProjectPath)
+    let localIndexStart = Date()
     let allFiles = await searchIndex(projectPath: resolvedProjectPath)
+    let localIndexElapsed = Date().timeIntervalSince(localIndexStart)
     let q = query.lowercased()
 
-    var scored: [FileSearchResult] = []
-    for file in allFiles {
-      let nameLower = file.name.lowercased()
-      let nameNoExt = (file.name as NSString).deletingPathExtension.lowercased()
-      let pathLower = file.relativePath.lowercased()
-
-      var score = 0
-      if nameNoExt == q {
-        // Exact match (without extension)
-        score = 5000
-      } else if nameNoExt.hasPrefix(q) {
-        // Filename starts with query (without extension)
-        score = 4000 + (100 - min(nameLower.count, 100))
-      } else if nameLower.hasPrefix(q) {
-        // Filename starts with query (with extension)
-        score = 3500 + (100 - min(nameLower.count, 100))
-      } else if nameLower.contains(q), let nameRange = nameLower.range(of: q) {
-        // Filename contains query
-        let pos = nameRange.lowerBound.utf16Offset(in: nameLower)
-        score = 2000 + (200 - pos) + (100 - min(nameLower.count, 100))
-      } else if pathLower.contains(q), let pathRange = pathLower.range(of: q) {
-        // Path contains query
-        let pos = pathRange.lowerBound.utf16Offset(in: pathLower)
-        score = 1000 + (500 - min(pos, 500))
-      }
-
-      guard score > 0 else { continue }
-      scored.append(FileSearchResult(
-        id: file.absolutePath, name: file.name, relativePath: file.relativePath,
-        absolutePath: file.absolutePath, score: score
-      ))
-    }
-
-    scored.sort {
-      if $0.score != $1.score { return $0.score > $1.score }
-      return $0.name < $1.name
-    }
-    return Array(scored.prefix(Self.maxSearchResults))
+    let scored = Self.rankIndexedFiles(allFiles, query: q)
+    return FileSearchDiagnostics(
+      results: Array(scored.prefix(Self.maxSearchResults)),
+      source: .localIndex,
+      spotlightCandidateCount: spotlightResponse.candidateCount,
+      spotlightElapsedSeconds: spotlightResponse.elapsedSeconds,
+      localIndexStatusBeforeFallback: localStatusBeforeFallback,
+      localIndexedFileCount: allFiles.count,
+      localIndexElapsedSeconds: localIndexElapsed
+    )
   }
 
   /// Removes the cache entry for `projectPath`.
@@ -306,6 +334,18 @@ public actor FileIndexService {
 
   private func isCacheStale(_ date: Date) -> Bool {
     Date().timeIntervalSince(date) > Self.cacheTTL
+  }
+
+  private func searchIndexStatus(resolvedProjectPath: String) -> FileSearchIndexStatus {
+    if searchBuildTasks[resolvedProjectPath] != nil {
+      return .building
+    }
+
+    if let entry = searchCache[resolvedProjectPath], !isCacheStale(entry.date) {
+      return .ready
+    }
+
+    return .idle
   }
 
   // MARK: - Scanning
@@ -688,6 +728,43 @@ public actor FileIndexService {
   }
 
   // MARK: - Search Helpers
+
+  private static func rankIndexedFiles(_ files: [IndexedFile], query: String) -> [FileSearchResult] {
+    var scored: [FileSearchResult] = []
+    scored.reserveCapacity(min(files.count, maxSearchResults))
+
+    for file in files {
+      let nameLower = file.name.lowercased()
+      let nameNoExt = (file.name as NSString).deletingPathExtension.lowercased()
+      let pathLower = file.relativePath.lowercased()
+
+      var score = 0
+      if nameNoExt == query {
+        score = 5000
+      } else if nameNoExt.hasPrefix(query) {
+        score = 4000 + (100 - min(nameLower.count, 100))
+      } else if nameLower.hasPrefix(query) {
+        score = 3500 + (100 - min(nameLower.count, 100))
+      } else if nameLower.contains(query), let nameRange = nameLower.range(of: query) {
+        let position = nameRange.lowerBound.utf16Offset(in: nameLower)
+        score = 2000 + (200 - position) + (100 - min(nameLower.count, 100))
+      } else if pathLower.contains(query), let pathRange = pathLower.range(of: query) {
+        let position = pathRange.lowerBound.utf16Offset(in: pathLower)
+        score = 1000 + (500 - min(position, 500))
+      }
+
+      guard score > 0 else { continue }
+      scored.append(FileSearchResult(
+        id: file.absolutePath,
+        name: file.name,
+        relativePath: file.relativePath,
+        absolutePath: file.absolutePath,
+        score: score
+      ))
+    }
+
+    return scored.sortedBySearchScore()
+  }
 
 }
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/QuickFilePickerView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/QuickFilePickerView.swift
@@ -5,7 +5,83 @@
 //  Cmd+P modal for Spotlight-backed file search within a project.
 //
 
+import Foundation
 import SwiftUI
+
+private let quickFileSearchStateAnimation = Animation.easeInOut(duration: 0.18)
+
+private enum QuickFileSearchPhase: Equatable {
+  case idle
+  case preparing
+  case checkingSpotlight(fallbackStatus: FileSearchIndexStatus)
+  case warmingLocalIndex
+  case stillWorking
+
+  var title: String {
+    switch self {
+    case .idle: return ""
+    case .preparing: return "Preparing search"
+    case .checkingSpotlight: return "Checking Spotlight index"
+    case .warmingLocalIndex: return "Warming local file index"
+    case .stillWorking: return "Still searching"
+    }
+  }
+
+  var detail: String {
+    switch self {
+    case .idle:
+      return ""
+    case .preparing:
+      return "Debouncing input before querying the project."
+    case .checkingSpotlight(let fallbackStatus):
+      switch fallbackStatus {
+      case .ready:
+        return "Local fallback is ready if Spotlight has no indexed match."
+      case .building:
+        return "AgentHub is also building a local fallback for unindexed files."
+      case .idle:
+        return "AgentHub will build a local fallback if Spotlight has no indexed match."
+      }
+    case .warmingLocalIndex:
+      return "Spotlight is taking longer than usual; the local scanner is catching up."
+    case .stillWorking:
+      return "Large repositories can take longer while Spotlight and the local fallback catch up."
+    }
+  }
+
+  var spotlightStep: QuickFileSearchStepState {
+    switch self {
+    case .idle, .preparing:
+      return .queued
+    case .checkingSpotlight, .warmingLocalIndex, .stillWorking:
+      return .active
+    }
+  }
+
+  var localIndexStep: QuickFileSearchStepState {
+    switch self {
+    case .idle, .preparing:
+      return .queued
+    case .checkingSpotlight(let fallbackStatus):
+      switch fallbackStatus {
+      case .ready:
+        return .complete
+      case .building:
+        return .active
+      case .idle:
+        return .queued
+      }
+    case .warmingLocalIndex, .stillWorking:
+      return .active
+    }
+  }
+}
+
+private enum QuickFileSearchStepState {
+  case queued
+  case active
+  case complete
+}
 
 // MARK: - QuickFilePickerView
 
@@ -19,6 +95,8 @@ public struct QuickFilePickerView: View {
   @State private var selectedIndex = 0
   @State private var showingRecent = true
   @State private var isIndexing = false
+  @State private var searchPhase: QuickFileSearchPhase = .idle
+  @State private var lastSearchDiagnostics: FileSearchDiagnostics?
   @FocusState private var isSearchFocused: Bool
 
   public init(
@@ -51,6 +129,7 @@ public struct QuickFilePickerView: View {
               .foregroundColor(.secondary)
           }
           .buttonStyle(.plain)
+          .accessibilityLabel("Clear search")
         }
 
         Spacer()
@@ -87,10 +166,11 @@ public struct QuickFilePickerView: View {
           ScrollView {
             LazyVStack(spacing: 0) {
               ForEach(Array(results.enumerated()), id: \.element.id) { index, result in
-                QuickFileResultRow(result: result, isSelected: index == selectedIndex)
-                  .id(index)
-                  .contentShape(Rectangle())
-                  .onTapGesture { selectItem(at: index) }
+                Button(action: { selectItem(at: index) }) {
+                  QuickFileResultRow(result: result, isSelected: index == selectedIndex)
+                }
+                .buttonStyle(.plain)
+                .id(index)
               }
             }
           }
@@ -99,21 +179,16 @@ public struct QuickFilePickerView: View {
             withAnimation { proxy.scrollTo(newIndex, anchor: .center) }
           }
         }
+
+        if shouldShowSearchDiagnostics {
+          Divider()
+          QuickFileSearchDiagnosticsFooter(diagnostics: lastSearchDiagnostics)
+            .transition(.opacity.combined(with: .move(edge: .bottom)))
+        }
       } else if isIndexing && !searchQuery.isEmpty {
         Divider()
-        VStack(spacing: 8) {
-          ProgressView()
-            .controlSize(.small)
-          Text("Searching files…")
-            .font(.caption)
-            .foregroundColor(.secondary)
-          Text("Large repositories may take a moment if Spotlight has not indexed them yet.")
-            .font(.caption2)
-            .foregroundColor(.secondary.opacity(0.7))
-            .multilineTextAlignment(.center)
-        }
-        .frame(maxWidth: .infinity)
-        .padding(.vertical, 20)
+        QuickFileSearchProgressView(phase: searchPhase)
+          .transition(.opacity.combined(with: .scale(scale: 0.98)))
       } else if !searchQuery.isEmpty {
         Divider()
         VStack(spacing: 6) {
@@ -123,9 +198,16 @@ public struct QuickFilePickerView: View {
           Text("No files found for \"\(searchQuery)\"")
             .font(.caption)
             .foregroundColor(.secondary)
+          if lastSearchDiagnostics?.source == .localIndex {
+            Text("Spotlight returned no indexed matches; local index scanned \(lastSearchDiagnostics?.localIndexedFileCount ?? 0) files.")
+              .font(.caption2)
+              .foregroundColor(.secondary.opacity(0.7))
+              .multilineTextAlignment(.center)
+          }
         }
         .frame(maxWidth: .infinity)
         .padding(.vertical, 20)
+        .transition(.opacity)
       } else if results.isEmpty {
         Divider()
         VStack(spacing: 6) {
@@ -141,8 +223,13 @@ public struct QuickFilePickerView: View {
         }
         .frame(maxWidth: .infinity)
         .padding(.vertical, 20)
+        .transition(.opacity)
       }
     }
+    .animation(quickFileSearchStateAnimation, value: isIndexing)
+    .animation(quickFileSearchStateAnimation, value: results.isEmpty)
+    .animation(quickFileSearchStateAnimation, value: searchPhase)
+    .animation(quickFileSearchStateAnimation, value: shouldShowSearchDiagnostics)
     .frame(width: 580)
     .fixedSize(horizontal: false, vertical: true)
     .background(.regularMaterial)
@@ -174,29 +261,69 @@ public struct QuickFilePickerView: View {
         }
       }
     }
+    .task(id: projectPath) {
+      await FileIndexService.shared.prepareSearchIndex(projectPath: projectPath)
+    }
     .task(id: searchQuery) {
       // Automatically cancels previous task when searchQuery changes
       if searchQuery.isEmpty {
-        isIndexing = false
+        withAnimation(quickFileSearchStateAnimation) {
+          isIndexing = false
+          searchPhase = .idle
+          lastSearchDiagnostics = nil
+        }
         let recent = await FileIndexService.shared.recentFiles(in: projectPath)
-        results = recent
-        showingRecent = true
-        selectedIndex = 0
+        withAnimation(quickFileSearchStateAnimation) {
+          results = recent
+          showingRecent = true
+          selectedIndex = 0
+        }
         return
       }
-      showingRecent = false
-      // Debounce — but clear results immediately to avoid showing stale data
-      results = []
-      selectedIndex = 0
-      isIndexing = false
+      withAnimation(quickFileSearchStateAnimation) {
+        showingRecent = false
+        // Debounce — but clear results immediately to avoid showing stale data
+        results = []
+        lastSearchDiagnostics = nil
+        selectedIndex = 0
+        isIndexing = false
+        searchPhase = .preparing
+      }
       try? await Task.sleep(for: .milliseconds(150))
       guard !Task.isCancelled else { return }
-      isIndexing = true
-      let found = await FileIndexService.shared.search(query: searchQuery, in: projectPath)
+      let fallbackStatus = await FileIndexService.shared.searchIndexStatus(projectPath: projectPath)
       guard !Task.isCancelled else { return }
-      isIndexing = false
-      results = found
-      selectedIndex = 0
+      withAnimation(quickFileSearchStateAnimation) {
+        isIndexing = true
+        searchPhase = .checkingSpotlight(fallbackStatus: fallbackStatus)
+      }
+      let diagnostics = await FileIndexService.shared.searchWithDiagnostics(query: searchQuery, in: projectPath)
+      guard !Task.isCancelled else { return }
+      withAnimation(quickFileSearchStateAnimation) {
+        isIndexing = false
+        lastSearchDiagnostics = diagnostics
+        results = diagnostics.results
+        selectedIndex = 0
+      }
+    }
+    .task(id: isIndexing) {
+      guard isIndexing, !searchQuery.isEmpty else { return }
+
+      try? await Task.sleep(for: .milliseconds(700))
+      guard !Task.isCancelled, isIndexing else { return }
+      let fallbackStatus = await FileIndexService.shared.searchIndexStatus(projectPath: projectPath)
+      guard !Task.isCancelled, isIndexing else { return }
+      withAnimation(quickFileSearchStateAnimation) {
+        searchPhase = fallbackStatus == .ready
+          ? .checkingSpotlight(fallbackStatus: .ready)
+          : .warmingLocalIndex
+      }
+
+      try? await Task.sleep(for: .milliseconds(1200))
+      guard !Task.isCancelled, isIndexing else { return }
+      withAnimation(quickFileSearchStateAnimation) {
+        searchPhase = .stillWorking
+      }
     }
     .onKeyPress(.upArrow) {
       selectedIndex = max(0, selectedIndex - 1)
@@ -227,6 +354,165 @@ public struct QuickFilePickerView: View {
     guard index < results.count else { return }
     isPresented = false
     onFileSelected(results[index].absolutePath)
+  }
+
+  private var shouldShowSearchDiagnostics: Bool {
+    guard !showingRecent,
+          let lastSearchDiagnostics,
+          !searchQuery.isEmpty else {
+      return false
+    }
+
+    return lastSearchDiagnostics.source == .localIndex ||
+      lastSearchDiagnostics.spotlightElapsedSeconds >= 0.75
+  }
+}
+
+// MARK: - QuickFileSearchProgressView
+
+private struct QuickFileSearchProgressView: View {
+  let phase: QuickFileSearchPhase
+
+  var body: some View {
+    VStack(spacing: 10) {
+      ProgressView()
+        .controlSize(.small)
+
+      VStack(spacing: 4) {
+        Text(phase.title)
+          .font(.caption)
+          .foregroundColor(.primary)
+        Text(phase.detail)
+          .font(.caption2)
+          .foregroundColor(.secondary.opacity(0.75))
+          .multilineTextAlignment(.center)
+      }
+
+      HStack(spacing: 8) {
+        QuickFileSearchProgressStep(
+          title: "Spotlight",
+          systemImage: "magnifyingglass",
+          state: phase.spotlightStep
+        )
+        QuickFileSearchProgressStep(
+          title: "Local index",
+          systemImage: "folder.badge.gearshape",
+          state: phase.localIndexStep
+        )
+      }
+    }
+    .frame(maxWidth: .infinity)
+    .padding(.horizontal, 20)
+    .padding(.vertical, 20)
+  }
+}
+
+private struct QuickFileSearchProgressStep: View {
+  let title: String
+  let systemImage: String
+  let state: QuickFileSearchStepState
+
+  private var iconName: String {
+    switch state {
+    case .queued: return systemImage
+    case .active: return "clock.arrow.circlepath"
+    case .complete: return "checkmark.circle.fill"
+    }
+  }
+
+  private var foregroundStyle: Color {
+    switch state {
+    case .queued: return .secondary
+    case .active: return .accentColor
+    case .complete: return .accentColor
+    }
+  }
+
+  private var statusText: String {
+    switch state {
+    case .queued: return "Queued"
+    case .active: return "Active"
+    case .complete: return "Ready"
+    }
+  }
+
+  var body: some View {
+    HStack(spacing: 6) {
+      Image(systemName: iconName)
+        .foregroundColor(foregroundStyle)
+        .accessibilityHidden(true)
+        .id(iconName)
+        .transition(.opacity.combined(with: .scale(scale: 0.92)))
+
+      VStack(alignment: .leading, spacing: 1) {
+        Text(title)
+          .font(.caption2)
+          .foregroundColor(.primary)
+        Text(statusText)
+          .font(.caption2)
+          .foregroundColor(.secondary)
+          .contentTransition(.opacity)
+      }
+      .lineLimit(1)
+
+      Spacer(minLength: 0)
+    }
+    .padding(.horizontal, 10)
+    .padding(.vertical, 7)
+    .frame(maxWidth: .infinity)
+    .background(Color.primary.opacity(0.05))
+    .clipShape(RoundedRectangle(cornerRadius: 8))
+    .animation(quickFileSearchStateAnimation, value: state)
+    .accessibilityElement(children: .combine)
+  }
+}
+
+// MARK: - QuickFileSearchDiagnosticsFooter
+
+private struct QuickFileSearchDiagnosticsFooter: View {
+  let diagnostics: FileSearchDiagnostics?
+
+  @ViewBuilder
+  var body: some View {
+    if let diagnostics {
+      HStack(spacing: 8) {
+        Image(systemName: iconName(for: diagnostics))
+          .font(.caption)
+          .foregroundColor(.secondary)
+          .accessibilityHidden(true)
+
+        Text(message(for: diagnostics))
+          .font(.caption2)
+          .foregroundColor(.secondary)
+          .lineLimit(2)
+
+        Spacer(minLength: 0)
+      }
+      .padding(.horizontal, 16)
+      .padding(.vertical, 8)
+      .background(Color.primary.opacity(0.035))
+    }
+  }
+
+  private func iconName(for diagnostics: FileSearchDiagnostics) -> String {
+    diagnostics.source == .localIndex ? "folder.badge.gearshape" : "magnifyingglass"
+  }
+
+  private func message(for diagnostics: FileSearchDiagnostics) -> String {
+    switch diagnostics.source {
+    case .localIndex:
+      return "Using local index. Spotlight returned \(diagnostics.spotlightCandidateCount) indexed candidates in \(formattedDuration(diagnostics.spotlightElapsedSeconds)); scanned \(diagnostics.localIndexedFileCount) files."
+    case .spotlight:
+      return "Spotlight returned \(diagnostics.spotlightCandidateCount) indexed candidates in \(formattedDuration(diagnostics.spotlightElapsedSeconds))."
+    }
+  }
+
+  private func formattedDuration(_ seconds: TimeInterval) -> String {
+    if seconds < 1 {
+      return "\(Int((seconds * 1000).rounded()))ms"
+    }
+
+    return String(format: "%.1fs", seconds)
   }
 }
 

--- a/app/modules/AgentHubCore/Sources/AgentHubFileSearch/ProjectFileSearchServiceProtocol.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHubFileSearch/ProjectFileSearchServiceProtocol.swift
@@ -1,6 +1,34 @@
 import Foundation
 
-public protocol ProjectFileSearchServiceProtocol: Sendable {
-  func search(query: String, in projectPath: String, limit: Int) async -> [ProjectFileSearchResult]
+public struct ProjectFileSearchResponse: Sendable, Equatable {
+  public let results: [ProjectFileSearchResult]
+  public let candidateCount: Int
+  public let elapsedSeconds: TimeInterval
+
+  public init(
+    results: [ProjectFileSearchResult],
+    candidateCount: Int,
+    elapsedSeconds: TimeInterval
+  ) {
+    self.results = results
+    self.candidateCount = candidateCount
+    self.elapsedSeconds = elapsedSeconds
+  }
 }
 
+public protocol ProjectFileSearchServiceProtocol: Sendable {
+  func search(query: String, in projectPath: String, limit: Int) async -> [ProjectFileSearchResult]
+  func searchWithDiagnostics(query: String, in projectPath: String, limit: Int) async -> ProjectFileSearchResponse
+}
+
+public extension ProjectFileSearchServiceProtocol {
+  func searchWithDiagnostics(query: String, in projectPath: String, limit: Int) async -> ProjectFileSearchResponse {
+    let start = Date()
+    let results = await search(query: query, in: projectPath, limit: limit)
+    return ProjectFileSearchResponse(
+      results: results,
+      candidateCount: results.count,
+      elapsedSeconds: Date().timeIntervalSince(start)
+    )
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHubFileSearch/SpotlightProjectFileSearchService.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHubFileSearch/SpotlightProjectFileSearchService.swift
@@ -4,6 +4,9 @@ import Foundation
 public actor SpotlightProjectFileSearchService: ProjectFileSearchServiceProtocol {
   public static let shared = SpotlightProjectFileSearchService()
 
+  private static let minimumMetadataCandidateLimit = 100
+  private static let maximumMetadataCandidateLimit = 800
+
   private let metadataClient: any SpotlightMetadataQuerying
   private let fileChecker: any SearchableFileChecking
 
@@ -23,10 +26,20 @@ public actor SpotlightProjectFileSearchService: ProjectFileSearchServiceProtocol
   }
 
   public func search(query: String, in projectPath: String, limit: Int) async -> [ProjectFileSearchResult] {
-    guard !query.isEmpty, query.count < 200, limit > 0 else { return [] }
+    await searchWithDiagnostics(query: query, in: projectPath, limit: limit).results
+  }
 
+  public func searchWithDiagnostics(query: String, in projectPath: String, limit: Int) async -> ProjectFileSearchResponse {
+    guard !query.isEmpty, query.count < 200, limit > 0 else {
+      return ProjectFileSearchResponse(results: [], candidateCount: 0, elapsedSeconds: 0)
+    }
+
+    let start = Date()
     let resolvedProjectPath = Self.resolvedURL(for: projectPath).path
-    let candidateLimit = max(limit * 8, 200)
+    let candidateLimit = min(
+      max(limit * 2, Self.minimumMetadataCandidateLimit),
+      Self.maximumMetadataCandidateLimit
+    )
     let metadataClient = metadataClient
     let paths = await Task.detached(priority: .userInitiated) {
       metadataClient.searchFilePaths(
@@ -36,12 +49,17 @@ public actor SpotlightProjectFileSearchService: ProjectFileSearchServiceProtocol
       )
     }.value
 
-    return SpotlightFileSearchRanker.rankedResults(
+    let results = SpotlightFileSearchRanker.rankedResults(
       paths: paths,
       query: query,
       projectPath: resolvedProjectPath,
       limit: limit,
       fileChecker: fileChecker
+    )
+    return ProjectFileSearchResponse(
+      results: results,
+      candidateCount: paths.count,
+      elapsedSeconds: Date().timeIntervalSince(start)
     )
   }
 
@@ -100,13 +118,12 @@ struct CoreServicesSpotlightMetadataClient: SpotlightMetadataQuerying {
 
 enum SpotlightQueryBuilder {
   private static let searchableAttributes = [
-    "kMDItemDisplayName",
     "kMDItemFSName",
-    "kMDItemPath"
+    "kMDItemDisplayName"
   ]
 
   static func expression(for query: String) -> String? {
-    let term = normalizedTerm(query)
+    let term = normalizedFileNameTerm(query)
     guard !term.isEmpty else { return nil }
 
     let pattern = "*\(escapeQuotedString(term))*"
@@ -122,6 +139,17 @@ enum SpotlightQueryBuilder {
       CharacterSet.controlCharacters.contains(scalar) ? " " : String(scalar)
     }
     return scalars.joined()
+  }
+
+  private static func normalizedFileNameTerm(_ query: String) -> String {
+    let term = normalizedTerm(query)
+    let separators = CharacterSet(charactersIn: "/\\")
+    let components = term
+      .components(separatedBy: separators)
+      .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+      .filter { !$0.isEmpty }
+
+    return components.last ?? term
   }
 
   private static func escapeQuotedString(_ value: String) -> String {

--- a/app/modules/AgentHubCore/Tests/AgentHubFileSearchTests/SpotlightProjectFileSearchServiceTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubFileSearchTests/SpotlightProjectFileSearchServiceTests.swift
@@ -62,14 +62,24 @@ private struct FakeSpotlightMetadataClient: SpotlightMetadataQuerying {
 
 @Suite("SpotlightProjectFileSearchService")
 struct SpotlightProjectFileSearchServiceTests {
-  @Test("Builds the Spotlight metadata query across file name and path attributes")
+  @Test("Builds the Spotlight metadata query across filename attributes")
   func buildsQueryExpression() {
     let expression = SpotlightQueryBuilder.expression(for: "App")
 
     #expect(expression == """
-    (kMDItemDisplayName == "*App*"cd || kMDItemFSName == "*App*"cd || kMDItemPath == "*App*"cd)
+    (kMDItemFSName == "*App*"cd || kMDItemDisplayName == "*App*"cd)
     """)
+    #expect(expression?.contains("kMDItemPath") == false)
     #expect(SpotlightQueryBuilder.expression(for: "   ") == nil)
+  }
+
+  @Test("Uses the filename component for path-like queries")
+  func pathLikeQueryExpressionUsesFilenameComponent() {
+    let expression = SpotlightQueryBuilder.expression(for: "Sources/App")
+
+    #expect(expression == """
+    (kMDItemFSName == "*App*"cd || kMDItemDisplayName == "*App*"cd)
+    """)
   }
 
   @Test("Escapes quoted query literals before building the metadata query")
@@ -111,4 +121,3 @@ struct SpotlightProjectFileSearchServiceTests {
     #expect(results.allSatisfy { $0.absolutePath.hasPrefix(fixture.projectPath + "/") })
   }
 }
-

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/FileIndexServiceTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/FileIndexServiceTests.swift
@@ -250,7 +250,7 @@ struct FileIndexServicePrivacyTests {
 
     try fixture.writeProjectFile("Sources/App.swift", content: "struct App {}")
 
-    let service = FileIndexService()
+    let service = FileIndexService(projectFileSearchService: FakeProjectFileSearchService(results: []))
     let initialResults = await service.search(query: "app", in: fixture.projectPath)
     let initialStatus = await service.searchIndexStatus(projectPath: fixture.projectPath)
 
@@ -266,6 +266,40 @@ struct FileIndexServicePrivacyTests {
     #expect(initialResults.map(\.absolutePath) == resultsAfterWrite.map(\.absolutePath))
     #expect(initialStatus == .ready)
     #expect(statusAfterWrite == .ready)
+  }
+
+  @Test("Reports idle search status until the local fallback index is built")
+  func reportsIdleSearchStatusBeforeFallbackIndexIsBuilt() async throws {
+    let fixture = try FileIndexFixture.create()
+    defer { fixture.cleanup() }
+
+    try fixture.writeProjectFile("Sources/App.swift", content: "struct App {}")
+
+    let service = FileIndexService(projectFileSearchService: FakeProjectFileSearchService(results: []))
+
+    let initialStatus = await service.searchIndexStatus(projectPath: fixture.projectPath)
+    await service.prepareSearchIndex(projectPath: fixture.projectPath)
+    let readyStatus = await service.searchIndexStatus(projectPath: fixture.projectPath)
+
+    #expect(initialStatus == .idle)
+    #expect(readyStatus == .ready)
+  }
+
+  @Test("Search diagnostics identify local fallback results when Spotlight returns no matches")
+  func searchDiagnosticsIdentifyLocalFallbackResults() async throws {
+    let fixture = try FileIndexFixture.create()
+    defer { fixture.cleanup() }
+
+    try fixture.writeProjectFile("Sources/App.swift", content: "struct App {}")
+
+    let service = FileIndexService(projectFileSearchService: FakeProjectFileSearchService(results: []))
+    let diagnostics = await service.searchWithDiagnostics(query: "app", in: fixture.projectPath)
+
+    #expect(diagnostics.source == .localIndex)
+    #expect(diagnostics.spotlightCandidateCount == 0)
+    #expect(diagnostics.localIndexStatusBeforeFallback == .idle)
+    #expect(diagnostics.localIndexedFileCount == 1)
+    #expect(diagnostics.results.map(\.relativePath) == ["Sources/App.swift"])
   }
 
   @Test("Creating a new file invalidates cached directory listings")


### PR DESCRIPTION
## What changed

- Added file-search diagnostics so Cmd+P can distinguish Spotlight results from the local fallback index.
- Tightened the Spotlight metadata query to search filename/display-name attributes instead of broad path wildcard matching, then rely on the local scanner for path matches and unindexed files.
- Fixed local fallback index status reporting so it can show `idle`, `building`, or `ready` accurately.
- Updated the quick file picker loading UI with explicit Spotlight/local-index progress states, fallback diagnostics, and animated transitions to avoid abrupt flashes.
- Added focused tests for Spotlight query construction and local fallback diagnostics/status behavior.

## Why

The old UI only showed a generic loading state. When Spotlight was slow or had not indexed a repository yet, users could not tell whether search was waiting on Spotlight, building AgentHub's fallback index, or simply stuck. The broad Spotlight path query also made large-project searches more expensive than needed.

## Impact

Cmd+P should feel more transparent during slow searches: it now explains which search path is active, warms the local fallback index on open, and reports when fallback results are used. Fast searches remain fast, while slow/unindexed cases are easier to understand.

## Validation

- `swift build --package-path app/modules/AgentHubCore --target AgentHubFileSearch`
- `swift build --package-path app/modules/AgentHubCore --target AgentHubFileSearchTests`
- `xcodebuild -project app/AgentHub.xcodeproj -scheme AgentHubFileSearch -destination 'platform=macOS' build`
- `xcodebuild -project app/AgentHub.xcodeproj -scheme AgentHub -destination 'platform=macOS' build`
- `git diff --check`

Note: direct package test execution is blocked in this checkout because raw SwiftPM fails before these tests on the `CodeEditSymbols` resource accessor issue, and the app schemes are not configured for test actions.