### PR TITLE
Unified worktree generation progress UI

### DIFF
--- a/app/modules/AgentHubCLI/Sources/AgentHubCLI/AgentHubMCPServer.swift
+++ b/app/modules/AgentHubCLI/Sources/AgentHubCLI/AgentHubMCPServer.swift
@@ -105,12 +105,10 @@ struct AgentHubMCPServer {
     let checkoutExisting = arguments["checkoutExisting"] as? Bool ?? false
     let directoryName = WorktreeNaming.worktreeDirectoryName(for: branch)
 
-    // Resolve the main repo root up front so progress snapshots (which the app
-    // watches via kqueue) carry it for display. Resolving from `repositoryPath`
-    // — the original repo — is unaffected by creating a new worktree.
-    let mainRepositoryPath = try await service.findMainRepositoryRoot(at: repositoryPath)
-
-    // Stream live progress to a sidecar file the app reads. The closure is
+    // Emit a "starting" progress snapshot IMMEDIATELY — before any git work —
+    // so the app's banner shows the creation the instant the tool is invoked,
+    // matching the in-process side-panel path. We use `repositoryPath` (the raw
+    // input) for display so nothing has to be resolved first; the closure is
     // `@Sendable` (the service invokes it from detached tasks), so capture only
     // the `Sendable` queue and value-type metadata.
     let snapshotQueue = progressQueue
@@ -120,12 +118,12 @@ struct AgentHubMCPServer {
       try? snapshotQueue.write(WorktreeProgressSnapshot(
         operationID: snapshotID,
         branchName: branch,
-        repositoryPath: mainRepositoryPath,
+        repositoryPath: repositoryPath,
         provider: provider,
         progress: progress
       ))
     }
-    writeProgress(.preparing(message: "Preparing worktree…"))
+    writeProgress(.preparing(message: "Starting worktree…"))
 
     let worktreePath: String
     do {
@@ -152,6 +150,8 @@ struct AgentHubMCPServer {
     }
 
     writeProgress(.completed(path: worktreePath))
+
+    let mainRepositoryPath = try await service.findMainRepositoryRoot(at: repositoryPath)
     let sourceProvider = ProcessInfo.processInfo.environment["AGENTHUB_PROVIDER"]
       .flatMap(WorktreeLaunchProvider.init(commandLineValue:))
     let sourceSessionId = ProcessInfo.processInfo.environment["AGENTHUB_SESSION_ID"]

--- a/app/modules/AgentHubCLI/Sources/AgentHubCLI/AgentHubMCPServer.swift
+++ b/app/modules/AgentHubCLI/Sources/AgentHubCLI/AgentHubMCPServer.swift
@@ -5,6 +5,7 @@ struct AgentHubMCPServer {
   private let service = WorktreeManagementService()
   private let queue = WorktreeLaunchRequestQueue()
   private let deletionQueue = WorktreeDeletionRequestQueue()
+  private let progressQueue = WorktreeProgressQueue()
 
   func run() async throws {
     while let line = readLine(strippingNewline: true) {
@@ -104,23 +105,53 @@ struct AgentHubMCPServer {
     let checkoutExisting = arguments["checkoutExisting"] as? Bool ?? false
     let directoryName = WorktreeNaming.worktreeDirectoryName(for: branch)
 
+    // Resolve the main repo root up front so progress snapshots (which the app
+    // watches via kqueue) carry it for display. Resolving from `repositoryPath`
+    // — the original repo — is unaffected by creating a new worktree.
+    let mainRepositoryPath = try await service.findMainRepositoryRoot(at: repositoryPath)
+
+    // Stream live progress to a sidecar file the app reads. The closure is
+    // `@Sendable` (the service invokes it from detached tasks), so capture only
+    // the `Sendable` queue and value-type metadata.
+    let snapshotQueue = progressQueue
+    let operationID = WorktreeOperationID()
+    let snapshotID = operationID.value.uuidString
+    let writeProgress: @Sendable (WorktreeCreationProgress) -> Void = { progress in
+      try? snapshotQueue.write(WorktreeProgressSnapshot(
+        operationID: snapshotID,
+        branchName: branch,
+        repositoryPath: mainRepositoryPath,
+        provider: provider,
+        progress: progress
+      ))
+    }
+    writeProgress(.preparing(message: "Preparing worktree…"))
+
     let worktreePath: String
-    if checkoutExisting {
-      worktreePath = try await service.checkoutWorktree(
-        at: repositoryPath,
-        branch: branch,
-        directoryName: directoryName
-      )
-    } else {
-      worktreePath = try await service.createWorktreeWithNewBranch(
-        at: repositoryPath,
-        newBranchName: branch,
-        directoryName: directoryName,
-        startPoint: startPoint
-      )
+    do {
+      if checkoutExisting {
+        // No progress-enabled overload for checkout; emit preparing→completed bookends.
+        worktreePath = try await service.checkoutWorktree(
+          at: repositoryPath,
+          branch: branch,
+          directoryName: directoryName
+        )
+      } else {
+        worktreePath = try await service.createWorktreeWithNewBranch(
+          at: repositoryPath,
+          newBranchName: branch,
+          directoryName: directoryName,
+          startPoint: startPoint,
+          operationID: operationID,
+          onProgress: { progress in writeProgress(progress) }
+        )
+      }
+    } catch {
+      writeProgress(.failed(error: error.localizedDescription))
+      throw error
     }
 
-    let mainRepositoryPath = try await service.findMainRepositoryRoot(at: repositoryPath)
+    writeProgress(.completed(path: worktreePath))
     let sourceProvider = ProcessInfo.processInfo.environment["AGENTHUB_PROVIDER"]
       .flatMap(WorktreeLaunchProvider.init(commandLineValue:))
     let sourceSessionId = ProcessInfo.processInfo.environment["AGENTHUB_SESSION_ID"]

--- a/app/modules/AgentHubCLI/Sources/AgentHubCLIKit/WorktreeModels.swift
+++ b/app/modules/AgentHubCLI/Sources/AgentHubCLIKit/WorktreeModels.swift
@@ -117,7 +117,7 @@ public struct WorktreeInfo: Codable, Equatable, Identifiable, Sendable {
   public var id: String { path }
 }
 
-public enum WorktreeCreationProgress: Equatable, Sendable {
+public enum WorktreeCreationProgress: Equatable, Sendable, Codable {
   case idle
   case preparing(message: String)
   case updatingFiles(current: Int, total: Int)

--- a/app/modules/AgentHubCLI/Sources/AgentHubCLIKit/WorktreeProgressQueue.swift
+++ b/app/modules/AgentHubCLI/Sources/AgentHubCLIKit/WorktreeProgressQueue.swift
@@ -1,0 +1,138 @@
+import Foundation
+
+// MARK: - WorktreeProgressSnapshot
+
+/// A point-in-time snapshot of a single worktree creation's progress, written
+/// by the `agenthub` CLI (which performs the actual `git worktree add`) and
+/// read by the app so it can surface live progress in the top bar.
+///
+/// Each in-flight creation owns one file `{operationID}.json` in the
+/// `worktree-progress/` directory; the CLI overwrites it atomically on every
+/// progress update until it reaches a terminal state.
+public struct WorktreeProgressSnapshot: Codable, Sendable, Equatable, Identifiable {
+  /// Stable identifier for the creation; also the file stem on disk.
+  public let operationID: String
+  public let branchName: String
+  /// Main repository root the worktree is being created from (for display).
+  public let repositoryPath: String
+  public let provider: WorktreeLaunchProvider
+  public let progress: WorktreeCreationProgress
+  public let updatedAt: Date
+
+  public init(
+    operationID: String,
+    branchName: String,
+    repositoryPath: String,
+    provider: WorktreeLaunchProvider,
+    progress: WorktreeCreationProgress,
+    updatedAt: Date = Date()
+  ) {
+    self.operationID = operationID
+    self.branchName = branchName
+    self.repositoryPath = repositoryPath
+    self.provider = provider
+    self.progress = progress
+    self.updatedAt = updatedAt
+  }
+
+  public var id: String { operationID }
+}
+
+// MARK: - WorktreeProgressQueue
+
+/// File-backed channel for worktree creation progress between the `agenthub`
+/// CLI process and the app. Mirrors `WorktreeLaunchRequestQueue`'s conventions
+/// (App Support directory, atomic temp-then-move writes) but lives in its OWN
+/// directory — the launch monitor enumerates `*.json` in `cli-requests/`, so
+/// progress files must never co-locate there or they'd be mis-parsed as launch
+/// requests.
+public struct WorktreeProgressQueue: Sendable {
+  public let directoryURL: URL
+
+  public init(directoryURL: URL = WorktreeProgressQueue.defaultDirectoryURL()) {
+    self.directoryURL = directoryURL
+  }
+
+  public static func defaultDirectoryURL(fileManager: FileManager = .default) -> URL {
+    let appSupportURL = fileManager.urls(
+      for: .applicationSupportDirectory,
+      in: .userDomainMask
+    ).first ?? URL(fileURLWithPath: NSHomeDirectory()).appendingPathComponent("Library/Application Support")
+
+    return appSupportURL
+      .appendingPathComponent("AgentHub", isDirectory: true)
+      .appendingPathComponent("worktree-progress", isDirectory: true)
+  }
+
+  /// Atomically writes (or overwrites) the snapshot for its operation.
+  public func write(_ snapshot: WorktreeProgressSnapshot) throws {
+    try FileManager.default.createDirectory(
+      at: directoryURL,
+      withIntermediateDirectories: true
+    )
+
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+    encoder.dateEncodingStrategy = .iso8601
+    let data = try encoder.encode(snapshot)
+
+    let finalURL = fileURL(for: snapshot.operationID)
+    let temporaryURL = directoryURL.appendingPathComponent(".\(snapshot.operationID).tmp", isDirectory: false)
+
+    try data.write(to: temporaryURL, options: [.atomic])
+    if FileManager.default.fileExists(atPath: finalURL.path) {
+      try FileManager.default.removeItem(at: finalURL)
+    }
+    try FileManager.default.moveItem(at: temporaryURL, to: finalURL)
+  }
+
+  public func pendingSnapshots() throws -> [WorktreeProgressSnapshot] {
+    guard FileManager.default.fileExists(atPath: directoryURL.path) else {
+      return []
+    }
+
+    let files = try FileManager.default.contentsOfDirectory(
+      at: directoryURL,
+      includingPropertiesForKeys: nil
+    )
+
+    let decoder = JSONDecoder()
+    decoder.dateDecodingStrategy = .iso8601
+    return files
+      .filter { $0.pathExtension == "json" && !$0.lastPathComponent.hasPrefix(".") }
+      .compactMap { url in
+        guard let data = try? Data(contentsOf: url) else { return nil }
+        return try? decoder.decode(WorktreeProgressSnapshot.self, from: data)
+      }
+      .sorted {
+        if $0.updatedAt == $1.updatedAt {
+          return $0.operationID < $1.operationID
+        }
+        return $0.updatedAt < $1.updatedAt
+      }
+  }
+
+  public func remove(operationID: String) throws {
+    let url = fileURL(for: operationID)
+    guard FileManager.default.fileExists(atPath: url.path) else { return }
+    try FileManager.default.removeItem(at: url)
+  }
+
+  /// Removes every progress file. Called at app launch so a snapshot left
+  /// behind by a creation that finished while AgentHub was down can't be
+  /// replayed as a fake in-flight operation on the next launch.
+  public func wipeAll() throws {
+    guard FileManager.default.fileExists(atPath: directoryURL.path) else { return }
+    let files = try FileManager.default.contentsOfDirectory(
+      at: directoryURL,
+      includingPropertiesForKeys: nil
+    )
+    for url in files {
+      try? FileManager.default.removeItem(at: url)
+    }
+  }
+
+  public func fileURL(for operationID: String) -> URL {
+    directoryURL.appendingPathComponent("\(operationID).json", isDirectory: false)
+  }
+}

--- a/app/modules/AgentHubCLI/Tests/AgentHubCLIKitTests/WorktreeProgressQueueTests.swift
+++ b/app/modules/AgentHubCLI/Tests/AgentHubCLIKitTests/WorktreeProgressQueueTests.swift
@@ -1,0 +1,117 @@
+import Foundation
+import Testing
+
+@testable import AgentHubCLIKit
+
+@Suite("WorktreeProgressQueue")
+struct WorktreeProgressQueueTests {
+
+  @Test("Write then read round-trips the snapshot")
+  func writeReadRoundTrip() throws {
+    let directory = try temporaryProgressDirectory()
+    defer { try? FileManager.default.removeItem(at: directory.deletingLastPathComponent()) }
+
+    let queue = WorktreeProgressQueue(directoryURL: directory)
+    let snapshot = WorktreeProgressSnapshot(
+      operationID: "op-1",
+      branchName: "feature/x",
+      repositoryPath: "/tmp/repo",
+      provider: .claude,
+      progress: .updatingFiles(current: 84, total: 194),
+      updatedAt: Date(timeIntervalSince1970: 1_000)
+    )
+
+    try queue.write(snapshot)
+    let pending = try queue.pendingSnapshots()
+
+    #expect(pending == [snapshot])
+    #expect(FileManager.default.fileExists(atPath: queue.fileURL(for: "op-1").path))
+  }
+
+  @Test("Write overwrites the previous snapshot for the same operation")
+  func writeOverwrites() throws {
+    let directory = try temporaryProgressDirectory()
+    defer { try? FileManager.default.removeItem(at: directory.deletingLastPathComponent()) }
+
+    let queue = WorktreeProgressQueue(directoryURL: directory)
+    try queue.write(snapshot(id: "op-1", progress: .preparing(message: "Preparing…"), at: 1))
+    try queue.write(snapshot(id: "op-1", progress: .completed(path: "/tmp/repo/.worktrees/x"), at: 2))
+
+    let pending = try queue.pendingSnapshots()
+    #expect(pending.count == 1)
+    #expect(pending.first?.progress == .completed(path: "/tmp/repo/.worktrees/x"))
+  }
+
+  @Test("Remove deletes a single operation's file")
+  func removeDeletes() throws {
+    let directory = try temporaryProgressDirectory()
+    defer { try? FileManager.default.removeItem(at: directory.deletingLastPathComponent()) }
+
+    let queue = WorktreeProgressQueue(directoryURL: directory)
+    try queue.write(snapshot(id: "op-1", progress: .preparing(message: "x"), at: 1))
+    try queue.write(snapshot(id: "op-2", progress: .preparing(message: "y"), at: 1))
+
+    try queue.remove(operationID: "op-1")
+
+    let pending = try queue.pendingSnapshots()
+    #expect(pending.map(\.operationID) == ["op-2"])
+  }
+
+  @Test("wipeAll clears every snapshot file")
+  func wipeAllClears() throws {
+    let directory = try temporaryProgressDirectory()
+    defer { try? FileManager.default.removeItem(at: directory.deletingLastPathComponent()) }
+
+    let queue = WorktreeProgressQueue(directoryURL: directory)
+    try queue.write(snapshot(id: "op-1", progress: .preparing(message: "x"), at: 1))
+    try queue.write(snapshot(id: "op-2", progress: .preparing(message: "y"), at: 2))
+
+    try queue.wipeAll()
+
+    #expect(try queue.pendingSnapshots().isEmpty)
+  }
+
+  @Test("WorktreeCreationProgress round-trips through Codable for every case")
+  func progressCodableRoundTrip() throws {
+    let cases: [WorktreeCreationProgress] = [
+      .idle,
+      .preparing(message: "Preparing worktree…"),
+      .updatingFiles(current: 84, total: 194),
+      .completed(path: "/tmp/repo/.worktrees/feature"),
+      .cancelled(message: "Cancelled by user"),
+      .failed(error: "Directory already exists")
+    ]
+
+    let encoder = JSONEncoder()
+    let decoder = JSONDecoder()
+    for value in cases {
+      let data = try encoder.encode(value)
+      let decoded = try decoder.decode(WorktreeCreationProgress.self, from: data)
+      #expect(decoded == value)
+    }
+  }
+
+  // MARK: - Helpers
+
+  private func snapshot(
+    id: String,
+    progress: WorktreeCreationProgress,
+    at seconds: TimeInterval
+  ) -> WorktreeProgressSnapshot {
+    WorktreeProgressSnapshot(
+      operationID: id,
+      branchName: "feature/\(id)",
+      repositoryPath: "/tmp/repo",
+      provider: .claude,
+      progress: progress,
+      updatedAt: Date(timeIntervalSince1970: seconds)
+    )
+  }
+}
+
+private func temporaryProgressDirectory() throws -> URL {
+  let root = FileManager.default.temporaryDirectory
+    .appendingPathComponent("agenthub-progress-tests-\(UUID().uuidString)", isDirectory: true)
+  try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+  return root.appendingPathComponent("worktree-progress", isDirectory: true)
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubEnvironment.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubEnvironment.swift
@@ -53,6 +53,7 @@ private struct AgentHubModifier: ViewModifier {
       .environment(\.agentHub, provider)
       .environment(provider.statsService)
       .environment(provider.displaySettings)
+      .environment(provider.worktreeGenerationProgressCoordinator)
       .environment(themeManager)
       .environment(\.runtimeTheme, themeManager.currentTheme)
   }

--- a/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubProvider.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubProvider.swift
@@ -205,8 +205,29 @@ public final class AgentHubProvider {
     )
   }()
 
+  /// Watches the worktree-progress sidecar directory the `agenthub` CLI writes
+  /// during MCP-initiated creations, so the app can surface live git progress.
+  public private(set) lazy var worktreeProgressSidecarWatcher: any WorktreeProgressSidecarWatcherProtocol = {
+    WorktreeProgressSidecarWatcher()
+  }()
+
+  /// Posts the "worktrees ready" macOS notification when a batch completes.
+  public private(set) lazy var worktreeReadyNotificationService: any WorktreeReadyNotificationServiceProtocol = {
+    WorktreeReadyNotificationService()
+  }()
+
+  /// App-wide coordinator unifying worktree creation progress (side panel + MCP)
+  /// for the top bar; fires the completion sound/notification once per batch.
+  public private(set) lazy var worktreeGenerationProgressCoordinator: WorktreeGenerationProgressCoordinator = {
+    WorktreeGenerationProgressCoordinator(
+      soundService: worktreeSuccessSoundService,
+      notificationService: worktreeReadyNotificationService
+    )
+  }()
+
   private var isWorktreeLaunchRequestMonitoringStarted = false
   private var isWorktreeDeletionRequestMonitoringStarted = false
+  private var isWorktreeProgressMonitoringStarted = false
 
   // MARK: - GitHub Integration
 
@@ -414,6 +435,24 @@ public final class AgentHubProvider {
   public func startWorktreeLaunchRequestMonitoring() {
     startWorktreeLaunchQueueMonitoring()
     startWorktreeDeletionQueueMonitoring()
+    startWorktreeProgressMonitoring()
+  }
+
+  private func startWorktreeProgressMonitoring() {
+    guard !isWorktreeProgressMonitoringStarted else { return }
+    isWorktreeProgressMonitoringStarted = true
+
+    let watcher = worktreeProgressSidecarWatcher
+    // Subscribe before starting the watcher so we don't miss its initial scan.
+    worktreeGenerationProgressCoordinator.startObservingMCP(watcher: watcher)
+    let notifications = worktreeReadyNotificationService
+    Task {
+      // Drop snapshots left behind by a creation that finished while the app
+      // was down, then begin watching for live progress.
+      await watcher.wipeAll()
+      await watcher.start()
+      await notifications.requestPermission()
+    }
   }
 
   private func startWorktreeLaunchQueueMonitoring() {

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/WorktreeProgressSidecarWatcher.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/WorktreeProgressSidecarWatcher.swift
@@ -41,6 +41,11 @@ public actor WorktreeProgressSidecarWatcher: WorktreeProgressSidecarWatcherProto
   private var directorySource: DispatchSourceFileSystemObject?
   private var lastEmitted: [String: WorktreeProgressSnapshot] = [:]
   private var started = false
+  private var pollTask: Task<Void, Never>?
+  /// Poll cadence — a low-latency backstop alongside kqueue so a fast,
+  /// cross-process MCP creation is shown promptly even if a directory event is
+  /// coalesced or delayed.
+  private static let pollInterval: Duration = .milliseconds(250)
 
   public nonisolated var updates: AnyPublisher<WorktreeProgressSnapshot, Never> {
     subject.eraseToAnyPublisher()
@@ -61,12 +66,15 @@ public actor WorktreeProgressSidecarWatcher: WorktreeProgressSidecarWatcherProto
     started = true
     ensureDirectory()
     startDirectorySourceIfNeeded()
+    startPolling()
     // Emit anything already on disk (a creation may have started before we
     // attached the source).
     scanAndEmit()
   }
 
   public func wipeAll() async {
+    pollTask?.cancel()
+    pollTask = nil
     directorySource?.cancel()
     directorySource = nil
     started = false
@@ -84,6 +92,22 @@ public actor WorktreeProgressSidecarWatcher: WorktreeProgressSidecarWatcherProto
 
   private func ensureDirectory() {
     try? fileManager.createDirectory(at: queue.directoryURL, withIntermediateDirectories: true)
+  }
+
+  private func startPolling() {
+    guard pollTask == nil else { return }
+    pollTask = Task { [weak self] in
+      while !Task.isCancelled {
+        try? await Task.sleep(for: Self.pollInterval)
+        guard let self else { return }
+        await self.pollTick()
+      }
+    }
+  }
+
+  private func pollTick() {
+    guard started else { return }
+    scanAndEmit()
   }
 
   private func startDirectorySourceIfNeeded() {
@@ -132,6 +156,7 @@ public actor WorktreeProgressSidecarWatcher: WorktreeProgressSidecarWatcherProto
   }
 
   deinit {
+    pollTask?.cancel()
     directorySource?.cancel()
   }
 }

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/WorktreeProgressSidecarWatcher.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/WorktreeProgressSidecarWatcher.swift
@@ -1,0 +1,137 @@
+import AgentHubCLIKit
+import Combine
+import Foundation
+
+// MARK: - WorktreeProgressSidecarWatcherProtocol
+
+/// Watches the `worktree-progress/` sidecar directory that the `agenthub` CLI
+/// writes while it performs `git worktree add` for MCP-initiated creations.
+/// Emits the latest `WorktreeProgressSnapshot` for each operation so the app
+/// can surface live progress even though the work happens in another process.
+public protocol WorktreeProgressSidecarWatcherProtocol: AnyObject, Sendable {
+  var updates: AnyPublisher<WorktreeProgressSnapshot, Never> { get }
+  /// Begins watching the directory and emits any snapshots already on disk.
+  func start() async
+  /// Removes every progress file and drops all in-memory state. Called at
+  /// launch so a snapshot left behind by a creation that finished while
+  /// AgentHub was down can't be replayed as a fake in-flight operation.
+  func wipeAll() async
+  /// Deletes the sidecar file for a finished operation once the coordinator has
+  /// shown its terminal state. Owned by the coordinator's clearing policy.
+  func discardSnapshot(operationID: String) async
+}
+
+// MARK: - WorktreeProgressSidecarWatcher
+
+/// kqueue-based watcher mirroring `ClaudeHookSidecarWatcher`'s structure, with
+/// one deliberate difference: the CLI writes each snapshot via an **atomic
+/// temp-then-move** (see `WorktreeProgressQueue.write`), which changes the
+/// file's inode on every update. A per-file `O_EVTONLY` fd opened on the old
+/// inode goes stale after the first move, so we rely on the **directory**
+/// source — it fires on every rename-into-directory — and re-scan + decode all
+/// files on each event. Snapshots are whole-file overwrites, so we dedupe by
+/// `Equatable` value per operation rather than tracking byte offsets.
+public actor WorktreeProgressSidecarWatcher: WorktreeProgressSidecarWatcherProtocol {
+
+  private let queue: WorktreeProgressQueue
+  private let fileManager: FileManager
+  private nonisolated let subject = PassthroughSubject<WorktreeProgressSnapshot, Never>()
+  private nonisolated let processingQueue = DispatchQueue(label: "com.agenthub.worktree-progress.sidecar")
+
+  private var directorySource: DispatchSourceFileSystemObject?
+  private var lastEmitted: [String: WorktreeProgressSnapshot] = [:]
+  private var started = false
+
+  public nonisolated var updates: AnyPublisher<WorktreeProgressSnapshot, Never> {
+    subject.eraseToAnyPublisher()
+  }
+
+  public init(
+    queue: WorktreeProgressQueue = WorktreeProgressQueue(),
+    fileManager: FileManager = .default
+  ) {
+    self.queue = queue
+    self.fileManager = fileManager
+  }
+
+  // MARK: - Public API
+
+  public func start() async {
+    guard !started else { return }
+    started = true
+    ensureDirectory()
+    startDirectorySourceIfNeeded()
+    // Emit anything already on disk (a creation may have started before we
+    // attached the source).
+    scanAndEmit()
+  }
+
+  public func wipeAll() async {
+    directorySource?.cancel()
+    directorySource = nil
+    started = false
+    lastEmitted.removeAll()
+    try? queue.wipeAll()
+    ensureDirectory()
+  }
+
+  public func discardSnapshot(operationID: String) async {
+    lastEmitted.removeValue(forKey: operationID)
+    try? queue.remove(operationID: operationID)
+  }
+
+  // MARK: - Internals
+
+  private func ensureDirectory() {
+    try? fileManager.createDirectory(at: queue.directoryURL, withIntermediateDirectories: true)
+  }
+
+  private func startDirectorySourceIfNeeded() {
+    guard directorySource == nil else { return }
+    let fd = open(queue.directoryURL.path, O_EVTONLY)
+    guard fd >= 0 else {
+      AppLogger.watcher.error("[WorktreeProgress] Could not open progress dir: \(self.queue.directoryURL.path)")
+      return
+    }
+    let source = DispatchSource.makeFileSystemObjectSource(
+      fileDescriptor: fd,
+      eventMask: [.write, .extend, .rename, .delete],
+      queue: processingQueue
+    )
+    source.setEventHandler { [weak self] in
+      guard let self else { return }
+      Task { await self.scanAndEmit() }
+    }
+    source.setCancelHandler {
+      close(fd)
+    }
+    source.resume()
+    directorySource = source
+  }
+
+  /// Re-reads every snapshot file and emits the ones whose value changed since
+  /// the last emission, ignoring snapshots older than the last seen for the
+  /// same operation (progress callbacks can arrive slightly out of order).
+  private func scanAndEmit() {
+    let snapshots: [WorktreeProgressSnapshot]
+    do {
+      snapshots = try queue.pendingSnapshots()
+    } catch {
+      AppLogger.watcher.error("[WorktreeProgress] Failed to read snapshots: \(error.localizedDescription)")
+      return
+    }
+
+    for snapshot in snapshots {
+      if let previous = lastEmitted[snapshot.operationID] {
+        if previous == snapshot { continue }
+        if snapshot.updatedAt < previous.updatedAt { continue }
+      }
+      lastEmitted[snapshot.operationID] = snapshot
+      subject.send(snapshot)
+    }
+  }
+
+  deinit {
+    directorySource?.cancel()
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/WorktreeReadyNotificationService.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/WorktreeReadyNotificationService.swift
@@ -1,0 +1,84 @@
+//
+//  WorktreeReadyNotificationService.swift
+//  AgentHub
+//
+
+import Foundation
+import UserNotifications
+
+// MARK: - WorktreeReadyNotificationServiceProtocol
+
+/// Posts a macOS notification when all in-flight worktree creations have
+/// finished. Mirrors `ApprovalNotificationService` but is provider-injected
+/// (not a singleton) so it can be mocked in tests.
+public protocol WorktreeReadyNotificationServiceProtocol: AnyObject, Sendable {
+  @discardableResult
+  func requestPermission() async -> Bool
+  /// Posts a "Worktrees ready" notification listing the freshly created
+  /// branches. No-op (silent) when push notifications are disabled.
+  func notifyReady(branchNames: [String])
+}
+
+// MARK: - WorktreeReadyNotificationService
+
+public final class WorktreeReadyNotificationService: WorktreeReadyNotificationServiceProtocol {
+
+  public init() {}
+
+  @discardableResult
+  public func requestPermission() async -> Bool {
+    do {
+      return try await UNUserNotificationCenter.current()
+        .requestAuthorization(options: [.alert, .sound])
+    } catch {
+      return false
+    }
+  }
+
+  public func notifyReady(branchNames: [String]) {
+    guard pushNotificationsEnabled, !branchNames.isEmpty else { return }
+
+    let content = UNMutableNotificationContent()
+    content.title = Self.notificationTitle(branchCount: branchNames.count)
+    content.body = Self.notificationBody(branchNames: branchNames)
+    content.sound = .none // The Glass success sound is played separately by the coordinator.
+
+    let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 0.1, repeats: false)
+    let request = UNNotificationRequest(
+      identifier: "worktree-ready-\(branchNames.joined(separator: ","))",
+      content: content,
+      trigger: trigger
+    )
+
+    Task(priority: .userInitiated) {
+      do {
+        try await UNUserNotificationCenter.current().add(request)
+      } catch {
+        // Best-effort enhancement — silently ignore failures.
+      }
+    }
+  }
+
+  // MARK: - Message construction (pure, unit-testable)
+
+  static func notificationTitle(branchCount: Int) -> String {
+    branchCount == 1 ? "Worktree ready" : "Worktrees ready"
+  }
+
+  static func notificationBody(branchNames: [String]) -> String {
+    switch branchNames.count {
+    case 0:
+      return ""
+    case 1:
+      return "\(branchNames[0]) is ready."
+    default:
+      return "\(branchNames.count) worktrees are ready: \(branchNames.joined(separator: ", "))."
+    }
+  }
+
+  // MARK: - Private
+
+  private var pushNotificationsEnabled: Bool {
+    UserDefaults.standard.object(forKey: AgentHubDefaults.pushNotificationsEnabled) as? Bool ?? true
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/CLISessionsListView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/CLISessionsListView.swift
@@ -132,14 +132,32 @@ public struct CLISessionsListView: View {
         repositoryPath: repository.path,
         repositoryName: repository.name,
         onDismiss: { createWorktreeRepository = nil },
-        onCreate: { branchName, directoryName, baseBranch, onProgress in
-          try await viewModel.createWorktree(
-            for: repository,
-            branchName: branchName,
-            directoryName: directoryName,
-            baseBranch: baseBranch,
-            onProgress: onProgress
-          )
+        onCreate: { branchName, directoryName, baseBranch in
+          if let coordinator = viewModel.agentHubProvider?.worktreeGenerationProgressCoordinator {
+            coordinator.beginSidePanelOperation(
+              branchName: branchName,
+              repoName: repository.name,
+              providerKind: viewModel.providerKind
+            ) { onProgress in
+              try await viewModel.createWorktree(
+                for: repository,
+                branchName: branchName,
+                directoryName: directoryName,
+                baseBranch: baseBranch,
+                onProgress: onProgress
+              )
+            }
+          } else {
+            Task {
+              try? await viewModel.createWorktree(
+                for: repository,
+                branchName: branchName,
+                directoryName: directoryName,
+                baseBranch: baseBranch,
+                onProgress: { _ in }
+              )
+            }
+          }
         }
       )
     }

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/CreateWorktreeSheet.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/CreateWorktreeSheet.swift
@@ -14,14 +14,16 @@ public struct CreateWorktreeSheet: View {
   let repositoryPath: String
   let repositoryName: String
   let onDismiss: () -> Void
-  let onCreate: (String, String, String?, @escaping @Sendable (WorktreeCreationProgress) async -> Void) async throws -> Void
+  /// Fire-and-forget: hands the creation off to the progress coordinator and
+  /// the sheet dismisses immediately. Live progress and any failure surface in
+  /// the top bar, not here.
+  let onCreate: (_ branchName: String, _ directoryName: String, _ baseBranch: String?) -> Void
 
   @State private var branchName: String = ""
   @State private var baseBranch: RemoteBranch?
   @State private var directoryName: String = ""
   @State private var availableBranches: [RemoteBranch] = []
   @State private var isLoading: Bool = true
-  @State private var creationProgress: WorktreeCreationProgress = .idle
   @State private var errorMessage: String?
   @State private var showError: Bool = false
 
@@ -31,7 +33,7 @@ public struct CreateWorktreeSheet: View {
     repositoryPath: String,
     repositoryName: String,
     onDismiss: @escaping () -> Void,
-    onCreate: @escaping (String, String, String?, @escaping @Sendable (WorktreeCreationProgress) async -> Void) async throws -> Void
+    onCreate: @escaping (_ branchName: String, _ directoryName: String, _ baseBranch: String?) -> Void
   ) {
     self.repositoryPath = repositoryPath
     self.repositoryName = repositoryName
@@ -236,71 +238,22 @@ public struct CreateWorktreeSheet: View {
   // MARK: - Action Buttons
 
   private var actionButtons: some View {
-    VStack(spacing: 12) {
-      // Progress indicator (only show when creating)
-      if creationProgress.isInProgress {
-        worktreeProgressView
+    HStack {
+      Button("Cancel") {
+        onDismiss()
       }
+      .keyboardShortcut(.escape)
 
-      // Buttons
-      HStack {
-        Button("Cancel") {
-          onDismiss()
-        }
-        .keyboardShortcut(.escape)
-        .disabled(creationProgress.isInProgress)
+      Spacer()
 
-        Spacer()
-
-        Button(action: { Task { await createWorktree() } }) {
-          HStack(spacing: 6) {
-            if creationProgress.isInProgress {
-              ProgressView()
-                .scaleEffect(0.7)
-            }
-            Text(creationProgress.isInProgress ? "Creating..." : "Create Worktree")
-          }
-        }
-        .keyboardShortcut(.return)
-        .disabled(!isValid || creationProgress.isInProgress)
-        .buttonStyle(.borderedProminent)
-        .tint(.primary)
+      Button("Create Worktree") {
+        startCreation()
       }
+      .keyboardShortcut(.return)
+      .disabled(!isValid)
+      .buttonStyle(.borderedProminent)
+      .tint(.primary)
     }
-  }
-
-  // MARK: - Progress View
-
-  private var worktreeProgressView: some View {
-    VStack(alignment: .leading, spacing: 8) {
-      // Progress bar with real file counts
-      ProgressView(value: creationProgress.progressValue)
-        .tint(.primary)
-        .animation(.linear(duration: 0.1), value: creationProgress.progressValue)
-
-      // Status message: "Updating files: 84/194"
-      HStack {
-        Image(systemName: creationProgress.icon)
-          .font(.caption)
-          .foregroundColor(.primary)
-
-        Text(creationProgress.statusMessage)
-          .font(.caption)
-          .foregroundColor(.secondary)
-          .monospacedDigit()
-
-        Spacer()
-
-        // Percentage
-        Text("\(Int(creationProgress.progressValue * 100))%")
-          .font(.caption)
-          .foregroundColor(.secondary)
-          .monospacedDigit()
-      }
-    }
-    .padding(12)
-    .background(Color.primary.opacity(0.05))
-    .cornerRadius(8)
   }
 
   // MARK: - Computed Properties
@@ -334,28 +287,12 @@ public struct CreateWorktreeSheet: View {
     isLoading = false
   }
 
-  private func createWorktree() async {
-    creationProgress = .preparing(message: "Preparing worktree...")
-
-    do {
-      try await onCreate(branchName, directoryName, baseBranch?.displayName) { [self] newProgress in
-        await MainActor.run {
-          self.creationProgress = newProgress
-        }
-      }
-
-      // Brief delay to show completion state
-      try? await Task.sleep(for: .milliseconds(500))
-      onDismiss()
-    } catch {
-      creationProgress = .failed(error: error.localizedDescription)
-      errorMessage = error.localizedDescription
-      showError = true
-
-      // Reset to idle after showing error
-      try? await Task.sleep(for: .seconds(2))
-      creationProgress = .idle
-    }
+  /// Hands the creation off to the progress coordinator (which owns the work
+  /// and surfaces progress in the top bar) and dismisses the sheet immediately.
+  private func startCreation() {
+    guard isValid else { return }
+    onCreate(branchName, directoryName, baseBranch?.displayName)
+    onDismiss()
   }
 }
 
@@ -366,14 +303,8 @@ public struct CreateWorktreeSheet: View {
     repositoryPath: "/Users/james/git/ClaudeCodeUI",
     repositoryName: "ClaudeCodeUI",
     onDismiss: { },
-    onCreate: { branch, directory, baseBranch, onProgress in
-      // Simulate progress
-      await onProgress(.preparing(message: "Preparing worktree..."))
-      try? await Task.sleep(for: .milliseconds(500))
-      for i in stride(from: 0, through: 100, by: 10) {
-        await onProgress(.updatingFiles(current: i, total: 100))
-        try? await Task.sleep(for: .milliseconds(100))
-      }
+    onCreate: { branch, directory, baseBranch in
+      print("Create worktree: \(branch) at \(directory) from \(baseBranch ?? "HEAD")")
     }
   )
 }

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
@@ -192,7 +192,9 @@ public struct MultiProviderSessionsListView: View {
   public var body: some View {
     GeometryReader { proxy in
       let sidebarMax = max(280, proxy.size.width * 0.20)
-    ZStack {
+    VStack(spacing: 0) {
+      WorktreeGenerationProgressBar()
+      ZStack {
       NavigationSplitView(columnVisibility: $columnVisibility) {
         sidePanelView
           .agentHubPanel()
@@ -366,14 +368,12 @@ public struct MultiProviderSessionsListView: View {
         repositoryPath: context.repository.path,
         repositoryName: context.repository.name,
         onDismiss: { createWorktreeContext = nil },
-        onCreate: { branchName, directoryName, baseBranch, onProgress in
-          let vm = viewModel(for: context.providerKind)
-          try await vm.createWorktree(
-            for: context.repository,
+        onCreate: { branchName, directoryName, baseBranch in
+          beginSidePanelWorktree(
+            context: context,
             branchName: branchName,
             directoryName: directoryName,
-            baseBranch: baseBranch,
-            onProgress: onProgress
+            baseBranch: baseBranch
           )
         }
       )
@@ -415,6 +415,7 @@ public struct MultiProviderSessionsListView: View {
     }
     .modifier(ArchiveConfirmationAlert(confirmation: $archiveConfirmation))
     .modifier(RemoveConfirmationAlert(confirmation: $removeConfirmation))
+    }
     }
   }
 
@@ -1402,6 +1403,46 @@ public struct MultiProviderSessionsListView: View {
     }
   }
 
+  /// Hands a side-panel worktree creation to the app-wide progress coordinator
+  /// (which owns the work and surfaces it in the top bar) so the sheet can
+  /// dismiss immediately. Falls back to a direct, untracked creation if no
+  /// coordinator is available (e.g. previews).
+  private func beginSidePanelWorktree(
+    context: WorktreeCreateContext,
+    branchName: String,
+    directoryName: String,
+    baseBranch: String?
+  ) {
+    let vm = viewModel(for: context.providerKind)
+    let repo = context.repository
+    let providerKind = context.providerKind
+    if let coordinator = vm.agentHubProvider?.worktreeGenerationProgressCoordinator {
+      coordinator.beginSidePanelOperation(
+        branchName: branchName,
+        repoName: repo.name,
+        providerKind: providerKind
+      ) { onProgress in
+        try await vm.createWorktree(
+          for: repo,
+          branchName: branchName,
+          directoryName: directoryName,
+          baseBranch: baseBranch,
+          onProgress: onProgress
+        )
+      }
+    } else {
+      Task {
+        try? await vm.createWorktree(
+          for: repo,
+          branchName: branchName,
+          directoryName: directoryName,
+          baseBranch: baseBranch,
+          onProgress: { _ in }
+        )
+      }
+    }
+  }
+
   private var selectedProvider: SessionProviderKind {
     SessionProviderKind(rawValue: selectedProviderRaw) ?? .claude
   }
@@ -2030,10 +2071,20 @@ private struct StartSessionSheet: View {
     .frame(minWidth: 480, idealWidth: 520)
     .background(colorScheme == .dark ? Color.black : Color(nsColor: .windowBackgroundColor))
     .onChange(of: launchViewModel.isLaunching) { wasLaunching, isLaunching in
-      guard wasLaunching, !isLaunching else { return }
-      if launchViewModel.isSmartInteractive { return }
-      if launchViewModel.lastLaunchEndedByCancellation { return }
-      onDismiss()
+      if !wasLaunching, isLaunching {
+        // Launch started: manual launches hand progress off to the top bar and
+        // close immediately. Smart (interactive) launches stay open to review
+        // the orchestration plan.
+        if !launchViewModel.isSmartInteractive {
+          onDismiss()
+        }
+      } else if wasLaunching, !isLaunching {
+        // Launch finished: dismiss flows that stayed open (e.g. smart), unless
+        // still interactive or ended by cancellation.
+        if launchViewModel.isSmartInteractive { return }
+        if launchViewModel.lastLaunchEndedByCancellation { return }
+        onDismiss()
+      }
     }
   }
 }

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
@@ -192,9 +192,7 @@ public struct MultiProviderSessionsListView: View {
   public var body: some View {
     GeometryReader { proxy in
       let sidebarMax = max(280, proxy.size.width * 0.20)
-    VStack(spacing: 0) {
-      WorktreeGenerationProgressBar()
-      ZStack {
+    ZStack {
       NavigationSplitView(columnVisibility: $columnVisibility) {
         sidePanelView
           .agentHubPanel()
@@ -202,29 +200,34 @@ public struct MultiProviderSessionsListView: View {
           .padding(.vertical, 8)
           .padding(.horizontal, 8)
       } detail: {
-        MultiProviderMonitoringPanelView(
-          claudeViewModel: claudeViewModel,
-          codexViewModel: codexViewModel,
-          primarySessionId: $primarySessionId,
-          selectedModuleLandingPath: $selectedModuleLandingPath,
-          onEmbeddedSidePanelVisibilityChange: handleEmbeddedSidePanelVisibilityChange,
-          onAddFolder: { showAddRepositoryPicker() },
-          onRequestStartSession: { preferredRepositoryPath in
-            triggerNewSessionFlow(preferredRepositoryPath: preferredRepositoryPath)
-          },
-          onRequestForkSession: { session, targetProvider in
-            triggerForkSessionFlow(session: session, targetProvider: targetProvider)
+        VStack(spacing: 0) {
+          // Progress bar lives above the detail pane only (not over the sidebar).
+          WorktreeGenerationProgressBar()
+
+          MultiProviderMonitoringPanelView(
+            claudeViewModel: claudeViewModel,
+            codexViewModel: codexViewModel,
+            primarySessionId: $primarySessionId,
+            selectedModuleLandingPath: $selectedModuleLandingPath,
+            onEmbeddedSidePanelVisibilityChange: handleEmbeddedSidePanelVisibilityChange,
+            onAddFolder: { showAddRepositoryPicker() },
+            onRequestStartSession: { preferredRepositoryPath in
+              triggerNewSessionFlow(preferredRepositoryPath: preferredRepositoryPath)
+            },
+            onRequestForkSession: { session, targetProvider in
+              triggerForkSessionFlow(session: session, targetProvider: targetProvider)
+            }
+          )
+          .padding(12)
+          .agentHubPanel()
+          .frame(minWidth: 300)
+          .padding(.vertical, 8)
+          .padding(.horizontal, 8)
+          .background {
+            NSSplitViewAutosaveDisabler()
+              .frame(width: 0, height: 0)
+              .allowsHitTesting(false)
           }
-        )
-        .padding(12)
-        .agentHubPanel()
-        .frame(minWidth: 300)
-        .padding(.vertical, 8)
-        .padding(.horizontal, 8)
-        .background {
-          NSSplitViewAutosaveDisabler()
-            .frame(width: 0, height: 0)
-            .allowsHitTesting(false)
         }
       }
       .navigationSplitViewStyle(.balanced)
@@ -415,7 +418,6 @@ public struct MultiProviderSessionsListView: View {
     }
     .modifier(ArchiveConfirmationAlert(confirmation: $archiveConfirmation))
     .modifier(RemoveConfirmationAlert(confirmation: $removeConfirmation))
-    }
     }
   }
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/WorktreeGenerationProgressBar.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/WorktreeGenerationProgressBar.swift
@@ -8,11 +8,13 @@ import SwiftUI
 
 // MARK: - WorktreeGenerationProgressBar
 
-/// Compact top bar that surfaces live worktree-creation progress from both the
-/// side panel and MCP. Collapsed: an aggregate progress bar + count. Expanded:
-/// a per-worktree detail list. Renders nothing when no creations are tracked.
+/// Compact, self-contained card that surfaces live worktree-creation progress
+/// (side panel, MCP, and Start Session) above the detail pane. Collapsed: a
+/// context-aware summary with a progress hairline. Expanded: per-worktree rows.
+/// Renders nothing (zero height) when no creations are tracked.
 public struct WorktreeGenerationProgressBar: View {
   @Environment(WorktreeGenerationProgressCoordinator.self) private var coordinator: WorktreeGenerationProgressCoordinator?
+  @Environment(\.colorScheme) private var colorScheme
   @State private var isExpanded = false
 
   public init() {}
@@ -20,112 +22,119 @@ public struct WorktreeGenerationProgressBar: View {
   public var body: some View {
     Group {
       if let coordinator, coordinator.isActive {
-        content(coordinator)
+        card(coordinator)
+          .padding(.horizontal, 8)
+          .padding(.top, 8)
           .transition(.move(edge: .top).combined(with: .opacity))
       }
     }
-    // Appear/dismiss is driven by isActive; row add/remove and expand toggle
-    // get their own shorter animations.
     .animation(.spring(response: 0.34, dampingFraction: 0.86), value: coordinator?.isActive ?? false)
     .animation(.easeInOut(duration: 0.2), value: coordinator?.operations.count ?? 0)
     .animation(.easeInOut(duration: 0.18), value: isExpanded)
   }
 
-  @ViewBuilder
-  private func content(_ coordinator: WorktreeGenerationProgressCoordinator) -> some View {
+  // MARK: - Card
+
+  private func card(_ coordinator: WorktreeGenerationProgressCoordinator) -> some View {
     VStack(spacing: 0) {
-      collapsedHeader(coordinator)
+      header(coordinator)
       if isExpanded {
-        Divider().opacity(0.4)
+        Divider().opacity(0.5)
         detailList(coordinator)
       }
     }
-    .background(.bar)
+    .background(
+      RoundedRectangle(cornerRadius: AgentHubLayout.cardCornerRadius, style: .continuous)
+        .fill(cardColor)
+    )
     .overlay(alignment: .bottom) {
-      Divider().opacity(0.6)
+      progressHairline(coordinator)
     }
+    .clipShape(RoundedRectangle(cornerRadius: AgentHubLayout.cardCornerRadius, style: .continuous))
+    .overlay(
+      RoundedRectangle(cornerRadius: AgentHubLayout.cardCornerRadius, style: .continuous)
+        .stroke(accent(coordinator).opacity(0.22), lineWidth: 1)
+    )
+    .shadow(color: .black.opacity(colorScheme == .dark ? 0.28 : 0.08), radius: 7, y: 2)
   }
 
-  // MARK: - Collapsed header
+  private var cardColor: Color {
+    colorScheme == .dark ? Color(white: 0.13) : Color(white: 0.99)
+  }
 
-  private func collapsedHeader(_ coordinator: WorktreeGenerationProgressCoordinator) -> some View {
-    HStack(spacing: 10) {
-      headlineIcon(coordinator)
+  // MARK: - Header (collapsed summary)
 
-      Text(headline(coordinator))
-        .font(.system(.subheadline, weight: .medium))
-        .lineLimit(1)
-        .layoutPriority(1)
+  private func header(_ coordinator: WorktreeGenerationProgressCoordinator) -> some View {
+    let model = summary(coordinator)
+    return HStack(spacing: 10) {
+      leadingIcon(coordinator)
+        .frame(width: 18, height: 18)
 
-      aggregateBar(coordinator)
-        .frame(maxWidth: 220)
-
-      Text("\(Int(coordinator.aggregateProgress * 100))%")
-        .font(.system(.caption, design: .monospaced))
-        .foregroundStyle(.secondary)
-        .monospacedDigit()
-
-      Button {
-        isExpanded.toggle()
-      } label: {
-        Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
-          .font(.caption.weight(.semibold))
-          .foregroundStyle(.secondary)
-          .contentShape(Rectangle())
+      VStack(alignment: .leading, spacing: 1) {
+        Text(model.title)
+          .font(.system(.subheadline, weight: .semibold))
+          .lineLimit(1)
+        if let subtitle = model.subtitle, !subtitle.isEmpty {
+          Text(subtitle)
+            .font(.caption2)
+            .foregroundStyle(.secondary)
+            .lineLimit(1)
+            .monospacedDigit()
+        }
       }
-      .buttonStyle(.plain)
-      .help(isExpanded ? "Hide details" : "Show details")
+
+      Spacer(minLength: 8)
+
+      if coordinator.inFlightCount > 0 {
+        Text("\(Int(coordinator.aggregateProgress * 100))%")
+          .font(.system(.caption, design: .monospaced))
+          .foregroundStyle(.secondary)
+          .monospacedDigit()
+      }
+
+      Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
+        .font(.caption.weight(.semibold))
+        .foregroundStyle(.secondary)
     }
-    .padding(.horizontal, 14)
-    .frame(height: AgentHubLayout.topBarHeight)
+    .padding(.horizontal, 12)
+    .padding(.vertical, 8)
     .contentShape(Rectangle())
     .onTapGesture { isExpanded.toggle() }
+    .help(isExpanded ? "Hide details" : "Show details")
   }
 
   @ViewBuilder
-  private func headlineIcon(_ coordinator: WorktreeGenerationProgressCoordinator) -> some View {
+  private func leadingIcon(_ coordinator: WorktreeGenerationProgressCoordinator) -> some View {
     if coordinator.inFlightCount > 0 {
       ProgressView()
         .controlSize(.small)
-        .scaleEffect(0.7)
-        .frame(width: 16, height: 16)
+        .scaleEffect(0.85)
     } else if coordinator.hasFailures {
       Image(systemName: "exclamationmark.triangle.fill")
-        .font(.caption)
+        .font(.system(size: 14))
         .foregroundStyle(.orange)
-        .frame(width: 16, height: 16)
     } else {
       Image(systemName: "checkmark.circle.fill")
-        .font(.caption)
+        .font(.system(size: 15))
         .foregroundStyle(.green)
-        .frame(width: 16, height: 16)
+        .symbolEffect(.bounce, value: coordinator.operations.isEmpty)
     }
   }
 
-  private func aggregateBar(_ coordinator: WorktreeGenerationProgressCoordinator) -> some View {
-    GeometryReader { geometry in
+  // MARK: - Progress hairline (bottom edge)
+
+  private func progressHairline(_ coordinator: WorktreeGenerationProgressCoordinator) -> some View {
+    GeometryReader { geo in
       ZStack(alignment: .leading) {
-        RoundedRectangle(cornerRadius: 2)
-          .fill(Color.gray.opacity(0.2))
-        RoundedRectangle(cornerRadius: 2)
-          .fill(coordinator.hasFailures ? Color.orange : Color.brandPrimary)
-          .frame(width: geometry.size.width * min(coordinator.aggregateProgress, 1.0))
-          .animation(.linear(duration: 0.15), value: coordinator.aggregateProgress)
+        Rectangle().fill(Color.secondary.opacity(0.12))
+        Rectangle()
+          .fill(accent(coordinator))
+          .frame(width: geo.size.width * min(max(coordinator.aggregateProgress, 0), 1))
+          .animation(.linear(duration: 0.2), value: coordinator.aggregateProgress)
       }
     }
-    .frame(height: 4)
-  }
-
-  private func headline(_ coordinator: WorktreeGenerationProgressCoordinator) -> String {
-    let inFlight = coordinator.inFlightCount
-    if inFlight > 0 {
-      return inFlight == 1 ? "Creating worktree…" : "Creating \(inFlight) worktrees…"
-    }
-    if coordinator.hasFailures {
-      return "Worktree creation failed"
-    }
-    let done = coordinator.operations.count
-    return done == 1 ? "Worktree ready" : "Worktrees ready"
+    .frame(height: 3)
+    .opacity(coordinator.inFlightCount > 0 ? 1 : 0.6)
   }
 
   // MARK: - Expanded detail
@@ -142,7 +151,46 @@ public struct WorktreeGenerationProgressBar: View {
       }
       .padding(10)
     }
-    .frame(maxHeight: 220)
+    .frame(maxHeight: 240)
+  }
+
+  // MARK: - Summary model
+
+  private func accent(_ coordinator: WorktreeGenerationProgressCoordinator) -> Color {
+    if coordinator.hasFailures && coordinator.inFlightCount == 0 { return .orange }
+    if coordinator.inFlightCount == 0 { return .green }
+    return .brandPrimary
+  }
+
+  private func summary(_ coordinator: WorktreeGenerationProgressCoordinator) -> (title: String, subtitle: String?) {
+    if coordinator.operations.count == 1, let op = coordinator.operations.first {
+      return singleSummary(op)
+    }
+    if coordinator.inFlightCount > 0 {
+      return ("Creating \(coordinator.inFlightCount) worktrees…", "\(coordinator.operations.count) total")
+    }
+    if coordinator.hasFailures {
+      return ("Worktree creation failed", nil)
+    }
+    return ("\(coordinator.operations.count) worktrees ready", nil)
+  }
+
+  private func singleSummary(_ op: WorktreeGenerationOperation) -> (title: String, subtitle: String?) {
+    if op.isNaming {
+      return ("Generating branch name", op.repoName.isEmpty ? op.progress.statusMessage : op.repoName)
+    }
+    switch op.progress {
+    case .completed:
+      return (op.branchName.isEmpty ? "Worktree ready" : op.branchName, "Ready")
+    case .failed(let error):
+      return (op.branchName.isEmpty ? "Creation failed" : op.branchName, error)
+    case .cancelled:
+      return (op.branchName.isEmpty ? "Cancelled" : op.branchName, "Cancelled")
+    case .idle, .preparing, .updatingFiles:
+      let title = op.branchName.isEmpty ? "Creating worktree" : op.branchName
+      let subtitle = op.progress.statusMessage.isEmpty ? op.repoName : op.progress.statusMessage
+      return (title, subtitle)
+    }
   }
 }
 
@@ -179,7 +227,6 @@ private struct WorktreeGenerationOperationRow: View {
           }
         }
 
-        // Naming has no meaningful percentage — show an indeterminate bar.
         if isNaming && operation.progress.isInProgress {
           ProgressView()
             .progressViewStyle(.linear)

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/WorktreeGenerationProgressBar.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/WorktreeGenerationProgressBar.swift
@@ -103,6 +103,18 @@ public struct WorktreeGenerationProgressBar: View {
           .font(.caption.weight(.semibold))
           .foregroundStyle(.secondary)
       }
+
+      if coordinator.hasFailures {
+        Button {
+          coordinator.dismissAllFailed()
+        } label: {
+          Image(systemName: "xmark.circle.fill")
+            .font(.system(size: 14))
+            .foregroundStyle(.secondary)
+        }
+        .buttonStyle(.plain)
+        .help("Dismiss")
+      }
     }
     .padding(.horizontal, 12)
     .padding(.vertical, 8)

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/WorktreeGenerationProgressBar.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/WorktreeGenerationProgressBar.swift
@@ -27,7 +27,6 @@ public struct WorktreeGenerationProgressBar: View {
       if let coordinator, coordinator.isActive {
         card(coordinator)
           .padding(.horizontal, 12)
-          .padding(.top, 8)
           .transition(.move(edge: .top).combined(with: .opacity))
       }
     }

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/WorktreeGenerationProgressBar.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/WorktreeGenerationProgressBar.swift
@@ -12,6 +12,10 @@ import SwiftUI
 /// (side panel, MCP, and Start Session) above the detail pane. Collapsed: a
 /// context-aware summary with a progress hairline. Expanded: per-worktree rows.
 /// Renders nothing (zero height) when no creations are tracked.
+///
+/// Counts and the single/multi summary are based on **creation** operations
+/// only — the transient branch-naming step is shown as a display state but
+/// never counted as a worktree.
 public struct WorktreeGenerationProgressBar: View {
   @Environment(WorktreeGenerationProgressCoordinator.self) private var coordinator: WorktreeGenerationProgressCoordinator?
   @Environment(\.colorScheme) private var colorScheme
@@ -35,20 +39,46 @@ public struct WorktreeGenerationProgressBar: View {
     }
   }
 
+  // MARK: - Derived state (creation ops are the real worktrees; naming is transient)
+
+  private func creations(_ coordinator: WorktreeGenerationProgressCoordinator) -> [WorktreeGenerationOperation] {
+    coordinator.operations.filter { $0.kind == .creation }
+  }
+
+  private func canExpand(_ coordinator: WorktreeGenerationProgressCoordinator) -> Bool {
+    creations(coordinator).count > 1
+  }
+
+  private func anyInFlight(_ coordinator: WorktreeGenerationProgressCoordinator) -> Bool {
+    coordinator.operations.contains { $0.progress.isInProgress }
+  }
+
+  private func creationInFlight(_ coordinator: WorktreeGenerationProgressCoordinator) -> Bool {
+    creations(coordinator).contains { $0.progress.isInProgress }
+  }
+
+  /// Mean progress over the real worktrees, or the naming step before any
+  /// creation exists.
+  private func displayProgress(_ coordinator: WorktreeGenerationProgressCoordinator) -> Double {
+    let set = creations(coordinator).isEmpty ? coordinator.operations : creations(coordinator)
+    guard !set.isEmpty else { return 0 }
+    return set.reduce(0.0) { $0 + $1.progress.progressValue } / Double(set.count)
+  }
+
   // MARK: - Card
 
   private func card(_ coordinator: WorktreeGenerationProgressCoordinator) -> some View {
     VStack(spacing: 0) {
       header(coordinator)
       // Only multi-worktree batches expand; a single worktree is already shown
-      // uniquely in the header, so there's nothing extra to reveal.
-      if isExpanded && coordinator.operations.count > 1 {
+      // uniquely in the header.
+      if isExpanded && canExpand(coordinator) {
         Divider().opacity(0.5)
         detailList(coordinator)
       }
     }
     .animation(.easeInOut(duration: 0.18), value: isExpanded)
-    .animation(.easeInOut(duration: 0.2), value: coordinator.operations.count)
+    .animation(.easeInOut(duration: 0.2), value: creations(coordinator).count)
     .background(
       RoundedRectangle(cornerRadius: AgentHubLayout.cardCornerRadius, style: .continuous)
         .fill(cardColor)
@@ -93,14 +123,14 @@ public struct WorktreeGenerationProgressBar: View {
 
       Spacer(minLength: 8)
 
-      if coordinator.inFlightCount > 0 {
-        Text("\(Int(coordinator.aggregateProgress * 100))%")
+      if creationInFlight(coordinator) {
+        Text("\(Int(displayProgress(coordinator) * 100))%")
           .font(.system(.caption, design: .monospaced))
           .foregroundStyle(.secondary)
           .monospacedDigit()
       }
 
-      if coordinator.operations.count > 1 {
+      if canExpand(coordinator) {
         Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
           .font(.caption.weight(.semibold))
           .foregroundStyle(.secondary)
@@ -122,14 +152,14 @@ public struct WorktreeGenerationProgressBar: View {
     .padding(.vertical, 8)
     .contentShape(Rectangle())
     .onTapGesture {
-      guard coordinator.operations.count > 1 else { return }
+      guard canExpand(coordinator) else { return }
       isExpanded.toggle()
     }
   }
 
   @ViewBuilder
   private func leadingIcon(_ coordinator: WorktreeGenerationProgressCoordinator) -> some View {
-    if coordinator.inFlightCount > 0 {
+    if anyInFlight(coordinator) {
       ProgressView()
         .controlSize(.small)
         .scaleEffect(0.85)
@@ -148,17 +178,18 @@ public struct WorktreeGenerationProgressBar: View {
   // MARK: - Progress hairline (bottom edge)
 
   private func progressHairline(_ coordinator: WorktreeGenerationProgressCoordinator) -> some View {
-    GeometryReader { geo in
+    let progress = displayProgress(coordinator)
+    return GeometryReader { geo in
       ZStack(alignment: .leading) {
         Rectangle().fill(Color.secondary.opacity(0.12))
         Rectangle()
           .fill(accent(coordinator))
-          .frame(width: geo.size.width * min(max(coordinator.aggregateProgress, 0), 1))
-          .animation(.linear(duration: 0.2), value: coordinator.aggregateProgress)
+          .frame(width: geo.size.width * min(max(progress, 0), 1))
+          .animation(.linear(duration: 0.2), value: progress)
       }
     }
     .frame(height: 3)
-    .opacity(coordinator.inFlightCount > 0 ? 1 : 0.6)
+    .opacity(anyInFlight(coordinator) ? 1 : 0.6)
   }
 
   // MARK: - Expanded detail
@@ -166,7 +197,7 @@ public struct WorktreeGenerationProgressBar: View {
   private func detailList(_ coordinator: WorktreeGenerationProgressCoordinator) -> some View {
     ScrollView {
       VStack(spacing: 6) {
-        ForEach(coordinator.operations) { op in
+        ForEach(creations(coordinator)) { op in
           WorktreeGenerationOperationRow(operation: op) {
             coordinator.dismiss(id: op.id)
           }
@@ -181,26 +212,44 @@ public struct WorktreeGenerationProgressBar: View {
   // MARK: - Summary model
 
   private func accent(_ coordinator: WorktreeGenerationProgressCoordinator) -> Color {
-    if coordinator.hasFailures && coordinator.inFlightCount == 0 { return .orange }
-    if coordinator.inFlightCount == 0 { return .green }
+    if coordinator.hasFailures && !anyInFlight(coordinator) { return .orange }
+    if !anyInFlight(coordinator) { return .green }
     return .brandPrimary
   }
 
   private func summary(_ coordinator: WorktreeGenerationProgressCoordinator) -> (title: String, subtitle: String?) {
-    if coordinator.operations.count == 1, let op = coordinator.operations.first {
-      return singleSummary(op)
+    let worktrees = creations(coordinator)
+
+    // Before any worktree exists, the only operation is the naming step.
+    if worktrees.isEmpty {
+      if let naming = coordinator.operations.first(where: { $0.isNaming }) {
+        return singleSummary(naming)
+      }
+      return ("Preparing worktree…", nil)
     }
-    if coordinator.inFlightCount > 0 {
-      return ("Creating \(coordinator.inFlightCount) worktrees…", "\(coordinator.operations.count) total")
+
+    if worktrees.count == 1 {
+      return singleSummary(worktrees[0])
     }
-    if coordinator.hasFailures {
+
+    let inFlight = worktrees.filter { $0.progress.isInProgress }.count
+    if inFlight > 0 {
+      return ("Creating \(inFlight) worktrees…", "\(worktrees.count) total")
+    }
+    if worktrees.contains(where: { $0.isFailure }) {
       return ("Worktree creation failed", nil)
     }
-    return ("\(coordinator.operations.count) worktrees ready", nil)
+    return ("\(worktrees.count) worktrees ready", nil)
   }
 
   private func singleSummary(_ op: WorktreeGenerationOperation) -> (title: String, subtitle: String?) {
     if op.isNaming {
+      if case .completed = op.progress {
+        return ("Branch name ready", op.repoName)
+      }
+      if case .failed(let error) = op.progress {
+        return ("Branch naming failed", error)
+      }
       return ("Generating branch name", op.repoName.isEmpty ? op.progress.statusMessage : op.repoName)
     }
     switch op.progress {

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/WorktreeGenerationProgressBar.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/WorktreeGenerationProgressBar.swift
@@ -1,0 +1,269 @@
+//
+//  WorktreeGenerationProgressBar.swift
+//  AgentHub
+//
+
+import AgentHubCLIKit
+import SwiftUI
+
+// MARK: - WorktreeGenerationProgressBar
+
+/// Compact top bar that surfaces live worktree-creation progress from both the
+/// side panel and MCP. Collapsed: an aggregate progress bar + count. Expanded:
+/// a per-worktree detail list. Renders nothing when no creations are tracked.
+public struct WorktreeGenerationProgressBar: View {
+  @Environment(WorktreeGenerationProgressCoordinator.self) private var coordinator: WorktreeGenerationProgressCoordinator?
+  @State private var isExpanded = false
+
+  public init() {}
+
+  public var body: some View {
+    Group {
+      if let coordinator, coordinator.isActive {
+        content(coordinator)
+          .transition(.move(edge: .top).combined(with: .opacity))
+      }
+    }
+    // Appear/dismiss is driven by isActive; row add/remove and expand toggle
+    // get their own shorter animations.
+    .animation(.spring(response: 0.34, dampingFraction: 0.86), value: coordinator?.isActive ?? false)
+    .animation(.easeInOut(duration: 0.2), value: coordinator?.operations.count ?? 0)
+    .animation(.easeInOut(duration: 0.18), value: isExpanded)
+  }
+
+  @ViewBuilder
+  private func content(_ coordinator: WorktreeGenerationProgressCoordinator) -> some View {
+    VStack(spacing: 0) {
+      collapsedHeader(coordinator)
+      if isExpanded {
+        Divider().opacity(0.4)
+        detailList(coordinator)
+      }
+    }
+    .background(.bar)
+    .overlay(alignment: .bottom) {
+      Divider().opacity(0.6)
+    }
+  }
+
+  // MARK: - Collapsed header
+
+  private func collapsedHeader(_ coordinator: WorktreeGenerationProgressCoordinator) -> some View {
+    HStack(spacing: 10) {
+      headlineIcon(coordinator)
+
+      Text(headline(coordinator))
+        .font(.system(.subheadline, weight: .medium))
+        .lineLimit(1)
+        .layoutPriority(1)
+
+      aggregateBar(coordinator)
+        .frame(maxWidth: 220)
+
+      Text("\(Int(coordinator.aggregateProgress * 100))%")
+        .font(.system(.caption, design: .monospaced))
+        .foregroundStyle(.secondary)
+        .monospacedDigit()
+
+      Button {
+        isExpanded.toggle()
+      } label: {
+        Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
+          .font(.caption.weight(.semibold))
+          .foregroundStyle(.secondary)
+          .contentShape(Rectangle())
+      }
+      .buttonStyle(.plain)
+      .help(isExpanded ? "Hide details" : "Show details")
+    }
+    .padding(.horizontal, 14)
+    .frame(height: AgentHubLayout.topBarHeight)
+    .contentShape(Rectangle())
+    .onTapGesture { isExpanded.toggle() }
+  }
+
+  @ViewBuilder
+  private func headlineIcon(_ coordinator: WorktreeGenerationProgressCoordinator) -> some View {
+    if coordinator.inFlightCount > 0 {
+      ProgressView()
+        .controlSize(.small)
+        .scaleEffect(0.7)
+        .frame(width: 16, height: 16)
+    } else if coordinator.hasFailures {
+      Image(systemName: "exclamationmark.triangle.fill")
+        .font(.caption)
+        .foregroundStyle(.orange)
+        .frame(width: 16, height: 16)
+    } else {
+      Image(systemName: "checkmark.circle.fill")
+        .font(.caption)
+        .foregroundStyle(.green)
+        .frame(width: 16, height: 16)
+    }
+  }
+
+  private func aggregateBar(_ coordinator: WorktreeGenerationProgressCoordinator) -> some View {
+    GeometryReader { geometry in
+      ZStack(alignment: .leading) {
+        RoundedRectangle(cornerRadius: 2)
+          .fill(Color.gray.opacity(0.2))
+        RoundedRectangle(cornerRadius: 2)
+          .fill(coordinator.hasFailures ? Color.orange : Color.brandPrimary)
+          .frame(width: geometry.size.width * min(coordinator.aggregateProgress, 1.0))
+          .animation(.linear(duration: 0.15), value: coordinator.aggregateProgress)
+      }
+    }
+    .frame(height: 4)
+  }
+
+  private func headline(_ coordinator: WorktreeGenerationProgressCoordinator) -> String {
+    let inFlight = coordinator.inFlightCount
+    if inFlight > 0 {
+      return inFlight == 1 ? "Creating worktree…" : "Creating \(inFlight) worktrees…"
+    }
+    if coordinator.hasFailures {
+      return "Worktree creation failed"
+    }
+    let done = coordinator.operations.count
+    return done == 1 ? "Worktree ready" : "Worktrees ready"
+  }
+
+  // MARK: - Expanded detail
+
+  private func detailList(_ coordinator: WorktreeGenerationProgressCoordinator) -> some View {
+    ScrollView {
+      VStack(spacing: 6) {
+        ForEach(coordinator.operations) { op in
+          WorktreeGenerationOperationRow(operation: op) {
+            coordinator.dismiss(id: op.id)
+          }
+          .transition(.opacity.combined(with: .move(edge: .top)))
+        }
+      }
+      .padding(10)
+    }
+    .frame(maxHeight: 220)
+  }
+}
+
+// MARK: - WorktreeGenerationOperationRow
+
+private struct WorktreeGenerationOperationRow: View {
+  let operation: WorktreeGenerationOperation
+  let onDismiss: () -> Void
+
+  private var isNaming: Bool { operation.isNaming }
+
+  var body: some View {
+    HStack(spacing: 10) {
+      Image(systemName: rowIcon)
+        .font(.system(.body))
+        .foregroundStyle(statusColor)
+        .frame(width: 20)
+        .symbolEffect(.pulse, isActive: isNaming && operation.progress.isInProgress)
+
+      VStack(alignment: .leading, spacing: 3) {
+        HStack(spacing: 6) {
+          Text(titleText)
+            .font(.system(.subheadline, weight: .medium))
+            .lineLimit(1)
+          if !isNaming {
+            providerTag
+          }
+          Spacer(minLength: 4)
+          if !detailTrailing.isEmpty {
+            Text(detailTrailing)
+              .font(.system(.caption, design: .monospaced))
+              .foregroundStyle(.secondary)
+              .monospacedDigit()
+          }
+        }
+
+        // Naming has no meaningful percentage — show an indeterminate bar.
+        if isNaming && operation.progress.isInProgress {
+          ProgressView()
+            .progressViewStyle(.linear)
+            .tint(statusColor)
+        } else {
+          ProgressView(value: operation.progress.progressValue)
+            .tint(statusColor)
+            .animation(.linear(duration: 0.15), value: operation.progress.progressValue)
+        }
+
+        Text(statusLine)
+          .font(.caption2)
+          .foregroundStyle(.secondary)
+          .lineLimit(1)
+      }
+
+      if operation.isFailure {
+        Button(action: onDismiss) {
+          Image(systemName: "xmark.circle.fill")
+            .foregroundStyle(.secondary)
+        }
+        .buttonStyle(.plain)
+        .help("Dismiss")
+      }
+    }
+    .padding(10)
+    .agentHubRow()
+  }
+
+  private var rowIcon: String {
+    if isNaming {
+      if case .completed = operation.progress { return "checkmark.circle.fill" }
+      return "sparkles"
+    }
+    return operation.progress.icon
+  }
+
+  private var titleText: String {
+    if isNaming {
+      if case .completed = operation.progress { return "Branch name ready" }
+      return "Generating branch name"
+    }
+    return operation.branchName
+  }
+
+  private var providerTag: some View {
+    Text(operation.provider.rawValue)
+      .font(.caption2.weight(.medium))
+      .foregroundStyle(.secondary)
+      .padding(.horizontal, 6)
+      .padding(.vertical, 1)
+      .background(
+        RoundedRectangle(cornerRadius: AgentHubLayout.chipCornerRadius)
+          .fill(Color.secondary.opacity(0.12))
+      )
+  }
+
+  private var statusColor: Color {
+    switch operation.progress {
+    case .completed: return .green
+    case .failed: return .red
+    case .cancelled: return .secondary
+    case .idle, .preparing, .updatingFiles: return .brandPrimary
+    }
+  }
+
+  private var statusLine: String {
+    let message = operation.progress.statusMessage
+    if message.isEmpty {
+      return operation.repoName
+    }
+    return "\(operation.repoName) · \(message)"
+  }
+
+  private var detailTrailing: String {
+    if isNaming { return "" }
+    if operation.progress.isInProgress {
+      return "\(Int(operation.progress.progressValue * 100))%"
+    }
+    switch operation.progress {
+    case .completed: return "Ready"
+    case .failed: return "Failed"
+    case .cancelled: return "Cancelled"
+    default: return ""
+    }
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/WorktreeGenerationProgressBar.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/WorktreeGenerationProgressBar.swift
@@ -18,7 +18,6 @@ import SwiftUI
 /// never counted as a worktree.
 public struct WorktreeGenerationProgressBar: View {
   @Environment(WorktreeGenerationProgressCoordinator.self) private var coordinator: WorktreeGenerationProgressCoordinator?
-  @Environment(\.colorScheme) private var colorScheme
   @State private var isExpanded = false
 
   public init() {}
@@ -79,23 +78,11 @@ public struct WorktreeGenerationProgressBar: View {
     }
     .animation(.easeInOut(duration: 0.18), value: isExpanded)
     .animation(.easeInOut(duration: 0.2), value: creations(coordinator).count)
-    .background(
-      RoundedRectangle(cornerRadius: AgentHubLayout.cardCornerRadius, style: .continuous)
-        .fill(cardColor)
-    )
+    // Flat: no background fill, border, rounded corners, or shadow — just the
+    // content with the progress hairline along the bottom.
     .overlay(alignment: .bottom) {
       progressHairline(coordinator)
     }
-    .clipShape(RoundedRectangle(cornerRadius: AgentHubLayout.cardCornerRadius, style: .continuous))
-    .overlay(
-      RoundedRectangle(cornerRadius: AgentHubLayout.cardCornerRadius, style: .continuous)
-        .stroke(accent(coordinator).opacity(0.22), lineWidth: 1)
-    )
-    .shadow(color: .black.opacity(colorScheme == .dark ? 0.28 : 0.08), radius: 7, y: 2)
-  }
-
-  private var cardColor: Color {
-    colorScheme == .dark ? Color(white: 0.13) : Color(white: 0.99)
   }
 
   // MARK: - Header (collapsed summary)

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/WorktreeGenerationProgressBar.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/WorktreeGenerationProgressBar.swift
@@ -83,9 +83,11 @@ public struct WorktreeGenerationProgressBar: View {
         if let subtitle = model.subtitle, !subtitle.isEmpty {
           Text(subtitle)
             .font(.caption2)
-            .foregroundStyle(.secondary)
-            .lineLimit(1)
+            .foregroundStyle(coordinator.hasFailures ? Color.red.opacity(0.9) : Color.secondary)
+            .lineLimit(coordinator.hasFailures ? 4 : 1)
+            .fixedSize(horizontal: false, vertical: true)
             .monospacedDigit()
+            .help(subtitle)
         }
       }
 
@@ -261,8 +263,10 @@ private struct WorktreeGenerationOperationRow: View {
 
         Text(statusLine)
           .font(.caption2)
-          .foregroundStyle(.secondary)
-          .lineLimit(1)
+          .foregroundStyle(operation.isFailure ? Color.red.opacity(0.9) : .secondary)
+          .lineLimit(operation.isFailure ? 4 : 1)
+          .fixedSize(horizontal: false, vertical: true)
+          .help(statusLine)
       }
 
       if operation.isFailure {

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/WorktreeGenerationProgressBar.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/WorktreeGenerationProgressBar.swift
@@ -23,14 +23,16 @@ public struct WorktreeGenerationProgressBar: View {
     Group {
       if let coordinator, coordinator.isActive {
         card(coordinator)
-          .padding(.horizontal, 8)
+          .padding(.horizontal, 12)
           .padding(.top, 8)
           .transition(.move(edge: .top).combined(with: .opacity))
       }
     }
-    .animation(.spring(response: 0.34, dampingFraction: 0.86), value: coordinator?.isActive ?? false)
-    .animation(.easeInOut(duration: 0.2), value: coordinator?.operations.count ?? 0)
-    .animation(.easeInOut(duration: 0.18), value: isExpanded)
+    // Whole-bar appear/dismiss; inner content (expand, rows) animates in card().
+    .animation(.spring(response: 0.36, dampingFraction: 0.85), value: coordinator?.isActive ?? false)
+    .onChange(of: coordinator?.isActive ?? false) { _, active in
+      if !active { isExpanded = false }
+    }
   }
 
   // MARK: - Card
@@ -38,11 +40,15 @@ public struct WorktreeGenerationProgressBar: View {
   private func card(_ coordinator: WorktreeGenerationProgressCoordinator) -> some View {
     VStack(spacing: 0) {
       header(coordinator)
-      if isExpanded {
+      // Only multi-worktree batches expand; a single worktree is already shown
+      // uniquely in the header, so there's nothing extra to reveal.
+      if isExpanded && coordinator.operations.count > 1 {
         Divider().opacity(0.5)
         detailList(coordinator)
       }
     }
+    .animation(.easeInOut(duration: 0.18), value: isExpanded)
+    .animation(.easeInOut(duration: 0.2), value: coordinator.operations.count)
     .background(
       RoundedRectangle(cornerRadius: AgentHubLayout.cardCornerRadius, style: .continuous)
         .fill(cardColor)
@@ -92,15 +98,19 @@ public struct WorktreeGenerationProgressBar: View {
           .monospacedDigit()
       }
 
-      Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
-        .font(.caption.weight(.semibold))
-        .foregroundStyle(.secondary)
+      if coordinator.operations.count > 1 {
+        Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
+          .font(.caption.weight(.semibold))
+          .foregroundStyle(.secondary)
+      }
     }
     .padding(.horizontal, 12)
     .padding(.vertical, 8)
     .contentShape(Rectangle())
-    .onTapGesture { isExpanded.toggle() }
-    .help(isExpanded ? "Hide details" : "Show details")
+    .onTapGesture {
+      guard coordinator.operations.count > 1 else { return }
+      isExpanded.toggle()
+    }
   }
 
   @ViewBuilder

--- a/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/MultiSessionLaunchViewModel.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/MultiSessionLaunchViewModel.swift
@@ -128,6 +128,9 @@ public final class MultiSessionLaunchViewModel {
   private let worktreeBranchNamingService: (any WorktreeBranchNamingServiceProtocol)?
   private let worktreeSuccessSoundService: (any WorktreeSuccessSoundServiceProtocol)?
   private var playedWorktreeSuccessPaths: Set<String> = []
+  /// Stable id for the in-flight branch-naming step, so its progress maps to a
+  /// single transient row in the unified top bar (the coordinator).
+  private var namingCoordinatorOperationID: String?
   private var activeLaunchTask: Task<Void, Never>?
   private var activeWorktreeOperations: [WorktreeCreationOperationID: ActiveWorktreeOperation] = [:]
 
@@ -1172,11 +1175,11 @@ public final class MultiSessionLaunchViewModel {
     if let worktreeBranchNamingService {
       branchNamingStartedAt = Date()
       branchNamingCompletedAt = nil
-      branchNamingProgress = .preparingContext(
+      applyBranchNamingProgress(.preparingContext(
         message: request.hasMeaningfulContext
           ? "Preparing branch naming context"
           : "Preparing repository context"
-      )
+      ))
       do {
         let result = try await worktreeBranchNamingService.resolveBranchNames(for: request) { [weak self] progress in
           self?.applyBranchNamingProgress(progress)
@@ -1200,7 +1203,7 @@ public final class MultiSessionLaunchViewModel {
 
     branchNamingStartedAt = Date()
     branchNamingCompletedAt = nil
-    branchNamingProgress = .preparingContext(message: "Preparing fallback branch name")
+    applyBranchNamingProgress(.preparingContext(message: "Preparing fallback branch name"))
     let fallback = ClaudeWorktreeBranchNamingService.deterministicFallback(for: request)
     finalizeBranchNamingProgress(with: fallback)
     AppLogger.intelligence.info(
@@ -1318,6 +1321,33 @@ public final class MultiSessionLaunchViewModel {
     } else {
       branchNamingCompletedAt = nil
     }
+
+    forwardNamingProgressToCoordinator(progress)
+  }
+
+  /// Mirrors the AI branch-naming step into the unified top bar so the user
+  /// sees "Generating branch name…" before git creation begins.
+  private func forwardNamingProgressToCoordinator(_ progress: WorktreeBranchNamingProgress) {
+    guard let coordinator = progressCoordinator else { return }
+
+    if namingCoordinatorOperationID == nil {
+      // Only start tracking once a real in-progress state arrives.
+      guard progress.isInProgress else { return }
+      namingCoordinatorOperationID = UUID().uuidString
+    }
+    guard let operationID = namingCoordinatorOperationID else { return }
+
+    coordinator.reportNamingProgress(
+      operationID: operationID,
+      repoName: selectedRepository?.name ?? "",
+      providerKind: .claude,
+      progress: progress
+    )
+
+    if progress.isFinished {
+      // Coordinator now owns the transient row's clear timer.
+      namingCoordinatorOperationID = nil
+    }
   }
 
   private func finalizeBranchNamingProgress(with result: WorktreeBranchNamingResult) {
@@ -1346,6 +1376,10 @@ public final class MultiSessionLaunchViewModel {
     branchNamingProgress = .idle
     branchNamingStartedAt = nil
     branchNamingCompletedAt = nil
+    if let operationID = namingCoordinatorOperationID {
+      progressCoordinator?.dismiss(id: operationID)
+      namingCoordinatorOperationID = nil
+    }
   }
 
   private func handleLaunchCancellation() {
@@ -1410,8 +1444,22 @@ public final class MultiSessionLaunchViewModel {
     let sourceChangesPath = carrySourceChangesPath
     let sourceChangeSnapshot = try await captureSourceChangesIfNeeded(at: sourceChangesPath)
 
+    // Mirror progress into the app-wide coordinator so the top bar shows this
+    // launch-flow creation alongside side-panel and MCP creations.
+    let coordinator = progressCoordinator
+    let coordinatorProvider = SessionProviderKind(rawValue: providerLabel) ?? .claude
+    let coordinatorRepoName = URL(fileURLWithPath: repoPath).lastPathComponent
+    let coordinatorOperationID = operationID.value.uuidString
+
     let progressUpdater: @MainActor (WorktreeCreationProgress) -> Void = { [weak self] progress in
       self?.applyWorktreeProgress(progress, to: progressKeyPath)
+      coordinator?.reportLaunchProgress(
+        operationID: coordinatorOperationID,
+        branchName: branchName,
+        repoName: coordinatorRepoName,
+        providerKind: coordinatorProvider,
+        progress: progress
+      )
     }
 
     do {
@@ -1441,6 +1489,13 @@ public final class MultiSessionLaunchViewModel {
     } catch WorktreeCreationError.cancelled {
       activeWorktreeOperations.removeValue(forKey: operationID)
       applyWorktreeProgress(.cancelled(message: "Worktree creation cancelled"), to: progressKeyPath)
+      coordinator?.reportLaunchProgress(
+        operationID: coordinatorOperationID,
+        branchName: branchName,
+        repoName: coordinatorRepoName,
+        providerKind: coordinatorProvider,
+        progress: .cancelled(message: "Worktree creation cancelled")
+      )
       AppLogger.intelligence.info(
         "\(Self.aiWorktreeLogPrefix, privacy: .public) Worktree creation cancelled provider=\(providerLabel, privacy: .public) branch=\(branchName, privacy: .public) elapsed=\(Self.formattedElapsed(since: operation.startedAt), privacy: .public)"
       )
@@ -1455,6 +1510,13 @@ public final class MultiSessionLaunchViewModel {
       throw CancellationError()
     } catch {
       activeWorktreeOperations.removeValue(forKey: operationID)
+      coordinator?.reportLaunchProgress(
+        operationID: coordinatorOperationID,
+        branchName: branchName,
+        repoName: coordinatorRepoName,
+        providerKind: coordinatorProvider,
+        progress: .failed(error: error.localizedDescription)
+      )
       AppLogger.intelligence.error(
         "\(Self.aiWorktreeLogPrefix, privacy: .public) Worktree creation failed provider=\(providerLabel, privacy: .public) branch=\(branchName, privacy: .public) elapsed=\(Self.formattedElapsed(since: operation.startedAt), privacy: .public) error=\(error.localizedDescription, privacy: .public)"
       )
@@ -1477,6 +1539,13 @@ public final class MultiSessionLaunchViewModel {
     String(format: "%.2fs", Date().timeIntervalSince(startDate))
   }
 
+  /// The app-wide progress coordinator, reached via the injected view models'
+  /// provider. When present it owns the unified top-bar progress plus the batch
+  /// completion sound and macOS notification.
+  private var progressCoordinator: WorktreeGenerationProgressCoordinator? {
+    claudeViewModel.agentHubProvider?.worktreeGenerationProgressCoordinator
+  }
+
   private func applyWorktreeProgress(
     _ progress: WorktreeCreationProgress,
     to keyPath: ReferenceWritableKeyPath<MultiSessionLaunchViewModel, WorktreeCreationProgress>
@@ -1487,6 +1556,10 @@ public final class MultiSessionLaunchViewModel {
           playedWorktreeSuccessPaths.insert(path).inserted else {
       return
     }
+
+    // When the unified coordinator is active it fires a single batch completion
+    // sound + notification; skip the per-worktree ding to avoid duplicates.
+    if progressCoordinator != nil { return }
 
     AppLogger.intelligence.info(
       "\(Self.aiWorktreeLogPrefix, privacy: .public) Worktree creation completed path=\(path, privacy: .public); playing success sound"

--- a/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/WorktreeGenerationProgressCoordinator.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/WorktreeGenerationProgressCoordinator.swift
@@ -302,6 +302,15 @@ public final class WorktreeGenerationProgressCoordinator {
     finalizeClear(id: id)
   }
 
+  /// Clears every failed operation. Backs the header's dismiss control so a
+  /// failed creation (which otherwise lingers) can be dismissed immediately —
+  /// including a single failure, which doesn't expand to a per-row dismiss.
+  public func dismissAllFailed() {
+    for op in operations where op.isFailure {
+      dismiss(id: op.id)
+    }
+  }
+
   // MARK: - Ingest / state machine
 
   private func ingest(_ progress: WorktreeCreationProgress, for id: String) {

--- a/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/WorktreeGenerationProgressCoordinator.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/WorktreeGenerationProgressCoordinator.swift
@@ -1,0 +1,418 @@
+//
+//  WorktreeGenerationProgressCoordinator.swift
+//  AgentHub
+//
+
+import AgentHubCLIKit
+import Combine
+import Foundation
+
+// MARK: - WorktreeGenerationOperation
+
+/// One tracked worktree creation, regardless of which entry point started it.
+public struct WorktreeGenerationOperation: Identifiable, Equatable, Sendable {
+  public enum Source: Sendable, Equatable {
+    /// Created in-process from the side-panel sheet.
+    case sidePanel
+    /// Created by the `agenthub` CLI for an MCP tool call (progress streamed via sidecar).
+    case mcp
+    /// Created in-process by the Start Session / multi-session launch flow.
+    case launch
+  }
+
+  public enum Kind: Sendable, Equatable {
+    /// Git worktree creation (preparing → updating files → completed).
+    case creation
+    /// The AI branch-naming request that runs before creation. Transient: it
+    /// doesn't count toward the "all ready" notification and clears quickly.
+    case naming
+  }
+
+  public let id: String
+  public let branchName: String
+  public let repoName: String
+  public let provider: SessionProviderKind
+  public let source: Source
+  public let kind: Kind
+  public var progress: WorktreeCreationProgress
+  public let startedAt: Date
+  public var finishedAt: Date?
+
+  public init(
+    id: String,
+    branchName: String,
+    repoName: String,
+    provider: SessionProviderKind,
+    source: Source,
+    kind: Kind = .creation,
+    progress: WorktreeCreationProgress,
+    startedAt: Date,
+    finishedAt: Date? = nil
+  ) {
+    self.id = id
+    self.branchName = branchName
+    self.repoName = repoName
+    self.provider = provider
+    self.source = source
+    self.kind = kind
+    self.progress = progress
+    self.startedAt = startedAt
+    self.finishedAt = finishedAt
+  }
+
+  public var isFailure: Bool {
+    if case .failed = progress { return true }
+    return false
+  }
+
+  public var isNaming: Bool { kind == .naming }
+}
+
+// MARK: - WorktreeGenerationProgressCoordinator
+
+/// App-wide, single source of truth for "what worktrees are being created right
+/// now." Unifies the in-process side-panel path and the cross-process MCP path
+/// (via `WorktreeProgressSidecarWatcher`), drives the top-bar UI, and fires a
+/// single completion sound + notification when a batch finishes.
+///
+/// Provider-owned (one instance shared across windows) so the completion
+/// sound/notification fire exactly once regardless of how many windows render
+/// the top bar — the fire logic lives here, never in a per-view `onChange`.
+@MainActor
+@Observable
+public final class WorktreeGenerationProgressCoordinator {
+
+  // MARK: Tunables
+
+  /// Debounce before announcing "all ready": a single MCP batch creates
+  /// worktrees sequentially, so the in-flight count momentarily hits zero
+  /// between them. Wait for the idle state to be stable before firing.
+  static let doneDebounce: Duration = .milliseconds(750)
+  static let successClearDelay: Duration = .seconds(3)
+  static let failureClearDelay: Duration = .seconds(30)
+  /// Naming finishes just before creation begins; keep its row briefly so the
+  /// bar doesn't flicker empty during the handoff, then let creation take over.
+  static let namingClearDelay: Duration = .seconds(1)
+
+  // MARK: Observable state
+
+  public private(set) var operations: [WorktreeGenerationOperation] = []
+
+  // MARK: Dependencies
+
+  private let soundService: any WorktreeSuccessSoundServiceProtocol
+  private let notificationService: any WorktreeReadyNotificationServiceProtocol
+
+  // MARK: Private state (not observed)
+
+  @ObservationIgnored private var mcpWatcher: (any WorktreeProgressSidecarWatcherProtocol)?
+  @ObservationIgnored private var mcpCancellable: AnyCancellable?
+  @ObservationIgnored private var clearTasks: [String: Task<Void, Never>] = [:]
+  @ObservationIgnored private var doneDebounceTask: Task<Void, Never>?
+  /// Branch names that reached `.completed` since the last "all ready" fire.
+  @ObservationIgnored private var pendingReadyBranches: [String] = []
+
+  public init(
+    soundService: any WorktreeSuccessSoundServiceProtocol,
+    notificationService: any WorktreeReadyNotificationServiceProtocol
+  ) {
+    self.soundService = soundService
+    self.notificationService = notificationService
+  }
+
+  // MARK: - Derived UI state
+
+  public var isActive: Bool { !operations.isEmpty }
+
+  public var inFlightCount: Int {
+    operations.filter { $0.progress.isInProgress }.count
+  }
+
+  /// Mean of all tracked operations' progress (0...1), for the collapsed bar.
+  public var aggregateProgress: Double {
+    guard !operations.isEmpty else { return 0 }
+    let total = operations.reduce(0.0) { $0 + $1.progress.progressValue }
+    return total / Double(operations.count)
+  }
+
+  public var hasFailures: Bool {
+    operations.contains { $0.isFailure }
+  }
+
+  // MARK: - Side-panel entry point
+
+  /// Begins an in-process side-panel creation. The coordinator owns the `Task`
+  /// (so it survives the sheet dismissing immediately) and pipes progress into
+  /// the tracked operation. `create` performs the work and receives the
+  /// `onProgress` callback to forward to the underlying service.
+  public func beginSidePanelOperation(
+    branchName: String,
+    repoName: String,
+    providerKind: SessionProviderKind,
+    create: @escaping @MainActor (_ onProgress: @escaping @Sendable (WorktreeCreationProgress) async -> Void) async throws -> Void
+  ) {
+    let id = UUID().uuidString
+    upsert(WorktreeGenerationOperation(
+      id: id,
+      branchName: branchName,
+      repoName: repoName,
+      provider: providerKind,
+      source: .sidePanel,
+      progress: .preparing(message: "Preparing worktree…"),
+      startedAt: Date()
+    ))
+
+    Task {
+      do {
+        try await create { progress in
+          await self.ingest(progress, for: id)
+        }
+        // Safety net: if the service returned without delivering a terminal
+        // state, mark it complete so the op doesn't linger as in-flight.
+        self.markCompletedIfNeeded(id: id)
+      } catch {
+        self.ingest(.failed(error: error.localizedDescription), for: id)
+      }
+    }
+  }
+
+  // MARK: - MCP entry point
+
+  /// Subscribes to the cross-process progress watcher. Call once at startup.
+  public func startObservingMCP(watcher: any WorktreeProgressSidecarWatcherProtocol) {
+    guard mcpCancellable == nil else { return }
+    mcpWatcher = watcher
+    mcpCancellable = watcher.updates
+      .receive(on: DispatchQueue.main)
+      .sink { [weak self] snapshot in
+        self?.ingestMCP(snapshot)
+      }
+  }
+
+  private func ingestMCP(_ snapshot: WorktreeProgressSnapshot) {
+    upsertProgress(
+      operationID: snapshot.operationID,
+      branchName: snapshot.branchName,
+      repoName: URL(fileURLWithPath: snapshot.repositoryPath).lastPathComponent,
+      provider: Self.providerKind(from: snapshot.provider),
+      source: .mcp,
+      progress: snapshot.progress,
+      startedAt: snapshot.updatedAt
+    )
+  }
+
+  // MARK: - Launch-flow entry point
+
+  /// Tracks an externally-owned in-process creation (the Start Session /
+  /// multi-session launch flow, which needs the worktree path back so it owns
+  /// the work). Call repeatedly with progress keyed by the same `operationID`.
+  public func reportLaunchProgress(
+    operationID: String,
+    branchName: String,
+    repoName: String,
+    providerKind: SessionProviderKind,
+    progress: WorktreeCreationProgress
+  ) {
+    upsertProgress(
+      operationID: operationID,
+      branchName: branchName,
+      repoName: repoName,
+      provider: providerKind,
+      source: .launch,
+      progress: progress,
+      startedAt: nil
+    )
+  }
+
+  /// Tracks the AI branch-naming request that runs before git creation. Shown
+  /// as a transient "Generating branch name…" row; never counts toward the
+  /// "all ready" notification and clears quickly so creation rows take over.
+  public func reportNamingProgress(
+    operationID: String,
+    repoName: String,
+    providerKind: SessionProviderKind,
+    progress: WorktreeBranchNamingProgress
+  ) {
+    let mapped: WorktreeCreationProgress
+    switch progress {
+    case .idle:
+      return
+    case .preparingContext(let message), .sanitizing(let message), .queryingModel(_, let message):
+      mapped = .preparing(message: message.isEmpty ? "Generating branch name…" : message)
+    case .completed:
+      mapped = .completed(path: "")
+    case .cancelled(let message):
+      mapped = .cancelled(message: message)
+    case .failed(let message):
+      mapped = .failed(error: message)
+    }
+    upsertProgress(
+      operationID: operationID,
+      branchName: "",
+      repoName: repoName,
+      provider: providerKind,
+      source: .launch,
+      kind: .naming,
+      progress: mapped,
+      startedAt: nil
+    )
+  }
+
+  /// Finds-or-creates an operation by id and applies the progress. Used by the
+  /// MCP sidecar path, the launch-flow creation path, and branch naming.
+  private func upsertProgress(
+    operationID id: String,
+    branchName: String,
+    repoName: String,
+    provider: SessionProviderKind,
+    source: WorktreeGenerationOperation.Source,
+    kind: WorktreeGenerationOperation.Kind = .creation,
+    progress: WorktreeCreationProgress,
+    startedAt: Date?
+  ) {
+    if operations.contains(where: { $0.id == id }) {
+      ingest(progress, for: id)
+    } else {
+      var op = WorktreeGenerationOperation(
+        id: id,
+        branchName: branchName,
+        repoName: repoName,
+        provider: provider,
+        source: source,
+        kind: kind,
+        progress: progress,
+        startedAt: startedAt ?? Date()
+      )
+      if !progress.isInProgress {
+        op.finishedAt = Date()
+      }
+      operations.append(op)
+      if !progress.isInProgress {
+        handleTerminal(op)
+      }
+      scheduleDoneCheck()
+    }
+  }
+
+  // MARK: - Manual dismissal (for failed rows)
+
+  public func dismiss(id: String) {
+    clearTasks[id]?.cancel()
+    clearTasks[id] = nil
+    finalizeClear(id: id)
+  }
+
+  // MARK: - Ingest / state machine
+
+  private func ingest(_ progress: WorktreeCreationProgress, for id: String) {
+    guard let idx = operations.firstIndex(where: { $0.id == id }) else { return }
+    guard operations[idx].progress != progress else { return }
+    operations[idx].progress = progress
+    if !progress.isInProgress {
+      operations[idx].finishedAt = Date()
+      handleTerminal(operations[idx])
+    }
+    scheduleDoneCheck()
+  }
+
+  private func markCompletedIfNeeded(id: String) {
+    guard let idx = operations.firstIndex(where: { $0.id == id }),
+          operations[idx].progress.isInProgress else { return }
+    ingest(.completed(path: operations[idx].branchName), for: id)
+  }
+
+  private func handleTerminal(_ op: WorktreeGenerationOperation) {
+    switch op.progress {
+    case .completed:
+      if op.isNaming {
+        // Naming done — don't announce it as a ready worktree; clear quickly.
+        scheduleClear(id: op.id, delay: Self.namingClearDelay)
+      } else {
+        if !pendingReadyBranches.contains(op.branchName) {
+          pendingReadyBranches.append(op.branchName)
+        }
+        scheduleClear(id: op.id, delay: Self.successClearDelay)
+      }
+    case .failed:
+      scheduleClear(id: op.id, delay: Self.failureClearDelay)
+    case .cancelled:
+      scheduleClear(id: op.id, delay: op.isNaming ? Self.namingClearDelay : Self.successClearDelay)
+    case .idle, .preparing, .updatingFiles:
+      break
+    }
+  }
+
+  // MARK: - Grace-clear
+
+  private func scheduleClear(id: String, delay: Duration) {
+    clearTasks[id]?.cancel()
+    clearTasks[id] = Task { [weak self] in
+      try? await Task.sleep(for: delay)
+      guard !Task.isCancelled else { return }
+      self?.finalizeClear(id: id)
+    }
+  }
+
+  private func finalizeClear(id: String) {
+    clearTasks[id]?.cancel()
+    clearTasks[id] = nil
+    let wasMCP = operations.first(where: { $0.id == id })?.source == .mcp
+    operations.removeAll { $0.id == id }
+    if wasMCP, let watcher = mcpWatcher {
+      Task { await watcher.discardSnapshot(operationID: id) }
+    }
+  }
+
+  // MARK: - "All ready" detection (debounced)
+
+  private func scheduleDoneCheck() {
+    let inFlight = operations.contains { $0.progress.isInProgress }
+    if inFlight {
+      doneDebounceTask?.cancel()
+      doneDebounceTask = nil
+      return
+    }
+    guard !pendingReadyBranches.isEmpty else { return }
+    doneDebounceTask?.cancel()
+    doneDebounceTask = Task { [weak self] in
+      try? await Task.sleep(for: Self.doneDebounce)
+      guard !Task.isCancelled else { return }
+      self?.fireDoneIfStillIdle()
+    }
+  }
+
+  private func fireDoneIfStillIdle() {
+    doneDebounceTask = nil
+    guard !operations.contains(where: { $0.progress.isInProgress }) else { return }
+    guard !pendingReadyBranches.isEmpty else { return }
+    let branches = pendingReadyBranches
+    pendingReadyBranches = []
+
+    if soundsEnabled {
+      let sound = soundService
+      Task { await sound.playWorktreeCreatedSound() }
+    }
+    notificationService.notifyReady(branchNames: branches)
+  }
+
+  // MARK: - Helpers
+
+  private func upsert(_ op: WorktreeGenerationOperation) {
+    if let idx = operations.firstIndex(where: { $0.id == op.id }) {
+      operations[idx] = op
+    } else {
+      operations.append(op)
+    }
+  }
+
+  private var soundsEnabled: Bool {
+    UserDefaults.standard.object(forKey: AgentHubDefaults.notificationSoundsEnabled) as? Bool ?? true
+  }
+
+  static func providerKind(from provider: WorktreeLaunchProvider) -> SessionProviderKind {
+    switch provider {
+    case .claude: return .claude
+    case .codex: return .codex
+    }
+  }
+}

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/WorktreeGenerationProgressCoordinatorTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/WorktreeGenerationProgressCoordinatorTests.swift
@@ -111,6 +111,23 @@ struct WorktreeGenerationProgressCoordinatorTests {
     #expect(coord.hasFailures)
   }
 
+  @Test("dismissAllFailed clears failed operations")
+  func dismissAllFailedClears() async {
+    let coord = WorktreeGenerationProgressCoordinator(soundService: MockSound(), notificationService: MockNotifier())
+
+    struct Boom: Error {}
+    coord.beginSidePanelOperation(branchName: "feature/x", repoName: "repo", providerKind: .claude) { _ in
+      throw Boom()
+    }
+    try? await Task.sleep(for: .milliseconds(200))
+    #expect(coord.hasFailures)
+    #expect(coord.operations.count == 1)
+
+    coord.dismissAllFailed()
+    #expect(coord.operations.isEmpty)
+    #expect(!coord.hasFailures)
+  }
+
   @Test("Sequential MCP completions fire once, not per-worktree (debounce)")
   func sequentialMCPFiresOnce() async {
     UserDefaults.standard.set(true, forKey: AgentHubDefaults.notificationSoundsEnabled)

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/WorktreeGenerationProgressCoordinatorTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/WorktreeGenerationProgressCoordinatorTests.swift
@@ -92,6 +92,24 @@ struct WorktreeGenerationProgressCoordinatorTests {
     #expect(notif.calls.isEmpty)
   }
 
+  @Test("Naming + creation announces a single ready worktree, not two")
+  func namingPlusCreationCountsOnce() async {
+    UserDefaults.standard.set(true, forKey: AgentHubDefaults.notificationSoundsEnabled)
+    let sound = MockSound()
+    let notif = MockNotifier()
+    let coord = WorktreeGenerationProgressCoordinator(soundService: sound, notificationService: notif)
+
+    // The transient naming step followed by the real creation, same worktree.
+    coord.reportNamingProgress(operationID: "N1", repoName: "repo", providerKind: .claude, progress: .preparingContext(message: "Preparing"))
+    coord.reportNamingProgress(operationID: "N1", repoName: "repo", providerKind: .claude, progress: .completed(message: "ready", source: .ai, branchNames: ["feature/x"]))
+    coord.reportLaunchProgress(operationID: "C1", branchName: "feature/x", repoName: "repo", providerKind: .claude, progress: .updatingFiles(current: 1, total: 4))
+    coord.reportLaunchProgress(operationID: "C1", branchName: "feature/x", repoName: "repo", providerKind: .claude, progress: .completed(path: "/tmp/x"))
+    try? await Task.sleep(for: .milliseconds(1100))
+
+    #expect(sound.count == 1)
+    #expect(notif.calls == [["feature/x"]])
+  }
+
   @Test("Failure does not fire ready and keeps the entry visible")
   func failureDoesNotFire() async {
     let sound = MockSound()

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/WorktreeGenerationProgressCoordinatorTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/WorktreeGenerationProgressCoordinatorTests.swift
@@ -1,0 +1,215 @@
+import AgentHubCLIKit
+import Combine
+import Foundation
+import Testing
+
+@testable import AgentHubCore
+
+@MainActor
+@Suite("WorktreeGenerationProgressCoordinator")
+struct WorktreeGenerationProgressCoordinatorTests {
+
+  @Test("Side-panel completion fires sound and notification once")
+  func sidePanelCompletionFires() async {
+    UserDefaults.standard.set(true, forKey: AgentHubDefaults.notificationSoundsEnabled)
+    let sound = MockSound()
+    let notif = MockNotifier()
+    let coord = WorktreeGenerationProgressCoordinator(soundService: sound, notificationService: notif)
+
+    coord.beginSidePanelOperation(branchName: "feature/x", repoName: "repo", providerKind: .claude) { onProgress in
+      await onProgress(.updatingFiles(current: 1, total: 2))
+      await onProgress(.completed(path: "/tmp/repo/.worktrees/x"))
+    }
+
+    try? await Task.sleep(for: .milliseconds(1100))
+
+    #expect(notif.calls == [["feature/x"]])
+    #expect(sound.count == 1)
+  }
+
+  @Test("Side-panel and MCP completions fire once with both branches")
+  func mixedCompletionFiresOnce() async {
+    UserDefaults.standard.set(true, forKey: AgentHubDefaults.notificationSoundsEnabled)
+    let sound = MockSound()
+    let notif = MockNotifier()
+    let watcher = MockProgressWatcher()
+    let coord = WorktreeGenerationProgressCoordinator(soundService: sound, notificationService: notif)
+    coord.startObservingMCP(watcher: watcher)
+
+    // Keep an MCP op in-flight so the side-panel completion can't fire early.
+    watcher.send(snapshot("mcp-1", "mcp/work", .updatingFiles(current: 1, total: 10), at: 1))
+    await settle()
+
+    coord.beginSidePanelOperation(branchName: "feature/x", repoName: "repo", providerKind: .claude) { onProgress in
+      await onProgress(.completed(path: "/tmp/repo/.worktrees/x"))
+    }
+    try? await Task.sleep(for: .milliseconds(200))
+    #expect(notif.calls.isEmpty)
+
+    watcher.send(snapshot("mcp-1", "mcp/work", .completed(path: "/tmp/repo/.worktrees/mcp"), at: 2))
+    try? await Task.sleep(for: .milliseconds(1100))
+
+    #expect(sound.count == 1)
+    #expect(notif.calls.count == 1)
+    #expect(Set(notif.calls.first ?? []) == ["feature/x", "mcp/work"])
+  }
+
+  @Test("Launch-flow progress is tracked and fires once on completion")
+  func launchProgressFires() async {
+    UserDefaults.standard.set(true, forKey: AgentHubDefaults.notificationSoundsEnabled)
+    let sound = MockSound()
+    let notif = MockNotifier()
+    let coord = WorktreeGenerationProgressCoordinator(soundService: sound, notificationService: notif)
+
+    coord.reportLaunchProgress(operationID: "L1", branchName: "add-logging", repoName: "repo", providerKind: .claude, progress: .updatingFiles(current: 1, total: 4))
+    #expect(coord.operations.count == 1)
+    #expect(coord.inFlightCount == 1)
+
+    coord.reportLaunchProgress(operationID: "L1", branchName: "add-logging", repoName: "repo", providerKind: .claude, progress: .completed(path: "/tmp/repo/.worktrees/add-logging"))
+    try? await Task.sleep(for: .milliseconds(1100))
+
+    #expect(sound.count == 1)
+    #expect(notif.calls == [["add-logging"]])
+  }
+
+  @Test("Branch naming shows a transient row that never announces ready")
+  func namingDoesNotFireReady() async {
+    UserDefaults.standard.set(true, forKey: AgentHubDefaults.notificationSoundsEnabled)
+    let sound = MockSound()
+    let notif = MockNotifier()
+    let coord = WorktreeGenerationProgressCoordinator(soundService: sound, notificationService: notif)
+
+    coord.reportNamingProgress(operationID: "N1", repoName: "repo", providerKind: .claude, progress: .preparingContext(message: "Preparing"))
+    #expect(coord.operations.count == 1)
+    #expect(coord.inFlightCount == 1)
+    #expect(coord.operations.first?.isNaming == true)
+
+    coord.reportNamingProgress(operationID: "N1", repoName: "repo", providerKind: .claude, progress: .completed(message: "ready", source: .ai, branchNames: ["feature/x"]))
+    try? await Task.sleep(for: .milliseconds(900))
+
+    // Naming on its own must never play the sound or post the notification.
+    #expect(sound.count == 0)
+    #expect(notif.calls.isEmpty)
+  }
+
+  @Test("Failure does not fire ready and keeps the entry visible")
+  func failureDoesNotFire() async {
+    let sound = MockSound()
+    let notif = MockNotifier()
+    let coord = WorktreeGenerationProgressCoordinator(soundService: sound, notificationService: notif)
+
+    struct Boom: Error {}
+    coord.beginSidePanelOperation(branchName: "feature/x", repoName: "repo", providerKind: .claude) { _ in
+      throw Boom()
+    }
+
+    try? await Task.sleep(for: .milliseconds(1100))
+
+    #expect(sound.count == 0)
+    #expect(notif.calls.isEmpty)
+    #expect(coord.operations.count == 1)
+    #expect(coord.hasFailures)
+  }
+
+  @Test("Sequential MCP completions fire once, not per-worktree (debounce)")
+  func sequentialMCPFiresOnce() async {
+    UserDefaults.standard.set(true, forKey: AgentHubDefaults.notificationSoundsEnabled)
+    let sound = MockSound()
+    let notif = MockNotifier()
+    let watcher = MockProgressWatcher()
+    let coord = WorktreeGenerationProgressCoordinator(soundService: sound, notificationService: notif)
+    coord.startObservingMCP(watcher: watcher)
+
+    watcher.send(snapshot("op-1", "b1", .updatingFiles(current: 1, total: 10), at: 1))
+    await settle()
+    watcher.send(snapshot("op-1", "b1", .completed(path: "/tmp/1"), at: 2))
+    await settle() // momentary idle — must NOT fire because op-2 starts within the debounce window
+    watcher.send(snapshot("op-2", "b2", .updatingFiles(current: 1, total: 10), at: 3))
+    await settle()
+    watcher.send(snapshot("op-2", "b2", .completed(path: "/tmp/2"), at: 4))
+    try? await Task.sleep(for: .milliseconds(1100))
+
+    #expect(sound.count == 1)
+    #expect(notif.calls.count == 1)
+    #expect(Set(notif.calls.first ?? []) == ["b1", "b2"])
+  }
+
+  @Test("Dismiss removes the operation and discards its MCP snapshot")
+  func dismissRemovesAndDiscards() async {
+    let watcher = MockProgressWatcher()
+    let coord = WorktreeGenerationProgressCoordinator(soundService: MockSound(), notificationService: MockNotifier())
+    coord.startObservingMCP(watcher: watcher)
+
+    watcher.send(snapshot("op-1", "b1", .failed(error: "nope"), at: 1))
+    await settle()
+    #expect(coord.operations.count == 1)
+
+    coord.dismiss(id: "op-1")
+    await settle()
+
+    #expect(coord.operations.isEmpty)
+    #expect(watcher.discarded == ["op-1"])
+  }
+
+  // MARK: - Helpers
+
+  private func snapshot(
+    _ id: String,
+    _ branch: String,
+    _ progress: WorktreeCreationProgress,
+    at seconds: TimeInterval
+  ) -> WorktreeProgressSnapshot {
+    WorktreeProgressSnapshot(
+      operationID: id,
+      branchName: branch,
+      repositoryPath: "/tmp/repo",
+      provider: .codex,
+      progress: progress,
+      updatedAt: Date(timeIntervalSince1970: seconds)
+    )
+  }
+
+  private func settle() async {
+    try? await Task.sleep(for: .milliseconds(40))
+  }
+}
+
+// MARK: - Mocks
+
+private final class MockSound: WorktreeSuccessSoundServiceProtocol, @unchecked Sendable {
+  private let lock = NSLock()
+  private var _count = 0
+  var count: Int { lock.lock(); defer { lock.unlock() }; return _count }
+  func playWorktreeCreatedSound() async {
+    lock.lock(); _count += 1; lock.unlock()
+  }
+}
+
+private final class MockNotifier: WorktreeReadyNotificationServiceProtocol, @unchecked Sendable {
+  private let lock = NSLock()
+  private var _calls: [[String]] = []
+  var calls: [[String]] { lock.lock(); defer { lock.unlock() }; return _calls }
+  func requestPermission() async -> Bool { true }
+  func notifyReady(branchNames: [String]) {
+    lock.lock(); _calls.append(branchNames); lock.unlock()
+  }
+}
+
+private final class MockProgressWatcher: WorktreeProgressSidecarWatcherProtocol, @unchecked Sendable {
+  private let subject = PassthroughSubject<WorktreeProgressSnapshot, Never>()
+  var updates: AnyPublisher<WorktreeProgressSnapshot, Never> { subject.eraseToAnyPublisher() }
+
+  private let lock = NSLock()
+  private var _discarded: [String] = []
+  var discarded: [String] { lock.lock(); defer { lock.unlock() }; return _discarded }
+
+  func start() async {}
+  func wipeAll() async {}
+  func discardSnapshot(operationID: String) async {
+    lock.lock(); _discarded.append(operationID); lock.unlock()
+  }
+
+  func send(_ snapshot: WorktreeProgressSnapshot) {
+    subject.send(snapshot)
+  }
+}

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/WorktreeProgressSidecarWatcherTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/WorktreeProgressSidecarWatcherTests.swift
@@ -1,0 +1,120 @@
+import AgentHubCLIKit
+import Combine
+import Foundation
+import Testing
+
+@testable import AgentHubCore
+
+@Suite("WorktreeProgressSidecarWatcher")
+struct WorktreeProgressSidecarWatcherTests {
+
+  @Test("start emits snapshots already on disk")
+  func emitsPreexistingOnStart() async throws {
+    let dir = try tempDir()
+    defer { try? FileManager.default.removeItem(at: dir.deletingLastPathComponent()) }
+    let writer = WorktreeProgressQueue(directoryURL: dir)
+    try writer.write(snap("op-1", .updatingFiles(current: 1, total: 4)))
+    try writer.write(snap("op-2", .preparing(message: "Preparing…")))
+
+    let recorder = SnapshotRecorder()
+    let watcher = WorktreeProgressSidecarWatcher(queue: WorktreeProgressQueue(directoryURL: dir))
+    let cancellable = watcher.updates.sink { recorder.record($0) }
+    defer { cancellable.cancel() }
+
+    // The initial scan runs synchronously inside start().
+    await watcher.start()
+
+    #expect(Set(recorder.snapshot().map(\.operationID)) == ["op-1", "op-2"])
+  }
+
+  @Test("emits when a snapshot file is written after start")
+  func emitsOnLiveWrite() async throws {
+    let dir = try tempDir()
+    defer { try? FileManager.default.removeItem(at: dir.deletingLastPathComponent()) }
+    let writer = WorktreeProgressQueue(directoryURL: dir)
+
+    let recorder = SnapshotRecorder()
+    let watcher = WorktreeProgressSidecarWatcher(queue: WorktreeProgressQueue(directoryURL: dir))
+    let cancellable = watcher.updates.sink { recorder.record($0) }
+    defer { cancellable.cancel() }
+    await watcher.start()
+
+    // Atomic temp-then-move write — the directory source must fire and re-scan.
+    try writer.write(snap("op-live", .updatingFiles(current: 2, total: 10)))
+    try await waitUntil { recorder.snapshot().contains { $0.operationID == "op-live" } }
+
+    #expect(recorder.snapshot().contains { $0.operationID == "op-live" })
+  }
+
+  @Test("discardSnapshot removes the file")
+  func discardRemovesFile() async throws {
+    let dir = try tempDir()
+    defer { try? FileManager.default.removeItem(at: dir.deletingLastPathComponent()) }
+    try WorktreeProgressQueue(directoryURL: dir).write(snap("op-1", .completed(path: "/tmp/x")))
+
+    let watcher = WorktreeProgressSidecarWatcher(queue: WorktreeProgressQueue(directoryURL: dir))
+    await watcher.start()
+    await watcher.discardSnapshot(operationID: "op-1")
+
+    #expect(try WorktreeProgressQueue(directoryURL: dir).pendingSnapshots().isEmpty)
+  }
+
+  @Test("wipeAll clears the directory")
+  func wipeAllClears() async throws {
+    let dir = try tempDir()
+    defer { try? FileManager.default.removeItem(at: dir.deletingLastPathComponent()) }
+    try WorktreeProgressQueue(directoryURL: dir).write(snap("op-1", .preparing(message: "x")))
+
+    let watcher = WorktreeProgressSidecarWatcher(queue: WorktreeProgressQueue(directoryURL: dir))
+    await watcher.wipeAll()
+
+    #expect(try WorktreeProgressQueue(directoryURL: dir).pendingSnapshots().isEmpty)
+  }
+
+  // MARK: - Helpers
+
+  private func snap(_ id: String, _ progress: WorktreeCreationProgress) -> WorktreeProgressSnapshot {
+    WorktreeProgressSnapshot(
+      operationID: id,
+      branchName: "feature/\(id)",
+      repositoryPath: "/tmp/repo",
+      provider: .claude,
+      progress: progress
+    )
+  }
+
+  private func tempDir() throws -> URL {
+    let root = FileManager.default.temporaryDirectory
+      .appendingPathComponent("agenthub-progress-watcher-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+    return root.appendingPathComponent("worktree-progress", isDirectory: true)
+  }
+
+  private func waitUntil(
+    timeout: Duration = .seconds(3),
+    _ condition: @escaping () -> Bool
+  ) async throws {
+    let start = ContinuousClock.now
+    while ContinuousClock.now - start < timeout {
+      if condition() { return }
+      try await Task.sleep(for: .milliseconds(25))
+    }
+  }
+}
+
+private final class SnapshotRecorder: @unchecked Sendable {
+  private let lock = NSLock()
+  private var items: [WorktreeProgressSnapshot] = []
+
+  func record(_ snapshot: WorktreeProgressSnapshot) {
+    lock.lock()
+    items.append(snapshot)
+    lock.unlock()
+  }
+
+  func snapshot() -> [WorktreeProgressSnapshot] {
+    lock.lock()
+    defer { lock.unlock() }
+    return items
+  }
+}


### PR DESCRIPTION
## Summary

Adds a compact **top bar** that unifies real-time progress for git worktree creation across **all three entry points** — the side-panel sheet, the MCP tools, and the Start Session / multi-session launch flow. Previously the side panel and Start Session trapped the user in a blocking sheet, the MCP path showed no progress at all (the worktree is created in a separate `agenthub` CLI process), and there was no completion notification.

The bar has two states and notifies once per batch:
- **Collapsed:** aggregate progress bar + count.
- **Expanded:** per-worktree rows (branch, provider, live `Updating files: X/Y`, status).
- **Completion:** a single Glass sound + macOS notification when all in-flight worktrees finish (debounced so a sequential MCP batch doesn't fire early).

## How it works

- **`WorktreeGenerationProgressCoordinator`** (`@MainActor @Observable`, provider-owned singleton): the app-wide source of truth for in-flight creations. Debounced "all ready" detection, grace-clear of finished rows (failures linger and are dismissible).
- **Side panel & Start Session** hand creation off to the coordinator and **dismiss immediately**; progress and errors surface in the bar. Smart/interactive launches still keep their sheet open to review the orchestration plan.
- **MCP (cross-process):** the `agenthub` CLI now streams `WorktreeCreationProgress` to a dedicated `~/Library/Application Support/AgentHub/worktree-progress/` sidecar (separate from `cli-requests/`). `WorktreeProgressSidecarWatcher` (kqueue, directory-source re-scan to survive atomic temp-then-move writes) feeds the coordinator.
- **AI branch-naming** shows as a transient "Generating branch name" row before git creation; it never triggers the "ready" sound.
- Animated appear/dismiss + row transitions.

## Key files

**New:** `WorktreeProgressQueue.swift` (+ `WorktreeProgressSnapshot`), `WorktreeProgressSidecarWatcher.swift`, `WorktreeReadyNotificationService.swift`, `WorktreeGenerationProgressCoordinator.swift`, `WorktreeGenerationProgressBar.swift`.
**Modified:** `WorktreeModels.swift` (`WorktreeCreationProgress` → `Codable`), `AgentHubMCPServer.swift` (emit snapshots), `AgentHubProvider.swift` / `AgentHubEnvironment.swift` (wiring), `CreateWorktreeSheet.swift` + `MultiProviderSessionsListView.swift` + `MultiSessionLaunchViewModel.swift` (fire-and-forget handoff + naming/launch progress), `CLISessionsListView.swift` (compile-fix; dead code).

## Testing

- ✅ Full app builds (`xcodebuild … -scheme AgentHub build`).
- ✅ `AgentHubCLIKit` tests pass via `swift test` — `WorktreeProgressQueue` incl. `WorktreeCreationProgress` Codable round-trip (all 6 cases).
- ⚠️ `AgentHubCore` test suites (coordinator debounce/single-fire/naming, sidecar watcher) are written but must be run via **Xcode Cmd+U** — `swift test` can't build the package headlessly (the `CodeEditSymbols` dependency needs Xcode's asset-bundle handling) and no shared scheme has a test action.

## Manual verification
Create a worktree from the side panel, Start Session (default naming → "Generating branch name" → creation), and an MCP tool call; confirm the bar streams live progress, collapses/expands, fires one sound + notification per batch, and that failures show a dismissible row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)