### PR TITLE
[codex] Add AgentHub MCP worktree sessions

### DIFF
--- a/app/AgentHub/AgentHubApp.swift
+++ b/app/AgentHub/AgentHubApp.swift
@@ -36,6 +36,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
     // session begins monitoring.
     provider.reconcileClaudeHooksOnLaunch()
     provider.cleanupOrphanedProcesses()
+    provider.startWorktreeLaunchRequestMonitoring()
   }
 
   /// Register all bundled fonts (Geist, GeistMono, JetBrains Mono)
@@ -64,6 +65,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
   }
 
   func applicationWillTerminate(_ notification: Notification) {
+    provider.stopWorktreeLaunchRequestMonitoring()
     // Terminate all active terminal processes on app quit
     provider.terminateAllTerminals()
     // Stop all dev servers spawned for web preview

--- a/app/modules/AgentHubCLI/Sources/AgentHubCLI/AgentHubCLI.swift
+++ b/app/modules/AgentHubCLI/Sources/AgentHubCLI/AgentHubCLI.swift
@@ -8,9 +8,21 @@ struct AgentHubCLI: AsyncParsableCommand {
     commandName: "agenthub",
     abstract: "AgentHub command-line helper.",
     subcommands: [
+      AgentHubMCPServerCommand.self,
       WorktreeCommand.self,
     ]
   )
+}
+
+struct AgentHubMCPServerCommand: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "mcp-server",
+    abstract: "Run the AgentHub MCP server over stdio."
+  )
+
+  func run() async throws {
+    try await AgentHubMCPServer().run()
+  }
 }
 
 struct WorktreeCommand: AsyncParsableCommand {
@@ -75,6 +87,15 @@ struct CreateWorktree: AsyncParsableCommand {
 
   @OptionGroup var options: WorktreeOptions
 
+  @Flag(name: .long, help: "Request AgentHub to launch an embedded session in the worktree.")
+  var launchSession = false
+
+  @Option(name: .long, help: "Provider for the launched session: claude or codex. Defaults to AGENTHUB_PROVIDER.")
+  var provider: String?
+
+  @Option(name: .long, help: "Prompt for the launched session. Required with --launch-session.")
+  var prompt: String?
+
   func run() async throws {
     let service = WorktreeManagementService()
     let directoryName = WorktreeNaming.worktreeDirectoryName(for: branch)
@@ -84,7 +105,16 @@ struct CreateWorktree: AsyncParsableCommand {
       directoryName: directoryName,
       startPoint: from
     )
-    try printResult(path: path, branch: branch, json: options.json)
+    let launchRequestId = try await queueLaunchIfRequested(
+      launchSession: launchSession,
+      provider: provider,
+      prompt: prompt,
+      service: service,
+      repositoryPath: options.repositoryPath,
+      worktreePath: path,
+      branch: branch
+    )
+    try printResult(path: path, branch: branch, launchRequestId: launchRequestId, json: options.json)
   }
 }
 
@@ -99,6 +129,15 @@ struct CheckoutWorktree: AsyncParsableCommand {
 
   @OptionGroup var options: WorktreeOptions
 
+  @Flag(name: .long, help: "Request AgentHub to launch an embedded session in the worktree.")
+  var launchSession = false
+
+  @Option(name: .long, help: "Provider for the launched session: claude or codex. Defaults to AGENTHUB_PROVIDER.")
+  var provider: String?
+
+  @Option(name: .long, help: "Prompt for the launched session. Required with --launch-session.")
+  var prompt: String?
+
   func run() async throws {
     let service = WorktreeManagementService()
     let directoryName = WorktreeNaming.worktreeDirectoryName(for: branch)
@@ -108,7 +147,16 @@ struct CheckoutWorktree: AsyncParsableCommand {
       directoryName: directoryName
     )
 
-    try printResult(path: resolvedPath, branch: branch, json: options.json)
+    let launchRequestId = try await queueLaunchIfRequested(
+      launchSession: launchSession,
+      provider: provider,
+      prompt: prompt,
+      service: service,
+      repositoryPath: options.repositoryPath,
+      worktreePath: resolvedPath,
+      branch: branch
+    )
+    try printResult(path: resolvedPath, branch: branch, launchRequestId: launchRequestId, json: options.json)
   }
 }
 
@@ -164,6 +212,7 @@ struct PrintWorktreeRoot: AsyncParsableCommand {
 private struct WorktreePathResult: Codable {
   let path: String
   let branch: String
+  let launchRequestId: String?
 }
 
 private struct DeleteResult: Codable {
@@ -187,10 +236,67 @@ private enum JSONPrinter {
   }
 }
 
-private func printResult(path: String, branch: String, json: Bool) throws {
+private func printResult(path: String, branch: String, launchRequestId: String? = nil, json: Bool) throws {
   if json {
-    try JSONPrinter.print(WorktreePathResult(path: path, branch: branch))
+    try JSONPrinter.print(WorktreePathResult(path: path, branch: branch, launchRequestId: launchRequestId))
   } else {
     Swift.print(path)
   }
+}
+
+private func queueLaunchIfRequested(
+  launchSession: Bool,
+  provider providerOption: String?,
+  prompt promptOption: String?,
+  service: WorktreeManagementService,
+  repositoryPath: String,
+  worktreePath: String,
+  branch: String
+) async throws -> String? {
+  guard launchSession else { return nil }
+
+  let launchProvider = try resolveLaunchProvider(providerOption)
+  let prompt = try resolveLaunchPrompt(promptOption)
+  let sourceProvider = ProcessInfo.processInfo.environment["AGENTHUB_PROVIDER"]
+    .flatMap(WorktreeLaunchProvider.init(commandLineValue:))
+  let sourceSessionId = ProcessInfo.processInfo.environment["AGENTHUB_SESSION_ID"]
+  let mainRepositoryPath = try await service.findMainRepositoryRoot(at: repositoryPath)
+  let request = WorktreeLaunchRequest(
+    provider: launchProvider,
+    repositoryPath: mainRepositoryPath,
+    worktreePath: worktreePath,
+    branchName: branch,
+    prompt: prompt,
+    sourceProvider: sourceProvider,
+    sourceSessionId: sourceSessionId
+  )
+
+  let queued = try WorktreeLaunchRequestQueue().enqueue(request)
+  return queued.request.id
+}
+
+private func resolveLaunchProvider(_ providerOption: String?) throws -> WorktreeLaunchProvider {
+  let explicitProvider = providerOption.flatMap(WorktreeLaunchProvider.init(commandLineValue:))
+  if let explicitProvider {
+    return explicitProvider
+  }
+
+  if let providerOption, !providerOption.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+    throw ValidationError("Invalid provider '\(providerOption)'. Expected claude or codex.")
+  }
+
+  if let environmentProvider = ProcessInfo.processInfo.environment["AGENTHUB_PROVIDER"]
+    .flatMap(WorktreeLaunchProvider.init(commandLineValue:)) {
+    return environmentProvider
+  }
+
+  throw ValidationError(WorktreeLaunchRequestQueueError.missingProvider.localizedDescription)
+}
+
+private func resolveLaunchPrompt(_ promptOption: String?) throws -> String {
+  let prompt = promptOption?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+  guard !prompt.isEmpty else {
+    throw ValidationError(WorktreeLaunchRequestQueueError.missingPrompt.localizedDescription)
+  }
+  return prompt
 }

--- a/app/modules/AgentHubCLI/Sources/AgentHubCLI/AgentHubMCPServer.swift
+++ b/app/modules/AgentHubCLI/Sources/AgentHubCLI/AgentHubMCPServer.swift
@@ -1,0 +1,355 @@
+import AgentHubCLIKit
+import Foundation
+
+struct AgentHubMCPServer {
+  private let service = WorktreeManagementService()
+  private let queue = WorktreeLaunchRequestQueue()
+
+  func run() async throws {
+    while let line = readLine(strippingNewline: true) {
+      guard !line.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { continue }
+      await handleLine(line)
+    }
+  }
+
+  private func handleLine(_ line: String) async {
+    do {
+      guard let data = line.data(using: .utf8),
+            let object = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+            let method = object["method"] as? String else {
+        return
+      }
+
+      let id = object["id"]
+      switch method {
+      case "initialize":
+        guard let id else { return }
+        let protocolVersion = ((object["params"] as? [String: Any])?["protocolVersion"] as? String)
+          ?? "2024-11-05"
+        writeResponse(id: id, result: [
+          "protocolVersion": protocolVersion,
+          "capabilities": [
+            "tools": [:]
+          ],
+          "serverInfo": [
+            "name": "agenthub",
+            "version": "1.0.0"
+          ]
+        ])
+
+      case "tools/list":
+        guard let id else { return }
+        writeResponse(id: id, result: [
+          "tools": [
+            createWorktreeSessionToolSchema(),
+            createWorktreeSessionsToolSchema()
+          ]
+        ])
+
+      case "tools/call":
+        guard let id else { return }
+        let result = try await handleToolCall(params: object["params"] as? [String: Any])
+        writeResponse(id: id, result: result)
+
+      default:
+        guard let id else { return }
+        writeError(id: id, code: -32601, message: "Method not found: \(method)")
+      }
+    } catch {
+      let id = requestId(from: line)
+      writeError(id: id, code: -32000, message: error.localizedDescription)
+    }
+  }
+
+  private func handleToolCall(params: [String: Any]?) async throws -> [String: Any] {
+    guard let params,
+          let name = params["name"] as? String else {
+      throw MCPError.invalidRequest("Missing tool name.")
+    }
+    let arguments = params["arguments"] as? [String: Any] ?? [:]
+
+    switch name {
+    case "agenthub_create_worktree_session":
+      let result = try await createWorktreeSession(arguments: arguments)
+      return toolResult(text: result.summary, structuredContent: result.dictionary)
+
+    case "agenthub_create_worktree_sessions":
+      let results = try await createWorktreeSessions(arguments: arguments)
+      return toolResult(
+        text: results.map(\.summary).joined(separator: "\n"),
+        structuredContent: [
+          "sessions": results.map(\.dictionary)
+        ]
+      )
+
+    default:
+      throw MCPError.invalidRequest("Unknown AgentHub tool: \(name).")
+    }
+  }
+
+  private func createWorktreeSession(arguments: [String: Any]) async throws -> MCPWorktreeLaunchResult {
+    let branch = try requiredString("branch", in: arguments)
+    let prompt = try requiredString("prompt", in: arguments)
+    let repositoryPath = optionalString("repo", in: arguments)
+      ?? ProcessInfo.processInfo.environment["AGENTHUB_PROJECT_PATH"]
+      ?? FileManager.default.currentDirectoryPath
+    let provider = try resolveProvider(optionalString("provider", in: arguments))
+    let startPoint = optionalString("from", in: arguments)
+    let checkoutExisting = arguments["checkoutExisting"] as? Bool ?? false
+    let directoryName = WorktreeNaming.worktreeDirectoryName(for: branch)
+
+    let worktreePath: String
+    if checkoutExisting {
+      worktreePath = try await service.checkoutWorktree(
+        at: repositoryPath,
+        branch: branch,
+        directoryName: directoryName
+      )
+    } else {
+      worktreePath = try await service.createWorktreeWithNewBranch(
+        at: repositoryPath,
+        newBranchName: branch,
+        directoryName: directoryName,
+        startPoint: startPoint
+      )
+    }
+
+    let mainRepositoryPath = try await service.findMainRepositoryRoot(at: repositoryPath)
+    let sourceProvider = ProcessInfo.processInfo.environment["AGENTHUB_PROVIDER"]
+      .flatMap(WorktreeLaunchProvider.init(commandLineValue:))
+    let sourceSessionId = ProcessInfo.processInfo.environment["AGENTHUB_SESSION_ID"]
+    let request = WorktreeLaunchRequest(
+      provider: provider,
+      repositoryPath: mainRepositoryPath,
+      worktreePath: worktreePath,
+      branchName: branch,
+      prompt: prompt,
+      sourceProvider: sourceProvider,
+      sourceSessionId: sourceSessionId
+    )
+    let queued = try queue.enqueue(request)
+
+    return MCPWorktreeLaunchResult(
+      branch: branch,
+      provider: provider,
+      repositoryPath: mainRepositoryPath,
+      worktreePath: worktreePath,
+      launchRequestId: queued.request.id
+    )
+  }
+
+  private func createWorktreeSessions(arguments: [String: Any]) async throws -> [MCPWorktreeLaunchResult] {
+    guard let tasks = arguments["tasks"] as? [[String: Any]], !tasks.isEmpty else {
+      throw MCPError.invalidRequest("Expected a non-empty tasks array.")
+    }
+
+    let defaultRepo = optionalString("repo", in: arguments)
+    let defaultProvider = optionalString("provider", in: arguments)
+
+    var results: [MCPWorktreeLaunchResult] = []
+    for task in tasks {
+      var merged = task
+      if merged["repo"] == nil, let defaultRepo {
+        merged["repo"] = defaultRepo
+      }
+      if merged["provider"] == nil, let defaultProvider {
+        merged["provider"] = defaultProvider
+      }
+      results.append(try await createWorktreeSession(arguments: merged))
+    }
+    return results
+  }
+
+  private func resolveProvider(_ explicit: String?) throws -> WorktreeLaunchProvider {
+    if let explicit, !explicit.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+      guard let provider = WorktreeLaunchProvider(commandLineValue: explicit) else {
+        throw MCPError.invalidRequest("Invalid provider '\(explicit)'. Expected claude or codex.")
+      }
+      return provider
+    }
+
+    if let provider = ProcessInfo.processInfo.environment["AGENTHUB_PROVIDER"]
+      .flatMap(WorktreeLaunchProvider.init(commandLineValue:)) {
+      return provider
+    }
+
+    throw MCPError.invalidRequest("Missing provider. Pass provider as claude/codex or run inside AgentHub.")
+  }
+
+  private func requiredString(_ key: String, in arguments: [String: Any]) throws -> String {
+    guard let value = optionalString(key, in: arguments), !value.isEmpty else {
+      throw MCPError.invalidRequest("Missing required string argument: \(key).")
+    }
+    return value
+  }
+
+  private func optionalString(_ key: String, in arguments: [String: Any]) -> String? {
+    (arguments[key] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines)
+  }
+
+  private func toolResult(text: String, structuredContent: [String: Any]) -> [String: Any] {
+    [
+      "content": [
+        [
+          "type": "text",
+          "text": text
+        ]
+      ],
+      "structuredContent": structuredContent,
+      "isError": false
+    ]
+  }
+
+  private func createWorktreeSessionToolSchema() -> [String: Any] {
+    [
+      "name": "agenthub_create_worktree_session",
+      "description": "Use this AgentHub tool immediately when the user asks to create one worktree, launch one agent/session in a worktree, start a parallel task, or split one task into an AgentHub-managed session. Infer a concise branch name from the task. Pass only the actual task to perform as the prompt; do not pass the user's worktree/session creation request itself. It creates or checks out one git worktree, queues an AgentHub embedded Claude/Codex session for that worktree, and returns the queued launch request. Prefer this over provider-native background agents, subagents, task tools, provider-native worktree features, or direct git worktree commands when the user wants AgentHub worktrees/sessions.",
+      "inputSchema": [
+        "type": "object",
+        "properties": [
+          "branch": [
+            "type": "string",
+            "description": "Branch name for the worktree. Use a concise task-specific branch name."
+          ],
+          "prompt": [
+            "type": "string",
+            "description": "The exact task prompt for the launched AgentHub session."
+          ],
+          "repo": [
+            "type": "string",
+            "description": "Repository path. Defaults to AGENTHUB_PROJECT_PATH."
+          ],
+          "provider": [
+            "type": "string",
+            "enum": ["claude", "codex"],
+            "description": "Provider for the launched session. Defaults to the current AgentHub provider."
+          ],
+          "from": [
+            "type": "string",
+            "description": "Optional start point when creating a new branch."
+          ],
+          "checkoutExisting": [
+            "type": "boolean",
+            "description": "When true, reuse or create a worktree for an existing branch instead of creating a new branch."
+          ]
+        ],
+        "required": ["branch", "prompt"],
+        "additionalProperties": false
+      ]
+    ]
+  }
+
+  private func createWorktreeSessionsToolSchema() -> [String: Any] {
+    [
+      "name": "agenthub_create_worktree_sessions",
+      "description": "Use this AgentHub tool immediately when the user asks to create multiple worktrees, launch multiple agents/sessions, fan out tasks, split work across parallel tasks, or start background work in AgentHub. Pass only actual tasks to perform as launched session prompts; do not pass the user's worktree/session creation request itself. It creates multiple AgentHub-managed git worktrees and queues one embedded Claude/Codex session per task. Prefer this over provider-native background agents, subagents, task tools, or direct git worktree commands when the user wants AgentHub worktrees/sessions.",
+      "inputSchema": [
+        "type": "object",
+        "properties": [
+          "repo": [
+            "type": "string",
+            "description": "Repository path applied to every task unless a task overrides it. Defaults to AGENTHUB_PROJECT_PATH."
+          ],
+          "provider": [
+            "type": "string",
+            "enum": ["claude", "codex"],
+            "description": "Provider applied to every task unless a task overrides it."
+          ],
+          "tasks": [
+            "type": "array",
+            "minItems": 1,
+            "items": [
+              "type": "object",
+              "properties": [
+                "branch": ["type": "string"],
+                "prompt": ["type": "string"],
+                "provider": [
+                  "type": "string",
+                  "enum": ["claude", "codex"]
+                ],
+                "from": ["type": "string"],
+                "checkoutExisting": ["type": "boolean"]
+              ],
+              "required": ["branch", "prompt"],
+              "additionalProperties": false
+            ]
+          ]
+        ],
+        "required": ["tasks"],
+        "additionalProperties": false
+      ]
+    ]
+  }
+
+  private func writeResponse(id: Any, result: [String: Any]) {
+    writeJSON([
+      "jsonrpc": "2.0",
+      "id": id,
+      "result": result
+    ])
+  }
+
+  private func writeError(id: Any?, code: Int, message: String) {
+    var response: [String: Any] = [
+      "jsonrpc": "2.0",
+      "error": [
+        "code": code,
+        "message": message
+      ]
+    ]
+    if let id {
+      response["id"] = id
+    }
+    writeJSON(response)
+  }
+
+  private func writeJSON(_ object: [String: Any]) {
+    guard JSONSerialization.isValidJSONObject(object),
+          let data = try? JSONSerialization.data(withJSONObject: object, options: []) else {
+      return
+    }
+    FileHandle.standardOutput.write(data)
+    FileHandle.standardOutput.write(Data([0x0A]))
+  }
+
+  private func requestId(from line: String) -> Any? {
+    guard let data = line.data(using: .utf8),
+          let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+      return nil
+    }
+    return object["id"]
+  }
+}
+
+private struct MCPWorktreeLaunchResult {
+  let branch: String
+  let provider: WorktreeLaunchProvider
+  let repositoryPath: String
+  let worktreePath: String
+  let launchRequestId: String
+
+  var summary: String {
+    "Queued AgentHub \(provider.rawValue) session for \(branch) at \(worktreePath) (request \(launchRequestId))."
+  }
+
+  var dictionary: [String: Any] {
+    [
+      "branch": branch,
+      "provider": provider.commandLineValue,
+      "repositoryPath": repositoryPath,
+      "worktreePath": worktreePath,
+      "launchRequestId": launchRequestId
+    ]
+  }
+}
+
+private enum MCPError: LocalizedError {
+  case invalidRequest(String)
+
+  var errorDescription: String? {
+    switch self {
+    case .invalidRequest(let message):
+      return message
+    }
+  }
+}

--- a/app/modules/AgentHubCLI/Sources/AgentHubCLIKit/WorktreeLaunchRequestQueue.swift
+++ b/app/modules/AgentHubCLI/Sources/AgentHubCLIKit/WorktreeLaunchRequestQueue.swift
@@ -1,0 +1,166 @@
+import Foundation
+
+public enum WorktreeLaunchProvider: String, Codable, CaseIterable, Equatable, Sendable {
+  case claude = "Claude"
+  case codex = "Codex"
+
+  public init?(commandLineValue: String) {
+    let normalized = commandLineValue.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    switch normalized {
+    case "claude":
+      self = .claude
+    case "codex":
+      self = .codex
+    default:
+      return nil
+    }
+  }
+
+  public var commandLineValue: String {
+    rawValue.lowercased()
+  }
+}
+
+public struct WorktreeLaunchRequest: Codable, Equatable, Identifiable, Sendable {
+  public let id: String
+  public let createdAt: Date
+  public let provider: WorktreeLaunchProvider
+  public let repositoryPath: String
+  public let worktreePath: String
+  public let branchName: String
+  public let prompt: String
+  public let sourceProvider: WorktreeLaunchProvider?
+  public let sourceSessionId: String?
+
+  public init(
+    id: String = UUID().uuidString,
+    createdAt: Date = Date(),
+    provider: WorktreeLaunchProvider,
+    repositoryPath: String,
+    worktreePath: String,
+    branchName: String,
+    prompt: String,
+    sourceProvider: WorktreeLaunchProvider? = nil,
+    sourceSessionId: String? = nil
+  ) {
+    self.id = id
+    self.createdAt = createdAt
+    self.provider = provider
+    self.repositoryPath = repositoryPath
+    self.worktreePath = worktreePath
+    self.branchName = branchName
+    self.prompt = prompt
+    self.sourceProvider = sourceProvider
+    self.sourceSessionId = sourceSessionId
+  }
+}
+
+public struct QueuedWorktreeLaunchRequest: Equatable, Sendable {
+  public let request: WorktreeLaunchRequest
+  public let fileURL: URL
+
+  public init(request: WorktreeLaunchRequest, fileURL: URL) {
+    self.request = request
+    self.fileURL = fileURL
+  }
+}
+
+public enum WorktreeLaunchRequestQueueError: LocalizedError, Sendable {
+  case missingProvider
+  case missingPrompt
+
+  public var errorDescription: String? {
+    switch self {
+    case .missingProvider:
+      return "Missing launch provider. Pass --provider claude|codex or run inside an AgentHub embedded session."
+    case .missingPrompt:
+      return "Missing launch prompt. Pass --prompt when using --launch-session."
+    }
+  }
+}
+
+public struct WorktreeLaunchRequestQueue: Sendable {
+  public let directoryURL: URL
+
+  public init(directoryURL: URL = WorktreeLaunchRequestQueue.defaultDirectoryURL()) {
+    self.directoryURL = directoryURL
+  }
+
+  public static func defaultDirectoryURL(fileManager: FileManager = .default) -> URL {
+    let appSupportURL = fileManager.urls(
+      for: .applicationSupportDirectory,
+      in: .userDomainMask
+    ).first ?? URL(fileURLWithPath: NSHomeDirectory()).appendingPathComponent("Library/Application Support")
+
+    return appSupportURL
+      .appendingPathComponent("AgentHub", isDirectory: true)
+      .appendingPathComponent("cli-requests", isDirectory: true)
+  }
+
+  @discardableResult
+  public func enqueue(_ request: WorktreeLaunchRequest) throws -> QueuedWorktreeLaunchRequest {
+    try FileManager.default.createDirectory(
+      at: directoryURL,
+      withIntermediateDirectories: true
+    )
+
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+    let data = try encoder.encode(request)
+
+    let finalURL = directoryURL.appendingPathComponent("\(request.id).json", isDirectory: false)
+    let temporaryURL = directoryURL.appendingPathComponent(".\(request.id).tmp", isDirectory: false)
+
+    try data.write(to: temporaryURL, options: [.atomic])
+    if FileManager.default.fileExists(atPath: finalURL.path) {
+      try FileManager.default.removeItem(at: finalURL)
+    }
+    try FileManager.default.moveItem(at: temporaryURL, to: finalURL)
+
+    return QueuedWorktreeLaunchRequest(request: request, fileURL: finalURL)
+  }
+
+  public func pendingRequests() throws -> [QueuedWorktreeLaunchRequest] {
+    guard FileManager.default.fileExists(atPath: directoryURL.path) else {
+      return []
+    }
+
+    let files = try FileManager.default.contentsOfDirectory(
+      at: directoryURL,
+      includingPropertiesForKeys: nil
+    )
+
+    let decoder = JSONDecoder()
+    return files
+      .filter { $0.pathExtension == "json" && !$0.lastPathComponent.hasPrefix(".") }
+      .compactMap { url in
+        guard let data = try? Data(contentsOf: url),
+              let request = try? decoder.decode(WorktreeLaunchRequest.self, from: data) else {
+          return nil
+        }
+        return QueuedWorktreeLaunchRequest(request: request, fileURL: url)
+      }
+      .sorted {
+        if $0.request.createdAt == $1.request.createdAt {
+          return $0.request.id < $1.request.id
+        }
+        return $0.request.createdAt < $1.request.createdAt
+      }
+  }
+
+  public func remove(_ queued: QueuedWorktreeLaunchRequest) throws {
+    guard FileManager.default.fileExists(atPath: queued.fileURL.path) else { return }
+    try FileManager.default.removeItem(at: queued.fileURL)
+  }
+
+  public func markFailed(_ queued: QueuedWorktreeLaunchRequest) throws {
+    guard FileManager.default.fileExists(atPath: queued.fileURL.path) else { return }
+    let failedURL = queued.fileURL
+      .deletingPathExtension()
+      .appendingPathExtension("failed")
+    if FileManager.default.fileExists(atPath: failedURL.path) {
+      try FileManager.default.removeItem(at: failedURL)
+    }
+    try FileManager.default.moveItem(at: queued.fileURL, to: failedURL)
+  }
+}

--- a/app/modules/AgentHubCLI/Tests/AgentHubCLIKitTests/WorktreeLaunchRequestQueueTests.swift
+++ b/app/modules/AgentHubCLI/Tests/AgentHubCLIKitTests/WorktreeLaunchRequestQueueTests.swift
@@ -1,0 +1,91 @@
+import Foundation
+import Testing
+
+@testable import AgentHubCLIKit
+
+@Suite("WorktreeLaunchRequestQueue")
+struct WorktreeLaunchRequestQueueTests {
+  @Test("Enqueue writes pending request and preserves payload")
+  func enqueueWritesPendingRequest() throws {
+    let directory = try temporaryRequestDirectory()
+    defer { try? FileManager.default.removeItem(at: directory.deletingLastPathComponent()) }
+
+    let queue = WorktreeLaunchRequestQueue(directoryURL: directory)
+    let request = WorktreeLaunchRequest(
+      id: "request-1",
+      createdAt: Date(timeIntervalSince1970: 1_000),
+      provider: .claude,
+      repositoryPath: "/tmp/repo",
+      worktreePath: "/tmp/repo/.worktrees/feature",
+      branchName: "feature",
+      prompt: "Implement feature",
+      sourceProvider: .codex,
+      sourceSessionId: "source-1"
+    )
+
+    let queued = try queue.enqueue(request)
+    let pending = try queue.pendingRequests()
+
+    #expect(FileManager.default.fileExists(atPath: queued.fileURL.path))
+    #expect(pending.map(\.request) == [request])
+    #expect(pending.first?.request == request)
+  }
+
+  @Test("Remove deletes handled request")
+  func removeDeletesHandledRequest() throws {
+    let directory = try temporaryRequestDirectory()
+    defer { try? FileManager.default.removeItem(at: directory.deletingLastPathComponent()) }
+
+    let queue = WorktreeLaunchRequestQueue(directoryURL: directory)
+    let queued = try queue.enqueue(WorktreeLaunchRequest(
+      id: "request-1",
+      provider: .codex,
+      repositoryPath: "/tmp/repo",
+      worktreePath: "/tmp/repo/.worktrees/feature",
+      branchName: "feature",
+      prompt: "Implement feature"
+    ))
+
+    try queue.remove(queued)
+
+    #expect(try queue.pendingRequests().isEmpty)
+    #expect(!FileManager.default.fileExists(atPath: queued.fileURL.path))
+  }
+
+  @Test("Mark failed moves request out of pending queue")
+  func markFailedMovesRequestOutOfPendingQueue() throws {
+    let directory = try temporaryRequestDirectory()
+    defer { try? FileManager.default.removeItem(at: directory.deletingLastPathComponent()) }
+
+    let queue = WorktreeLaunchRequestQueue(directoryURL: directory)
+    let queued = try queue.enqueue(WorktreeLaunchRequest(
+      id: "request-1",
+      provider: .claude,
+      repositoryPath: "/tmp/repo",
+      worktreePath: "/tmp/repo/.worktrees/feature",
+      branchName: "feature",
+      prompt: "Implement feature"
+    ))
+
+    try queue.markFailed(queued)
+
+    let failedURL = queued.fileURL.deletingPathExtension().appendingPathExtension("failed")
+    #expect(try queue.pendingRequests().isEmpty)
+    #expect(FileManager.default.fileExists(atPath: failedURL.path))
+  }
+
+  @Test("Provider parses command line and environment style values")
+  func providerParsesValues() {
+    #expect(WorktreeLaunchProvider(commandLineValue: "claude") == .claude)
+    #expect(WorktreeLaunchProvider(commandLineValue: "Claude") == .claude)
+    #expect(WorktreeLaunchProvider(commandLineValue: "codex") == .codex)
+    #expect(WorktreeLaunchProvider(commandLineValue: "unknown") == nil)
+  }
+}
+
+private func temporaryRequestDirectory() throws -> URL {
+  let root = FileManager.default.temporaryDirectory
+    .appendingPathComponent("agenthub-cli-request-tests-\(UUID().uuidString)", isDirectory: true)
+  try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+  return root.appendingPathComponent("requests", isDirectory: true)
+}

--- a/app/modules/AgentHubCore/Package.swift
+++ b/app/modules/AgentHubCore/Package.swift
@@ -144,6 +144,7 @@ let package = Package(
       name: "AgentHubTests",
       dependencies: [
         "AgentHubCore",
+        .product(name: "AgentHubCLIKit", package: "AgentHubCLI"),
         "AgentHubGitDiff",
         "AgentHubFileSearch",
         "ClaudeCodeClient",

--- a/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubProvider.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubProvider.swift
@@ -7,6 +7,7 @@
 
 import AgentHubGitHub
 import AgentHubGitDiff
+import AgentHubCLIKit
 import Foundation
 import os
 import ClaudeCodeClient
@@ -47,6 +48,7 @@ public final class AgentHubProvider {
   /// SwiftTerm surface when `.ghostty` is selected.
   public let terminalSurfaceFactory: any EmbeddedTerminalSurfaceFactory
   private let metadataStoreOverride: SessionMetadataStore?
+  private let worktreeLaunchRequestMonitorOverride: (any WorktreeLaunchRequestMonitorProtocol)?
 
   // MARK: - Lazy Services
 
@@ -178,6 +180,20 @@ public final class AgentHubProvider {
     WorktreeSuccessSoundService()
   }()
 
+  /// Watches requests written by the bundled `agenthub` helper.
+  public private(set) lazy var worktreeLaunchRequestMonitor: any WorktreeLaunchRequestMonitorProtocol = {
+    worktreeLaunchRequestMonitorOverride ?? WorktreeLaunchRequestMonitor()
+  }()
+
+  public private(set) lazy var worktreeLaunchRequestHandler: any WorktreeLaunchRequestHandlingProtocol = {
+    WorktreeLaunchRequestHandler(
+      claudeViewModel: claudeSessionsViewModel,
+      codexViewModel: codexSessionsViewModel
+    )
+  }()
+
+  private var isWorktreeLaunchRequestMonitoringStarted = false
+
   // MARK: - GitHub Integration
 
   /// GitHub CLI service for PR/issue operations
@@ -236,12 +252,14 @@ public final class AgentHubProvider {
   public init(
     configuration: AgentHubConfiguration = .default,
     terminalSurfaceFactory: any EmbeddedTerminalSurfaceFactory = DefaultEmbeddedTerminalSurfaceFactory(),
-    metadataStore: SessionMetadataStore? = nil
+    metadataStore: SessionMetadataStore? = nil,
+    worktreeLaunchRequestMonitor: (any WorktreeLaunchRequestMonitorProtocol)? = nil
   ) {
     self.configuration = configuration
     self.terminalBackend = .storedPreference
     self.terminalSurfaceFactory = terminalSurfaceFactory
     self.metadataStoreOverride = metadataStore
+    self.worktreeLaunchRequestMonitorOverride = worktreeLaunchRequestMonitor
     if let metadataStore {
       Task {
         await TerminalProcessRegistry.shared.configure(store: metadataStore)
@@ -373,6 +391,31 @@ public final class AgentHubProvider {
   public func cleanupOrphanedProcesses() {
     Task(priority: .utility) {
       await TerminalProcessRegistry.shared.cleanupRegisteredProcesses()
+    }
+  }
+
+  public func startWorktreeLaunchRequestMonitoring() {
+    guard !isWorktreeLaunchRequestMonitoringStarted else { return }
+    isWorktreeLaunchRequestMonitoringStarted = true
+
+    let monitor = worktreeLaunchRequestMonitor
+    Task {
+      await monitor.start { [weak self] queued in
+        guard let self else {
+          throw WorktreeLaunchRequestHandlingError.providerUnavailable
+        }
+        try await self.worktreeLaunchRequestHandler.handle(queued.request)
+      }
+    }
+  }
+
+  public func stopWorktreeLaunchRequestMonitoring() {
+    guard isWorktreeLaunchRequestMonitoringStarted else { return }
+    isWorktreeLaunchRequestMonitoringStarted = false
+
+    let monitor = worktreeLaunchRequestMonitor
+    Task {
+      await monitor.stop()
     }
   }
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubViews.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubViews.swift
@@ -60,6 +60,9 @@ public struct AgentHubSessionsView: View {
     )
       .frame(minWidth: 1200, minHeight: 750)
       .modifier(RemoveTitleToolbarModifier())
+      .task {
+        provider.startWorktreeLaunchRequestMonitoring()
+      }
   }
 
   private var missingProviderView: some View {

--- a/app/modules/AgentHubCore/Sources/AgentHub/Configuration/CLICommandConfiguration.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Configuration/CLICommandConfiguration.swift
@@ -50,6 +50,7 @@ public struct CLICommandConfiguration: Codable, Sendable {
   public func argumentsForSession(
     sessionId: String?,
     prompt: String?,
+    agentHubMCPServerPath: String? = nil,
     dangerouslySkipPermissions: Bool = false,
     worktreeName: String? = nil,
     permissionModePlan: Bool = false,
@@ -66,6 +67,11 @@ public struct CLICommandConfiguration: Codable, Sendable {
       var args: [String] = []
 
       let isNewSession = sessionId == nil || sessionId?.isEmpty == true || sessionId?.hasPrefix("pending-") == true
+
+      if let agentHubMCPServerPath, !agentHubMCPServerPath.isEmpty {
+        args += ["--mcp-config", claudeMCPConfig(agentHubCLIPath: agentHubMCPServerPath)]
+        args += ["--append-system-prompt", Self.agentHubMCPRoutingInstructions]
+      }
 
       // Add flags only for NEW sessions (not resume)
       if isNewSession {
@@ -114,11 +120,18 @@ public struct CLICommandConfiguration: Codable, Sendable {
     case .codex:
       if let sessionId, !sessionId.isEmpty, !sessionId.hasPrefix("pending-") {
         // Codex CLI resume: codex resume <SESSION_ID>
-        return prefix + ["resume", sessionId]
+        var args: [String] = []
+        if let agentHubMCPServerPath, !agentHubMCPServerPath.isEmpty {
+          args += codexMCPConfigArgs(agentHubCLIPath: agentHubMCPServerPath)
+        }
+        return prefix + args + ["resume", sessionId]
       }
 
       // AI configuration flags for new Codex sessions
       var args: [String] = []
+      if let agentHubMCPServerPath, !agentHubMCPServerPath.isEmpty {
+        args += codexMCPConfigArgs(agentHubCLIPath: agentHubMCPServerPath)
+      }
       if let model, !model.isEmpty {
         args += ["--model", model]
       }
@@ -145,4 +158,59 @@ public struct CLICommandConfiguration: Codable, Sendable {
       return prefix + args
     }
   }
+
+  private func claudeMCPConfig(agentHubCLIPath: String) -> String {
+    let config: [String: Any] = [
+      "mcpServers": [
+        "agenthub": [
+          "command": "/bin/sh",
+          "args": ["-lc", mcpServerShellScript(agentHubCLIPath: agentHubCLIPath)]
+        ]
+      ]
+    ]
+    guard let data = try? JSONSerialization.data(withJSONObject: config),
+          let encoded = String(data: data, encoding: .utf8) else {
+      return "{}"
+    }
+    return encoded
+  }
+
+  private func codexMCPConfigArgs(agentHubCLIPath: String) -> [String] {
+    [
+      "-c", "mcp_servers.agenthub.command=\(tomlStringLiteral("/bin/sh"))",
+      "-c", "mcp_servers.agenthub.args=\(tomlStringArray(["-lc", mcpServerShellScript(agentHubCLIPath: agentHubCLIPath)]))",
+      "-c", "developer_instructions=\(tomlStringLiteral(Self.agentHubMCPRoutingInstructions))"
+    ]
+  }
+
+  private func mcpServerShellScript(agentHubCLIPath: String) -> String {
+    let escapedCLIPath = shellSingleQuoted(agentHubCLIPath)
+    return """
+    if [ -n "${AGENTHUB_CLI:-}" ] && [ -x "${AGENTHUB_CLI:-}" ]; then exec "$AGENTHUB_CLI" mcp-server; fi
+    if [ -x \(escapedCLIPath) ]; then exec \(escapedCLIPath) mcp-server; fi
+    exec agenthub mcp-server
+    """
+  }
+
+  private func shellSingleQuoted(_ value: String) -> String {
+    "'\(value.replacingOccurrences(of: "'", with: "'\\''"))'"
+  }
+
+  private func tomlStringLiteral(_ value: String) -> String {
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.withoutEscapingSlashes]
+    guard let data = try? encoder.encode(value),
+          let encoded = String(data: data, encoding: .utf8) else {
+      return "\"\""
+    }
+    return encoded
+  }
+
+  private func tomlStringArray(_ values: [String]) -> String {
+    "[\(values.map(tomlStringLiteral).joined(separator: ","))]"
+  }
+
+  private static let agentHubMCPRoutingInstructions = """
+  In AgentHub sessions, when the user asks to create worktrees, launch agents/sessions, fan out work, split work across tasks, or start parallel/background work, immediately use the AgentHub MCP worktree-session tool. For one task use agenthub_create_worktree_session; for multiple tasks use agenthub_create_worktree_sessions. Infer concise branch names from the tasks. Pass only the actual task to perform as each launched session prompt; do not pass the user's worktree/session creation request itself. Do not use provider-native worktree/background-agent features for AgentHub-managed launches.
+  """
 }

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/WorktreeLaunchRequestHandler.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/WorktreeLaunchRequestHandler.swift
@@ -1,0 +1,134 @@
+import AgentHubCLIKit
+import Foundation
+
+@MainActor
+public protocol WorktreeLaunchRequestHandlingProtocol: AnyObject {
+  func handle(_ request: WorktreeLaunchRequest) async throws
+}
+
+enum WorktreeLaunchRequestHandlingError: LocalizedError {
+  case providerUnavailable
+  case emptyPrompt
+
+  var errorDescription: String? {
+    switch self {
+    case .providerUnavailable:
+      return "AgentHub provider is unavailable."
+    case .emptyPrompt:
+      return "The queued worktree launch request did not include a prompt."
+    }
+  }
+}
+
+@MainActor
+public final class WorktreeLaunchRequestHandler: WorktreeLaunchRequestHandlingProtocol {
+  private let claudeViewModel: CLISessionsViewModel
+  private let codexViewModel: CLISessionsViewModel
+
+  public init(
+    claudeViewModel: CLISessionsViewModel,
+    codexViewModel: CLISessionsViewModel
+  ) {
+    self.claudeViewModel = claudeViewModel
+    self.codexViewModel = codexViewModel
+  }
+
+  public func handle(_ request: WorktreeLaunchRequest) async throws {
+    let prompt = WorktreeLaunchPromptSanitizer.launchedTaskPrompt(
+      from: request.prompt,
+      branchName: request.branchName
+    )
+    guard !prompt.isEmpty else {
+      throw WorktreeLaunchRequestHandlingError.emptyPrompt
+    }
+
+    let viewModel: CLISessionsViewModel
+    switch request.provider {
+    case .claude:
+      viewModel = claudeViewModel
+    case .codex:
+      viewModel = codexViewModel
+    }
+
+    let worktree = await viewModel.registerCreatedWorktree(
+      name: request.branchName,
+      path: request.worktreePath,
+      parentRepositoryPath: request.repositoryPath
+    )
+    viewModel.startNewSessionInHub(worktree, initialPrompt: prompt)
+    viewModel.refresh()
+  }
+}
+
+enum WorktreeLaunchPromptSanitizer {
+  static func launchedTaskPrompt(from prompt: String, branchName: String) -> String {
+    let trimmed = prompt.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else { return "" }
+
+    if let extracted = extractedTask(from: trimmed) {
+      return extracted
+    }
+
+    if isLikelyWorktreeOrchestrationPrompt(trimmed) {
+      return readableTaskPrompt(from: branchName)
+    }
+
+    return trimmed
+  }
+
+  private static func extractedTask(from prompt: String) -> String? {
+    let patterns = [
+      #"^\s*(?:please\s+)?(?:create|make|start|launch|spin\s+up)\s+(?:one\s+|onw\s+|a\s+|an\s+|new\s+)?(?:agenthub\s+)?worktree\s+(?:for|to|because|so\s+i\s+can|i\s+have\s+to)\s+(.+)$"#,
+      #"^\s*(?:please\s+)?(?:create|make|start|launch|spin\s+up)\s+(?:one\s+|onw\s+|a\s+|an\s+|new\s+)?(?:agenthub\s+)?(?:agent|session)\s+(?:for|to)\s+(.+)$"#
+    ]
+
+    for pattern in patterns {
+      guard let match = firstCapture(in: prompt, pattern: pattern) else { continue }
+      let extracted = match.trimmingCharacters(in: .whitespacesAndNewlines)
+      if !extracted.isEmpty {
+        return extracted
+      }
+    }
+    return nil
+  }
+
+  private static func isLikelyWorktreeOrchestrationPrompt(_ prompt: String) -> Bool {
+    let lowercased = prompt.lowercased()
+    let hasCreateVerb = [
+      "create",
+      "make",
+      "start",
+      "launch",
+      "spin up"
+    ].contains { lowercased.contains($0) }
+    let hasLaunchTarget = [
+      "worktree",
+      "agent",
+      "session"
+    ].contains { lowercased.contains($0) }
+    return hasCreateVerb && hasLaunchTarget
+  }
+
+  private static func readableTaskPrompt(from branchName: String) -> String {
+    let task = branchName
+      .replacingOccurrences(of: "/", with: " ")
+      .replacingOccurrences(of: "-", with: " ")
+      .replacingOccurrences(of: "_", with: " ")
+      .trimmingCharacters(in: .whitespacesAndNewlines)
+    return task.isEmpty ? "" : "Work on \(task)."
+  }
+
+  private static func firstCapture(in value: String, pattern: String) -> String? {
+    guard let regex = try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive]) else {
+      return nil
+    }
+
+    let range = NSRange(value.startIndex..<value.endIndex, in: value)
+    guard let match = regex.firstMatch(in: value, range: range),
+          match.numberOfRanges > 1,
+          let captureRange = Range(match.range(at: 1), in: value) else {
+      return nil
+    }
+    return String(value[captureRange])
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/WorktreeLaunchRequestMonitor.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/WorktreeLaunchRequestMonitor.swift
@@ -1,0 +1,71 @@
+import AgentHubCLIKit
+import Foundation
+
+public protocol WorktreeLaunchRequestMonitorProtocol: AnyObject, Sendable {
+  func start(handler: @escaping @MainActor @Sendable (QueuedWorktreeLaunchRequest) async throws -> Void) async
+  func stop() async
+}
+
+public actor WorktreeLaunchRequestMonitor: WorktreeLaunchRequestMonitorProtocol {
+  private let queue: WorktreeLaunchRequestQueue
+  private let pollInterval: Duration
+  private var task: Task<Void, Never>?
+  private var activeRequestIds: Set<String> = []
+
+  public init(
+    queue: WorktreeLaunchRequestQueue = WorktreeLaunchRequestQueue(),
+    pollInterval: Duration = .seconds(1)
+  ) {
+    self.queue = queue
+    self.pollInterval = pollInterval
+  }
+
+  public func start(
+    handler: @escaping @MainActor @Sendable (QueuedWorktreeLaunchRequest) async throws -> Void
+  ) async {
+    guard task == nil else { return }
+
+    task = Task { [queue, pollInterval] in
+      while !Task.isCancelled {
+        await self.processPendingRequests(queue: queue, handler: handler)
+        try? await Task.sleep(for: pollInterval)
+      }
+    }
+  }
+
+  public func stop() async {
+    task?.cancel()
+    task = nil
+    activeRequestIds.removeAll()
+  }
+
+  private func processPendingRequests(
+    queue: WorktreeLaunchRequestQueue,
+    handler: @escaping @MainActor @Sendable (QueuedWorktreeLaunchRequest) async throws -> Void
+  ) async {
+    let queuedRequests: [QueuedWorktreeLaunchRequest]
+    do {
+      queuedRequests = try queue.pendingRequests()
+    } catch {
+      AppLogger.session.error("Failed to read AgentHub CLI launch requests: \(error.localizedDescription)")
+      return
+    }
+
+    for queued in queuedRequests {
+      guard activeRequestIds.insert(queued.request.id).inserted else { continue }
+      defer { activeRequestIds.remove(queued.request.id) }
+
+      do {
+        try await handler(queued)
+        try queue.remove(queued)
+      } catch {
+        AppLogger.session.error("Failed to handle AgentHub CLI launch request: \(error.localizedDescription)")
+        do {
+          try queue.markFailed(queued)
+        } catch {
+          AppLogger.session.error("Failed to mark AgentHub CLI launch request failed: \(error.localizedDescription)")
+        }
+      }
+    }
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/EmbeddedTerminalLaunchBuilder.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/EmbeddedTerminalLaunchBuilder.swift
@@ -74,25 +74,24 @@ public enum EmbeddedTerminalLaunchBuilder {
     }
 
     let resolvedAgentHubCLIPath = agentHubCLIPath ?? AgentHubCLILocator.bundledCLIPath()
+    let workingDirectory = projectPath.isEmpty ? NSHomeDirectory() : projectPath
+    let providerKind = SessionProviderKind(cliMode: cliConfiguration.mode)
     let environment = makeProcessEnvironment(
       additionalPaths: cliConfiguration.additionalPaths,
-      agentHubCLIPath: resolvedAgentHubCLIPath
+      agentHubCLIPath: resolvedAgentHubCLIPath,
+      providerKind: providerKind,
+      projectPath: workingDirectory,
+      sessionId: sessionId
     )
-    let workingDirectory = projectPath.isEmpty ? NSHomeDirectory() : projectPath
     let escapedPath = shellEscape(workingDirectory)
     let escapedCLIPath = shellEscape(executablePath)
-    let launchPrompt = AgentHubSessionInstructionBuilder.decoratedPrompt(
-      initialPrompt,
-      sessionId: sessionId,
-      agentHubCLIPath: resolvedAgentHubCLIPath
-    )
-
     let aiConfig = metadataStore?.getAIConfigSync(for: cliConfiguration.mode.rawValue)
     let allowedTools = AIConfigRecord.parseToolPatterns(aiConfig?.allowedTools)
     let disallowedTools = AIConfigRecord.parseToolPatterns(aiConfig?.disallowedTools)
     let args = cliConfiguration.argumentsForSession(
       sessionId: sessionId,
-      prompt: launchPrompt,
+      prompt: initialPrompt,
+      agentHubMCPServerPath: resolvedAgentHubCLIPath,
       dangerouslySkipPermissions: dangerouslySkipPermissions,
       worktreeName: worktreeName,
       permissionModePlan: permissionModePlan,
@@ -126,19 +125,36 @@ public enum EmbeddedTerminalLaunchBuilder {
 
   static func makeProcessEnvironment(
     additionalPaths: [String],
-    agentHubCLIPath: String? = AgentHubCLILocator.bundledCLIPath()
+    agentHubCLIPath: String? = AgentHubCLILocator.bundledCLIPath(),
+    providerKind: SessionProviderKind? = nil,
+    projectPath: String? = nil,
+    sessionId: String? = nil
   ) -> [String: String] {
     var environment = ProcessInfo.processInfo.environment
     environment["TERM"] = "xterm-256color"
     environment["COLORTERM"] = "truecolor"
     environment["LANG"] = "en_US.UTF-8"
     environment.removeValue(forKey: "TERM_PROGRAM")
+    environment.removeValue(forKey: "AGENTHUB_CLI")
+    environment.removeValue(forKey: "AGENTHUB_PROVIDER")
+    environment.removeValue(forKey: "AGENTHUB_PROJECT_PATH")
+    environment.removeValue(forKey: "AGENTHUB_SESSION_ID")
 
     var paths = CLIPathResolver.executableSearchPaths(additionalPaths: additionalPaths)
     if let agentHubCLIPath, !agentHubCLIPath.isEmpty {
       environment["AGENTHUB_CLI"] = agentHubCLIPath
       let agentHubCLIDirectory = (agentHubCLIPath as NSString).deletingLastPathComponent
       paths.insert(agentHubCLIDirectory, at: 0)
+    }
+
+    if let providerKind {
+      environment["AGENTHUB_PROVIDER"] = providerKind.rawValue
+    }
+    if let projectPath, !projectPath.isEmpty {
+      environment["AGENTHUB_PROJECT_PATH"] = projectPath
+    }
+    if let sessionId, !sessionId.isEmpty, !sessionId.hasPrefix("pending-") {
+      environment["AGENTHUB_SESSION_ID"] = sessionId
     }
 
     let pathString = paths.joined(separator: ":")
@@ -181,36 +197,5 @@ enum AgentHubCLILocator {
       return nil
     }
     return cliPath
-  }
-}
-
-enum AgentHubSessionInstructionBuilder {
-  private static let marker = "AgentHub session context:"
-
-  static func decoratedPrompt(
-    _ prompt: String?,
-    sessionId: String?,
-    agentHubCLIPath: String?
-  ) -> String? {
-    guard isNewSession(sessionId),
-          agentHubCLIPath != nil,
-          let prompt,
-          !prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
-          !prompt.hasPrefix(marker) else {
-      return prompt
-    }
-
-    return """
-    \(marker)
-    - The AgentHub CLI is available as `agenthub` and at `$AGENTHUB_CLI`.
-    - For AgentHub-managed worktree operations, use `agenthub worktree ... --json` instead of direct `git worktree` commands.
-
-    User request:
-    \(prompt)
-    """
-  }
-
-  private static func isNewSession(_ sessionId: String?) -> Bool {
-    sessionId == nil || sessionId?.isEmpty == true || sessionId?.hasPrefix("pending-") == true
   }
 }

--- a/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/CLISessionsViewModel.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/CLISessionsViewModel.swift
@@ -2605,11 +2605,14 @@ public final class CLISessionsViewModel {
     permissionModePlan: Bool = false,
     worktreeName: String? = nil
   ) {
+    let promptForTerminalSubmission = providerKind == .claude ? nonEmpty(initialPrompt) : nil
+    let promptForProcessLaunch = providerKind == .claude ? nil : initialPrompt
+
     // Each pending session gets a unique ID, so no need to clear existing terminals
     // Terminals are now keyed by session ID, not worktree path
     let pending = PendingHubSession(
       worktree: worktree,
-      initialPrompt: initialPrompt,
+      initialPrompt: promptForProcessLaunch,
       initialInputText: initialInputText,
       dangerouslySkipPermissions: dangerouslySkipPermissions,
       permissionModePlan: permissionModePlan,
@@ -2617,6 +2620,9 @@ public final class CLISessionsViewModel {
     )
     pendingHubSessions.append(pending)
     lastCreatedPendingId = pending.id
+    if let promptForTerminalSubmission {
+      pendingTerminalPrompts["pending-\(pending.id.uuidString)"] = promptForTerminalSubmission
+    }
 
 #if DEBUG
     let encodedPath = worktree.path.claudeProjectPathEncoded

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/EmbeddedTerminalLaunchBuilderTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/EmbeddedTerminalLaunchBuilderTests.swift
@@ -19,32 +19,23 @@ struct EmbeddedTerminalLaunchBuilderAgentHubCLITests {
     #expect(environment["PATH"]?.contains("/custom/bin") == true)
   }
 
-  @Test("New session prompt includes visible AgentHub CLI guidance")
-  func newSessionPromptIncludesAgentHubCLIGuidance() throws {
-    let prompt = try #require(AgentHubSessionInstructionBuilder.decoratedPrompt(
-      "Build the login flow",
-      sessionId: nil,
-      agentHubCLIPath: agentHubCLIPath
-    ))
-
-    #expect(prompt.contains("AgentHub session context:"))
-    #expect(prompt.contains("agenthub worktree ... --json"))
-    #expect(prompt.contains("User request:\nBuild the login flow"))
-  }
-
-  @Test("Resume prompt is not decorated")
-  func resumePromptIsNotDecorated() {
-    let prompt = AgentHubSessionInstructionBuilder.decoratedPrompt(
-      "Continue the previous task",
-      sessionId: "session-123",
-      agentHubCLIPath: agentHubCLIPath
+  @Test("Environment exposes AgentHub launch context")
+  func environmentExposesAgentHubLaunchContext() {
+    let environment = EmbeddedTerminalLaunchBuilder.makeProcessEnvironment(
+      additionalPaths: [],
+      agentHubCLIPath: agentHubCLIPath,
+      providerKind: .claude,
+      projectPath: "/tmp/project",
+      sessionId: "session-123"
     )
 
-    #expect(prompt == "Continue the previous task")
+    #expect(environment["AGENTHUB_PROVIDER"] == "Claude")
+    #expect(environment["AGENTHUB_PROJECT_PATH"] == "/tmp/project")
+    #expect(environment["AGENTHUB_SESSION_ID"] == "session-123")
   }
 
-  @Test("CLI launch passes decorated prompt and AgentHub CLI environment")
-  func cliLaunchPassesDecoratedPromptAndEnvironment() throws {
+  @Test("Claude launch passes raw prompt, AgentHub MCP config, and hidden routing instruction")
+  func claudeLaunchPassesRawPromptAgentHubMCPConfigAndRoutingInstruction() throws {
     let result = EmbeddedTerminalLaunchBuilder.cliLaunch(
       sessionId: nil,
       projectPath: "/tmp",
@@ -63,7 +54,70 @@ struct EmbeddedTerminalLaunchBuilderAgentHubCLITests {
     }
 
     #expect(launch.environment["AGENTHUB_CLI"] == agentHubCLIPath)
-    #expect(launch.shellCommand.contains("AgentHub session context:"))
+    #expect(launch.environment["AGENTHUB_PROVIDER"] == "Claude")
+    #expect(launch.environment["AGENTHUB_PROJECT_PATH"] == "/tmp")
+    #expect(launch.shellCommand.contains("--mcp-config"))
+    #expect(launch.shellCommand.contains("/bin/sh"))
+    #expect(launch.shellCommand.contains("mcp-server"))
+    #expect(launch.shellCommand.contains("--append-system-prompt"))
+    #expect(launch.shellCommand.contains("agenthub_create_worktree_session"))
+    #expect(!launch.shellCommand.contains("AgentHub session context:"))
+    #expect(!launch.shellCommand.contains("User request:"))
     #expect(launch.shellCommand.contains("Create a worktree for the issue"))
+  }
+
+  @Test("Blank Claude launch still passes AgentHub MCP config")
+  func blankClaudeLaunchStillPassesAgentHubMCPConfig() throws {
+    let result = EmbeddedTerminalLaunchBuilder.cliLaunch(
+      sessionId: nil,
+      projectPath: "/tmp",
+      cliConfiguration: CLICommandConfiguration(command: "echo", additionalPaths: ["/bin"], mode: .claude),
+      initialPrompt: nil,
+      dangerouslySkipPermissions: false,
+      permissionModePlan: false,
+      worktreeName: nil,
+      metadataStore: nil,
+      agentHubCLIPath: agentHubCLIPath
+    )
+
+    guard case .success(let launch) = result else {
+      Issue.record("Expected launch builder success")
+      return
+    }
+
+    #expect(launch.shellCommand.contains("--mcp-config"))
+    #expect(launch.shellCommand.contains("/bin/sh"))
+    #expect(launch.shellCommand.contains("mcp-server"))
+    #expect(launch.shellCommand.contains("--append-system-prompt"))
+    #expect(launch.shellCommand.contains("agenthub_create_worktree_session"))
+    #expect(!launch.shellCommand.contains("AgentHub session context:"))
+  }
+
+  @Test("Codex launch passes AgentHub MCP config and routing instruction")
+  func codexLaunchPassesAgentHubMCPConfigAndRoutingInstruction() throws {
+    let result = EmbeddedTerminalLaunchBuilder.cliLaunch(
+      sessionId: nil,
+      projectPath: "/tmp",
+      cliConfiguration: CLICommandConfiguration(command: "echo", additionalPaths: ["/bin"], mode: .codex),
+      initialPrompt: nil,
+      dangerouslySkipPermissions: false,
+      permissionModePlan: false,
+      worktreeName: nil,
+      metadataStore: nil,
+      agentHubCLIPath: agentHubCLIPath
+    )
+
+    guard case .success(let launch) = result else {
+      Issue.record("Expected launch builder success")
+      return
+    }
+
+    #expect(launch.shellCommand.contains("mcp_servers.agenthub.command"))
+    #expect(launch.shellCommand.contains("/bin/sh"))
+    #expect(launch.shellCommand.contains("mcp-server"))
+    #expect(launch.shellCommand.contains("developer_instructions="))
+    #expect(launch.shellCommand.contains("agenthub_create_worktree_session"))
+    #expect(!launch.shellCommand.contains("\\/"))
+    #expect(!launch.shellCommand.contains("AgentHub session context:"))
   }
 }

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/WorktreeLaunchRequestHandlerTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/WorktreeLaunchRequestHandlerTests.swift
@@ -1,0 +1,251 @@
+import AgentHubCLIKit
+import Combine
+import Foundation
+import Testing
+
+@testable import AgentHubCore
+
+@Suite("WorktreeLaunchRequestHandler")
+@MainActor
+struct WorktreeLaunchRequestHandlerTests {
+  @Test("Handler registers worktree and launches pending session for requested provider")
+  func handlerRegistersWorktreeAndLaunchesPendingSession() async throws {
+    let claudeMonitor = TestLaunchMonitorService()
+    let codexMonitor = TestLaunchMonitorService()
+    let claudeViewModel = makeLaunchRequestViewModel(
+      providerKind: .claude,
+      monitorService: claudeMonitor
+    )
+    let codexViewModel = makeLaunchRequestViewModel(
+      providerKind: .codex,
+      monitorService: codexMonitor
+    )
+    let handler = WorktreeLaunchRequestHandler(
+      claudeViewModel: claudeViewModel,
+      codexViewModel: codexViewModel
+    )
+    let root = FileManager.default.temporaryDirectory
+      .appendingPathComponent("agenthub-launch-handler-\(UUID().uuidString)", isDirectory: true)
+    let repoPath = root.appendingPathComponent("repo", isDirectory: true).path
+    let worktreePath = root.appendingPathComponent("repo/.worktrees/feature", isDirectory: true).path
+    try FileManager.default.createDirectory(atPath: worktreePath, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    try await handler.handle(WorktreeLaunchRequest(
+      id: "request-1",
+      provider: .codex,
+      repositoryPath: repoPath,
+      worktreePath: worktreePath,
+      branchName: "feature",
+      prompt: "Implement the feature"
+    ))
+
+    #expect(claudeViewModel.pendingHubSessions.isEmpty)
+    let pending = try #require(codexViewModel.pendingHubSessions.first)
+    #expect(pending.worktree.path == worktreePath)
+    #expect(pending.worktree.name == "feature")
+    #expect(pending.initialPrompt == "Implement the feature")
+    #expect(
+      codexViewModel.selectedRepositories.first?.worktrees.contains {
+        $0.path == worktreePath && $0.isWorktree
+      } == true
+    )
+
+    codexViewModel.cancelPendingSession(pending)
+  }
+
+  @Test("Handler strips worktree creation wording before launching child session")
+  func handlerStripsWorktreeCreationWordingBeforeLaunchingChildSession() async throws {
+    let codexViewModel = makeLaunchRequestViewModel(providerKind: .codex)
+    let handler = WorktreeLaunchRequestHandler(
+      claudeViewModel: makeLaunchRequestViewModel(providerKind: .claude),
+      codexViewModel: codexViewModel
+    )
+    let root = FileManager.default.temporaryDirectory
+      .appendingPathComponent("agenthub-launch-handler-\(UUID().uuidString)", isDirectory: true)
+    let repoPath = root.appendingPathComponent("repo", isDirectory: true).path
+    let worktreePath = root.appendingPathComponent("repo/.worktrees/logging", isDirectory: true).path
+    try FileManager.default.createDirectory(atPath: worktreePath, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    try await handler.handle(WorktreeLaunchRequest(
+      provider: .codex,
+      repositoryPath: repoPath,
+      worktreePath: worktreePath,
+      branchName: "logging",
+      prompt: "create onw worktree I have to add logging"
+    ))
+
+    let pending = try #require(codexViewModel.pendingHubSessions.first)
+    #expect(pending.initialPrompt == "add logging")
+
+    codexViewModel.cancelPendingSession(pending)
+  }
+
+  @Test("Claude launches queue initial prompt for terminal submission")
+  func claudeLaunchesQueueInitialPromptForTerminalSubmission() async throws {
+    let claudeViewModel = makeLaunchRequestViewModel(providerKind: .claude)
+    let handler = WorktreeLaunchRequestHandler(
+      claudeViewModel: claudeViewModel,
+      codexViewModel: makeLaunchRequestViewModel(providerKind: .codex)
+    )
+    let root = FileManager.default.temporaryDirectory
+      .appendingPathComponent("agenthub-launch-handler-\(UUID().uuidString)", isDirectory: true)
+    let repoPath = root.appendingPathComponent("repo", isDirectory: true).path
+    let worktreePath = root.appendingPathComponent("repo/.worktrees/logging", isDirectory: true).path
+    try FileManager.default.createDirectory(atPath: worktreePath, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    try await handler.handle(WorktreeLaunchRequest(
+      provider: .claude,
+      repositoryPath: repoPath,
+      worktreePath: worktreePath,
+      branchName: "logging",
+      prompt: "add logging"
+    ))
+
+    let pending = try #require(claudeViewModel.pendingHubSessions.first)
+    #expect(pending.initialPrompt == nil)
+    #expect(claudeViewModel.pendingPrompt(for: "pending-\(pending.id.uuidString)") == "add logging")
+
+    claudeViewModel.cancelPendingSession(pending)
+  }
+
+  @Test("Handler falls back to branch name for worktree-only orchestration prompts")
+  func handlerFallsBackToBranchNameForWorktreeOnlyOrchestrationPrompts() async throws {
+    let codexViewModel = makeLaunchRequestViewModel(providerKind: .codex)
+    let handler = WorktreeLaunchRequestHandler(
+      claudeViewModel: makeLaunchRequestViewModel(providerKind: .claude),
+      codexViewModel: codexViewModel
+    )
+    let root = FileManager.default.temporaryDirectory
+      .appendingPathComponent("agenthub-launch-handler-\(UUID().uuidString)", isDirectory: true)
+    let repoPath = root.appendingPathComponent("repo", isDirectory: true).path
+    let worktreePath = root.appendingPathComponent("repo/.worktrees/review-tests", isDirectory: true).path
+    try FileManager.default.createDirectory(atPath: worktreePath, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    try await handler.handle(WorktreeLaunchRequest(
+      provider: .codex,
+      repositoryPath: repoPath,
+      worktreePath: worktreePath,
+      branchName: "review-tests",
+      prompt: "create a worktree"
+    ))
+
+    let pending = try #require(codexViewModel.pendingHubSessions.first)
+    #expect(pending.initialPrompt == "Work on review tests.")
+
+    codexViewModel.cancelPendingSession(pending)
+  }
+
+  @Test("Handler rejects empty prompt")
+  func handlerRejectsEmptyPrompt() async throws {
+    let handler = WorktreeLaunchRequestHandler(
+      claudeViewModel: makeLaunchRequestViewModel(providerKind: .claude),
+      codexViewModel: makeLaunchRequestViewModel(providerKind: .codex)
+    )
+
+    await #expect(throws: WorktreeLaunchRequestHandlingError.self) {
+      try await handler.handle(WorktreeLaunchRequest(
+        provider: .claude,
+        repositoryPath: "/tmp/repo",
+        worktreePath: "/tmp/repo/.worktrees/feature",
+        branchName: "feature",
+        prompt: "   "
+      ))
+    }
+  }
+}
+
+@MainActor
+private func makeLaunchRequestViewModel(
+  providerKind: SessionProviderKind,
+  monitorService: TestLaunchMonitorService = TestLaunchMonitorService()
+) -> CLISessionsViewModel {
+  CLISessionsViewModel(
+    monitorService: monitorService,
+    fileWatcher: TestLaunchFileWatcher(),
+    searchService: nil,
+    cliConfiguration: providerKind == .claude ? .claudeDefault : .codexDefault,
+    providerKind: providerKind,
+    approvalNotificationService: TestLaunchApprovalNotificationService(),
+    codexDataPath: FileManager.default.temporaryDirectory
+      .appendingPathComponent("agenthub-launch-codex-\(UUID().uuidString)", isDirectory: true)
+      .path
+  )
+}
+
+private final class TestLaunchApprovalNotificationService: ApprovalNotificationServiceProtocol, @unchecked Sendable {
+  func requestPermission() async -> Bool { false }
+  func sendApprovalNotification(sessionId: String, toolName: String, projectPath: String?, model: String?, lastMessage: String?) {}
+}
+
+private final class TestLaunchFileWatcher: SessionFileWatcherProtocol, @unchecked Sendable {
+  private let subject = PassthroughSubject<SessionFileWatcher.StateUpdate, Never>()
+  var statePublisher: AnyPublisher<SessionFileWatcher.StateUpdate, Never> { subject.eraseToAnyPublisher() }
+
+  func startMonitoring(sessionId: String, projectPath: String, sessionFilePath: String?) async {}
+  func stopMonitoring(sessionId: String) async {}
+  func getState(sessionId: String) async -> SessionMonitorState? { nil }
+  func refreshState(sessionId: String) async {}
+  func setApprovalTimeout(_ seconds: Int) async {}
+}
+
+private actor TestLaunchMonitorService: SessionMonitorServiceProtocol {
+  private nonisolated(unsafe) let subject = CurrentValueSubject<[SelectedRepository], Never>([])
+  private var repositories: [SelectedRepository] = []
+  private var ownedWorktreePaths: Set<String> = []
+
+  nonisolated var repositoriesPublisher: AnyPublisher<[SelectedRepository], Never> {
+    subject.eraseToAnyPublisher()
+  }
+
+  func addRepository(_ path: String) async -> SelectedRepository? {
+    guard !repositories.contains(where: { $0.path == path }) else { return nil }
+    let repository = SelectedRepository(path: path, worktrees: [
+      WorktreeBranch(name: "main", path: path)
+    ])
+    repositories.append(repository)
+    subject.send(repositories)
+    return repository
+  }
+
+  func removeRepository(_ path: String) async {
+    repositories.removeAll { $0.path == path }
+    subject.send(repositories)
+  }
+
+  func setOwnedWorktreePaths(_ paths: Set<String>) async {
+    ownedWorktreePaths = paths
+  }
+
+  func registerWorktree(_ worktree: WorktreeBranch, parentRepositoryPath: String) async {
+    if let index = repositories.firstIndex(where: { $0.path == parentRepositoryPath }) {
+      if let worktreeIndex = repositories[index].worktrees.firstIndex(where: { $0.path == worktree.path }) {
+        repositories[index].worktrees[worktreeIndex] = worktree
+      } else {
+        repositories[index].worktrees.append(worktree)
+      }
+    } else {
+      repositories.append(SelectedRepository(path: parentRepositoryPath, worktrees: [
+        WorktreeBranch(name: "main", path: parentRepositoryPath),
+        worktree
+      ]))
+    }
+    subject.send(repositories)
+  }
+
+  func getSelectedRepositories() async -> [SelectedRepository] {
+    repositories
+  }
+
+  func setSelectedRepositories(_ repositories: [SelectedRepository]) async {
+    self.repositories = repositories
+    subject.send(repositories)
+  }
+
+  func refreshSessions(skipWorktreeRedetection: Bool) async {
+    subject.send(repositories)
+  }
+}

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/WorktreeLaunchRequestMonitorTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/WorktreeLaunchRequestMonitorTests.swift
@@ -1,0 +1,95 @@
+import AgentHubCLIKit
+import Foundation
+import Testing
+
+@testable import AgentHubCore
+
+@Suite("WorktreeLaunchRequestMonitor")
+struct WorktreeLaunchRequestMonitorTests {
+  @Test("Monitor handles queued request and removes it")
+  func monitorHandlesQueuedRequestAndRemovesIt() async throws {
+    let directory = try temporaryMonitorRequestDirectory()
+    defer { try? FileManager.default.removeItem(at: directory.deletingLastPathComponent()) }
+
+    let queue = WorktreeLaunchRequestQueue(directoryURL: directory)
+    let request = WorktreeLaunchRequest(
+      id: "request-1",
+      provider: .claude,
+      repositoryPath: "/tmp/repo",
+      worktreePath: "/tmp/repo/.worktrees/feature",
+      branchName: "feature",
+      prompt: "Implement feature"
+    )
+    try queue.enqueue(request)
+
+    let recorder = WorktreeLaunchRequestRecorder()
+    let monitor = WorktreeLaunchRequestMonitor(queue: queue, pollInterval: .milliseconds(20))
+    await monitor.start { queued in
+      await recorder.record(queued.request)
+    }
+
+    await waitForMonitorCondition {
+      await recorder.requests() == [request]
+        && ((try? queue.pendingRequests().isEmpty) == true)
+    }
+    await monitor.stop()
+  }
+
+  @Test("Monitor marks failed request out of pending queue")
+  func monitorMarksFailedRequestOutOfPendingQueue() async throws {
+    let directory = try temporaryMonitorRequestDirectory()
+    defer { try? FileManager.default.removeItem(at: directory.deletingLastPathComponent()) }
+
+    let queue = WorktreeLaunchRequestQueue(directoryURL: directory)
+    let queued = try queue.enqueue(WorktreeLaunchRequest(
+      id: "request-1",
+      provider: .codex,
+      repositoryPath: "/tmp/repo",
+      worktreePath: "/tmp/repo/.worktrees/feature",
+      branchName: "feature",
+      prompt: "Implement feature"
+    ))
+
+    let monitor = WorktreeLaunchRequestMonitor(queue: queue, pollInterval: .milliseconds(20))
+    await monitor.start { _ in
+      throw WorktreeLaunchRequestHandlingError.emptyPrompt
+    }
+
+    await waitForMonitorCondition {
+      let failedURL = queued.fileURL.deletingPathExtension().appendingPathExtension("failed")
+      return ((try? queue.pendingRequests().isEmpty) == true)
+        && FileManager.default.fileExists(atPath: failedURL.path)
+    }
+    await monitor.stop()
+  }
+}
+
+private actor WorktreeLaunchRequestRecorder {
+  private var recordedRequests: [WorktreeLaunchRequest] = []
+
+  func record(_ request: WorktreeLaunchRequest) {
+    recordedRequests.append(request)
+  }
+
+  func requests() -> [WorktreeLaunchRequest] {
+    recordedRequests
+  }
+}
+
+private func waitForMonitorCondition(
+  timeout: Duration = .seconds(2),
+  condition: @escaping () async -> Bool
+) async {
+  let start = ContinuousClock.now
+  while !(await condition()), ContinuousClock.now - start < timeout {
+    try? await Task.sleep(for: .milliseconds(20))
+  }
+  #expect(await condition())
+}
+
+private func temporaryMonitorRequestDirectory() throws -> URL {
+  let root = FileManager.default.temporaryDirectory
+    .appendingPathComponent("agenthub-launch-monitor-tests-\(UUID().uuidString)", isDirectory: true)
+  try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+  return root.appendingPathComponent("requests", isDirectory: true)
+}


### PR DESCRIPTION
## Summary
- add a bundled AgentHub MCP server with single and multi worktree-session tools
- queue CLI-created worktree launches and have the app monitor the queue to start embedded Claude/Codex sessions
- configure fresh provider sessions with the AgentHub MCP and short routing instructions, while sanitizing child prompts to avoid recursive worktree creation
- pass Claude child prompts through the terminal submission path and keep Codex using launch prompts

## Validation
- `swift build --package-path app/modules/AgentHubCLI`
- `swift test --package-path app/modules/AgentHubCLI --filter WorktreeLaunchRequestQueue`
- MCP initialize/tools/list smoke test via `swift run --package-path app/modules/AgentHubCLI agenthub mcp-server`
- `xcodebuild -project app/AgentHub.xcodeproj -scheme AgentHub -destination 'platform=macOS' build`

## Notes
- Targeted AgentHubCore SwiftPM tests are still blocked by the existing `CodeEditSymbols.swift: type 'Bundle' has no member 'module'` package issue.
