### PR TITLE
[codex] Fix source editor find navigation

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/SourceCodeEditorView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/SourceCodeEditorView.swift
@@ -114,10 +114,27 @@ private struct SourceCodeEditorHost: View {
         onTextChange: onTextChange,
         onIdleTextSnapshot: onIdleTextSnapshot
       )
+      editCoordinator.repairFindPanelHitTesting()
+      editCoordinator.updateFindNavigation(
+        text: editorState.findText,
+        isPanelVisible: editorState.findPanelVisible == true
+      )
       editCoordinator.syncExternalText(text)
     }
     .onChange(of: text) { _, newText in
       editCoordinator.syncExternalText(newText)
+    }
+    .onChange(of: editorState.findText) { _, newText in
+      editCoordinator.updateFindNavigation(
+        text: newText,
+        isPanelVisible: editorState.findPanelVisible == true
+      )
+    }
+    .onChange(of: editorState.findPanelVisible) { _, isVisible in
+      editCoordinator.updateFindNavigation(
+        text: editorState.findText,
+        isPanelVisible: isVisible == true
+      )
     }
   }
 
@@ -207,6 +224,11 @@ private final class SourceEditorEditCoordinator: TextViewCoordinator {
   private weak var controller: TextViewController?
   private var isApplyingExternalText = false
   private var idleTask: Task<Void, Never>?
+  private var findNavigationEventMonitor: Any?
+  private var findNavigationText = ""
+  private var isFindPanelVisible = false
+  private var isUsingFindPanelNavigation = false
+  private var lastFindNavigationRange: NSRange?
   private var onTextChange: (String) -> Void = { _ in }
   private var onIdleTextSnapshot: (String) -> Void = { _ in }
 
@@ -220,6 +242,30 @@ private final class SourceEditorEditCoordinator: TextViewCoordinator {
 
   func prepareCoordinator(controller: TextViewController) {
     self.controller = controller
+    installFindNavigationEventMonitor()
+  }
+
+  func controllerDidAppear(controller: TextViewController) {
+    SourceEditorFindPanelHitTestingFix.apply(to: controller)
+  }
+
+  func repairFindPanelHitTesting() {
+    guard let controller else { return }
+    SourceEditorFindPanelHitTestingFix.apply(to: controller)
+  }
+
+  func updateFindNavigation(text: String?, isPanelVisible: Bool) {
+    let nextText = text ?? ""
+    if nextText != findNavigationText {
+      lastFindNavigationRange = nil
+    }
+    findNavigationText = nextText
+    self.isFindPanelVisible = isPanelVisible
+    if isPanelVisible, !nextText.isEmpty {
+      isUsingFindPanelNavigation = true
+    } else if !isPanelVisible {
+      isUsingFindPanelNavigation = false
+    }
   }
 
   func textViewDidChangeText(controller: TextViewController) {
@@ -227,6 +273,15 @@ private final class SourceEditorEditCoordinator: TextViewCoordinator {
     let updatedText = controller.text
     onTextChange(updatedText)
     scheduleIdleSnapshot(updatedText)
+  }
+
+  func textViewDidChangeSelection(controller: TextViewController, newPositions: [CursorPosition]) {
+    guard let range = newPositions.first?.range else { return }
+    lastFindNavigationRange = range
+    syncFindNavigationTextFromPanel(in: controller)
+    guard shouldHandleFindNavigation(in: controller) else { return }
+    guard isFindMatchRange(range, in: controller) else { return }
+    scrollFindMatch(range, in: controller)
   }
 
   func syncExternalText(_ text: String) {
@@ -238,6 +293,10 @@ private final class SourceEditorEditCoordinator: TextViewCoordinator {
 
   func destroy() {
     idleTask?.cancel()
+    if let findNavigationEventMonitor {
+      NSEvent.removeMonitor(findNavigationEventMonitor)
+      self.findNavigationEventMonitor = nil
+    }
   }
 
   private func scheduleIdleSnapshot(_ text: String) {
@@ -246,6 +305,166 @@ private final class SourceEditorEditCoordinator: TextViewCoordinator {
       try? await Task.sleep(for: .milliseconds(650))
       guard !Task.isCancelled else { return }
       self?.onIdleTextSnapshot(text)
+    }
+  }
+
+  private func installFindNavigationEventMonitor() {
+    guard findNavigationEventMonitor == nil else { return }
+    findNavigationEventMonitor = NSEvent.addLocalMonitorForEvents(
+      matching: [.keyDown, .leftMouseDown, .leftMouseUp]
+    ) { [weak self] event in
+      self?.handleFindNavigationEvent(event) ?? event
+    }
+  }
+
+  private func handleFindNavigationEvent(_ event: NSEvent) -> NSEvent? {
+    guard let controller,
+          controller.view.window?.isKeyWindow == true,
+          shouldHandleFindNavigation(in: controller) else {
+      return event
+    }
+
+    syncFindNavigationTextFromPanel(in: controller)
+    guard !findNavigationText.isEmpty else { return event }
+
+    switch event.type {
+    case .keyDown:
+      return handleFindNavigationKeyDown(event, controller: controller)
+    case .leftMouseDown:
+      return handleFindNavigationMouseDown(event, controller: controller)
+    case .leftMouseUp:
+      return handleFindNavigationMouseUp(event, controller: controller)
+    default:
+      return event
+    }
+  }
+
+  private func handleFindNavigationKeyDown(
+    _ event: NSEvent,
+    controller: TextViewController
+  ) -> NSEvent? {
+    let returnKey: UInt16 = 36
+    let keypadEnterKey: UInt16 = 76
+    guard event.keyCode == returnKey || event.keyCode == keypadEnterKey else {
+      return event
+    }
+
+    let modifierFlags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+    guard modifierFlags.subtracting(.shift).isEmpty else {
+      return event
+    }
+
+    if controller.view.window?.firstResponder === controller.textView,
+       isUsingFindPanelNavigation == false {
+      return event
+    }
+
+    let direction: SourceEditorFindNavigationDirection = modifierFlags.contains(.shift)
+      ? .previous
+      : .next
+    navigateFindMatch(direction, in: controller)
+    return nil
+  }
+
+  private func handleFindNavigationMouseDown(
+    _ event: NSEvent,
+    controller: TextViewController
+  ) -> NSEvent? {
+    guard let findPanel = SourceEditorFindPanelHitTestingFix.findPanel(in: controller.view),
+          findPanel.isHidden == false else {
+      return event
+    }
+
+    let panelPoint = findPanel.convert(event.locationInWindow, from: nil)
+    isUsingFindPanelNavigation = findPanel.bounds.contains(panelPoint)
+    return event
+  }
+
+  private func handleFindNavigationMouseUp(
+    _ event: NSEvent,
+    controller: TextViewController
+  ) -> NSEvent? {
+    guard let findPanel = SourceEditorFindPanelHitTestingFix.findPanel(in: controller.view),
+          findPanel.isHidden == false else {
+      return event
+    }
+
+    let panelPoint = findPanel.convert(event.locationInWindow, from: nil)
+    guard let direction = SourceEditorFindNavigationControlRegion.direction(
+      for: panelPoint,
+      panelSize: findPanel.bounds.size
+    ) else {
+      return event
+    }
+
+    navigateFindMatch(direction, in: controller)
+    return nil
+  }
+
+  private func navigateFindMatch(
+    _ direction: SourceEditorFindNavigationDirection,
+    in controller: TextViewController
+  ) {
+    syncFindNavigationTextFromPanel(in: controller)
+    let codeEditFindEmphases = controller.textView.emphasisManager?
+      .getEmphases(for: SourceEditorFindNavigator.codeEditFindEmphasisGroup)
+      .sorted { $0.range.location < $1.range.location } ?? []
+    let codeEditFindRanges = codeEditFindEmphases.map(\.range)
+    let activeFindRange = codeEditFindEmphases.first { $0.selectInDocument }?.range
+      ?? codeEditFindEmphases.first { !$0.inactive }?.range
+    let currentRange = lastFindNavigationRange
+      ?? activeFindRange
+      ?? controller.cursorPositions.first?.range
+    guard let range = SourceEditorFindNavigator.targetRange(
+      matches: codeEditFindRanges.isEmpty
+        ? SourceEditorFindNavigator.matchRanges(query: findNavigationText, in: controller.text)
+        : codeEditFindRanges,
+      currentRange: currentRange,
+      direction: direction
+    ) else {
+      NSSound.beep()
+      return
+    }
+
+    isUsingFindPanelNavigation = true
+    lastFindNavigationRange = range
+    controller.setCursorPositions([CursorPosition(range: range)], scrollToVisible: true)
+    scrollFindMatch(range, in: controller)
+  }
+
+  private func shouldHandleFindNavigation(in controller: TextViewController) -> Bool {
+    isFindPanelVisible || SourceEditorFindPanelHitTestingFix.isFindPanelVisible(in: controller.view)
+  }
+
+  private func syncFindNavigationTextFromPanel(in controller: TextViewController) {
+    guard let panelText = SourceEditorFindPanelHitTestingFix.findText(in: controller.view) else {
+      return
+    }
+    if panelText != findNavigationText {
+      lastFindNavigationRange = nil
+    }
+    findNavigationText = panelText
+  }
+
+  private func isFindMatchRange(_ range: NSRange, in controller: TextViewController) -> Bool {
+    guard range.location != NSNotFound, !findNavigationText.isEmpty else { return false }
+    let codeEditFindRanges = controller.textView.emphasisManager?
+      .getEmphases(for: SourceEditorFindNavigator.codeEditFindEmphasisGroup)
+      .map(\.range) ?? []
+    let findRanges = codeEditFindRanges.isEmpty
+      ? SourceEditorFindNavigator.matchRanges(query: findNavigationText, in: controller.text)
+      : codeEditFindRanges
+    return findRanges.contains(range)
+  }
+
+  private func scrollFindMatch(_ range: NSRange, in controller: TextViewController) {
+    guard range.location != NSNotFound else { return }
+    controller.textView.scrollToRange(range, center: true)
+
+    DispatchQueue.main.async { [weak controller] in
+      guard let controller else { return }
+      controller.textView.scrollToRange(range, center: true)
+      controller.scrollView.reflectScrolledClipView(controller.scrollView.contentView)
     }
   }
 }

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/SourceEditorFindNavigation.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/SourceEditorFindNavigation.swift
@@ -1,0 +1,166 @@
+//
+//  SourceEditorFindNavigation.swift
+//  AgentHub
+//
+//  Local repairs for CodeEditSourceEditor's embedded find panel.
+//
+
+import AppKit
+import CodeEditSourceEditor
+
+// MARK: - SourceEditorFindPanelHitTestingFix
+
+enum SourceEditorFindPanelHitTestingFix {
+  @discardableResult
+  static func apply(to controller: TextViewController) -> Bool {
+    bringFindPanelToFront(in: controller.view)
+  }
+
+  @discardableResult
+  static func bringFindPanelToFront(in rootView: NSView) -> Bool {
+    if let findPanel = directFindPanel(in: rootView) {
+      guard rootView.subviews.last !== findPanel else { return false }
+      rootView.addSubview(findPanel, positioned: .above, relativeTo: nil)
+      findPanel.wantsLayer = true
+      findPanel.layer?.zPosition = 1000
+      return true
+    }
+
+    for subview in rootView.subviews {
+      if bringFindPanelToFront(in: subview) {
+        return true
+      }
+    }
+
+    return false
+  }
+
+  static func findPanel(in rootView: NSView) -> NSView? {
+    if let findPanel = directFindPanel(in: rootView) {
+      return findPanel
+    }
+
+    for subview in rootView.subviews {
+      if let findPanel = findPanel(in: subview) {
+        return findPanel
+      }
+    }
+
+    return nil
+  }
+
+  static func isFindPanelVisible(in rootView: NSView) -> Bool {
+    guard let findPanel = findPanel(in: rootView) else { return false }
+    return findPanel.isHidden == false && findPanel.window != nil && findPanel.bounds.height > 0
+  }
+
+  static func findText(in rootView: NSView) -> String? {
+    guard let findPanel = findPanel(in: rootView) else { return nil }
+    return textFieldValues(in: findPanel)
+      .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+      .first { !$0.isEmpty }
+  }
+
+  private static func directFindPanel(in rootView: NSView) -> NSView? {
+    rootView.subviews.first(where: isFindPanelHostingView)
+  }
+
+  private static func isFindPanelHostingView(_ view: NSView) -> Bool {
+    String(describing: type(of: view)) == "FindPanelHostingView"
+  }
+
+  private static func textFieldValues(in rootView: NSView) -> [String] {
+    var values: [String] = []
+    if let textField = rootView as? NSTextField {
+      values.append(textField.stringValue)
+    }
+
+    for subview in rootView.subviews {
+      values.append(contentsOf: textFieldValues(in: subview))
+    }
+
+    return values
+  }
+}
+
+// MARK: - SourceEditorFindNavigator
+
+enum SourceEditorFindNavigationDirection {
+  case next
+  case previous
+}
+
+enum SourceEditorFindNavigator {
+  static let codeEditFindEmphasisGroup = "codeedit.find"
+
+  static func matchRanges(query: String, in text: String) -> [NSRange] {
+    guard !query.isEmpty else { return [] }
+    let pattern = NSRegularExpression.escapedPattern(for: query)
+    guard let regex = try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive]) else {
+      return []
+    }
+    let searchRange = NSRange(location: 0, length: (text as NSString).length)
+    return regex.matches(in: text, range: searchRange)
+      .map(\.range)
+      .filter { !$0.isEmpty }
+  }
+
+  static func targetRange(
+    query: String,
+    text: String,
+    currentRange: NSRange?,
+    direction: SourceEditorFindNavigationDirection
+  ) -> NSRange? {
+    targetRange(
+      matches: matchRanges(query: query, in: text),
+      currentRange: currentRange,
+      direction: direction
+    )
+  }
+
+  static func targetRange(
+    matches: [NSRange],
+    currentRange: NSRange?,
+    direction: SourceEditorFindNavigationDirection
+  ) -> NSRange? {
+    guard !matches.isEmpty else { return nil }
+
+    guard let currentRange else {
+      return direction == .next ? matches.first : matches.last
+    }
+
+    switch direction {
+    case .next:
+      return matches.first { $0.location > currentRange.location } ?? matches.first
+    case .previous:
+      return matches.last { $0.location < currentRange.location } ?? matches.last
+    }
+  }
+}
+
+enum SourceEditorFindNavigationControlRegion {
+  static func direction(
+    for point: CGPoint,
+    panelSize: CGSize
+  ) -> SourceEditorFindNavigationDirection? {
+    guard panelSize.width > 0,
+          point.x >= 0,
+          point.x <= panelSize.width,
+          point.y >= 0,
+          point.y <= panelSize.height else {
+      return nil
+    }
+
+    let doneButtonWidth: CGFloat = panelSize.width < 360 ? 32 : 54
+    let navigationGroupWidth: CGFloat = panelSize.width < 360 ? 54 : 66
+    let trailingInset: CGFloat = 4
+    let navigationMaxX = panelSize.width - doneButtonWidth - trailingInset
+    let navigationMinX = navigationMaxX - navigationGroupWidth
+
+    guard point.x >= navigationMinX, point.x <= navigationMaxX else {
+      return nil
+    }
+
+    return point.x < navigationMinX + navigationGroupWidth / 2 ? .previous : .next
+  }
+}

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/SourceCodeEditorViewTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/SourceCodeEditorViewTests.swift
@@ -1,10 +1,148 @@
+import AppKit
 import Foundation
 import Testing
 
 @testable import AgentHubCore
 
+private final class FindPanelHostingView: NSView {}
+
 @Suite("SourceCodeEditorView")
 struct SourceCodeEditorViewTests {
+  @Test("Find panel repair brings CodeEdit find panel to the hit-test front")
+  func findPanelRepairBringsPanelToFront() {
+    let rootView = NSView()
+    let codeEditContainer = NSView()
+    let findPanel = FindPanelHostingView()
+    let editorScrollView = NSScrollView()
+
+    rootView.addSubview(codeEditContainer)
+    codeEditContainer.addSubview(findPanel)
+    codeEditContainer.addSubview(editorScrollView)
+
+    let didRepair = SourceEditorFindPanelHitTestingFix.bringFindPanelToFront(in: rootView)
+
+    #expect(didRepair)
+    #expect(codeEditContainer.subviews.last === findPanel)
+    #expect(findPanel.layer?.zPosition == 1000)
+  }
+
+  @Test("Find panel repair is a no-op when the panel is already in front")
+  func findPanelRepairNoopsWhenPanelAlreadyInFront() {
+    let codeEditContainer = NSView()
+    let editorScrollView = NSScrollView()
+    let findPanel = FindPanelHostingView()
+
+    codeEditContainer.addSubview(editorScrollView)
+    codeEditContainer.addSubview(findPanel)
+
+    let didRepair = SourceEditorFindPanelHitTestingFix.bringFindPanelToFront(in: codeEditContainer)
+
+    #expect(didRepair == false)
+    #expect(codeEditContainer.subviews.last === findPanel)
+  }
+
+  @Test("Find panel visibility uses the actual embedded panel state")
+  func findPanelVisibilityUsesEmbeddedPanelState() {
+    let codeEditContainer = NSView()
+    let findPanel = FindPanelHostingView(frame: CGRect(x: 0, y: 0, width: 240, height: 28))
+
+    codeEditContainer.addSubview(findPanel)
+
+    #expect(SourceEditorFindPanelHitTestingFix.isFindPanelVisible(in: codeEditContainer) == false)
+
+    let window = NSWindow(contentRect: CGRect(x: 0, y: 0, width: 300, height: 120), styleMask: [], backing: .buffered, defer: false)
+    window.contentView = codeEditContainer
+
+    #expect(SourceEditorFindPanelHitTestingFix.isFindPanelVisible(in: codeEditContainer))
+
+    findPanel.isHidden = true
+    #expect(SourceEditorFindPanelHitTestingFix.isFindPanelVisible(in: codeEditContainer) == false)
+  }
+
+  @Test("Find panel text is read from embedded text field")
+  func findPanelTextIsReadFromEmbeddedTextField() {
+    let codeEditContainer = NSView()
+    let findPanel = FindPanelHostingView(frame: CGRect(x: 0, y: 0, width: 240, height: 28))
+    let wrapper = NSView()
+    let textField = NSTextField(string: " provider ")
+
+    codeEditContainer.addSubview(findPanel)
+    findPanel.addSubview(wrapper)
+    wrapper.addSubview(textField)
+
+    #expect(SourceEditorFindPanelHitTestingFix.findText(in: codeEditContainer) == "provider")
+  }
+
+  @Test("Find navigator advances and wraps through contains matches")
+  func findNavigatorAdvancesAndWrapsThroughMatches() {
+    let text = "provider\nlet providerValue = provider"
+    let matches = SourceEditorFindNavigator.matchRanges(query: "provider", in: text)
+
+    #expect(matches.map(\.location) == [0, 13, 29])
+    #expect(
+      SourceEditorFindNavigator.targetRange(
+        matches: matches,
+        currentRange: matches[0],
+        direction: .next
+      ) == matches[1]
+    )
+    #expect(
+      SourceEditorFindNavigator.targetRange(
+        matches: matches,
+        currentRange: matches[2],
+        direction: .next
+      ) == matches[0]
+    )
+  }
+
+  @Test("Find navigator moves backward and wraps")
+  func findNavigatorMovesBackwardAndWraps() {
+    let matches = [
+      NSRange(location: 4, length: 3),
+      NSRange(location: 12, length: 3),
+      NSRange(location: 20, length: 3),
+    ]
+
+    #expect(
+      SourceEditorFindNavigator.targetRange(
+        matches: matches,
+        currentRange: matches[1],
+        direction: .previous
+      ) == matches[0]
+    )
+    #expect(
+      SourceEditorFindNavigator.targetRange(
+        matches: matches,
+        currentRange: matches[0],
+        direction: .previous
+      ) == matches[2]
+    )
+  }
+
+  @Test("Find navigation control region maps only arrow button clicks")
+  func findNavigationControlRegionMapsArrowButtons() {
+    let panelSize = CGSize(width: 592, height: 28)
+
+    #expect(
+      SourceEditorFindNavigationControlRegion.direction(
+        for: CGPoint(x: 480, y: 14),
+        panelSize: panelSize
+      ) == .previous
+    )
+    #expect(
+      SourceEditorFindNavigationControlRegion.direction(
+        for: CGPoint(x: 520, y: 14),
+        panelSize: panelSize
+      ) == .next
+    )
+    #expect(
+      SourceEditorFindNavigationControlRegion.direction(
+        for: CGPoint(x: 560, y: 14),
+        panelSize: panelSize
+      ) == nil
+    )
+  }
+
   @Test("Display mode enables highlighting for normal source files")
   func displayModeHighlightsNormalFiles() {
     let content = String(repeating: "a", count: 300_000)


### PR DESCRIPTION
## Summary

Fixes the embedded source editor find UI so the search controls remain interactive and navigation scrolls the document as matches advance.

## What changed

- Brings CodeEdit's embedded find panel to the front of the NSView hierarchy so close, arrows, and Done receive hit testing.
- Adds local find navigation handling for Return, Shift+Return, and arrow mouse clicks.
- Uses CodeEdit's active find emphases when available, with a fallback range matcher, then explicitly scrolls selected matches into view.
- Adds focused tests for find panel repair, match navigation, and arrow region mapping.

## Root cause

The CodeEdit find panel could be visually on top while still behind the editor in AppKit hit testing. Separately, AgentHub did not bridge find-panel navigation events into the embedded editor's scroll behavior, so match selection could advance without reliably bringing the target into view.

## Validation

- `xcodebuild build -project app/AgentHub.xcodeproj -scheme AgentHub -destination 'platform=macOS,arch=arm64,name=My Mac' -quiet`
- Runtime smoke test in the debug app: README search for `GitHub`; forward arrow and Return both advanced matches and scrolled from visible match groups to later offscreen matches.