### PR TITLE
[codex] Improve worktree file indexing

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/FileIndexService.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/FileIndexService.swift
@@ -49,6 +49,195 @@ public struct FileSearchDiagnostics: Sendable, Equatable {
   }
 }
 
+enum ProjectFileEnumerationKind: Sendable, Equatable {
+  case gitRepository
+  case gitWorktree
+}
+
+struct ProjectFileEnumeratorFile: Sendable, Equatable {
+  let relativePath: String
+}
+
+enum ProjectFileEnumerationResult: Sendable {
+  case files([ProjectFileEnumeratorFile], kind: ProjectFileEnumerationKind)
+  case notGitProject
+  case failed
+}
+
+protocol ProjectFileEnumerating: Sendable {
+  func gitProjectKind(at projectPath: String) -> ProjectFileEnumerationKind?
+  func enumerateFiles(in projectPath: String) async -> ProjectFileEnumerationResult
+}
+
+struct GitProjectFileEnumerator: ProjectFileEnumerating {
+  private struct GitCommandResult: Sendable {
+    let stdout: Data
+    let exitCode: Int32
+    let timedOut: Bool
+  }
+
+  private static let commandTimeout: TimeInterval = 3
+
+  func gitProjectKind(at projectPath: String) -> ProjectFileEnumerationKind? {
+    guard let gitPath = Self.nearestGitPath(containing: projectPath) else {
+      return nil
+    }
+
+    var isDirectory: ObjCBool = false
+    guard FileManager.default.fileExists(atPath: gitPath, isDirectory: &isDirectory) else {
+      return nil
+    }
+
+    return isDirectory.boolValue ? .gitRepository : .gitWorktree
+  }
+
+  func enumerateFiles(in projectPath: String) async -> ProjectFileEnumerationResult {
+    let resolvedProjectPath = Self.resolvedURL(for: projectPath).path
+    let knownKind = gitProjectKind(at: resolvedProjectPath)
+    guard let result = await runGitLSFiles(in: resolvedProjectPath) else {
+      return knownKind == nil ? .notGitProject : .failed
+    }
+
+    guard !result.timedOut, result.exitCode == 0 else {
+      return knownKind == nil ? .notGitProject : .failed
+    }
+
+    let files = Self.parseGitLSFilesOutput(result.stdout)
+    return .files(files, kind: knownKind ?? .gitRepository)
+  }
+
+  private func runGitLSFiles(in projectPath: String) async -> GitCommandResult? {
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "/usr/bin/git")
+    process.arguments = [
+      "ls-files",
+      "-z",
+      "--cached",
+      "--others",
+      "--exclude-standard",
+      "--",
+      "."
+    ]
+    process.currentDirectoryURL = URL(fileURLWithPath: projectPath)
+
+    var environment = ProcessInfo.processInfo.environment
+    environment["GIT_TERMINAL_PROMPT"] = "0"
+    environment["GIT_SSH_COMMAND"] = "ssh -o BatchMode=yes"
+    process.environment = environment
+
+    let inputPipe = Pipe()
+    let outputPipe = Pipe()
+    let errorPipe = Pipe()
+    process.standardInput = inputPipe
+    process.standardOutput = outputPipe
+    process.standardError = errorPipe
+
+    var outputData: Data?
+    let readGroup = DispatchGroup()
+
+    do {
+      try process.run()
+      try? inputPipe.fileHandleForWriting.close()
+    } catch {
+      return nil
+    }
+
+    readGroup.enter()
+    DispatchQueue.global(qos: .userInitiated).async {
+      outputData = try? outputPipe.fileHandleForReading.readToEnd()
+      readGroup.leave()
+    }
+
+    readGroup.enter()
+    DispatchQueue.global(qos: .utility).async {
+      _ = try? errorPipe.fileHandleForReading.readToEnd()
+      readGroup.leave()
+    }
+
+    let timedOut = await withTaskGroup(of: Bool.self) { group in
+      group.addTask {
+        await withCheckedContinuation { continuation in
+          DispatchQueue.global(qos: .utility).async {
+            readGroup.wait()
+            process.waitUntilExit()
+            continuation.resume(returning: false)
+          }
+        }
+      }
+
+      group.addTask {
+        do {
+          try await Task.sleep(for: .seconds(Self.commandTimeout))
+          if process.isRunning {
+            process.terminate()
+          }
+          return true
+        } catch {
+          return false
+        }
+      }
+
+      let result = await group.next() ?? false
+      group.cancelAll()
+      return result
+    }
+
+    return GitCommandResult(
+      stdout: outputData ?? Data(),
+      exitCode: process.terminationStatus,
+      timedOut: timedOut
+    )
+  }
+
+  private static func parseGitLSFilesOutput(_ data: Data) -> [ProjectFileEnumeratorFile] {
+    guard let output = String(data: data, encoding: .utf8) else { return [] }
+    var seen = Set<String>()
+    return output
+      .split(separator: "\0")
+      .compactMap { rawPath -> ProjectFileEnumeratorFile? in
+        let path = String(rawPath)
+        guard isSafeRelativePath(path), seen.insert(path).inserted else {
+          return nil
+        }
+        return ProjectFileEnumeratorFile(relativePath: path)
+      }
+  }
+
+  private static func isSafeRelativePath(_ path: String) -> Bool {
+    guard !path.isEmpty, !path.hasPrefix("/") else { return false }
+    return path.split(separator: "/").allSatisfy { component in
+      component != "." && component != ".."
+    }
+  }
+
+  private static func nearestGitPath(containing path: String) -> String? {
+    var currentPath = resolvedURL(for: path).path
+    var isDirectory: ObjCBool = false
+    if !FileManager.default.fileExists(atPath: currentPath, isDirectory: &isDirectory) || !isDirectory.boolValue {
+      currentPath = (currentPath as NSString).deletingLastPathComponent
+    }
+
+    while !currentPath.isEmpty {
+      let gitPath = (currentPath as NSString).appendingPathComponent(".git")
+      if FileManager.default.fileExists(atPath: gitPath) {
+        return gitPath
+      }
+
+      let parentPath = (currentPath as NSString).deletingLastPathComponent
+      if parentPath == currentPath {
+        return nil
+      }
+      currentPath = parentPath
+    }
+
+    return nil
+  }
+
+  private static func resolvedURL(for path: String) -> URL {
+    URL(fileURLWithPath: path).standardizedFileURL.resolvingSymlinksInPath()
+  }
+}
+
 /// Scans project directories, respects .gitignore, caches tree nodes, and provides project file search.
 public actor FileIndexService {
 
@@ -121,15 +310,21 @@ public actor FileIndexService {
   private var recentPaths: [String] = []
   private static let maxRecentFiles = 20
   private let projectFileSearchService: any ProjectFileSearchServiceProtocol
+  private let projectFileEnumerator: any ProjectFileEnumerating
 
   // MARK: - Initialization
 
   public init() {
     self.projectFileSearchService = SpotlightProjectFileSearchService.shared
+    self.projectFileEnumerator = GitProjectFileEnumerator()
   }
 
-  init(projectFileSearchService: any ProjectFileSearchServiceProtocol) {
+  init(
+    projectFileSearchService: any ProjectFileSearchServiceProtocol,
+    projectFileEnumerator: any ProjectFileEnumerating = GitProjectFileEnumerator()
+  ) {
     self.projectFileSearchService = projectFileSearchService
+    self.projectFileEnumerator = projectFileEnumerator
   }
 
   // MARK: - Public API
@@ -191,8 +386,10 @@ public actor FileIndexService {
     return searchIndexStatus(resolvedProjectPath: resolvedProjectPath)
   }
 
-  /// Searches files using Spotlight first, then falls back to the legacy in-process index if
-  /// Spotlight has no usable results for the project. Ranking uses a strict 3-tier approach:
+  /// Searches files using Spotlight first, then falls back to a local index if
+  /// Spotlight has no usable results for the project. Git worktrees use the local
+  /// Git-backed index first because Spotlight often lags or misses them entirely.
+  /// Ranking uses a strict 3-tier approach:
   /// 1. Filename starts with query → highest score
   /// 2. Filename contains query as substring → high score
   /// 3. Path contains query as substring → medium score
@@ -215,43 +412,52 @@ public actor FileIndexService {
     }
 
     let resolvedProjectPath = Self.resolvedURL(for: projectPath).path
-    let spotlightResponse = await projectFileSearchService.searchWithDiagnostics(
-      query: query,
-      in: resolvedProjectPath,
-      limit: Self.maxSearchResults * 10
-    )
-    let filteredSpotlightResults = spotlightResponse.results
-      .compactMap { spotlightResult -> FileSearchResult? in
-        let absolutePath = Self.resolvedURL(for: spotlightResult.absolutePath).path
-        guard Self.shouldIncludeSearchResult(at: absolutePath, rootPath: resolvedProjectPath),
-              let relativePath = Self.relativePathIfContained(absolutePath, within: resolvedProjectPath) else {
-          return nil
-        }
-        let name = URL(fileURLWithPath: absolutePath).lastPathComponent
+    let localStatusBeforeFallback = searchIndexStatus(resolvedProjectPath: resolvedProjectPath)
+    let usesWorktreeLocalIndexFirst = projectFileEnumerator.gitProjectKind(at: resolvedProjectPath) == .gitWorktree
 
-        return FileSearchResult(
-          id: absolutePath,
-          name: name,
-          relativePath: relativePath,
-          absolutePath: absolutePath,
-          score: spotlightResult.score
+    var spotlightCandidateCount = 0
+    var spotlightElapsedSeconds: TimeInterval = 0
+    if !usesWorktreeLocalIndexFirst {
+      let spotlightResponse = await projectFileSearchService.searchWithDiagnostics(
+        query: query,
+        in: resolvedProjectPath,
+        limit: Self.maxSearchResults * 10
+      )
+      spotlightCandidateCount = spotlightResponse.candidateCount
+      spotlightElapsedSeconds = spotlightResponse.elapsedSeconds
+
+      let filteredSpotlightResults = spotlightResponse.results
+        .compactMap { spotlightResult -> FileSearchResult? in
+          let absolutePath = Self.resolvedURL(for: spotlightResult.absolutePath).path
+          guard Self.shouldIncludeSearchResult(at: absolutePath, rootPath: resolvedProjectPath),
+                let relativePath = Self.relativePathIfContained(absolutePath, within: resolvedProjectPath) else {
+            return nil
+          }
+          let name = URL(fileURLWithPath: absolutePath).lastPathComponent
+
+          return FileSearchResult(
+            id: absolutePath,
+            name: name,
+            relativePath: relativePath,
+            absolutePath: absolutePath,
+            score: spotlightResult.score
+          )
+        }
+        .sortedBySearchScore()
+
+      if !filteredSpotlightResults.isEmpty {
+        return FileSearchDiagnostics(
+          results: Array(filteredSpotlightResults.prefix(Self.maxSearchResults)),
+          source: .spotlight,
+          spotlightCandidateCount: spotlightCandidateCount,
+          spotlightElapsedSeconds: spotlightElapsedSeconds,
+          localIndexStatusBeforeFallback: localStatusBeforeFallback,
+          localIndexedFileCount: searchCache[resolvedProjectPath]?.files.count ?? 0,
+          localIndexElapsedSeconds: nil
         )
       }
-      .sortedBySearchScore()
-
-    if !filteredSpotlightResults.isEmpty {
-      return FileSearchDiagnostics(
-        results: Array(filteredSpotlightResults.prefix(Self.maxSearchResults)),
-        source: .spotlight,
-        spotlightCandidateCount: spotlightResponse.candidateCount,
-        spotlightElapsedSeconds: spotlightResponse.elapsedSeconds,
-        localIndexStatusBeforeFallback: searchIndexStatus(resolvedProjectPath: resolvedProjectPath),
-        localIndexedFileCount: searchCache[resolvedProjectPath]?.files.count ?? 0,
-        localIndexElapsedSeconds: nil
-      )
     }
 
-    let localStatusBeforeFallback = searchIndexStatus(resolvedProjectPath: resolvedProjectPath)
     let localIndexStart = Date()
     let allFiles = await searchIndex(projectPath: resolvedProjectPath)
     let localIndexElapsed = Date().timeIntervalSince(localIndexStart)
@@ -261,8 +467,8 @@ public actor FileIndexService {
     return FileSearchDiagnostics(
       results: Array(scored.prefix(Self.maxSearchResults)),
       source: .localIndex,
-      spotlightCandidateCount: spotlightResponse.candidateCount,
-      spotlightElapsedSeconds: spotlightResponse.elapsedSeconds,
+      spotlightCandidateCount: spotlightCandidateCount,
+      spotlightElapsedSeconds: spotlightElapsedSeconds,
       localIndexStatusBeforeFallback: localStatusBeforeFallback,
       localIndexedFileCount: allFiles.count,
       localIndexElapsedSeconds: localIndexElapsed
@@ -395,8 +601,12 @@ public actor FileIndexService {
   }
 
   private func makeSearchBuildTask(projectPath: String) -> Task<SearchCacheEntry, Never> {
-    Task.detached(priority: .utility) {
-      let files = FileIndexService.buildSearchIndexSync(projectPath: projectPath)
+    let projectFileEnumerator = projectFileEnumerator
+    return Task.detached(priority: .utility) {
+      let files = await FileIndexService.buildSearchIndex(
+        projectPath: projectPath,
+        projectFileEnumerator: projectFileEnumerator
+      )
       return SearchCacheEntry(files: files, date: Date())
     }
   }
@@ -426,6 +636,39 @@ public actor FileIndexService {
       into: &files
     )
     return files
+  }
+
+  private static func buildSearchIndex(
+    projectPath: String,
+    projectFileEnumerator: any ProjectFileEnumerating
+  ) async -> [IndexedFile] {
+    switch await projectFileEnumerator.enumerateFiles(in: projectPath) {
+    case .files(let files, _):
+      return buildSearchIndexFromGitFiles(files, rootPath: projectPath)
+    case .notGitProject:
+      return buildSearchIndexSync(projectPath: projectPath)
+    case .failed:
+      return []
+    }
+  }
+
+  private static func buildSearchIndexFromGitFiles(
+    _ files: [ProjectFileEnumeratorFile],
+    rootPath: String
+  ) -> [IndexedFile] {
+    files.compactMap { file in
+      let absolutePath = (rootPath as NSString).appendingPathComponent(file.relativePath)
+      guard shouldIncludeSearchResult(at: absolutePath, rootPath: rootPath),
+            let relativePath = relativePathIfContained(absolutePath, within: rootPath) else {
+        return nil
+      }
+
+      return IndexedFile(
+        name: URL(fileURLWithPath: absolutePath).lastPathComponent,
+        relativePath: relativePath,
+        absolutePath: absolutePath
+      )
+    }
   }
 
   private static func collectSearchEntriesSync(
@@ -528,14 +771,26 @@ public actor FileIndexService {
     rootPath: String,
     rules: [IgnoreRule]
   ) -> Bool {
-    if hardExcludedNames.contains(entry.name) { return false }
-
-    if entry.name.hasPrefix(".") && !allowedHiddenNames.contains(entry.name) {
-      return false
-    }
-
     let relativePath = projectRelativePath(for: entry.path, relativeTo: rootPath)
+    guard pathComponentsAreSearchable(relativePath) else { return false }
     return !isIgnored(relativePath: relativePath, isDirectory: entry.isDirectory, rules: rules)
+  }
+
+  private static func pathComponentsAreSearchable(_ relativePath: String) -> Bool {
+    relativePath
+      .split(separator: "/")
+      .allSatisfy { component in
+        let name = String(component)
+        if hardExcludedNames.contains(name) {
+          return false
+        }
+
+        if name.hasPrefix(".") && !allowedHiddenNames.contains(name) {
+          return false
+        }
+
+        return true
+      }
   }
 
   private static func shouldIncludeSearchResult(at path: String, rootPath: String) -> Bool {

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/FileExplorerView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/FileExplorerView.swift
@@ -83,7 +83,7 @@ public struct FileExplorerView: View {
 
   public var body: some View {
     VStack(spacing: 0) {
-      if isLoading {
+      if isLoading && selectedFilePath == nil {
         VStack(spacing: 12) {
           ProgressView()
           Text("Loading files…")
@@ -121,9 +121,11 @@ public struct FileExplorerView: View {
       maxHeight: .infinity
     )
     .task(id: loadTaskID) {
-      await loadFileTree()
-      if navigationRequest == nil, let initialPath = selectedFilePath {
+      guard navigationRequest == nil else { return }
+      if let initialPath = selectedFilePath {
         await navigateToFile(at: initialPath)
+      } else {
+        await loadFileTree()
       }
     }
     .task(id: navigationRequest?.id) {
@@ -267,24 +269,36 @@ public struct FileExplorerView: View {
 
       ScrollViewReader { proxy in
         ScrollView {
-          LazyVStack(alignment: .leading, spacing: 0) {
-            ForEach(treeNodes) { node in
-              FileTreeNodeView(
-                node: node,
-                depth: 0,
-                selectedFilePath: $selectedFilePath,
-                expandedPaths: $expandedPaths,
-                loadingPaths: loadingDirectories,
-                onSelectFile: { path in
-                  Task { await openFile(at: path) }
-                },
-                onToggleDirectory: { directory in
-                  Task { await toggleDirectory(directory) }
-                }
-              )
+          if isLoading && treeNodes.isEmpty {
+            HStack(spacing: 8) {
+              ProgressView()
+                .controlSize(.small)
+              Text("Loading…")
+                .font(.caption)
+                .foregroundColor(.secondary)
             }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(12)
+          } else {
+            LazyVStack(alignment: .leading, spacing: 0) {
+              ForEach(treeNodes) { node in
+                FileTreeNodeView(
+                  node: node,
+                  depth: 0,
+                  selectedFilePath: $selectedFilePath,
+                  expandedPaths: $expandedPaths,
+                  loadingPaths: loadingDirectories,
+                  onSelectFile: { path in
+                    Task { await openFile(at: path) }
+                  },
+                  onToggleDirectory: { directory in
+                    Task { await toggleDirectory(directory) }
+                  }
+                )
+              }
+            }
+            .padding(8)
           }
-          .padding(8)
         }
         .onChange(of: scrollToPath) { _, target in
           guard let target else { return }
@@ -422,8 +436,8 @@ public struct FileExplorerView: View {
       .standardizedFileURL
       .resolvingSymlinksInPath()
       .path
-    await expandToFile(resolvedPath)
     await openFile(at: resolvedPath)
+    await expandToFile(resolvedPath)
     try? await Task.sleep(for: .milliseconds(100))
     scrollToPath = resolvedPath
   }

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/QuickFilePickerView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/QuickFilePickerView.swift
@@ -261,9 +261,6 @@ public struct QuickFilePickerView: View {
         }
       }
     }
-    .task(id: projectPath) {
-      await FileIndexService.shared.prepareSearchIndex(projectPath: projectPath)
-    }
     .task(id: searchQuery) {
       // Automatically cancels previous task when searchQuery changes
       if searchQuery.isEmpty {

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/FileIndexServiceTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/FileIndexServiceTests.swift
@@ -34,6 +34,10 @@ private struct FileIndexFixture {
     try writeFile(at: projectPath + "/" + relativePath, content: content)
   }
 
+  func writeFile(_ relativePath: String, inProjectAt path: String, content: String) throws {
+    try writeFile(at: path + "/" + relativePath, content: content)
+  }
+
   func writeExternalFile(_ relativePath: String, content: String) throws {
     try writeFile(at: externalPath + "/" + relativePath, content: content)
   }
@@ -45,6 +49,45 @@ private struct FileIndexFixture {
     )
   }
 
+  func initializeGitRepository() throws {
+    try runGit("init", "-b", "main")
+    try runGit("config", "user.email", "test@test.com")
+    try runGit("config", "user.name", "Test")
+  }
+
+  func addWorktree(branch: String) throws -> String {
+    try runGit("branch", branch)
+    let worktreePath = tempDir + "/" + branch.replacingOccurrences(of: "/", with: "-")
+    try runGit("worktree", "add", worktreePath, branch)
+    return worktreePath
+  }
+
+  @discardableResult
+  func runGit(_ args: String..., at path: String? = nil) throws -> String {
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "/usr/bin/git")
+    process.arguments = args
+    process.currentDirectoryURL = URL(fileURLWithPath: path ?? projectPath)
+
+    let outputPipe = Pipe()
+    let errorPipe = Pipe()
+    process.standardOutput = outputPipe
+    process.standardError = errorPipe
+
+    try process.run()
+    process.waitUntilExit()
+
+    let output = String(data: outputPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+    let error = String(data: errorPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+    guard process.terminationStatus == 0 else {
+      throw CocoaError(.fileReadUnknown, userInfo: [
+        NSLocalizedDescriptionKey: "git \(args.joined(separator: " ")) failed: \(error)"
+      ])
+    }
+
+    return output
+  }
+
   private func writeFile(at path: String, content: String) throws {
     let parentPath = URL(fileURLWithPath: path).deletingLastPathComponent().path
     try FileManager.default.createDirectory(atPath: parentPath, withIntermediateDirectories: true)
@@ -54,9 +97,23 @@ private struct FileIndexFixture {
 
 private struct FakeProjectFileSearchService: ProjectFileSearchServiceProtocol {
   let results: [ProjectFileSearchResult]
+  var resultsByQuery: [String: [ProjectFileSearchResult]] = [:]
 
   func search(query: String, in projectPath: String, limit: Int) async -> [ProjectFileSearchResult] {
-    Array(results.prefix(limit))
+    Array((resultsByQuery[query] ?? results).prefix(limit))
+  }
+}
+
+private struct FakeProjectFileEnumerator: ProjectFileEnumerating {
+  let kind: ProjectFileEnumerationKind?
+  let result: ProjectFileEnumerationResult
+
+  func gitProjectKind(at projectPath: String) -> ProjectFileEnumerationKind? {
+    kind
+  }
+
+  func enumerateFiles(in projectPath: String) async -> ProjectFileEnumerationResult {
+    result
   }
 }
 
@@ -300,6 +357,149 @@ struct FileIndexServicePrivacyTests {
     #expect(diagnostics.localIndexStatusBeforeFallback == .idle)
     #expect(diagnostics.localIndexedFileCount == 1)
     #expect(diagnostics.results.map(\.relativePath) == ["Sources/App.swift"])
+  }
+
+  @Test("Git-backed index searches worktree files and excludes ignored files")
+  func gitBackedIndexSearchesWorktreeFiles() async throws {
+    let fixture = try FileIndexFixture.create()
+    defer { fixture.cleanup() }
+
+    try fixture.initializeGitRepository()
+    try fixture.writeProjectFile(".gitignore", content: "ignored/\n")
+    try fixture.writeProjectFile("Sources/MainSearchTarget.swift", content: "struct MainSearchTarget {}")
+    try fixture.runGit("add", ".")
+    try fixture.runGit("commit", "-m", "initial")
+
+    let worktreePath = try fixture.addWorktree(branch: "feature/file-index")
+    try fixture.writeFile("Sources/WorktreeSearchTarget.swift", inProjectAt: worktreePath, content: "struct WorktreeSearchTarget {}")
+    try fixture.runGit("add", "Sources/WorktreeSearchTarget.swift", at: worktreePath)
+    try fixture.runGit("commit", "-m", "worktree file", at: worktreePath)
+    try fixture.writeFile("Sources/UntrackedSearchTarget.swift", inProjectAt: worktreePath, content: "struct UntrackedSearchTarget {}")
+    try fixture.writeFile("ignored/IgnoredSearchTarget.swift", inProjectAt: worktreePath, content: "struct IgnoredSearchTarget {}")
+
+    let service = FileIndexService(projectFileSearchService: FakeProjectFileSearchService(results: []))
+    let diagnostics = await service.searchWithDiagnostics(query: "searchtarget", in: worktreePath)
+    let relativePaths = Set(diagnostics.results.map(\.relativePath))
+
+    #expect(diagnostics.source == .localIndex)
+    #expect(diagnostics.spotlightCandidateCount == 0)
+    #expect(relativePaths.contains("Sources/MainSearchTarget.swift"))
+    #expect(relativePaths.contains("Sources/WorktreeSearchTarget.swift"))
+    #expect(relativePaths.contains("Sources/UntrackedSearchTarget.swift"))
+    #expect(!relativePaths.contains("ignored/IgnoredSearchTarget.swift"))
+  }
+
+  @Test("Worktree search uses local Git index before Spotlight")
+  func worktreeSearchSkipsSpotlight() async throws {
+    let fixture = try FileIndexFixture.create()
+    defer { fixture.cleanup() }
+
+    try fixture.writeProjectFile("LocalOnly.swift", content: "struct LocalOnly {}")
+    try fixture.writeProjectFile("SpotlightOnly.swift", content: "struct SpotlightOnly {}")
+
+    let service = FileIndexService(
+      projectFileSearchService: FakeProjectFileSearchService(results: [
+        ProjectFileSearchResult(
+          id: fixture.projectPath + "/SpotlightOnly.swift",
+          name: "SpotlightOnly.swift",
+          relativePath: "SpotlightOnly.swift",
+          absolutePath: fixture.projectPath + "/SpotlightOnly.swift",
+          score: 5000
+        )
+      ]),
+      projectFileEnumerator: FakeProjectFileEnumerator(
+        kind: .gitWorktree,
+        result: .files([
+          ProjectFileEnumeratorFile(relativePath: "LocalOnly.swift")
+        ], kind: .gitWorktree)
+      )
+    )
+
+    let diagnostics = await service.searchWithDiagnostics(query: "only", in: fixture.projectPath)
+
+    #expect(diagnostics.source == .localIndex)
+    #expect(diagnostics.spotlightCandidateCount == 0)
+    #expect(diagnostics.results.map(\.relativePath) == ["LocalOnly.swift"])
+  }
+
+  @Test("Non-Git folders fall back to recursive indexing")
+  func nonGitFoldersUseRecursiveIndex() async throws {
+    let fixture = try FileIndexFixture.create()
+    defer { fixture.cleanup() }
+
+    try fixture.writeProjectFile("Sources/App.swift", content: "struct App {}")
+
+    let service = FileIndexService(
+      projectFileSearchService: FakeProjectFileSearchService(results: []),
+      projectFileEnumerator: FakeProjectFileEnumerator(
+        kind: nil,
+        result: .notGitProject
+      )
+    )
+
+    let diagnostics = await service.searchWithDiagnostics(query: "app", in: fixture.projectPath)
+
+    #expect(diagnostics.source == .localIndex)
+    #expect(diagnostics.localIndexedFileCount == 1)
+    #expect(diagnostics.results.map(\.relativePath) == ["Sources/App.swift"])
+  }
+
+  @Test("Git enumeration failure stays bounded instead of recursively scanning")
+  func gitEnumerationFailureReturnsEmptyLocalIndex() async throws {
+    let fixture = try FileIndexFixture.create()
+    defer { fixture.cleanup() }
+
+    try fixture.writeProjectFile("Sources/App.swift", content: "struct App {}")
+
+    let service = FileIndexService(
+      projectFileSearchService: FakeProjectFileSearchService(results: []),
+      projectFileEnumerator: FakeProjectFileEnumerator(
+        kind: .gitRepository,
+        result: .failed
+      )
+    )
+
+    let diagnostics = await service.searchWithDiagnostics(query: "app", in: fixture.projectPath)
+
+    #expect(diagnostics.source == .localIndex)
+    #expect(diagnostics.localIndexedFileCount == 0)
+    #expect(diagnostics.results.isEmpty)
+  }
+
+  @Test("Filters hidden ancestor directories from search results")
+  func filtersHiddenAncestorDirectoriesFromSearchResults() async throws {
+    let fixture = try FileIndexFixture.create()
+    defer { fixture.cleanup() }
+
+    let claudePath = fixture.projectPath + "/.claude/settings.local.json"
+    let githubPath = fixture.projectPath + "/.github/workflows/build.yml"
+    try fixture.writeProjectFile(".claude/settings.local.json", content: "{}")
+    try fixture.writeProjectFile(".github/workflows/build.yml", content: "name: build")
+
+    let hiddenService = FileIndexService(projectFileSearchService: FakeProjectFileSearchService(results: [
+      ProjectFileSearchResult(
+        id: claudePath,
+        name: "settings.local.json",
+        relativePath: ".claude/settings.local.json",
+        absolutePath: claudePath,
+        score: 5000
+      )
+    ]))
+    let allowedService = FileIndexService(projectFileSearchService: FakeProjectFileSearchService(results: [
+      ProjectFileSearchResult(
+        id: githubPath,
+        name: "build.yml",
+        relativePath: ".github/workflows/build.yml",
+        absolutePath: githubPath,
+        score: 5000
+      )
+    ]))
+
+    let hiddenResults = await hiddenService.search(query: "settings", in: fixture.projectPath)
+    let allowedResults = await allowedService.search(query: "build", in: fixture.projectPath)
+
+    #expect(hiddenResults.isEmpty)
+    #expect(allowedResults.map(\.relativePath) == [".github/workflows/build.yml"])
   }
 
   @Test("Creating a new file invalidates cached directory listings")


### PR DESCRIPTION
## Summary

- Use Git-backed file enumeration for Git repositories and worktrees when building the file search index.
- Skip Spotlight for Git worktrees so Cmd+P does not wait on stale or missing Spotlight results.
- Let file content open before expensive sidebar tree expansion in the file explorer.
- Add focused FileIndexService coverage for worktree search behavior, bounded failure, fallback indexing, and hidden ancestor filtering.

## Why

Large monorepos opened through Git worktrees can make the file editor and Cmd+P unusable because Spotlight often lags or misses worktree files, while recursive fallback scanning can become too expensive. Git already has the bounded file list AgentHub needs for search, including tracked and untracked non-ignored files.

## Validation

- `git diff --check`
- `xcodebuild -quiet -workspace app/AgentHub.xcodeproj/project.xcworkspace -scheme AgentHub -destination 'platform=macOS' build`

Targeted SwiftPM test execution is currently blocked by an existing dependency issue in `CodeEditSymbols.swift` referencing `Bundle.module`. The app test schemes I tried are not configured for the `test` action.