### PR TITLE
[codex] Improve file explorer monorepo performance

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/Models/TextFileMetrics.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Models/TextFileMetrics.swift
@@ -1,0 +1,64 @@
+//
+//  TextFileMetrics.swift
+//  AgentHub
+//
+//  Lightweight metrics used to select an editor mode before expensive editor
+//  features are enabled.
+//
+
+import Foundation
+
+public struct TextFileMetrics: Equatable, Sendable {
+  public let byteCount: Int
+  public let lineCount: Int
+  public let maxLineByteCount: Int
+
+  public init(byteCount: Int, lineCount: Int, maxLineByteCount: Int) {
+    self.byteCount = byteCount
+    self.lineCount = lineCount
+    self.maxLineByteCount = maxLineByteCount
+  }
+
+  public static func metrics(forUTF8Data data: Data) -> TextFileMetrics {
+    metrics(forUTF8Bytes: data, byteCount: data.count)
+  }
+
+  public static func metrics(for content: String) -> TextFileMetrics {
+    metrics(forUTF8Bytes: content.utf8, byteCount: content.utf8.count)
+  }
+
+  private static func metrics<Bytes: Sequence>(
+    forUTF8Bytes bytes: Bytes,
+    byteCount: Int
+  ) -> TextFileMetrics where Bytes.Element == UInt8 {
+    guard byteCount > 0 else {
+      return TextFileMetrics(byteCount: 0, lineCount: 0, maxLineByteCount: 0)
+    }
+
+    var lineCount = 1
+    var currentLineByteCount = 0
+    var maxLineByteCount = 0
+
+    for byte in bytes {
+      if byte == 0x0A {
+        maxLineByteCount = max(maxLineByteCount, currentLineByteCount)
+        currentLineByteCount = 0
+        lineCount += 1
+      } else {
+        currentLineByteCount += 1
+      }
+    }
+
+    maxLineByteCount = max(maxLineByteCount, currentLineByteCount)
+    return TextFileMetrics(
+      byteCount: byteCount,
+      lineCount: lineCount,
+      maxLineByteCount: maxLineByteCount
+    )
+  }
+}
+
+struct ProjectTextFile: Sendable {
+  let content: String
+  let metrics: TextFileMetrics
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/FileIndexService.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/FileIndexService.swift
@@ -60,6 +60,7 @@ struct ProjectFileEnumeratorFile: Sendable, Equatable {
 
 enum ProjectFileEnumerationResult: Sendable {
   case files([ProjectFileEnumeratorFile], kind: ProjectFileEnumerationKind)
+  case partialFiles([ProjectFileEnumeratorFile], kind: ProjectFileEnumerationKind)
   case notGitProject
   case failed
 }
@@ -98,7 +99,15 @@ struct GitProjectFileEnumerator: ProjectFileEnumerating {
       return knownKind == nil ? .notGitProject : .failed
     }
 
-    guard !result.timedOut, result.exitCode == 0 else {
+    if result.timedOut {
+      let files = Self.parseGitLSFilesOutput(result.stdout)
+      guard !files.isEmpty, let knownKind else {
+        return knownKind == nil ? .notGitProject : .failed
+      }
+      return .partialFiles(files, kind: knownKind)
+    }
+
+    guard result.exitCode == 0 else {
       return knownKind == nil ? .notGitProject : .failed
     }
 
@@ -248,6 +257,7 @@ public actor FileIndexService {
   // MARK: - Constants
 
   private static let cacheTTL: TimeInterval = 5 * 60  // 5 minutes
+  private static let degradedSearchCacheTTL: TimeInterval = 10
   private static let maxDepth = 20
   private static let maxSearchResults = 50
 
@@ -271,7 +281,7 @@ public actor FileIndexService {
     ".github", ".vscode", ".cursor"
   ]
 
-  private struct IgnoreRule {
+  private struct IgnoreRule: Sendable {
     let basePath: String
     let pattern: String
     let isNegated: Bool
@@ -286,15 +296,26 @@ public actor FileIndexService {
     let date: Date
   }
 
+  private struct IgnoreRulesCacheEntry {
+    let rules: [IgnoreRule]
+    let date: Date
+  }
+
   private struct IndexedFile: Sendable {
     let name: String
     let relativePath: String
     let absolutePath: String
   }
 
+  private struct SearchIndexBuildResult: Sendable {
+    let files: [IndexedFile]
+    let ttl: TimeInterval
+  }
+
   private struct SearchCacheEntry: Sendable {
     let files: [IndexedFile]
     let date: Date
+    let ttl: TimeInterval
   }
 
   private struct DirectoryEntry: Sendable {
@@ -303,12 +324,20 @@ public actor FileIndexService {
     let isDirectory: Bool
   }
 
+  private struct ParsedGitignoreCacheEntry {
+    let modificationDate: Date?
+    let rules: [IgnoreRule]
+  }
+
   private var directoryCache: [String: CacheEntry] = [:]
   private var directoryLoadTasks: [String: Task<[FileTreeNode], Never>] = [:]
   private var searchCache: [String: SearchCacheEntry] = [:]
   private var searchBuildTasks: [String: Task<SearchCacheEntry, Never>] = [:]
+  private var parsedGitignoreCache: [String: ParsedGitignoreCacheEntry] = [:]
+  private var ignoreRulesCache: [String: IgnoreRulesCacheEntry] = [:]
   private var recentPaths: [String] = []
   private static let maxRecentFiles = 20
+  private static let globRegexCache = NSCache<NSString, NSRegularExpression>()
   private let projectFileSearchService: any ProjectFileSearchServiceProtocol
   private let projectFileEnumerator: any ProjectFileEnumerating
 
@@ -429,10 +458,10 @@ public actor FileIndexService {
       let filteredSpotlightResults = spotlightResponse.results
         .compactMap { spotlightResult -> FileSearchResult? in
           let absolutePath = Self.resolvedURL(for: spotlightResult.absolutePath).path
-          guard Self.shouldIncludeSearchResult(at: absolutePath, rootPath: resolvedProjectPath),
-                let relativePath = Self.relativePathIfContained(absolutePath, within: resolvedProjectPath) else {
+          guard shouldIncludeSearchResultCached(at: absolutePath, rootPath: resolvedProjectPath) else {
             return nil
           }
+          let relativePath = Self.projectRelativePath(for: absolutePath, relativeTo: resolvedProjectPath)
           let name = URL(fileURLWithPath: absolutePath).lastPathComponent
 
           return FileSearchResult(
@@ -490,13 +519,34 @@ public actor FileIndexService {
     searchCache.removeValue(forKey: resolvedProjectPath)
     searchBuildTasks[resolvedProjectPath]?.cancel()
     searchBuildTasks.removeValue(forKey: resolvedProjectPath)
+    ignoreRulesCache.keys
+      .filter { $0.hasPrefix(resolvedProjectPath + "\u{0}") }
+      .forEach { ignoreRulesCache.removeValue(forKey: $0) }
+    parsedGitignoreCache.keys
+      .filter { Self.isPath(($0 as NSString).deletingLastPathComponent, within: resolvedProjectPath) }
+      .forEach { parsedGitignoreCache.removeValue(forKey: $0) }
   }
 
   /// Reads a file at `path` as a UTF-8 string.
   /// `projectPath` is required so the read is validated to stay within the project root.
   public func readFile(at path: String, projectPath: String) throws -> String {
+    try readTextFile(at: path, projectPath: projectPath).content
+  }
+
+  /// Reads a UTF-8 file and returns lightweight metrics gathered from the bytes
+  /// before the editor is configured.
+  func readTextFile(at path: String, projectPath: String) throws -> ProjectTextFile {
     let validatedURL = try validatePath(path, within: projectPath, forWrite: false)
-    return try String(contentsOf: validatedURL, encoding: .utf8)
+    let data = try Data(contentsOf: validatedURL, options: [.mappedIfSafe])
+    guard let content = String(data: data, encoding: .utf8) else {
+      throw CocoaError(.fileReadCorruptFile, userInfo: [
+        NSLocalizedDescriptionKey: "File is not valid UTF-8 text."
+      ])
+    }
+    return ProjectTextFile(
+      content: content,
+      metrics: TextFileMetrics.metrics(forUTF8Data: data)
+    )
   }
 
   /// Writes `content` to the file at `path` atomically, then invalidates any matching project cache.
@@ -505,7 +555,7 @@ public actor FileIndexService {
     let validatedURL = try validatePath(path, within: projectPath, forWrite: true)
     let didExist = FileManager.default.fileExists(atPath: validatedURL.path)
     try content.write(to: validatedURL, atomically: true, encoding: .utf8)
-    if !didExist {
+    if !didExist || validatedURL.lastPathComponent == ".gitignore" {
       invalidate(projectPath: projectPath)
     }
   }
@@ -542,12 +592,16 @@ public actor FileIndexService {
     Date().timeIntervalSince(date) > Self.cacheTTL
   }
 
+  private func isSearchCacheStale(_ entry: SearchCacheEntry) -> Bool {
+    Date().timeIntervalSince(entry.date) > entry.ttl
+  }
+
   private func searchIndexStatus(resolvedProjectPath: String) -> FileSearchIndexStatus {
     if searchBuildTasks[resolvedProjectPath] != nil {
       return .building
     }
 
-    if let entry = searchCache[resolvedProjectPath], !isCacheStale(entry.date) {
+    if let entry = searchCache[resolvedProjectPath], !isSearchCacheStale(entry) {
       return .ready
     }
 
@@ -581,7 +635,7 @@ public actor FileIndexService {
   }
 
   private func searchIndex(projectPath: String) async -> [IndexedFile] {
-    if let entry = searchCache[projectPath], !isCacheStale(entry.date) {
+    if let entry = searchCache[projectPath], !isSearchCacheStale(entry) {
       return entry.files
     }
 
@@ -603,11 +657,11 @@ public actor FileIndexService {
   private func makeSearchBuildTask(projectPath: String) -> Task<SearchCacheEntry, Never> {
     let projectFileEnumerator = projectFileEnumerator
     return Task.detached(priority: .utility) {
-      let files = await FileIndexService.buildSearchIndex(
+      let result = await FileIndexService.buildSearchIndex(
         projectPath: projectPath,
         projectFileEnumerator: projectFileEnumerator
       )
-      return SearchCacheEntry(files: files, date: Date())
+      return SearchCacheEntry(files: result.files, date: Date(), ttl: result.ttl)
     }
   }
 
@@ -641,14 +695,22 @@ public actor FileIndexService {
   private static func buildSearchIndex(
     projectPath: String,
     projectFileEnumerator: any ProjectFileEnumerating
-  ) async -> [IndexedFile] {
+  ) async -> SearchIndexBuildResult {
     switch await projectFileEnumerator.enumerateFiles(in: projectPath) {
     case .files(let files, _):
-      return buildSearchIndexFromGitFiles(files, rootPath: projectPath)
+      return SearchIndexBuildResult(
+        files: buildSearchIndexFromGitFiles(files, rootPath: projectPath),
+        ttl: cacheTTL
+      )
+    case .partialFiles(let files, _):
+      return SearchIndexBuildResult(
+        files: buildSearchIndexFromGitFiles(files, rootPath: projectPath),
+        ttl: degradedSearchCacheTTL
+      )
     case .notGitProject:
-      return buildSearchIndexSync(projectPath: projectPath)
+      return SearchIndexBuildResult(files: buildSearchIndexSync(projectPath: projectPath), ttl: cacheTTL)
     case .failed:
-      return []
+      return SearchIndexBuildResult(files: [], ttl: degradedSearchCacheTTL)
     }
   }
 
@@ -656,17 +718,48 @@ public actor FileIndexService {
     _ files: [ProjectFileEnumeratorFile],
     rootPath: String
   ) -> [IndexedFile] {
-    files.compactMap { file in
+    var rulesByDirectory: [String: [IgnoreRule]] = [:]
+    return files.compactMap { file in
       let absolutePath = (rootPath as NSString).appendingPathComponent(file.relativePath)
-      guard shouldIncludeSearchResult(at: absolutePath, rootPath: rootPath),
-            let relativePath = relativePathIfContained(absolutePath, within: rootPath) else {
+      let standardizedPath = URL(fileURLWithPath: absolutePath).standardizedFileURL.path
+      guard isPath(standardizedPath, within: rootPath),
+            standardizedPath != rootPath else {
+        return nil
+      }
+
+      let url = URL(fileURLWithPath: standardizedPath)
+      guard let values = try? url.resourceValues(forKeys: [.isDirectoryKey, .isSymbolicLinkKey]),
+            values.isDirectory != true,
+            values.isSymbolicLink != true else {
+        return nil
+      }
+
+      let directoryPath = (standardizedPath as NSString).deletingLastPathComponent
+      let rules: [IgnoreRule]
+      if let cachedRules = rulesByDirectory[directoryPath] {
+        rules = cachedRules
+      } else {
+        let parsedRules = ignoreRules(forDirectoryAt: directoryPath, rootPath: rootPath)
+        rulesByDirectory[directoryPath] = parsedRules
+        rules = parsedRules
+      }
+
+      guard shouldIncludeEntry(
+        DirectoryEntry(
+          name: url.lastPathComponent,
+          path: standardizedPath,
+          isDirectory: false
+        ),
+        rootPath: rootPath,
+        rules: rules
+      ) else {
         return nil
       }
 
       return IndexedFile(
-        name: URL(fileURLWithPath: absolutePath).lastPathComponent,
-        relativePath: relativePath,
-        absolutePath: absolutePath
+        name: url.lastPathComponent,
+        relativePath: file.relativePath,
+        absolutePath: standardizedPath
       )
     }
   }
@@ -821,7 +914,82 @@ public actor FileIndexService {
     )
   }
 
+  private func shouldIncludeSearchResultCached(at path: String, rootPath: String) -> Bool {
+    let resolvedRootPath = Self.resolvedURL(for: rootPath).path
+    let resolvedPath = Self.resolvedURL(for: path).path
+    guard Self.isPath(resolvedPath, within: resolvedRootPath),
+          resolvedPath != resolvedRootPath else {
+      return false
+    }
+
+    let url = URL(fileURLWithPath: resolvedPath)
+    guard let values = try? url.resourceValues(forKeys: [.isDirectoryKey, .isSymbolicLinkKey]),
+          values.isDirectory != true,
+          values.isSymbolicLink != true else {
+      return false
+    }
+
+    let directoryPath = (resolvedPath as NSString).deletingLastPathComponent
+    let rules = cachedIgnoreRules(forDirectoryAt: directoryPath, rootPath: resolvedRootPath)
+    return Self.shouldIncludeEntry(
+      DirectoryEntry(
+        name: url.lastPathComponent,
+        path: resolvedPath,
+        isDirectory: false
+      ),
+      rootPath: resolvedRootPath,
+      rules: rules
+    )
+  }
+
   // MARK: - Gitignore Parsing
+
+  private func cachedIgnoreRules(forDirectoryAt directoryPath: String, rootPath: String) -> [IgnoreRule] {
+    let resolvedRootPath = Self.resolvedURL(for: rootPath).path
+    let resolvedDirectoryPath = Self.resolvedURL(for: directoryPath).path
+    let cacheKey = resolvedRootPath + "\u{0}" + resolvedDirectoryPath
+
+    if let entry = ignoreRulesCache[cacheKey], !isCacheStale(entry.date) {
+      return entry.rules
+    }
+
+    guard Self.isPath(resolvedDirectoryPath, within: resolvedRootPath) else { return [] }
+
+    var rules: [IgnoreRule] = []
+    var currentPath = resolvedRootPath
+    rules += cachedParseGitignore(at: currentPath, relativeTo: resolvedRootPath)
+
+    if resolvedDirectoryPath != resolvedRootPath {
+      let relativePath = String(resolvedDirectoryPath.dropFirst(resolvedRootPath.count + 1))
+      for component in relativePath.split(separator: "/") {
+        currentPath = (currentPath as NSString).appendingPathComponent(String(component))
+        rules += cachedParseGitignore(at: currentPath, relativeTo: resolvedRootPath)
+      }
+    }
+
+    ignoreRulesCache[cacheKey] = IgnoreRulesCacheEntry(rules: rules, date: Date())
+    return rules
+  }
+
+  private func cachedParseGitignore(at directoryPath: String, relativeTo rootPath: String) -> [IgnoreRule] {
+    let gitignorePath = (directoryPath as NSString).appendingPathComponent(".gitignore")
+    let modificationDate = Self.fileModificationDate(at: gitignorePath)
+    if let entry = parsedGitignoreCache[gitignorePath],
+       entry.modificationDate == modificationDate {
+      return entry.rules
+    }
+
+    let rules = Self.parseGitignore(at: directoryPath, relativeTo: rootPath)
+    parsedGitignoreCache[gitignorePath] = ParsedGitignoreCacheEntry(
+      modificationDate: modificationDate,
+      rules: rules
+    )
+    return rules
+  }
+
+  private static func fileModificationDate(at path: String) -> Date? {
+    (try? FileManager.default.attributesOfItem(atPath: path)[.modificationDate]) as? Date
+  }
 
   private static func parseGitignore(at directoryPath: String, relativeTo rootPath: String) -> [IgnoreRule] {
     let gitignorePath = (directoryPath as NSString).appendingPathComponent(".gitignore")
@@ -919,6 +1087,13 @@ public actor FileIndexService {
   /// Lightweight glob match for gitignore-style matching.
   /// Supports `*`, `**`, and `?`, with `*` not crossing path separators.
   private static func globMatch(pattern: String, string: String) -> Bool {
+    if let cachedRegex = globRegexCache.object(forKey: pattern as NSString) {
+      return cachedRegex.firstMatch(
+        in: string,
+        range: NSRange(location: 0, length: (string as NSString).length)
+      ) != nil
+    }
+
     let regexMetaCharacters = CharacterSet(charactersIn: "\\.^$+()[]{}|")
     var regex = "^"
     var index = pattern.startIndex
@@ -953,7 +1128,14 @@ public actor FileIndexService {
     }
 
     regex += "$"
-    return string.range(of: regex, options: .regularExpression) != nil
+    guard let compiledRegex = try? NSRegularExpression(pattern: regex) else {
+      return false
+    }
+    globRegexCache.setObject(compiledRegex, forKey: pattern as NSString)
+    return compiledRegex.firstMatch(
+      in: string,
+      range: NSRange(location: 0, length: (string as NSString).length)
+    ) != nil
   }
 
   private static func projectRelativePath(for path: String, relativeTo rootPath: String) -> String {

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/FileExplorerView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/FileExplorerView.swift
@@ -128,6 +128,9 @@ public struct FileExplorerView: View {
         await loadFileTree()
       }
     }
+    .task(id: normalizedProjectPath) {
+      await FileIndexService.shared.prepareSearchIndex(projectPath: normalizedProjectPath)
+    }
     .task(id: navigationRequest?.id) {
       guard let navigationRequest else { return }
       await navigateToFile(at: navigationRequest.filePath)
@@ -280,14 +283,12 @@ public struct FileExplorerView: View {
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(12)
           } else {
+            let rows = visibleTreeRows
             LazyVStack(alignment: .leading, spacing: 0) {
-              ForEach(treeNodes) { node in
-                FileTreeNodeView(
-                  node: node,
-                  depth: 0,
+              ForEach(rows) { row in
+                FileTreeRowView(
+                  row: row,
                   selectedFilePath: $selectedFilePath,
-                  expandedPaths: $expandedPaths,
-                  loadingPaths: loadingDirectories,
                   onSelectFile: { path in
                     Task { await openFile(at: path) }
                   },
@@ -357,13 +358,12 @@ public struct FileExplorerView: View {
         fileName: selectedFilePath.map { URL(fileURLWithPath: $0).lastPathComponent } ?? "",
         documentID: editorDocumentID,
         displayMode: editorDisplayMode,
-        onTextChange: { updatedText in
-          if updatedText != savedFileContent {
+        onTextChange: { _ in
+          if !hasUnsavedChanges {
             hasUnsavedChanges = true
           }
         },
         onIdleTextSnapshot: { idleText in
-          guard editorDisplayMode == .highlighted else { return }
           hasUnsavedChanges = idleText != savedFileContent
         }
       )
@@ -415,11 +415,11 @@ public struct FileExplorerView: View {
     isLoadingFile = true
 
     do {
-      let content = try await FileIndexService.shared.readFile(at: resolvedPath, projectPath: normalizedProjectPath)
-      fileContent = content
-      savedFileContent = content
+      let file = try await FileIndexService.shared.readTextFile(at: resolvedPath, projectPath: normalizedProjectPath)
+      fileContent = file.content
+      savedFileContent = file.content
       hasUnsavedChanges = false
-      editorDisplayMode = .displayMode(for: content)
+      editorDisplayMode = .displayMode(for: file.metrics)
       editorDocumentID = UUID()
       await FileIndexService.shared.addToRecent(resolvedPath)
     } catch {
@@ -484,11 +484,7 @@ public struct FileExplorerView: View {
     guard !loadingDirectories.contains(directoryPath) else { return }
     loadingDirectories.insert(directoryPath)
     let children = await FileIndexService.shared.children(of: directoryPath, in: normalizedProjectPath)
-    treeNodes = updatingChildren(
-      in: treeNodes,
-      for: directoryPath,
-      children: children
-    )
+    setChildren(children, for: directoryPath)
     loadingDirectories.remove(directoryPath)
   }
 
@@ -530,59 +526,112 @@ public struct FileExplorerView: View {
     return nil
   }
 
-  private func updatingChildren(
-    in nodes: [FileTreeNode],
+  private var visibleTreeRows: [FileTreeVisibleRow] {
+    var rows: [FileTreeVisibleRow] = []
+    rows.reserveCapacity(treeNodes.count)
+    appendVisibleRows(from: treeNodes, depth: 0, into: &rows)
+    return rows
+  }
+
+  private func appendVisibleRows(
+    from nodes: [FileTreeNode],
+    depth: Int,
+    into rows: inout [FileTreeVisibleRow]
+  ) {
+    for node in nodes {
+      let isExpanded = expandedPaths.contains(node.path)
+      rows.append(.node(node, depth: depth, isExpanded: isExpanded))
+      guard node.isDirectory, isExpanded else { continue }
+      if loadingDirectories.contains(node.path) {
+        rows.append(.loading(path: node.path, depth: depth + 1))
+      } else if let children = node.children {
+        appendVisibleRows(from: children, depth: depth + 1, into: &rows)
+      }
+    }
+  }
+
+  private func setChildren(_ children: [FileTreeNode], for targetPath: String) {
+    _ = setChildren(children, for: targetPath, in: &treeNodes)
+  }
+
+  private func setChildren(
+    _ children: [FileTreeNode],
     for targetPath: String,
-    children: [FileTreeNode]
-  ) -> [FileTreeNode] {
-    nodes.map { node in
-      var updated = node
-      if node.path == targetPath {
-        updated.children = children
-        return updated
+    in nodes: inout [FileTreeNode]
+  ) -> Bool {
+    for index in nodes.indices {
+      if nodes[index].path == targetPath {
+        nodes[index].children = children
+        return true
       }
-      if let existingChildren = node.children {
-        updated.children = updatingChildren(
-          in: existingChildren,
-          for: targetPath,
-          children: children
-        )
+
+      guard var existingChildren = nodes[index].children else { continue }
+      if setChildren(children, for: targetPath, in: &existingChildren) {
+        nodes[index].children = existingChildren
+        return true
       }
-      return updated
+    }
+
+    return false
+  }
+}
+
+// MARK: - FileTreeRowView
+
+private enum FileTreeVisibleRow: Identifiable, Equatable {
+  case node(FileTreeNode, depth: Int, isExpanded: Bool)
+  case loading(path: String, depth: Int)
+
+  var id: String {
+    switch self {
+    case .node(let node, _, _):
+      node.path
+    case .loading(let path, _):
+      path + "#loading"
     }
   }
 }
 
-// MARK: - FileTreeNodeView
-
-/// Recursive view that renders a single ``FileTreeNode`` and, when expanded, its children.
-private struct FileTreeNodeView: View {
-  let node: FileTreeNode
-  let depth: Int
+/// Renders one flattened tree row so the outer LazyVStack can virtualize a high-fanout directory.
+private struct FileTreeRowView: View {
+  let row: FileTreeVisibleRow
   @Binding var selectedFilePath: String?
-  @Binding var expandedPaths: Set<String>
-  let loadingPaths: Set<String>
   let onSelectFile: (String) -> Void
   let onToggleDirectory: (FileTreeNode) -> Void
 
   @State private var isHovered = false
 
-  private var isExpanded: Bool {
-    expandedPaths.contains(node.path)
+  private var node: FileTreeNode? {
+    if case .node(let node, _, _) = row {
+      return node
+    }
+    return nil
   }
 
-  private var isSelected: Bool {
-    !node.isDirectory && selectedFilePath == node.path
+  private var depth: Int {
+    switch row {
+    case .node(_, let depth, _), .loading(_, let depth):
+      depth
+    }
   }
 
   private var rowBackground: Color {
+    guard let node else { return Color.clear }
+    let isSelected = !node.isDirectory && selectedFilePath == node.path
     if isSelected { return Color.accentColor }
     if isHovered { return Color.primary.opacity(0.08) }
     return Color.clear
   }
 
+  private var isSelected: Bool {
+    guard let node else { return false }
+    return !node.isDirectory && selectedFilePath == node.path
+  }
+
+  @ViewBuilder
   var body: some View {
-    VStack(alignment: .leading, spacing: 0) {
+    switch row {
+    case .node(let node, _, let isExpanded):
       Button(action: handleTap) {
         HStack(spacing: 4) {
           // Indentation
@@ -628,38 +677,22 @@ private struct FileTreeNodeView: View {
       .buttonStyle(.plain)
       .onHover { isHovered = $0 }
       .id(node.path)
-
-      // Children
-      if node.isDirectory && isExpanded {
-        if loadingPaths.contains(node.path) {
-          HStack(spacing: 8) {
-            Spacer()
-              .frame(width: CGFloat(depth + 1) * 12 + 28)
-            ProgressView()
-              .controlSize(.small)
-            Text("Loading…")
-              .font(.system(size: 11))
-              .foregroundColor(.secondary)
-          }
-          .padding(.vertical, 4)
-        } else if let children = node.children {
-          ForEach(children) { child in
-            FileTreeNodeView(
-              node: child,
-              depth: depth + 1,
-              selectedFilePath: $selectedFilePath,
-              expandedPaths: $expandedPaths,
-              loadingPaths: loadingPaths,
-              onSelectFile: onSelectFile,
-              onToggleDirectory: onToggleDirectory
-            )
-          }
-        }
+    case .loading:
+      HStack(spacing: 8) {
+        Spacer()
+          .frame(width: CGFloat(depth) * 12 + 28)
+        ProgressView()
+          .controlSize(.small)
+        Text("Loading…")
+          .font(.system(size: 11))
+          .foregroundColor(.secondary)
       }
+      .padding(.vertical, 4)
     }
   }
 
   private func handleTap() {
+    guard let node else { return }
     if node.isDirectory {
       onToggleDirectory(node)
     } else {

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/QuickFilePickerView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/QuickFilePickerView.swift
@@ -261,6 +261,9 @@ public struct QuickFilePickerView: View {
         }
       }
     }
+    .task(id: projectPath) {
+      await FileIndexService.shared.prepareSearchIndex(projectPath: projectPath)
+    }
     .task(id: searchQuery) {
       // Automatically cancels previous task when searchQuery changes
       if searchQuery.isEmpty {

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/SourceCodeEditorView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/SourceCodeEditorView.swift
@@ -16,6 +16,10 @@ enum EditorDisplayMode: Equatable {
   case highlighted
   case plainText
 
+  private static let highlightedByteLimit = 300_000
+  private static let highlightedLineLimit = 5_000
+  private static let highlightedMaxLineByteLimit = 2_000
+
   var badgeLabel: String? {
     switch self {
     case .highlighted:
@@ -34,21 +38,16 @@ enum EditorDisplayMode: Equatable {
   }
 
   static func displayMode(for content: String) -> EditorDisplayMode {
-    let byteCount = content.utf8.count
-    let lineCount = lineCount(for: content)
-    if byteCount <= 300_000 && lineCount <= 5_000 {
+    displayMode(for: TextFileMetrics.metrics(for: content))
+  }
+
+  static func displayMode(for metrics: TextFileMetrics) -> EditorDisplayMode {
+    if metrics.byteCount <= highlightedByteLimit,
+       metrics.lineCount <= highlightedLineLimit,
+       metrics.maxLineByteCount <= highlightedMaxLineByteLimit {
       return .highlighted
     }
     return .plainText
-  }
-
-  private static func lineCount(for content: String) -> Int {
-    guard !content.isEmpty else { return 0 }
-    return content.utf8.reduce(into: 1) { count, byte in
-      if byte == 0x0A {
-        count += 1
-      }
-    }
   }
 }
 
@@ -169,7 +168,7 @@ struct AgentHubSourceEditorOptions {
   let additionalTextInsets = NSEdgeInsets(top: 2, left: 0, bottom: 2, right: 0)
 
   var wrapLines: Bool {
-    isWrapLinesEnabled
+    isWrapLinesEnabled && displayMode.usesFullEditorFeatures
   }
 
   var bracketPairEmphasis: BracketPairEmphasis? {
@@ -223,6 +222,7 @@ struct AgentHubSourceEditorOptions {
 private final class SourceEditorEditCoordinator: TextViewCoordinator {
   private weak var controller: TextViewController?
   private var isApplyingExternalText = false
+  private var shouldSkipNextExternalTextSync = false
   private var idleTask: Task<Void, Never>?
   private var findNavigationEventMonitor: Any?
   private var findNavigationText = ""
@@ -271,6 +271,7 @@ private final class SourceEditorEditCoordinator: TextViewCoordinator {
   func textViewDidChangeText(controller: TextViewController) {
     guard !isApplyingExternalText else { return }
     let updatedText = controller.text
+    shouldSkipNextExternalTextSync = true
     onTextChange(updatedText)
     scheduleIdleSnapshot(updatedText)
   }
@@ -285,7 +286,12 @@ private final class SourceEditorEditCoordinator: TextViewCoordinator {
   }
 
   func syncExternalText(_ text: String) {
-    guard let controller, controller.text != text else { return }
+    guard let controller else { return }
+    if shouldSkipNextExternalTextSync {
+      shouldSkipNextExternalTextSync = false
+      return
+    }
+    guard controller.text != text else { return }
     isApplyingExternalText = true
     controller.text = text
     isApplyingExternalText = false

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/FileIndexServiceTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/FileIndexServiceTests.swift
@@ -466,6 +466,31 @@ struct FileIndexServicePrivacyTests {
     #expect(diagnostics.results.isEmpty)
   }
 
+  @Test("Partial Git enumeration still returns degraded search results")
+  func partialGitEnumerationReturnsDegradedResults() async throws {
+    let fixture = try FileIndexFixture.create()
+    defer { fixture.cleanup() }
+
+    try fixture.writeProjectFile("Sources/App.swift", content: "struct App {}")
+    try fixture.writeProjectFile("Sources/Other.swift", content: "struct Other {}")
+
+    let service = FileIndexService(
+      projectFileSearchService: FakeProjectFileSearchService(results: []),
+      projectFileEnumerator: FakeProjectFileEnumerator(
+        kind: .gitWorktree,
+        result: .partialFiles([
+          ProjectFileEnumeratorFile(relativePath: "Sources/App.swift")
+        ], kind: .gitWorktree)
+      )
+    )
+
+    let diagnostics = await service.searchWithDiagnostics(query: "app", in: fixture.projectPath)
+
+    #expect(diagnostics.source == .localIndex)
+    #expect(diagnostics.localIndexedFileCount == 1)
+    #expect(diagnostics.results.map(\.relativePath) == ["Sources/App.swift"])
+  }
+
   @Test("Filters hidden ancestor directories from search results")
   func filtersHiddenAncestorDirectoriesFromSearchResults() async throws {
     let fixture = try FileIndexFixture.create()

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/SourceCodeEditorViewTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/SourceCodeEditorViewTests.swift
@@ -160,7 +160,7 @@ struct SourceCodeEditorViewTests {
 
   @Test("Display mode enables highlighting for normal source files")
   func displayModeHighlightsNormalFiles() {
-    let content = String(repeating: "a", count: 300_000)
+    let content = Array(repeating: "let value = 1", count: 1_000).joined(separator: "\n")
 
     #expect(EditorDisplayMode.displayMode(for: content) == .highlighted)
   }
@@ -172,6 +172,22 @@ struct SourceCodeEditorViewTests {
 
     #expect(EditorDisplayMode.displayMode(for: largeByteContent) == .plainText)
     #expect(EditorDisplayMode.displayMode(for: largeLineContent) == .plainText)
+  }
+
+  @Test("Display mode uses fast mode for long-line files")
+  func displayModeUsesFastModeForLongLineFiles() {
+    let longLineContent = String(repeating: "a", count: 2_001)
+
+    #expect(EditorDisplayMode.displayMode(for: longLineContent) == .plainText)
+  }
+
+  @Test("Text file metrics track bytes, lines, and longest line")
+  func textFileMetricsTrackLargestLine() {
+    let metrics = TextFileMetrics.metrics(for: "abc\nabcdef\nz")
+
+    #expect(metrics.byteCount == 12)
+    #expect(metrics.lineCount == 3)
+    #expect(metrics.maxLineByteCount == 6)
   }
 
   @Test("Editor options use neutral spacing and disable line wrapping")
@@ -201,9 +217,16 @@ struct SourceCodeEditorViewTests {
       isMinimapEnabled: false,
       isWrapLinesEnabled: false
     )
+    let plainText = AgentHubSourceEditorOptions(
+      displayMode: .plainText,
+      isEditable: true,
+      isMinimapEnabled: false,
+      isWrapLinesEnabled: true
+    )
 
     #expect(wrapped.wrapLines)
     #expect(unwrapped.wrapLines == false)
+    #expect(plainText.wrapLines == false)
   }
 
   @Test("Editor options only enable minimap when the setting is on")


### PR DESCRIPTION
## Summary

- Adds lightweight text-file metrics so large and long-line files can be classified before enabling expensive editor features.
- Forces long/minified files into Fast Mode and disables expensive editor peripherals like wrapping, minimap, and folding in that mode.
- Reduces whole-document editor work on each keystroke by deferring saved-content comparison to idle snapshots.
- Warms the file search index from the file explorer and Cmd+P picker.
- Improves monorepo/worktree search behavior by preserving partial `git ls-files` results on timeout, using a short degraded cache TTL, caching gitignore parsing, and caching compiled glob regexes.
- Flattens the file tree render path into visible rows and updates loaded children by target path.

## Why

Large monorepos were hitting multiple expensive paths: cold Cmd+P index builds, repeated gitignore/glob work, whole-tree value rebuilds on expand, and expensive editor setup/editing for large or minified files. The changes keep the first pass local and low-risk while addressing the largest measured bottlenecks.

## Validation

- `git diff --cached --check`
- `xcodebuild -project app/AgentHub.xcodeproj -scheme AgentHubCore -destination 'platform=macOS' build`

Focused test execution is currently blocked by repository tooling: the available Xcode schemes are not configured for test actions, and direct SwiftPM test execution fails in the existing `CodeEditSymbols` package resource setup around `Bundle.module`.