### PR TITLE
[codex] Fix quick file picker panel constraints

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/CollapsibleSessionRow.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/CollapsibleSessionRow.swift
@@ -20,6 +20,8 @@ struct CollapsibleSessionRow: View {
   var isDeletingWorktree: Bool = false
   let onSelect: () -> Void
 
+  private static let statusLabelMaxWidth: CGFloat = 96
+
   @State private var isHovered = false
   @State private var showArchiveConfirm = false
   @State private var pulseScale: CGFloat = 1.0
@@ -115,7 +117,8 @@ struct CollapsibleSessionRow: View {
 
           statusLabel
             .lineLimit(1)
-            .fixedSize(horizontal: true, vertical: false)
+            .truncationMode(.tail)
+            .frame(maxWidth: Self.statusLabelMaxWidth, alignment: .trailing)
             .animation(.easeInOut(duration: 0.3), value: isPending)
             .animation(.easeInOut(duration: 0.3), value: sessionStatus)
 
@@ -133,14 +136,18 @@ struct CollapsibleSessionRow: View {
               .font(.secondaryDefault)
               .foregroundColor(.primary)
               .lineLimit(1)
+              .truncationMode(.tail)
+              .frame(maxWidth: .infinity, alignment: .leading)
           }
 
           Spacer(minLength: 4)
 
           actionsView
+            .fixedSize(horizontal: true, vertical: false)
             .opacity(showActions ? 1 : 0)
             .animation(.easeInOut(duration: 0.25), value: showActions)
         }
+        .frame(maxWidth: .infinity, alignment: .leading)
 
         if let pullRequest = sessionGitHubQuickAccessViewModel.currentBranchPR {
           GitHubSessionRowStatusLine(
@@ -151,7 +158,9 @@ struct CollapsibleSessionRow: View {
           .transition(.opacity)
         }
       }
+      .frame(maxWidth: .infinity, alignment: .leading)
     }
+    .frame(maxWidth: .infinity, alignment: .leading)
     .padding(.horizontal, 10)
     .padding(.vertical, 8)
     .contentShape(Rectangle())

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/ModalPanelModifier.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/ModalPanelModifier.swift
@@ -158,10 +158,13 @@ private struct FloatingPanelModifier<PanelContent: View>: ViewModifier {
     dismissPanel()
 
     let view = panelContent()
+      .frame(width: defaultSize.width, height: defaultSize.height)
     let hostingView = NSHostingView(rootView: view)
     // Floating panels own their AppKit frame; SwiftUI should not resize the window
     // while animating internal content changes.
     hostingView.sizingOptions = []
+    hostingView.frame = NSRect(origin: .zero, size: defaultSize)
+    hostingView.autoresizingMask = [.width, .height]
 
     let newPanel = KeyablePanel(
       contentRect: NSRect(origin: .zero, size: defaultSize),
@@ -176,6 +179,8 @@ private struct FloatingPanelModifier<PanelContent: View>: ViewModifier {
     newPanel.backgroundColor = .clear
     newPanel.isOpaque = false
     newPanel.hasShadow = false
+    newPanel.contentMinSize = defaultSize
+    newPanel.contentMaxSize = defaultSize
     newPanel.contentView = hostingView
 
     let delegate = PanelWindowDelegate()


### PR DESCRIPTION
## Summary

- Lock the floating panel hosting root to the panel size so Cmd+P search-result layout changes do not resize the `NSPanel` through SwiftUI intrinsic content updates.
- Cap and truncate the session row status label while preserving action button width, preventing long status/tool text from crowding the row.

## Root Cause

The Cmd+P quick file picker is hosted in a borderless floating `NSPanel`. While the Files view is open, search state changes animate between recent files, progress, diagnostics, and results. Those changing intrinsic sizes could ask the panel-hosting `NSHostingView` to invalidate AppKit window constraints repeatedly, hitting AppKit's update-constraints pass limit.

## Validation

- `git diff --check`
- `xcodebuild -project app/AgentHub.xcodeproj -scheme AgentHub -destination 'platform=macOS' build`

Notes: `xcodebuild ... -scheme AgentHubCore test` cannot run because the scheme has no test action. `swift test --package-path app/modules/AgentHubCore` is blocked before AgentHub tests by the existing `CodeEditSymbols` SwiftPM `Bundle.module` resource issue.