### PR TITLE
[codex] Fix source editor theme resolution

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/SourceCodeEditorView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/SourceCodeEditorView.swift
@@ -536,54 +536,69 @@ enum SourceEditorLanguageResolver {
 
 private enum AgentHubSourceEditorTheme {
   static func theme(for colorScheme: ColorScheme) -> EditorTheme {
-    colorScheme == .dark ? darkTheme() : lightTheme()
+    switch colorScheme {
+    case .dark:
+      darkTheme(resolvingIn: .darkAqua)
+    case .light:
+      lightTheme(resolvingIn: .aqua)
+    @unknown default:
+      lightTheme(resolvingIn: .aqua)
+    }
   }
 
-  private static func lightTheme() -> EditorTheme {
+  private static func lightTheme(resolvingIn appearanceName: NSAppearance.Name) -> EditorTheme {
     EditorTheme(
-      text: .init(color: rgb(.labelColor)),
-      insertionPoint: rgb(.controlAccentColor),
-      invisibles: .init(color: rgb(.tertiaryLabelColor)),
-      background: rgb(.textBackgroundColor),
-      lineHighlight: rgb(NSColor.black.withAlphaComponent(0.05)),
-      selection: rgb(.selectedTextBackgroundColor),
-      keywords: .init(color: rgb(.systemPurple)),
-      commands: .init(color: rgb(.systemBlue)),
-      types: .init(color: rgb(.systemTeal)),
-      attributes: .init(color: rgb(.systemIndigo)),
-      variables: .init(color: rgb(.labelColor)),
-      values: .init(color: rgb(.systemMint)),
-      numbers: .init(color: rgb(.systemOrange)),
-      strings: .init(color: rgb(.systemRed)),
-      characters: .init(color: rgb(.systemPink)),
-      comments: .init(color: rgb(.secondaryLabelColor), italic: true)
+      text: .init(color: rgb(.labelColor, resolvingIn: appearanceName)),
+      insertionPoint: rgb(.controlAccentColor, resolvingIn: appearanceName),
+      invisibles: .init(color: rgb(.tertiaryLabelColor, resolvingIn: appearanceName)),
+      background: rgb(.textBackgroundColor, resolvingIn: appearanceName),
+      lineHighlight: rgb(NSColor.black.withAlphaComponent(0.05), resolvingIn: appearanceName),
+      selection: rgb(.selectedTextBackgroundColor, resolvingIn: appearanceName),
+      keywords: .init(color: rgb(.systemPurple, resolvingIn: appearanceName)),
+      commands: .init(color: rgb(.systemBlue, resolvingIn: appearanceName)),
+      types: .init(color: rgb(.systemTeal, resolvingIn: appearanceName)),
+      attributes: .init(color: rgb(.systemIndigo, resolvingIn: appearanceName)),
+      variables: .init(color: rgb(.labelColor, resolvingIn: appearanceName)),
+      values: .init(color: rgb(.systemMint, resolvingIn: appearanceName)),
+      numbers: .init(color: rgb(.systemOrange, resolvingIn: appearanceName)),
+      strings: .init(color: rgb(.systemRed, resolvingIn: appearanceName)),
+      characters: .init(color: rgb(.systemPink, resolvingIn: appearanceName)),
+      comments: .init(color: rgb(.secondaryLabelColor, resolvingIn: appearanceName), italic: true)
     )
   }
 
-  private static func darkTheme() -> EditorTheme {
+  private static func darkTheme(resolvingIn appearanceName: NSAppearance.Name) -> EditorTheme {
     EditorTheme(
-      text: .init(color: rgb(.labelColor)),
-      insertionPoint: rgb(.controlAccentColor),
-      invisibles: .init(color: rgb(.tertiaryLabelColor)),
-      background: rgb(.windowBackgroundColor),
-      lineHighlight: rgb(NSColor.white.withAlphaComponent(0.08)),
-      selection: rgb(.selectedTextBackgroundColor),
-      keywords: .init(color: rgb(.systemPurple)),
-      commands: .init(color: rgb(.systemBlue)),
-      types: .init(color: rgb(.systemTeal)),
-      attributes: .init(color: rgb(.systemIndigo)),
-      variables: .init(color: rgb(.labelColor)),
-      values: .init(color: rgb(.systemMint)),
-      numbers: .init(color: rgb(.systemOrange)),
-      strings: .init(color: rgb(.systemRed)),
-      characters: .init(color: rgb(.systemPink)),
-      comments: .init(color: rgb(.secondaryLabelColor), italic: true)
+      text: .init(color: rgb(.labelColor, resolvingIn: appearanceName)),
+      insertionPoint: rgb(.controlAccentColor, resolvingIn: appearanceName),
+      invisibles: .init(color: rgb(.tertiaryLabelColor, resolvingIn: appearanceName)),
+      background: rgb(.windowBackgroundColor, resolvingIn: appearanceName),
+      lineHighlight: rgb(NSColor.white.withAlphaComponent(0.08), resolvingIn: appearanceName),
+      selection: rgb(.selectedTextBackgroundColor, resolvingIn: appearanceName),
+      keywords: .init(color: rgb(.systemPurple, resolvingIn: appearanceName)),
+      commands: .init(color: rgb(.systemBlue, resolvingIn: appearanceName)),
+      types: .init(color: rgb(.systemTeal, resolvingIn: appearanceName)),
+      attributes: .init(color: rgb(.systemIndigo, resolvingIn: appearanceName)),
+      variables: .init(color: rgb(.labelColor, resolvingIn: appearanceName)),
+      values: .init(color: rgb(.systemMint, resolvingIn: appearanceName)),
+      numbers: .init(color: rgb(.systemOrange, resolvingIn: appearanceName)),
+      strings: .init(color: rgb(.systemRed, resolvingIn: appearanceName)),
+      characters: .init(color: rgb(.systemPink, resolvingIn: appearanceName)),
+      comments: .init(color: rgb(.secondaryLabelColor, resolvingIn: appearanceName), italic: true)
     )
   }
 
   // CodeEditSourceEditor reads color components (e.g. brightness) from theme
   // colors; catalog/system NSColors throw until resolved into an RGB colorspace.
-  private static func rgb(_ color: NSColor) -> NSColor {
-    color.usingColorSpace(.sRGB) ?? color
+  private static func rgb(_ color: NSColor, resolvingIn appearanceName: NSAppearance.Name) -> NSColor {
+    guard let appearance = NSAppearance(named: appearanceName) else {
+      return color.usingColorSpace(.sRGB) ?? color
+    }
+
+    var resolvedColor = color
+    appearance.performAsCurrentDrawingAppearance {
+      resolvedColor = color.usingColorSpace(.sRGB) ?? color
+    }
+    return resolvedColor
   }
 }

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/SourceCodeEditorViewTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/SourceCodeEditorViewTests.swift
@@ -1,10 +1,25 @@
 import AppKit
 import Foundation
+import SwiftUI
 import Testing
 
 @testable import AgentHubCore
 
 private final class FindPanelHostingView: NSView {}
+
+private func withCurrentDrawingAppearance<T>(_ name: NSAppearance.Name, _ body: () -> T) -> T {
+  guard let appearance = NSAppearance(named: name) else { return body() }
+
+  var result: T?
+  appearance.performAsCurrentDrawingAppearance {
+    result = body()
+  }
+  return result ?? body()
+}
+
+private func brightness(of color: NSColor) -> CGFloat {
+  (color.usingColorSpace(.sRGB) ?? color).brightnessComponent
+}
 
 @Suite("SourceCodeEditorView")
 struct SourceCodeEditorViewTests {
@@ -234,6 +249,28 @@ struct SourceCodeEditorViewTests {
 
     #expect(highlighted.showFoldingRibbon)
     #expect(plainText.showFoldingRibbon == false)
+  }
+
+  @Test("Editor theme resolves colors from requested color scheme")
+  func editorThemeResolvesColorsFromRequestedColorScheme() {
+    let options = AgentHubSourceEditorOptions(
+      displayMode: .highlighted,
+      isEditable: true,
+      isMinimapEnabled: true,
+      isWrapLinesEnabled: true
+    )
+
+    let lightThemeCreatedInDarkAppearance = withCurrentDrawingAppearance(.darkAqua) {
+      options.makeSourceEditorConfiguration(colorScheme: .light).appearance.theme
+    }
+    let darkThemeCreatedInLightAppearance = withCurrentDrawingAppearance(.aqua) {
+      options.makeSourceEditorConfiguration(colorScheme: .dark).appearance.theme
+    }
+
+    #expect(brightness(of: lightThemeCreatedInDarkAppearance.background) > 0.8)
+    #expect(brightness(of: lightThemeCreatedInDarkAppearance.text.color) < 0.3)
+    #expect(brightness(of: darkThemeCreatedInLightAppearance.background) < 0.3)
+    #expect(brightness(of: darkThemeCreatedInLightAppearance.text.color) > 0.7)
   }
 
   @Test("Language resolver detects supported extensions and special filenames")


### PR DESCRIPTION
## Summary

Fixes unreliable source editor light/dark updates by resolving CodeEdit editor theme colors against the SwiftUI-requested color scheme instead of whichever AppKit drawing appearance happens to be current during the transition.

## Root Cause

`SourceCodeEditorView` passed semantic `NSColor` values into `EditorTheme` after converting them through the current AppKit appearance. During a light/dark transition, that appearance can briefly differ from SwiftUI's `colorScheme`, so the editor could cache colors from the wrong mode.

## Changes

- Resolve source editor theme colors inside explicit `.aqua` or `.darkAqua` appearances derived from `ColorScheme`.
- Add a regression test that builds light colors while AppKit is dark, and dark colors while AppKit is light.

## Validation

- `git diff --check`
- `xcodebuild build -project app/AgentHub.xcodeproj -scheme AgentHub -destination 'platform=macOS'`

Notes: `swift test --filter SourceCodeEditorViewTests` is blocked before reaching these tests by the existing `CodeEditSymbols` `Bundle.module` package/resource issue. `xcodebuild test` could not run because the shared schemes are not configured for the test action.