### PR TITLE
[codex] Show all tracked repo worktrees in settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ Toggle between modes in the app settings.
 
 Worktree sessions are grouped under their parent module by default, so `ModuleA` shows its regular sessions plus AgentHub-owned worktree sessions. The Worktrees settings tab can switch to separate modules, where each AgentHub-owned worktree appears as its own module section.
 
-AgentHub only treats worktrees it created, explicitly added, or focused through monitored sessions as owned. External Git worktrees discovered from the repository are ignored for session grouping, which keeps large local worktree setups from flooding the session list.
+AgentHub only treats worktrees it created, explicitly added, or focused through monitored sessions as owned. External Git worktrees discovered from the repository are ignored for session grouping, which keeps large local worktree setups from flooding the session list. The Worktrees settings inventory still lists all Git worktrees for tracked repositories: focused rows participate in AgentHub grouping, while external rows can be deleted without becoming focused.
 
 ### Provider Defaults
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/Models/WorktreeSettingsInventory.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Models/WorktreeSettingsInventory.swift
@@ -24,7 +24,7 @@ struct WorktreeSettingsWorktree: Identifiable, Equatable {
   let worktree: WorktreeBranch
   let parentModulePath: String
   let providerKinds: [SessionProviderKind]
-  let deletionProviderKind: SessionProviderKind
+  let isFocusedInAgentHub: Bool
   let monitoredSessionCount: Int
   let activeMonitoredSessionCount: Int
   let historicalSessionCount: Int
@@ -39,7 +39,8 @@ enum WorktreeSettingsInventoryBuilder {
     claudeRepositories: [SelectedRepository],
     codexRepositories: [SelectedRepository],
     claudeMonitoredSessions: [CLISession],
-    codexMonitoredSessions: [CLISession]
+    codexMonitoredSessions: [CLISession],
+    discoveredWorktreesByRepositoryPath: [String: [GitWorktreeInventoryItem]] = [:]
   ) -> WorktreeSettingsSnapshot {
     let mergedRepositories = WorktreeModuleResolver
       .mergedRepositories(claudeRepositories + codexRepositories)
@@ -53,7 +54,8 @@ enum WorktreeSettingsInventoryBuilder {
         claudeRepositories: claudeRepositories,
         codexRepositories: codexRepositories,
         claudeMonitoredSessions: claudeMonitoredSessions,
-        codexMonitoredSessions: codexMonitoredSessions
+        codexMonitoredSessions: codexMonitoredSessions,
+        discoveredWorktrees: discoveredWorktreesByRepositoryPath[modulePath] ?? []
       )
 
       return WorktreeSettingsModule(
@@ -72,7 +74,8 @@ enum WorktreeSettingsInventoryBuilder {
     claudeRepositories: [SelectedRepository],
     codexRepositories: [SelectedRepository],
     claudeMonitoredSessions: [CLISession],
-    codexMonitoredSessions: [CLISession]
+    codexMonitoredSessions: [CLISession],
+    discoveredWorktrees: [GitWorktreeInventoryItem]
   ) -> [WorktreeSettingsWorktree] {
     let providerRepositories = [
       (kind: SessionProviderKind.claude, repositories: claudeRepositories),
@@ -92,6 +95,11 @@ enum WorktreeSettingsInventoryBuilder {
         appendPath(worktree.path, to: &orderedPaths, seen: &seenPaths)
       }
     }
+    for worktree in discoveredWorktrees where worktree.isWorktree {
+      let worktreePath = normalized(worktree.path)
+      guard worktreePath != modulePath else { continue }
+      appendPath(worktreePath, to: &orderedPaths, seen: &seenPaths)
+    }
 
     return orderedPaths.compactMap { worktreePath in
       let providerMatches = providerRepositories.compactMap { provider -> (SessionProviderKind, WorktreeBranch)? in
@@ -102,9 +110,12 @@ enum WorktreeSettingsInventoryBuilder {
         return (provider.kind, normalizedWorktree(worktree))
       }
 
-      guard let deletionMatch = providerMatches.first else { return nil }
       let providerKinds = providerMatches.map(\.0)
-      let representative = deletionMatch.1
+      let discoveredWorktree = discoveredWorktrees.first { normalized($0.path) == worktreePath && $0.isWorktree }
+      let representative = providerMatches.first?.1 ?? worktreeBranch(
+        from: discoveredWorktree,
+        fallbackPath: worktreePath
+      )
       let monitoredSessions = providerMatches.flatMap { providerKind, _ in
         switch providerKind {
         case .claude:
@@ -125,7 +136,7 @@ enum WorktreeSettingsInventoryBuilder {
         worktree: representative,
         parentModulePath: modulePath,
         providerKinds: providerKinds,
-        deletionProviderKind: deletionMatch.0,
+        isFocusedInAgentHub: !providerMatches.isEmpty,
         monitoredSessionCount: monitoredSessionsById.count,
         activeMonitoredSessionCount: monitoredSessionsById.values.filter(\.isActive).count,
         historicalSessionCount: historicalSessionCount
@@ -153,6 +164,21 @@ enum WorktreeSettingsInventoryBuilder {
       isWorktree: worktree.isWorktree,
       sessions: worktree.sessions,
       isExpanded: worktree.isExpanded
+    )
+  }
+
+  private static func worktreeBranch(
+    from discoveredWorktree: GitWorktreeInventoryItem?,
+    fallbackPath: String
+  ) -> WorktreeBranch {
+    let path = normalized(discoveredWorktree?.path ?? fallbackPath)
+    let fallbackName = URL(fileURLWithPath: path).lastPathComponent
+    let branchName = discoveredWorktree?.branchName.flatMap { $0.isEmpty ? nil : $0 } ?? fallbackName
+
+    return WorktreeBranch(
+      name: branchName,
+      path: path,
+      isWorktree: true
     )
   }
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/GitWorktreeService.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/GitWorktreeService.swift
@@ -10,6 +10,31 @@ public struct LocalBranchesResult: Sendable {
   public let currentBranchName: String
 }
 
+public struct GitWorktreeInventoryItem: Identifiable, Sendable, Equatable {
+  public var id: String { path }
+
+  public let path: String
+  public let branchName: String?
+  public let isWorktree: Bool
+  public let mainRepoPath: String?
+
+  public init(
+    path: String,
+    branchName: String?,
+    isWorktree: Bool,
+    mainRepoPath: String?
+  ) {
+    self.path = path
+    self.branchName = branchName
+    self.isWorktree = isWorktree
+    self.mainRepoPath = mainRepoPath
+  }
+}
+
+public protocol GitWorktreeInventoryServiceProtocol: Sendable {
+  func listWorktrees(at repoPath: String) async throws -> [GitWorktreeInventoryItem]
+}
+
 public protocol GitWorktreeRemovalServiceProtocol: Sendable {
   func removeWorktree(at worktreePath: String, force: Bool) async throws
   func removeWorktree(at worktreePath: String, relativeTo parentRepoPath: String, force: Bool) async throws
@@ -17,7 +42,7 @@ public protocol GitWorktreeRemovalServiceProtocol: Sendable {
   func removeOrphanedWorktree(at worktreePath: String, parentRepoPath: String) async throws
 }
 
-public actor GitWorktreeService: GitWorktreeRemovalServiceProtocol {
+public actor GitWorktreeService: GitWorktreeInventoryServiceProtocol, GitWorktreeRemovalServiceProtocol {
   private let service: WorktreeManagementService
 
   public init(service: WorktreeManagementService = WorktreeManagementService()) {
@@ -30,6 +55,10 @@ public actor GitWorktreeService: GitWorktreeRemovalServiceProtocol {
 
   public func findMainRepositoryRoot(at path: String) async throws -> String {
     try await service.findMainRepositoryRoot(at: path)
+  }
+
+  public func listWorktrees(at repoPath: String) async throws -> [GitWorktreeInventoryItem] {
+    try await service.listWorktrees(at: repoPath).map(Self.inventoryItem)
   }
 
   public func getRemoteBranches(at repoPath: String) async throws -> [RemoteBranch] {
@@ -178,5 +207,14 @@ public actor GitWorktreeService: GitWorktreeRemovalServiceProtocol {
 
   private static func remoteBranch(_ branch: BranchInfo) -> RemoteBranch {
     RemoteBranch(name: branch.name, remote: branch.remote)
+  }
+
+  private static func inventoryItem(_ worktree: WorktreeInfo) -> GitWorktreeInventoryItem {
+    GitWorktreeInventoryItem(
+      path: WorktreeModuleResolver.normalizedDirectoryPath(worktree.path),
+      branchName: worktree.branch,
+      isWorktree: worktree.isWorktree,
+      mainRepoPath: worktree.mainRepoPath.map(WorktreeModuleResolver.normalizedDirectoryPath)
+    )
   }
 }

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/WorktreeInventorySection.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/WorktreeInventorySection.swift
@@ -1,17 +1,32 @@
 import SwiftUI
 
 struct WorktreeInventorySection: View {
-  @Bindable var claudeViewModel: CLISessionsViewModel
-  @Bindable var codexViewModel: CLISessionsViewModel
+  let claudeViewModel: CLISessionsViewModel
+  let codexViewModel: CLISessionsViewModel
 
+  @State private var inventoryViewModel: WorktreeInventoryViewModel
   @State private var pendingDeletion: WorktreeSettingsWorktree?
   @State private var isDeleteConfirmationPresented = false
-  @State private var deletionFailure: WorktreeSettingsDeletionFailure?
+  @State private var deletionFailure: WorktreeInventoryDeletionError?
   @State private var isFailureAlertPresented = false
+
+  init(
+    claudeViewModel: CLISessionsViewModel,
+    codexViewModel: CLISessionsViewModel,
+    inventoryService: any GitWorktreeInventoryServiceProtocol = GitWorktreeService(),
+    worktreeRemovalService: any GitWorktreeRemovalServiceProtocol = GitWorktreeService()
+  ) {
+    self.claudeViewModel = claudeViewModel
+    self.codexViewModel = codexViewModel
+    self._inventoryViewModel = State(initialValue: WorktreeInventoryViewModel(
+      inventoryService: inventoryService,
+      removalService: worktreeRemovalService
+    ))
+  }
 
   var body: some View {
     Section("Worktrees") {
-      let currentSnapshot = snapshot
+      let currentSnapshot = inventoryViewModel.snapshot
 
       if currentSnapshot.modules.isEmpty {
         WorktreeInventoryEmptyView()
@@ -19,16 +34,23 @@ struct WorktreeInventorySection: View {
         VStack(alignment: .leading, spacing: 14) {
           WorktreeInventorySummaryView(snapshot: currentSnapshot)
 
+          if !inventoryViewModel.loadFailuresByRepositoryPath.isEmpty {
+            WorktreeInventoryLoadFailureView()
+          }
+
           ForEach(currentSnapshot.modules) { module in
             WorktreeInventoryModuleView(
               module: module,
-              isDeleting: { isDeletingWorktree(at: $0.path) },
+              isDeleting: { inventoryViewModel.deletingWorktreePath == $0.path },
               onDelete: requestDelete
             )
           }
         }
         .padding(.vertical, 4)
       }
+    }
+    .task(id: inventoryReloadID) {
+      await reloadInventory()
     }
     .alert("Delete Worktree?", isPresented: $isDeleteConfirmationPresented, presenting: pendingDeletion) { worktree in
       Button("Cancel", role: .cancel) {
@@ -45,7 +67,7 @@ struct WorktreeInventorySection: View {
       }
     }
     .alert("Failed to Delete Worktree", isPresented: $isFailureAlertPresented, presenting: deletionFailure) { failure in
-      if failure.error.isOrphaned, failure.error.parentRepoPath != nil {
+      if failure.isOrphaned, failure.parentRepoPath != nil {
         Button("Prune & Delete", role: .destructive) {
           pruneAndDelete(failure)
         }
@@ -58,21 +80,12 @@ struct WorktreeInventorySection: View {
         clearFailure(failure)
       }
     } message: { failure in
-      if failure.error.isOrphaned, let parentRepoPath = failure.error.parentRepoPath {
-        Text("The worktree at:\n\(failure.error.worktree.path)\n\nhas no parent repo. You can prune and delete it from:\n\(parentRepoPath)")
+      if failure.isOrphaned, let parentRepoPath = failure.parentRepoPath {
+        Text("The worktree at:\n\(failure.worktree.path)\n\nhas no parent repo. You can prune and delete it from:\n\(parentRepoPath)")
       } else {
-        Text("\(failure.error.message)\n\n\"Force Delete\" will remove the worktree even if it contains untracked files.")
+        Text("\(failure.message)\n\n\"Force Delete\" will remove the worktree even if it contains untracked files.")
       }
     }
-  }
-
-  private var snapshot: WorktreeSettingsSnapshot {
-    WorktreeSettingsInventoryBuilder.snapshot(
-      claudeRepositories: claudeViewModel.selectedRepositories,
-      codexRepositories: codexViewModel.selectedRepositories,
-      claudeMonitoredSessions: claudeViewModel.monitoredSessions.map(\.session),
-      codexMonitoredSessions: codexViewModel.monitoredSessions.map(\.session)
-    )
   }
 
   private func requestDelete(_ worktree: WorktreeSettingsWorktree) {
@@ -87,40 +100,40 @@ struct WorktreeInventorySection: View {
     }
   }
 
-  private func forceDelete(_ failure: WorktreeSettingsDeletionFailure) {
+  private func forceDelete(_ failure: WorktreeInventoryDeletionError) {
     Task {
       await delete(failure.worktree, force: true)
     }
   }
 
-  private func pruneAndDelete(_ failure: WorktreeSettingsDeletionFailure) {
-    guard let parentRepoPath = failure.error.parentRepoPath else { return }
+  private func pruneAndDelete(_ failure: WorktreeInventoryDeletionError) {
+    guard let parentRepoPath = failure.parentRepoPath else { return }
     clearFailure(failure)
 
     Task {
-      let viewModel = viewModel(for: failure.providerKind)
-      let succeeded = await viewModel.deleteOrphanedWorktree(
-        failure.error.worktree,
+      let succeeded = await inventoryViewModel.deleteOrphaned(
+        failure.worktree,
         parentRepoPath: parentRepoPath
       )
 
       if succeeded {
         completeSuccessfulDeletion(of: failure.worktree)
+        await reloadInventory()
       } else {
-        showFailure(from: viewModel, worktree: failure.worktree)
+        showFailure(worktree: failure.worktree)
       }
     }
   }
 
   private func delete(_ worktree: WorktreeSettingsWorktree, force: Bool) async {
-    clearFailure(providerKind: worktree.deletionProviderKind)
-    let viewModel = viewModel(for: worktree.deletionProviderKind)
-    let succeeded = await viewModel.deleteWorktree(worktree.worktree, force: force)
+    clearFailure()
+    let succeeded = await inventoryViewModel.delete(worktree, force: force)
 
     if succeeded {
       completeSuccessfulDeletion(of: worktree)
+      await reloadInventory()
     } else {
-      showFailure(from: viewModel, worktree: worktree)
+      showFailure(worktree: worktree)
     }
   }
 
@@ -133,48 +146,61 @@ struct WorktreeInventorySection: View {
     codexViewModel.refresh()
   }
 
-  private func showFailure(from viewModel: CLISessionsViewModel, worktree: WorktreeSettingsWorktree) {
-    let error = viewModel.worktreeDeletionError ?? CLISessionsViewModel.WorktreeDeletionError(
-      worktree: worktree.worktree,
+  private func showFailure(worktree: WorktreeSettingsWorktree) {
+    let error = inventoryViewModel.deletionError ?? WorktreeInventoryDeletionError(
+      worktree: worktree,
       message: "The worktree could not be deleted."
     )
-    deletionFailure = WorktreeSettingsDeletionFailure(
-      providerKind: viewModel.providerKind,
-      worktree: worktree,
-      error: error
-    )
+    deletionFailure = error
     isFailureAlertPresented = true
   }
 
-  private func clearFailure(_ failure: WorktreeSettingsDeletionFailure) {
-    clearFailure(providerKind: failure.providerKind)
+  private func clearFailure(_ failure: WorktreeInventoryDeletionError) {
+    clearFailure()
     deletionFailure = nil
   }
 
-  private func clearFailure(providerKind: SessionProviderKind) {
-    viewModel(for: providerKind).clearWorktreeDeletionError()
+  private func clearFailure() {
+    inventoryViewModel.clearDeletionError()
     deletionFailure = nil
     isFailureAlertPresented = false
   }
 
-  private func viewModel(for providerKind: SessionProviderKind) -> CLISessionsViewModel {
-    switch providerKind {
-    case .claude:
-      return claudeViewModel
-    case .codex:
-      return codexViewModel
+  private func reloadInventory() async {
+    await inventoryViewModel.reload(
+      claudeRepositories: claudeViewModel.selectedRepositories,
+      codexRepositories: codexViewModel.selectedRepositories,
+      claudeMonitoredSessions: claudeViewModel.monitoredSessions.map(\.session),
+      codexMonitoredSessions: codexViewModel.monitoredSessions.map(\.session)
+    )
+  }
+
+  private var inventoryReloadID: String {
+    [
+      repositoriesSignature(claudeViewModel.selectedRepositories),
+      repositoriesSignature(codexViewModel.selectedRepositories),
+      sessionsSignature(claudeViewModel.monitoredSessions.map(\.session)),
+      sessionsSignature(codexViewModel.monitoredSessions.map(\.session)),
+    ].joined(separator: "|")
+  }
+
+  private func repositoriesSignature(_ repositories: [SelectedRepository]) -> String {
+    repositories.map { repository in
+      let worktrees = repository.worktrees.map { worktree in
+        "\(worktree.path):\(worktree.name):\(worktree.isWorktree)"
+      }.joined(separator: ",")
+      return "\(repository.path)[\(worktrees)]"
     }
+    .joined(separator: ";")
   }
 
-  private func isDeletingWorktree(at path: String) -> Bool {
-    claudeViewModel.deletingWorktreePath == path || codexViewModel.deletingWorktreePath == path
+  private func sessionsSignature(_ sessions: [CLISession]) -> String {
+    sessions.map { session in
+      "\(session.id):\(session.projectPath):\(session.isActive)"
+    }
+    .sorted()
+    .joined(separator: ";")
   }
-}
-
-private struct WorktreeSettingsDeletionFailure {
-  let providerKind: SessionProviderKind
-  let worktree: WorktreeSettingsWorktree
-  let error: CLISessionsViewModel.WorktreeDeletionError
 }
 
 private struct WorktreeInventorySummaryView: View {
@@ -254,15 +280,23 @@ private struct WorktreeInventoryRow: View {
             .font(.subheadline.weight(.semibold))
             .lineLimit(1)
 
-          Text(worktree.providerLabel)
-            .font(.caption2.weight(.medium))
-            .foregroundStyle(.secondary)
-            .padding(.horizontal, 6)
-            .padding(.vertical, 2)
-            .background(
-              RoundedRectangle(cornerRadius: 5, style: .continuous)
-                .fill(Color.primary.opacity(0.06))
+          WorktreeInventoryBadge(
+            title: worktree.isFocusedInAgentHub ? "Focused in AgentHub" : "External",
+            systemImage: worktree.isFocusedInAgentHub ? "scope" : "externaldrive",
+            isProminent: worktree.isFocusedInAgentHub,
+            helpText: worktree.isFocusedInAgentHub
+              ? "This worktree is focused in AgentHub, so its sessions can appear in the session list and grouping."
+              : "This worktree belongs to a tracked repository, but AgentHub has not focused it for session grouping."
+          )
+
+          if worktree.isFocusedInAgentHub, !worktree.providerLabel.isEmpty {
+            WorktreeInventoryBadge(
+              title: worktree.providerLabel,
+              systemImage: "terminal",
+              isProminent: false,
+              helpText: "Providers with AgentHub session history for this worktree."
             )
+          }
         }
 
         Text(worktree.path)
@@ -286,16 +320,14 @@ private struct WorktreeInventoryRow: View {
           .scaleEffect(0.7)
           .frame(width: 28, height: 28)
       } else {
-        Button(action: onDelete) {
-          Image(systemName: "trash")
-            .font(.system(size: 13))
-            .frame(width: 28, height: 28)
-            .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
-        .foregroundStyle(.secondary)
-        .help("Delete worktree")
-        .accessibilityLabel("Delete worktree \(worktree.branchName)")
+        Button("Delete worktree \(worktree.branchName)", systemImage: "trash", action: onDelete)
+          .labelStyle(.iconOnly)
+          .font(.system(size: 13))
+          .frame(width: 28, height: 28)
+          .contentShape(Rectangle())
+          .buttonStyle(.plain)
+          .foregroundStyle(.secondary)
+          .help("Delete worktree")
       }
     }
     .padding(8)
@@ -303,6 +335,48 @@ private struct WorktreeInventoryRow: View {
       RoundedRectangle(cornerRadius: 8, style: .continuous)
         .fill(Color.primary.opacity(0.04))
     )
+  }
+}
+
+private struct WorktreeInventoryBadge: View {
+  let title: String
+  let systemImage: String
+  let isProminent: Bool
+  let helpText: String
+
+  @State private var isHelpPresented = false
+
+  var body: some View {
+    Label(title, systemImage: systemImage)
+      .font(.caption)
+      .labelStyle(.titleAndIcon)
+      .foregroundStyle(isProminent ? .primary : .secondary)
+      .padding(.horizontal, 6)
+      .padding(.vertical, 2)
+      .background(
+        RoundedRectangle(cornerRadius: 5)
+          .fill(Color.primary.opacity(isProminent ? 0.08 : 0.05))
+      )
+      .contentShape(RoundedRectangle(cornerRadius: 5))
+      .help(helpText)
+      .onHover { isHovering in
+        isHelpPresented = isHovering
+      }
+      .popover(isPresented: $isHelpPresented, arrowEdge: .top) {
+        Text(helpText)
+          .font(.caption)
+          .foregroundStyle(.primary)
+          .padding(10)
+          .frame(width: 240, alignment: .leading)
+      }
+  }
+}
+
+private struct WorktreeInventoryLoadFailureView: View {
+  var body: some View {
+    Label("Some git worktrees could not be loaded", systemImage: "exclamationmark.triangle")
+      .font(.caption)
+      .foregroundStyle(.secondary)
   }
 }
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/WorktreeSettingsView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/WorktreeSettingsView.swift
@@ -51,7 +51,9 @@ public struct WorktreeSettingsView: View {
       if let agentHub {
         WorktreeInventorySection(
           claudeViewModel: agentHub.claudeSessionsViewModel,
-          codexViewModel: agentHub.codexSessionsViewModel
+          codexViewModel: agentHub.codexSessionsViewModel,
+          inventoryService: agentHub.gitService,
+          worktreeRemovalService: agentHub.gitService
         )
       } else {
         Section("Worktrees") {

--- a/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/WorktreeInventoryViewModel.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/WorktreeInventoryViewModel.swift
@@ -1,0 +1,235 @@
+import Foundation
+
+@MainActor
+@Observable
+final class WorktreeInventoryViewModel {
+  private(set) var snapshot = WorktreeSettingsSnapshot(modules: [])
+  private(set) var isLoading = false
+  private(set) var loadFailuresByRepositoryPath: [String: String] = [:]
+  private(set) var deletingWorktreePath: String?
+  private(set) var deletionError: WorktreeInventoryDeletionError?
+
+  @ObservationIgnored private let inventoryService: any GitWorktreeInventoryServiceProtocol
+  @ObservationIgnored private let removalService: any GitWorktreeRemovalServiceProtocol
+  @ObservationIgnored private var locallyDeletedWorktreePaths: Set<String> = []
+
+  init(
+    inventoryService: any GitWorktreeInventoryServiceProtocol = GitWorktreeService(),
+    removalService: any GitWorktreeRemovalServiceProtocol = GitWorktreeService()
+  ) {
+    self.inventoryService = inventoryService
+    self.removalService = removalService
+  }
+
+  func reload(
+    claudeRepositories: [SelectedRepository],
+    codexRepositories: [SelectedRepository],
+    claudeMonitoredSessions: [CLISession],
+    codexMonitoredSessions: [CLISession]
+  ) async {
+    snapshot = makeSnapshot(
+      claudeRepositories: claudeRepositories,
+      codexRepositories: codexRepositories,
+      claudeMonitoredSessions: claudeMonitoredSessions,
+      codexMonitoredSessions: codexMonitoredSessions
+    )
+
+    let repositoryPaths = Self.repositoryPaths(
+      claudeRepositories: claudeRepositories,
+      codexRepositories: codexRepositories
+    )
+    guard !repositoryPaths.isEmpty else {
+      isLoading = false
+      loadFailuresByRepositoryPath = [:]
+      return
+    }
+
+    isLoading = true
+    let inventoryService = inventoryService
+    let loadResult = await withTaskGroup(of: WorktreeInventoryLoadResult.self) { group in
+      for path in repositoryPaths {
+        group.addTask {
+          do {
+            let worktrees = try await inventoryService.listWorktrees(at: path)
+            return WorktreeInventoryLoadResult(
+              repositoryPath: path,
+              worktrees: worktrees,
+              failureMessage: nil
+            )
+          } catch {
+            return WorktreeInventoryLoadResult(
+              repositoryPath: path,
+              worktrees: [],
+              failureMessage: error.localizedDescription
+            )
+          }
+        }
+      }
+
+      var worktreesByRepositoryPath: [String: [GitWorktreeInventoryItem]] = [:]
+      var failuresByRepositoryPath: [String: String] = [:]
+      for await result in group {
+        if let failureMessage = result.failureMessage {
+          failuresByRepositoryPath[result.repositoryPath] = failureMessage
+        } else {
+          worktreesByRepositoryPath[result.repositoryPath] = result.worktrees
+        }
+      }
+
+      return (worktreesByRepositoryPath, failuresByRepositoryPath)
+    }
+
+    snapshot = makeSnapshot(
+      claudeRepositories: claudeRepositories,
+      codexRepositories: codexRepositories,
+      claudeMonitoredSessions: claudeMonitoredSessions,
+      codexMonitoredSessions: codexMonitoredSessions,
+      discoveredWorktreesByRepositoryPath: loadResult.0
+    )
+    loadFailuresByRepositoryPath = loadResult.1
+    isLoading = false
+  }
+
+  @discardableResult
+  func delete(_ worktree: WorktreeSettingsWorktree, force: Bool = false) async -> Bool {
+    deletingWorktreePath = worktree.path
+    deletionError = nil
+
+    do {
+      try await removalService.removeWorktree(
+        at: worktree.path,
+        relativeTo: worktree.parentModulePath,
+        force: force
+      )
+      locallyDeletedWorktreePaths.insert(Self.normalized(worktree.path))
+      snapshot = filteredSnapshot(snapshot)
+      deletingWorktreePath = nil
+      return true
+    } catch {
+      deletionError = deletionFailure(for: worktree, error: error)
+      deletingWorktreePath = nil
+      return false
+    }
+  }
+
+  @discardableResult
+  func deleteOrphaned(_ worktree: WorktreeSettingsWorktree, parentRepoPath: String) async -> Bool {
+    deletingWorktreePath = worktree.path
+    deletionError = nil
+
+    do {
+      try await removalService.removeOrphanedWorktree(
+        at: worktree.path,
+        parentRepoPath: parentRepoPath
+      )
+      locallyDeletedWorktreePaths.insert(Self.normalized(worktree.path))
+      snapshot = filteredSnapshot(snapshot)
+      deletingWorktreePath = nil
+      return true
+    } catch {
+      deletionError = WorktreeInventoryDeletionError(
+        worktree: worktree,
+        message: "Failed to delete orphaned worktree: \(error.localizedDescription)"
+      )
+      deletingWorktreePath = nil
+      return false
+    }
+  }
+
+  func clearDeletionError() {
+    deletionError = nil
+  }
+
+  private func deletionFailure(
+    for worktree: WorktreeSettingsWorktree,
+    error: Error
+  ) -> WorktreeInventoryDeletionError {
+    if let orphanInfo = removalService.checkIfOrphaned(at: worktree.path),
+       orphanInfo.isOrphaned {
+      return WorktreeInventoryDeletionError(
+        worktree: worktree,
+        message: error.localizedDescription,
+        isOrphaned: true,
+        parentRepoPath: orphanInfo.parentRepoPath
+      )
+    }
+
+    return WorktreeInventoryDeletionError(
+      worktree: worktree,
+      message: error.localizedDescription
+    )
+  }
+
+  private static func repositoryPaths(
+    claudeRepositories: [SelectedRepository],
+    codexRepositories: [SelectedRepository]
+  ) -> [String] {
+    WorktreeModuleResolver
+      .mergedRepositories(claudeRepositories + codexRepositories)
+      .map { WorktreeModuleResolver.normalizedDirectoryPath($0.path) }
+  }
+
+  private func makeSnapshot(
+    claudeRepositories: [SelectedRepository],
+    codexRepositories: [SelectedRepository],
+    claudeMonitoredSessions: [CLISession],
+    codexMonitoredSessions: [CLISession],
+    discoveredWorktreesByRepositoryPath: [String: [GitWorktreeInventoryItem]] = [:]
+  ) -> WorktreeSettingsSnapshot {
+    filteredSnapshot(
+      WorktreeSettingsInventoryBuilder.snapshot(
+        claudeRepositories: claudeRepositories,
+        codexRepositories: codexRepositories,
+        claudeMonitoredSessions: claudeMonitoredSessions,
+        codexMonitoredSessions: codexMonitoredSessions,
+        discoveredWorktreesByRepositoryPath: discoveredWorktreesByRepositoryPath
+      )
+    )
+  }
+
+  private func filteredSnapshot(_ snapshot: WorktreeSettingsSnapshot) -> WorktreeSettingsSnapshot {
+    guard !locallyDeletedWorktreePaths.isEmpty else { return snapshot }
+
+    return WorktreeSettingsSnapshot(
+      modules: snapshot.modules.map { module in
+        WorktreeSettingsModule(
+          name: module.name,
+          path: module.path,
+          worktrees: module.worktrees.filter {
+            !locallyDeletedWorktreePaths.contains(Self.normalized($0.path))
+          }
+        )
+      }
+    )
+  }
+
+  private static func normalized(_ path: String) -> String {
+    WorktreeModuleResolver.normalizedDirectoryPath(path)
+  }
+}
+
+struct WorktreeInventoryDeletionError: Identifiable {
+  let id = UUID()
+  let worktree: WorktreeSettingsWorktree
+  let message: String
+  let isOrphaned: Bool
+  let parentRepoPath: String?
+
+  init(
+    worktree: WorktreeSettingsWorktree,
+    message: String,
+    isOrphaned: Bool = false,
+    parentRepoPath: String? = nil
+  ) {
+    self.worktree = worktree
+    self.message = message
+    self.isOrphaned = isOrphaned
+    self.parentRepoPath = parentRepoPath
+  }
+}
+
+private struct WorktreeInventoryLoadResult: Sendable {
+  let repositoryPath: String
+  let worktrees: [GitWorktreeInventoryItem]
+  let failureMessage: String?
+}

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/GitWorktreeServiceTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/GitWorktreeServiceTests.swift
@@ -150,6 +150,30 @@ struct RemoveWorktreeRelativeToTests {
   }
 }
 
+@Suite("GitWorktreeService.listWorktrees")
+struct ListWorktreesTests {
+  @Test("Returns main repository and secondary worktrees")
+  func returnsMainAndSecondaryWorktrees() async throws {
+    let fixture = try GitRepoFixture.create()
+    defer { fixture.cleanup() }
+
+    let worktreePath = try fixture.addWorktree(branch: "inventory-branch")
+
+    let service = GitWorktreeService()
+    let worktrees = try await service.listWorktrees(at: fixture.repoPath)
+
+    let main = try #require(worktrees.first(where: { !$0.isWorktree }))
+    let secondary = try #require(worktrees.first(where: { $0.isWorktree }))
+
+    #expect(main.path == fixture.repoPath)
+    #expect(main.branchName == "main")
+    #expect(main.mainRepoPath == nil)
+    #expect(secondary.path == worktreePath)
+    #expect(secondary.branchName == "inventory-branch")
+    #expect(secondary.mainRepoPath == fixture.repoPath)
+  }
+}
+
 @Suite("GitWorktreeService cancellation")
 struct GitWorktreeServiceCancellationTests {
 

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/WorktreeInventoryViewModelTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/WorktreeInventoryViewModelTests.swift
@@ -1,0 +1,228 @@
+import Foundation
+import Testing
+
+@testable import AgentHubCore
+
+@Suite("Worktree inventory view model")
+@MainActor
+struct WorktreeInventoryViewModelTests {
+  @Test("Loads external git worktrees for tracked repositories")
+  func loadsExternalWorktreesForTrackedRepositories() async throws {
+    let inventory = StubWorktreeInventoryService(results: [
+      "/tmp/AgentHub": .success([
+        inventoryItem(path: "/tmp/AgentHub", branchName: "main", isWorktree: false),
+        inventoryItem(path: "/tmp/AgentHub-external", branchName: "feature/external"),
+      ])
+    ])
+    let viewModel = WorktreeInventoryViewModel(
+      inventoryService: inventory,
+      removalService: RecordingInventoryRemovalService()
+    )
+
+    await viewModel.reload(
+      claudeRepositories: [SelectedRepository(path: "/tmp/AgentHub")],
+      codexRepositories: [],
+      claudeMonitoredSessions: [],
+      codexMonitoredSessions: []
+    )
+
+    let module = try #require(viewModel.snapshot.modules.first)
+    let worktree = try #require(module.worktrees.first)
+
+    #expect(viewModel.loadFailuresByRepositoryPath.isEmpty)
+    #expect(module.worktrees.count == 1)
+    #expect(worktree.path == "/tmp/AgentHub-external")
+    #expect(worktree.branchName == "feature/external")
+    #expect(!worktree.isFocusedInAgentHub)
+  }
+
+  @Test("Keeps focused rows when git inventory loading fails")
+  func keepsFocusedRowsWhenInventoryLoadingFails() async throws {
+    let focusedSession = session("focused-session", path: "/tmp/AgentHub-focused")
+    let repository = SelectedRepository(
+      path: "/tmp/AgentHub",
+      worktrees: [
+        WorktreeBranch(name: "main", path: "/tmp/AgentHub", isWorktree: false),
+        WorktreeBranch(
+          name: "feature/focused",
+          path: "/tmp/AgentHub-focused",
+          isWorktree: true,
+          sessions: [focusedSession]
+        ),
+      ]
+    )
+    let inventory = StubWorktreeInventoryService(results: [
+      "/tmp/AgentHub": .failure(.failed)
+    ])
+    let viewModel = WorktreeInventoryViewModel(
+      inventoryService: inventory,
+      removalService: RecordingInventoryRemovalService()
+    )
+
+    await viewModel.reload(
+      claudeRepositories: [repository],
+      codexRepositories: [],
+      claudeMonitoredSessions: [focusedSession],
+      codexMonitoredSessions: []
+    )
+
+    let module = try #require(viewModel.snapshot.modules.first)
+    let worktree = try #require(module.worktrees.first)
+
+    #expect(viewModel.loadFailuresByRepositoryPath["/tmp/AgentHub"] != nil)
+    #expect(module.worktrees.count == 1)
+    #expect(worktree.path == "/tmp/AgentHub-focused")
+    #expect(worktree.isFocusedInAgentHub)
+    #expect(worktree.monitoredSessionCount == 1)
+  }
+
+  @Test("Deletes external worktrees relative to their parent repository")
+  func deletesExternalWorktreesRelativeToParentRepository() async throws {
+    let remover = RecordingInventoryRemovalService()
+    let viewModel = WorktreeInventoryViewModel(
+      inventoryService: StubWorktreeInventoryService(results: [
+        "/tmp/AgentHub": .success([
+          inventoryItem(path: "/tmp/AgentHub-external", branchName: "feature/external"),
+        ])
+      ]),
+      removalService: remover
+    )
+
+    await viewModel.reload(
+      claudeRepositories: [SelectedRepository(path: "/tmp/AgentHub")],
+      codexRepositories: [],
+      claudeMonitoredSessions: [],
+      codexMonitoredSessions: []
+    )
+    let worktree = try #require(viewModel.snapshot.modules.first?.worktrees.first)
+
+    let succeeded = await viewModel.delete(worktree)
+
+    #expect(succeeded)
+    #expect(viewModel.deletionError == nil)
+    #expect(viewModel.deletingWorktreePath == nil)
+    #expect(viewModel.snapshot.modules.first?.worktrees.isEmpty == true)
+    #expect(await remover.relativeRemovals() == [
+      RelativeRemoval(path: "/tmp/AgentHub-external", parentRepoPath: "/tmp/AgentHub", force: false)
+    ])
+  }
+
+  @Test("Delete failure keeps row and records forceable error")
+  func deleteFailureKeepsRowAndRecordsError() async throws {
+    let remover = RecordingInventoryRemovalService(removeShouldFail: true)
+    let viewModel = WorktreeInventoryViewModel(
+      inventoryService: StubWorktreeInventoryService(results: [
+        "/tmp/AgentHub": .success([
+          inventoryItem(path: "/tmp/AgentHub-external", branchName: "feature/external"),
+        ])
+      ]),
+      removalService: remover
+    )
+
+    await viewModel.reload(
+      claudeRepositories: [SelectedRepository(path: "/tmp/AgentHub")],
+      codexRepositories: [],
+      claudeMonitoredSessions: [],
+      codexMonitoredSessions: []
+    )
+    let worktree = try #require(viewModel.snapshot.modules.first?.worktrees.first)
+
+    let succeeded = await viewModel.delete(worktree)
+
+    #expect(!succeeded)
+    #expect(viewModel.deletionError?.worktree.path == "/tmp/AgentHub-external")
+    #expect(viewModel.snapshot.modules.first?.worktrees.count == 1)
+  }
+}
+
+private struct StubWorktreeInventoryService: GitWorktreeInventoryServiceProtocol {
+  let results: [String: Result<[GitWorktreeInventoryItem], InventoryLoadError>]
+
+  func listWorktrees(at repoPath: String) async throws -> [GitWorktreeInventoryItem] {
+    switch results[WorktreeModuleResolver.normalizedDirectoryPath(repoPath)] ?? .success([]) {
+    case .success(let worktrees):
+      return worktrees
+    case .failure(let error):
+      throw error
+    }
+  }
+}
+
+private func session(_ id: String, path: String, isActive: Bool = false) -> CLISession {
+  CLISession(
+    id: id,
+    projectPath: path,
+    branchName: "feature",
+    isWorktree: true,
+    isActive: isActive,
+    sessionFilePath: "/tmp/\(id).jsonl"
+  )
+}
+
+private actor RecordingInventoryRemovalService: GitWorktreeRemovalServiceProtocol {
+  private let removeShouldFail: Bool
+  private let orphanResult: OrphanResult?
+  private var removals: [RelativeRemoval] = []
+
+  init(removeShouldFail: Bool = false, orphanResult: OrphanResult? = nil) {
+    self.removeShouldFail = removeShouldFail
+    self.orphanResult = orphanResult
+  }
+
+  func removeWorktree(at worktreePath: String, force: Bool) async throws {
+    if removeShouldFail { throw InventoryDeletionError.failed }
+    removals.append(RelativeRemoval(path: worktreePath, parentRepoPath: "", force: force))
+  }
+
+  func removeWorktree(at worktreePath: String, relativeTo parentRepoPath: String, force: Bool) async throws {
+    if removeShouldFail { throw InventoryDeletionError.failed }
+    removals.append(RelativeRemoval(path: worktreePath, parentRepoPath: parentRepoPath, force: force))
+  }
+
+  nonisolated func checkIfOrphaned(at worktreePath: String) -> (isOrphaned: Bool, parentRepoPath: String?)? {
+    guard let orphanResult else { return nil }
+    return (orphanResult.isOrphaned, orphanResult.parentRepoPath)
+  }
+
+  func removeOrphanedWorktree(at worktreePath: String, parentRepoPath: String) async throws {
+    if removeShouldFail { throw InventoryDeletionError.failed }
+    removals.append(RelativeRemoval(path: worktreePath, parentRepoPath: parentRepoPath, force: true))
+  }
+
+  func relativeRemovals() -> [RelativeRemoval] {
+    removals
+  }
+}
+
+private struct RelativeRemoval: Equatable, Sendable {
+  let path: String
+  let parentRepoPath: String
+  let force: Bool
+}
+
+private struct OrphanResult: Sendable {
+  let isOrphaned: Bool
+  let parentRepoPath: String?
+}
+
+private enum InventoryLoadError: Error, Sendable {
+  case failed
+}
+
+private enum InventoryDeletionError: Error, Sendable {
+  case failed
+}
+
+private func inventoryItem(
+  path: String,
+  branchName: String?,
+  isWorktree: Bool = true,
+  mainRepoPath: String = "/tmp/AgentHub"
+) -> GitWorktreeInventoryItem {
+  GitWorktreeInventoryItem(
+    path: path,
+    branchName: branchName,
+    isWorktree: isWorktree,
+    mainRepoPath: isWorktree ? mainRepoPath : nil
+  )
+}

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/WorktreeSettingsInventoryTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/WorktreeSettingsInventoryTests.swift
@@ -71,10 +71,91 @@ struct WorktreeSettingsInventoryTests {
     #expect(module.worktrees.count == 1)
     #expect(worktree.path == "/tmp/AgentHub-feature")
     #expect(worktree.providerKinds == [.claude, .codex])
-    #expect(worktree.deletionProviderKind == .claude)
+    #expect(worktree.isFocusedInAgentHub)
     #expect(worktree.monitoredSessionCount == 2)
     #expect(worktree.activeMonitoredSessionCount == 1)
     #expect(worktree.historicalSessionCount == 2)
+  }
+
+  @Test("Snapshot includes external discovered worktrees")
+  func snapshotIncludesExternalDiscoveredWorktrees() throws {
+    let repository = SelectedRepository(
+      path: "/tmp/AgentHub",
+      worktrees: [
+        WorktreeBranch(name: "main", path: "/tmp/AgentHub", isWorktree: false),
+      ]
+    )
+
+    let snapshot = WorktreeSettingsInventoryBuilder.snapshot(
+      claudeRepositories: [repository],
+      codexRepositories: [],
+      claudeMonitoredSessions: [],
+      codexMonitoredSessions: [],
+      discoveredWorktreesByRepositoryPath: [
+        "/tmp/AgentHub": [
+          GitWorktreeInventoryItem(
+            path: "/tmp/AgentHub",
+            branchName: "main",
+            isWorktree: false,
+            mainRepoPath: nil
+          ),
+          GitWorktreeInventoryItem(
+            path: "/tmp/AgentHub-external",
+            branchName: "feature/external",
+            isWorktree: true,
+            mainRepoPath: "/tmp/AgentHub"
+          ),
+        ]
+      ]
+    )
+
+    let module = try #require(snapshot.modules.first)
+    let worktree = try #require(module.worktrees.first)
+
+    #expect(module.worktrees.count == 1)
+    #expect(worktree.branchName == "feature/external")
+    #expect(worktree.path == "/tmp/AgentHub-external")
+    #expect(worktree.parentModulePath == "/tmp/AgentHub")
+    #expect(worktree.providerKinds.isEmpty)
+    #expect(!worktree.isFocusedInAgentHub)
+    #expect(worktree.monitoredSessionCount == 0)
+    #expect(worktree.historicalSessionCount == 0)
+  }
+
+  @Test("Snapshot deduplicates discovered and focused worktrees")
+  func snapshotDeduplicatesDiscoveredAndFocusedWorktrees() throws {
+    let repository = SelectedRepository(
+      path: "/tmp/AgentHub",
+      worktrees: [
+        WorktreeBranch(name: "main", path: "/tmp/AgentHub", isWorktree: false),
+        WorktreeBranch(name: "feature/focused", path: "/tmp/AgentHub-focused", isWorktree: true),
+      ]
+    )
+
+    let snapshot = WorktreeSettingsInventoryBuilder.snapshot(
+      claudeRepositories: [repository],
+      codexRepositories: [],
+      claudeMonitoredSessions: [],
+      codexMonitoredSessions: [],
+      discoveredWorktreesByRepositoryPath: [
+        "/tmp/AgentHub": [
+          GitWorktreeInventoryItem(
+            path: "/tmp/AgentHub-focused/",
+            branchName: "feature/focused",
+            isWorktree: true,
+            mainRepoPath: "/tmp/AgentHub"
+          )
+        ]
+      ]
+    )
+
+    let module = try #require(snapshot.modules.first)
+    let worktree = try #require(module.worktrees.first)
+
+    #expect(module.worktrees.count == 1)
+    #expect(worktree.path == "/tmp/AgentHub-focused")
+    #expect(worktree.providerKinds == [.claude])
+    #expect(worktree.isFocusedInAgentHub)
   }
 }
 


### PR DESCRIPTION
## Summary

- Show all git worktrees for repositories tracked by AgentHub in Settings, including external worktrees that are not focused in AgentHub.
- Add focused/external badges with hover popovers explaining what each state means.
- Route Settings deletion through the git worktree service while preserving AgentHub session cleanup for focused worktrees.

## Impact

Settings becomes a broader worktree management surface without changing session grouping. External worktrees remain excluded from AgentHub session/module grouping unless they are focused by AgentHub, but they can now be deleted from Settings.

## Validation

- `git diff --check`
- `xcodebuild build -project app/AgentHub.xcodeproj -scheme AgentHub -destination 'platform=macOS'`

Note: focused SwiftPM tests could not run because `AgentHubCore` SwiftPM currently fails before tests in `CodeEditSymbols` with `Bundle.module` missing, and the Xcode schemes are not configured for test actions.