### PR TITLE
[codex] Fix floating panel sizing loop

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/ModalPanelModifier.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/ModalPanelModifier.swift
@@ -159,6 +159,9 @@ private struct FloatingPanelModifier<PanelContent: View>: ViewModifier {
 
     let view = panelContent()
     let hostingView = NSHostingView(rootView: view)
+    // Floating panels own their AppKit frame; SwiftUI should not resize the window
+    // while animating internal content changes.
+    hostingView.sizingOptions = []
 
     let newPanel = KeyablePanel(
       contentRect: NSRect(origin: .zero, size: defaultSize),


### PR DESCRIPTION
## Summary

- Disable SwiftUI hosting sizing for borderless floating panels so AppKit keeps ownership of the panel frame.
- Prevent animated SwiftUI content changes inside Cmd+P from asking AppKit to resize the `NSPanel` during an update-constraints pass.

## Root Cause

The recent quick file picker progress UI introduced animated internal content-height changes. The picker is hosted in a borderless floating `NSPanel`, and SwiftUI's default `NSHostingView` sizing behavior can propagate those ideal-size changes back to the window during layout. That can produce the AppKit "Update Constraints in Window" loop seen when opening Cmd+P.

## Impact

Cmd+P can keep the new progress UI while avoiding window-level resize churn and the crash path.

## Validation

- `xcodebuild -project app/AgentHub.xcodeproj -scheme AgentHub -configuration Debug -destination 'platform=macOS' build` succeeded.
- `swift test --package-path app/modules/AgentHubCore --filter FileIndexServiceTests` was attempted, but SwiftPM failed before tests due to the existing CodeEditSymbols `Bundle.module` error.