### PR TITLE
[codex] Add generic CLI environment variables

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubConfiguration.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubConfiguration.swift
@@ -90,3 +90,55 @@ public struct AgentHubConfiguration: Sendable {
     )
   }
 }
+
+public struct CLIEnvironmentVariable: Codable, Equatable, Identifiable, Sendable {
+  public var id: UUID
+  public var name: String
+  public var value: String
+
+  public init(id: UUID = UUID(), name: String, value: String) {
+    self.id = id
+    self.name = name
+    self.value = value
+  }
+}
+
+public enum CLIEnvironmentOverrides {
+  public static let defaultVariables: [CLIEnvironmentVariable] = []
+
+  public static var variables: [CLIEnvironmentVariable] {
+    variables(defaults: .standard)
+  }
+
+  public static var environment: [String: String] {
+    environment(from: variables)
+  }
+
+  public static func variables(defaults: UserDefaults) -> [CLIEnvironmentVariable] {
+    guard let data = defaults.data(forKey: AgentHubDefaults.cliEnvironmentVariables) else {
+      return defaultVariables
+    }
+    return (try? JSONDecoder().decode([CLIEnvironmentVariable].self, from: data)) ?? defaultVariables
+  }
+
+  public static func save(_ variables: [CLIEnvironmentVariable], defaults: UserDefaults = .standard) {
+    guard let data = try? JSONEncoder().encode(variables) else { return }
+    defaults.set(data, forKey: AgentHubDefaults.cliEnvironmentVariables)
+  }
+
+  public static func environment(from variables: [CLIEnvironmentVariable]) -> [String: String] {
+    var environment: [String: String] = [:]
+    for variable in variables {
+      let name = variable.name.trimmingCharacters(in: .whitespacesAndNewlines)
+      guard isValidName(name) else { continue }
+      environment[name] = variable.value
+    }
+    return environment
+  }
+
+  private static func isValidName(_ name: String) -> Bool {
+    !name.isEmpty
+      && !name.contains("=")
+      && !name.contains(where: { $0.isNewline || $0 == "\0" })
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubDefaults.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubDefaults.swift
@@ -69,6 +69,10 @@ public enum AgentHubDefaults {
   /// Type: Bool (default: false)
   public static let codexCommandLockedByDeveloper = "\(keyPrefix)cli.codexCommandLocked"
 
+  /// Extra environment variables applied to launched CLI processes
+  /// Type: Data (JSON-encoded [CLIEnvironmentVariable])
+  public static let cliEnvironmentVariables = "\(keyPrefix)cli.environmentVariables"
+
   /// Selected provider in side panel segmented control
   /// Type: String (default: "Claude")
   public static let selectedSidePanelProvider = "\(keyPrefix)sidepanel.selectedProvider"

--- a/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubProvider.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubProvider.swift
@@ -308,6 +308,7 @@ public final class AgentHubProvider {
     return ClaudeCLIClient(
       command: configuration.cliCommand,
       additionalPaths: ClaudeCodePathResolver.searchPaths(additionalPaths: configuration.additionalCLIPaths),
+      environmentOverridesProvider: { CLIEnvironmentOverrides.environment },
       debugLogger: debugLogger
     )
   }

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/ClaudeProgrammaticService.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/ClaudeProgrammaticService.swift
@@ -125,6 +125,7 @@ public actor ClaudeProgrammaticService: ClaudeProgrammaticServiceProtocol {
       ClaudeCLIClient(
         command: command,
         additionalPaths: paths,
+        environmentOverridesProvider: { CLIEnvironmentOverrides.environment },
         debugLogger: { message in
           AppLogger.intelligence.error("[CLAUDEPROG] Claude CLI debug: \(message, privacy: .public)")
         }

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/TerminalLauncher.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/TerminalLauncher.swift
@@ -34,6 +34,17 @@ public struct TerminalLauncher {
     return "'\(escaped)'"
   }
 
+  static var cliEnvironmentExports: String {
+    cliEnvironmentExports(environment: CLIEnvironmentOverrides.environment)
+  }
+
+  static func cliEnvironmentExports(environment: [String: String]) -> String {
+    environment
+      .sorted { $0.key < $1.key }
+      .map { "export \($0.key)=\(shellEscapeSingleQuotedAllowingNewlines($0.value))" }
+      .joined(separator: "\n")
+  }
+
   /// Runs a Claude session in the background without opening Terminal
   /// - Parameters:
   ///   - sessionId: The session ID to resume
@@ -87,6 +98,7 @@ public struct TerminalLauncher {
           environment["PATH"] = additionalPaths
         }
       }
+      environment.merge(CLIEnvironmentOverrides.environment) { _, new in new }
       process.environment = environment
 
       let stdoutPipe = Pipe()
@@ -272,7 +284,8 @@ public struct TerminalLauncher {
     let tempDir = NSTemporaryDirectory()
     let scriptPath = (tempDir as NSString).appendingPathComponent("\(scriptPrefix)_\(UUID().uuidString).command")
 
-    let scriptContent = "#!/bin/bash\n\(command)\n"
+    let cliEnvironmentExports = Self.cliEnvironmentExports
+    let scriptContent = "#!/bin/bash\n\(cliEnvironmentExports)\n\(command)\n"
 
     // Atomically create the file with O_CREAT | O_EXCL (fails if path exists)
     // and set permissions to 0o700 at creation time — no separate chmod step.

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/WorktreeBranchNamingService.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/WorktreeBranchNamingService.swift
@@ -40,6 +40,7 @@ public actor ClaudeWorktreeBranchNamingService: WorktreeBranchNamingServiceProto
       ClaudeCLIClient(
         command: command,
         additionalPaths: paths,
+        environmentOverridesProvider: { CLIEnvironmentOverrides.environment },
         debugLogger: { message in
           AppLogger.intelligence.error("[AIWORKTREE] Claude CLI debug: \(message, privacy: .public)")
         }

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/CLIEnvironmentVariablesEditor.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/CLIEnvironmentVariablesEditor.swift
@@ -1,0 +1,100 @@
+//
+//  CLIEnvironmentVariablesEditor.swift
+//  AgentHub
+//
+
+import Foundation
+import SwiftUI
+
+struct CLIEnvironmentVariablesEditor: View {
+  @Binding var variables: [CLIEnvironmentVariable]
+
+  private let rowAnimation = Animation.easeInOut(duration: 0.18)
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 10) {
+      if variables.isEmpty {
+        Text("No environment variables configured.")
+          .foregroundColor(.secondary)
+          .transition(.opacity.combined(with: .move(edge: .top)))
+      } else {
+        VStack(alignment: .leading, spacing: 8) {
+          ForEach($variables) { $variable in
+            HStack(spacing: 8) {
+              TextField(
+                text: $variable.name,
+                prompt: Text("VARIABLE_NAME")
+              ) {
+                EmptyView()
+              }
+              .labelsHidden()
+              .textFieldStyle(.roundedBorder)
+              .font(.system(.body, design: .monospaced))
+              .lineLimit(1)
+              .frame(maxWidth: .infinity)
+
+              Text("=")
+                .foregroundColor(.secondary)
+
+              TextField(
+                text: $variable.value,
+                prompt: Text("value")
+              ) {
+                EmptyView()
+              }
+              .labelsHidden()
+              .textFieldStyle(.roundedBorder)
+              .font(.system(.body, design: .monospaced))
+              .lineLimit(1)
+              .frame(maxWidth: .infinity)
+
+              Button(action: { removeVariable(id: variable.id) }) {
+                Image(systemName: "minus.circle")
+              }
+              .buttonStyle(.borderless)
+              .foregroundColor(.secondary)
+              .accessibilityLabel("Remove variable")
+            }
+            .transition(.opacity.combined(with: .move(edge: .top)))
+          }
+        }
+        .transition(.opacity.combined(with: .move(edge: .top)))
+      }
+
+      HStack(spacing: 12) {
+        Button(action: addVariable) {
+          Label("Add variable", systemImage: "plus")
+        }
+
+        if !variables.isEmpty {
+          Button(role: .destructive, action: clearVariables) {
+            Label("Clear all", systemImage: "trash")
+          }
+          .transition(.opacity)
+        }
+      }
+    }
+    .animation(rowAnimation, value: variables.isEmpty)
+    .animation(rowAnimation, value: variables.count)
+    .frame(maxWidth: .infinity, alignment: .leading)
+  }
+
+  private func addVariable() {
+    withAnimation(rowAnimation) {
+      variables.append(CLIEnvironmentVariable(name: "", value: ""))
+    }
+  }
+
+  private func removeVariable(id: UUID) {
+    guard let index = variables.firstIndex(where: { $0.id == id }) else { return }
+    _ = withAnimation(rowAnimation) {
+      variables.remove(at: index)
+    }
+  }
+
+  private func clearVariables() {
+    withAnimation(rowAnimation) {
+      variables.removeAll()
+    }
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/EmbeddedTerminalLaunchBuilder.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/EmbeddedTerminalLaunchBuilder.swift
@@ -163,6 +163,7 @@ public enum EmbeddedTerminalLaunchBuilder {
     } else {
       environment["PATH"] = pathString
     }
+    environment.merge(CLIEnvironmentOverrides.environment) { _, new in new }
     return environment
   }
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/SettingsView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/SettingsView.swift
@@ -542,7 +542,7 @@ public struct SettingsView: View {
           Button(role: .destructive, action: clearCLIEnvironmentVariables) {
             Label("Clear all", systemImage: "trash")
           }
-          .transition(.opacity.combined(with: .move(edge: .trailing)))
+          .transition(.opacity)
         }
       }
     }

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/SettingsView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/SettingsView.swift
@@ -19,6 +19,7 @@ public struct SettingsView: View {
   @State private var isCodexConfigurationExpanded = true
   @State private var pendingTerminalBackend: EmbeddedTerminalBackend?
   @State private var showTerminalBackendRelaunchAlert = false
+  @State private var cliEnvironmentVariables = CLIEnvironmentOverrides.variables
 
   @AppStorage(AgentHubDefaults.smartModeEnabled)
   private var smartModeEnabled: Bool = false
@@ -141,8 +142,12 @@ public struct SettingsView: View {
     }
     .frame(width: 700, height: 620)
     .task {
+      cliEnvironmentVariables = CLIEnvironmentOverrides.variables
       await ensureSupportedThemeSelection()
       await aiConfigViewModel.load(service: agentHub?.aiConfigService)
+    }
+    .onChange(of: cliEnvironmentVariables) { _, newValue in
+      CLIEnvironmentOverrides.save(newValue)
     }
     .onDisappear {
       themeSelectionTask?.cancel()
@@ -253,6 +258,9 @@ public struct SettingsView: View {
         }
       }
 
+      Section("Environment Variables") {
+        cliEnvironmentVariablesEditor
+      }
     }
     .formStyle(.grouped)
     .scrollContentBackground(.hidden)
@@ -473,6 +481,81 @@ public struct SettingsView: View {
       }
     }
     .padding(.vertical, 4)
+  }
+
+  private var cliEnvironmentVariablesEditor: some View {
+    VStack(alignment: .leading, spacing: 10) {
+      if cliEnvironmentVariables.isEmpty {
+        Text("No environment variables configured.")
+          .foregroundColor(.secondary)
+      } else {
+        VStack(alignment: .leading, spacing: 8) {
+          ForEach(cliEnvironmentVariables.indices, id: \.self) { index in
+            HStack(spacing: 8) {
+              TextField(
+                text: $cliEnvironmentVariables[index].name,
+                prompt: Text("VARIABLE_NAME")
+              ) {
+                EmptyView()
+              }
+              .labelsHidden()
+              .textFieldStyle(.roundedBorder)
+              .font(.system(.body, design: .monospaced))
+              .lineLimit(1)
+              .frame(maxWidth: .infinity)
+
+              Text("=")
+                .foregroundColor(.secondary)
+
+              TextField(
+                text: $cliEnvironmentVariables[index].value,
+                prompt: Text("value")
+              ) {
+                EmptyView()
+              }
+              .labelsHidden()
+              .textFieldStyle(.roundedBorder)
+              .font(.system(.body, design: .monospaced))
+              .lineLimit(1)
+              .frame(maxWidth: .infinity)
+
+              Button(action: { removeCLIEnvironmentVariable(at: index) }) {
+                Image(systemName: "minus.circle")
+              }
+              .buttonStyle(.borderless)
+              .foregroundColor(.secondary)
+              .accessibilityLabel("Remove variable")
+            }
+          }
+        }
+      }
+
+      HStack(spacing: 12) {
+        Button(action: addCLIEnvironmentVariable) {
+          Label("Add variable", systemImage: "plus")
+        }
+
+        if !cliEnvironmentVariables.isEmpty {
+          Button(role: .destructive, action: clearCLIEnvironmentVariables) {
+            Label("Clear all", systemImage: "trash")
+          }
+        }
+      }
+    }
+    .frame(maxWidth: .infinity, alignment: .leading)
+  }
+
+  private func addCLIEnvironmentVariable() {
+    cliEnvironmentVariables.append(CLIEnvironmentVariable(name: "", value: ""))
+  }
+
+  private func removeCLIEnvironmentVariable(at index: Int) {
+    guard cliEnvironmentVariables.indices.contains(index) else { return }
+    cliEnvironmentVariables.remove(at: index)
+  }
+
+  private func clearCLIEnvironmentVariables() {
+    cliEnvironmentVariables.removeAll()
   }
 
   private func settingsToggle(

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/SettingsView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/SettingsView.swift
@@ -259,7 +259,7 @@ public struct SettingsView: View {
       }
 
       Section("Environment Variables") {
-        cliEnvironmentVariablesEditor
+        CLIEnvironmentVariablesEditor(variables: $cliEnvironmentVariables)
       }
     }
     .formStyle(.grouped)
@@ -481,93 +481,6 @@ public struct SettingsView: View {
       }
     }
     .padding(.vertical, 4)
-  }
-
-  private var cliEnvironmentVariablesEditor: some View {
-    VStack(alignment: .leading, spacing: 10) {
-      if cliEnvironmentVariables.isEmpty {
-        Text("No environment variables configured.")
-          .foregroundColor(.secondary)
-          .transition(.opacity.combined(with: .move(edge: .top)))
-      } else {
-        VStack(alignment: .leading, spacing: 8) {
-          ForEach($cliEnvironmentVariables) { $variable in
-            HStack(spacing: 8) {
-              TextField(
-                text: $variable.name,
-                prompt: Text("VARIABLE_NAME")
-              ) {
-                EmptyView()
-              }
-              .labelsHidden()
-              .textFieldStyle(.roundedBorder)
-              .font(.system(.body, design: .monospaced))
-              .lineLimit(1)
-              .frame(maxWidth: .infinity)
-
-              Text("=")
-                .foregroundColor(.secondary)
-
-              TextField(
-                text: $variable.value,
-                prompt: Text("value")
-              ) {
-                EmptyView()
-              }
-              .labelsHidden()
-              .textFieldStyle(.roundedBorder)
-              .font(.system(.body, design: .monospaced))
-              .lineLimit(1)
-              .frame(maxWidth: .infinity)
-
-              Button(action: { removeCLIEnvironmentVariable(id: variable.id) }) {
-                Image(systemName: "minus.circle")
-              }
-              .buttonStyle(.borderless)
-              .foregroundColor(.secondary)
-              .accessibilityLabel("Remove variable")
-            }
-            .transition(.opacity.combined(with: .move(edge: .top)))
-          }
-        }
-        .transition(.opacity.combined(with: .move(edge: .top)))
-      }
-
-      HStack(spacing: 12) {
-        Button(action: addCLIEnvironmentVariable) {
-          Label("Add variable", systemImage: "plus")
-        }
-
-        if !cliEnvironmentVariables.isEmpty {
-          Button(role: .destructive, action: clearCLIEnvironmentVariables) {
-            Label("Clear all", systemImage: "trash")
-          }
-          .transition(.opacity)
-        }
-      }
-    }
-    .animation(.easeInOut(duration: 0.18), value: cliEnvironmentVariables.isEmpty)
-    .animation(.easeInOut(duration: 0.18), value: cliEnvironmentVariables.count)
-    .frame(maxWidth: .infinity, alignment: .leading)
-  }
-
-  private func addCLIEnvironmentVariable() {
-    _ = withAnimation(.easeInOut(duration: 0.18)) {
-      cliEnvironmentVariables.append(CLIEnvironmentVariable(name: "", value: ""))
-    }
-  }
-
-  private func removeCLIEnvironmentVariable(id: UUID) {
-    guard let index = cliEnvironmentVariables.firstIndex(where: { $0.id == id }) else { return }
-    _ = withAnimation(.easeInOut(duration: 0.18)) {
-      cliEnvironmentVariables.remove(at: index)
-    }
-  }
-
-  private func clearCLIEnvironmentVariables() {
-    _ = withAnimation(.easeInOut(duration: 0.18)) {
-      cliEnvironmentVariables.removeAll()
-    }
   }
 
   private func settingsToggle(

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/SettingsView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/SettingsView.swift
@@ -488,12 +488,13 @@ public struct SettingsView: View {
       if cliEnvironmentVariables.isEmpty {
         Text("No environment variables configured.")
           .foregroundColor(.secondary)
+          .transition(.opacity.combined(with: .move(edge: .top)))
       } else {
         VStack(alignment: .leading, spacing: 8) {
-          ForEach(cliEnvironmentVariables.indices, id: \.self) { index in
+          ForEach($cliEnvironmentVariables) { $variable in
             HStack(spacing: 8) {
               TextField(
-                text: $cliEnvironmentVariables[index].name,
+                text: $variable.name,
                 prompt: Text("VARIABLE_NAME")
               ) {
                 EmptyView()
@@ -508,7 +509,7 @@ public struct SettingsView: View {
                 .foregroundColor(.secondary)
 
               TextField(
-                text: $cliEnvironmentVariables[index].value,
+                text: $variable.value,
                 prompt: Text("value")
               ) {
                 EmptyView()
@@ -519,15 +520,17 @@ public struct SettingsView: View {
               .lineLimit(1)
               .frame(maxWidth: .infinity)
 
-              Button(action: { removeCLIEnvironmentVariable(at: index) }) {
+              Button(action: { removeCLIEnvironmentVariable(id: variable.id) }) {
                 Image(systemName: "minus.circle")
               }
               .buttonStyle(.borderless)
               .foregroundColor(.secondary)
               .accessibilityLabel("Remove variable")
             }
+            .transition(.opacity.combined(with: .move(edge: .top)))
           }
         }
+        .transition(.opacity.combined(with: .move(edge: .top)))
       }
 
       HStack(spacing: 12) {
@@ -539,23 +542,32 @@ public struct SettingsView: View {
           Button(role: .destructive, action: clearCLIEnvironmentVariables) {
             Label("Clear all", systemImage: "trash")
           }
+          .transition(.opacity.combined(with: .move(edge: .trailing)))
         }
       }
     }
+    .animation(.easeInOut(duration: 0.18), value: cliEnvironmentVariables.isEmpty)
+    .animation(.easeInOut(duration: 0.18), value: cliEnvironmentVariables.count)
     .frame(maxWidth: .infinity, alignment: .leading)
   }
 
   private func addCLIEnvironmentVariable() {
-    cliEnvironmentVariables.append(CLIEnvironmentVariable(name: "", value: ""))
+    _ = withAnimation(.easeInOut(duration: 0.18)) {
+      cliEnvironmentVariables.append(CLIEnvironmentVariable(name: "", value: ""))
+    }
   }
 
-  private func removeCLIEnvironmentVariable(at index: Int) {
-    guard cliEnvironmentVariables.indices.contains(index) else { return }
-    cliEnvironmentVariables.remove(at: index)
+  private func removeCLIEnvironmentVariable(id: UUID) {
+    guard let index = cliEnvironmentVariables.firstIndex(where: { $0.id == id }) else { return }
+    _ = withAnimation(.easeInOut(duration: 0.18)) {
+      cliEnvironmentVariables.remove(at: index)
+    }
   }
 
   private func clearCLIEnvironmentVariables() {
-    cliEnvironmentVariables.removeAll()
+    _ = withAnimation(.easeInOut(duration: 0.18)) {
+      cliEnvironmentVariables.removeAll()
+    }
   }
 
   private func settingsToggle(

--- a/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/IntelligenceViewModel.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/IntelligenceViewModel.swift
@@ -74,6 +74,7 @@ public final class IntelligenceViewModel {
     return ClaudeCLIClient(
       command: "claude",
       additionalPaths: ClaudeCodePathResolver.searchPaths(additionalPaths: []),
+      environmentOverridesProvider: { CLIEnvironmentOverrides.environment },
       debugLogger: debugLogger
     )
   }

--- a/app/modules/AgentHubCore/Sources/ClaudeCodeClient/ClaudeCLIClient.swift
+++ b/app/modules/AgentHubCore/Sources/ClaudeCodeClient/ClaudeCLIClient.swift
@@ -23,6 +23,7 @@ public final class ClaudeCLIClient: ClaudeCLIClientProtocol, @unchecked Sendable
 
   private let command: String
   private let additionalPaths: [String]
+  private let environmentOverridesProvider: @Sendable () -> [String: String]
   private let debugLogger: (@Sendable (String) -> Void)?
 
   private var runningProcess: Process?
@@ -31,10 +32,13 @@ public final class ClaudeCLIClient: ClaudeCLIClientProtocol, @unchecked Sendable
   public init(
     command: String = "claude",
     additionalPaths: [String] = [],
+    environmentOverrides: [String: String] = [:],
+    environmentOverridesProvider: (@Sendable () -> [String: String])? = nil,
     debugLogger: (@Sendable (String) -> Void)? = nil
   ) {
     self.command = command
     self.additionalPaths = additionalPaths
+    self.environmentOverridesProvider = environmentOverridesProvider ?? { environmentOverrides }
     self.debugLogger = debugLogger
   }
 
@@ -59,6 +63,7 @@ public final class ClaudeCLIClient: ClaudeCLIClientProtocol, @unchecked Sendable
     let subject = PassthroughSubject<StreamJSONChunk, Error>()
     let decoder = JSONDecoder()
     let allPaths = ClaudeCLIExecutableResolver.searchPaths(additionalPaths: additionalPaths)
+    let environmentOverrides = environmentOverridesProvider()
 
     var args = parsedCommand.prefixArguments + ["-p", "--output-format", "stream-json", "--verbose"]
 
@@ -97,6 +102,7 @@ public final class ClaudeCLIClient: ClaudeCLIClientProtocol, @unchecked Sendable
           environment["PATH"] = joinedPaths
         }
       }
+      environment.merge(environmentOverrides) { _, new in new }
       process.environment = environment
 
       let stdinPipe = Pipe()

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/EmbeddedTerminalLaunchBuilderTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/EmbeddedTerminalLaunchBuilderTests.swift
@@ -3,9 +3,80 @@ import Testing
 
 @testable import AgentHubCore
 
-@Suite("EmbeddedTerminalLaunchBuilder AgentHub CLI context")
+@Suite("EmbeddedTerminalLaunchBuilder AgentHub CLI context", .serialized)
 struct EmbeddedTerminalLaunchBuilderAgentHubCLITests {
   private let agentHubCLIPath = "/Applications/AgentHub.app/Contents/Helpers/agenthub"
+
+  @Test("CLI environment variables are empty by default")
+  func cliEnvironmentVariablesAreEmptyByDefault() {
+    let suiteName = "AgentHubTests.CLIEnvironment.\(UUID().uuidString)"
+    let defaults = UserDefaults(suiteName: suiteName)!
+    defer { defaults.removePersistentDomain(forName: suiteName) }
+
+    #expect(CLIEnvironmentOverrides.variables(defaults: defaults).isEmpty)
+    #expect(CLIEnvironmentOverrides.environment(from: CLIEnvironmentOverrides.variables(defaults: defaults)).isEmpty)
+  }
+
+  @Test("Invalid CLI environment variable names are filtered")
+  func invalidCLIEnvironmentVariableNamesAreFiltered() {
+    let environment = CLIEnvironmentOverrides.environment(from: [
+      CLIEnvironmentVariable(name: "VALID", value: "first"),
+      CLIEnvironmentVariable(name: "", value: "empty"),
+      CLIEnvironmentVariable(name: "HAS=EQUALS", value: "equals"),
+      CLIEnvironmentVariable(name: "HAS\nNEWLINE", value: "newline"),
+      CLIEnvironmentVariable(name: "HAS\0NUL", value: "nul"),
+      CLIEnvironmentVariable(name: " VALID ", value: "last")
+    ])
+
+    #expect(environment == ["VALID": "last"])
+  }
+
+  @Test("CLI environment variable values persist through UserDefaults")
+  func cliEnvironmentVariablesPersistThroughUserDefaults() {
+    let suiteName = "AgentHubTests.CLIEnvironment.\(UUID().uuidString)"
+    let defaults = UserDefaults(suiteName: suiteName)!
+    defer { defaults.removePersistentDomain(forName: suiteName) }
+
+    let variables = [
+      CLIEnvironmentVariable(id: UUID(), name: "ONE", value: "1"),
+      CLIEnvironmentVariable(id: UUID(), name: "TWO", value: "value with spaces")
+    ]
+
+    CLIEnvironmentOverrides.save(variables, defaults: defaults)
+
+    #expect(CLIEnvironmentOverrides.variables(defaults: defaults) == variables)
+  }
+
+  @Test("Embedded terminal environment merges configured CLI variables")
+  func embeddedTerminalEnvironmentMergesConfiguredCLIVariables() {
+    withStandardCLIEnvironmentVariables([
+      CLIEnvironmentVariable(name: "AGENTHUB_TEST_ENV_OVERRIDE", value: "embedded")
+    ]) {
+      let environment = EmbeddedTerminalLaunchBuilder.makeProcessEnvironment(
+        additionalPaths: [],
+        agentHubCLIPath: agentHubCLIPath
+      )
+
+      #expect(environment["AGENTHUB_TEST_ENV_OVERRIDE"] == "embedded")
+    }
+  }
+
+  @Test("Terminal launcher exports CLI variables with deterministic shell escaping")
+  func terminalLauncherExportsCLIVariablesWithDeterministicShellEscaping() {
+    let exports = TerminalLauncher.cliEnvironmentExports(environment: [
+      "B": "two words",
+      "A": "quote'value",
+      "C": "line1\nline2"
+    ])
+    let expected = """
+    export A='quote'\\''value'
+    export B='two words'
+    export C='line1
+    line2'
+    """
+
+    #expect(exports == expected)
+  }
 
   @Test("Environment exposes AgentHub CLI and prepends its directory to PATH")
   func environmentExposesAgentHubCLI() {
@@ -119,5 +190,23 @@ struct EmbeddedTerminalLaunchBuilderAgentHubCLITests {
     #expect(launch.shellCommand.contains("agenthub_create_worktree_session"))
     #expect(!launch.shellCommand.contains("\\/"))
     #expect(!launch.shellCommand.contains("AgentHub session context:"))
+  }
+
+  private func withStandardCLIEnvironmentVariables(
+    _ variables: [CLIEnvironmentVariable],
+    perform: () -> Void
+  ) {
+    let defaults = UserDefaults.standard
+    let previousData = defaults.data(forKey: AgentHubDefaults.cliEnvironmentVariables)
+    CLIEnvironmentOverrides.save(variables, defaults: defaults)
+    defer {
+      if let previousData {
+        defaults.set(previousData, forKey: AgentHubDefaults.cliEnvironmentVariables)
+      } else {
+        defaults.removeObject(forKey: AgentHubDefaults.cliEnvironmentVariables)
+      }
+    }
+
+    perform()
   }
 }

--- a/app/modules/AgentHubCore/Tests/ClaudeCodeClientTests/ClaudeCodeClientTests.swift
+++ b/app/modules/AgentHubCore/Tests/ClaudeCodeClientTests/ClaudeCodeClientTests.swift
@@ -8,6 +8,14 @@ private final class CancellableBox: @unchecked Sendable {
   var cancellable: AnyCancellable?
 }
 
+private final class EnvironmentOverrideBox: @unchecked Sendable {
+  var value: String
+
+  init(value: String) {
+    self.value = value
+  }
+}
+
 private func awaitCompletion<Output>(
   from publisher: AnyPublisher<Output, Error>
 ) async -> Subscribers.Completion<Error> {
@@ -157,6 +165,50 @@ struct ClaudeCLIClientTests {
       .filter { !$0.isEmpty }
 
     #expect(!capturedArgs.contains("--model"))
+  }
+
+  @Test("Environment override provider is applied to launched process")
+  func environmentOverrideProviderIsAppliedToLaunchedProcess() async throws {
+    let tempDir = FileManager.default.temporaryDirectory
+      .appendingPathComponent("claude-client-tests-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+
+    let environmentFile = tempDir.appendingPathComponent("environment.txt")
+    let scriptURL = tempDir.appendingPathComponent("mock-claude.sh")
+    let escapedEnvironmentPath = environmentFile.path.replacingOccurrences(of: "\"", with: "\\\"")
+    let script = """
+    #!/bin/sh
+    printf '%s' "$AGENTHUB_TEST_ENV_OVERRIDE" > "\(escapedEnvironmentPath)"
+    cat >/dev/null
+    printf '{"type":"result","subtype":"success","result":"env"}\n'
+    """
+    try script.write(to: scriptURL, atomically: true, encoding: .utf8)
+    try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: scriptURL.path)
+
+    let overrideBox = EnvironmentOverrideBox(value: "initial")
+    let client = ClaudeCLIClient(
+      command: scriptURL.path,
+      environmentOverridesProvider: { ["AGENTHUB_TEST_ENV_OVERRIDE": overrideBox.value] }
+    )
+    overrideBox.value = "from-provider"
+
+    let (_, completion) = await awaitOutputs(from: client.runStreamingPrompt(
+      prompt: "hello",
+      workingDirectory: "",
+      systemPrompt: nil,
+      permissionMode: nil,
+      disallowedTools: nil,
+      model: nil
+    ))
+
+    guard case .finished = completion else {
+      Issue.record("Expected successful completion, got \(completion)")
+      return
+    }
+
+    let capturedEnvironment = try String(contentsOf: environmentFile, encoding: .utf8)
+    #expect(capturedEnvironment == "from-provider")
   }
 }
 


### PR DESCRIPTION
## Summary

Adds a generic CLI environment variables preference for AgentHub. Users can now configure arbitrary `name=value` rows in Settings without any seeded defaults, and valid entries are applied when AgentHub launches CLI processes.

## Changes

- Added `CLIEnvironmentVariable` and `CLIEnvironmentOverrides` with JSON-backed `UserDefaults` persistence under `com.agenthub.cli.environmentVariables`.
- Added a Settings UI section under CLI Configuration for adding, editing, removing, and clearing environment variable rows.
- Applies configured variables to embedded terminal launches, background terminal launches, and external `.command` scripts.
- Escapes exported script values safely and sorts exports for deterministic script output.
- Updated `ClaudeCLIClient` to read environment overrides through a provider at launch time so long-lived clients pick up Settings changes.
- Added focused tests for default empty state, invalid-name filtering, persistence, embedded environment merging, shell export escaping, and Claude process environment injection.

## Validation

- Passed: `git diff --check`
- Passed: `swift build --target ClaudeCodeClient`
- Passed: `swift build --target ClaudeCodeClientTests`
- Blocked: full `swift test` / `AgentHubCore` SwiftPM build fails before project code type-checks in the existing `CodeEditSymbols` dependency because `Bundle.module` is unavailable after its asset catalog is reported as unhandled.
- Blocked: `swift build --target AgentHubCore --build-system xcode` gets past that package path but fails because the Metal Toolchain is not installed (`xcodebuild -downloadComponent MetalToolchain`).