### PR TITLE
[codex] Queue worktree creation

### DIFF
--- a/app/AgentHubTests/WorktreeCreationTests.swift
+++ b/app/AgentHubTests/WorktreeCreationTests.swift
@@ -408,6 +408,21 @@ struct MultiSessionLaunchViewModelResetTests {
     #expect(vm.branchNamingCompletedAt == nil)
   }
 
+  @Test("reset() clears launcher busy state")
+  @MainActor
+  func resetClearsLauncherBusyState() {
+    let vm = makeViewModel()
+    vm.isLaunching = true
+    vm.isLoadingBranches = true
+    vm.isLoadingCurrentBranch = true
+
+    vm.reset()
+
+    #expect(vm.isLaunching == false)
+    #expect(vm.isLoadingBranches == false)
+    #expect(vm.isLoadingCurrentBranch == false)
+  }
+
   @Test("reset() clears manual worktree naming state")
   @MainActor
   func resetClearsManualWorktreeNamingState() {

--- a/app/modules/AgentHubCLI/Sources/AgentHubCLIKit/WorktreeCreationQueue.swift
+++ b/app/modules/AgentHubCLI/Sources/AgentHubCLIKit/WorktreeCreationQueue.swift
@@ -1,0 +1,110 @@
+import Foundation
+
+actor WorktreeCreationQueue {
+  private struct Waiter {
+    let id: UUID
+    let repoKey: String
+    let continuation: CheckedContinuation<Void, Error>
+  }
+
+  private let maxConcurrentGlobally: Int
+  private let maxConcurrentPerRepository: Int
+  private var runningGlobal = 0
+  private var runningByRepository: [String: Int] = [:]
+  private var waiters: [Waiter] = []
+
+  init(maxConcurrentGlobally: Int, maxConcurrentPerRepository: Int) {
+    self.maxConcurrentGlobally = max(1, maxConcurrentGlobally)
+    self.maxConcurrentPerRepository = max(1, maxConcurrentPerRepository)
+  }
+
+  func withPermit<T: Sendable>(
+    repoKey: String,
+    onQueued: (@Sendable () async -> Void)? = nil,
+    operation: @Sendable () async throws -> T
+  ) async throws -> T {
+    try await waitForPermit(repoKey: repoKey, onQueued: onQueued)
+    defer { release(repoKey: repoKey) }
+
+    try Task.checkCancellation()
+    return try await operation()
+  }
+
+  private func waitForPermit(
+    repoKey: String,
+    onQueued: (@Sendable () async -> Void)?
+  ) async throws {
+    try Task.checkCancellation()
+    if canStart(repoKey: repoKey) {
+      markStarted(repoKey: repoKey)
+      return
+    }
+
+    if let onQueued {
+      await onQueued()
+    }
+
+    try Task.checkCancellation()
+    if canStart(repoKey: repoKey) {
+      markStarted(repoKey: repoKey)
+      return
+    }
+
+    let waiterID = UUID()
+    try await withTaskCancellationHandler {
+      try await withCheckedThrowingContinuation { continuation in
+        if canStart(repoKey: repoKey) {
+          markStarted(repoKey: repoKey)
+          continuation.resume()
+          return
+        }
+
+        waiters.append(Waiter(
+          id: waiterID,
+          repoKey: repoKey,
+          continuation: continuation
+        ))
+      }
+    } onCancel: {
+      Task {
+        await self.cancelWaiter(id: waiterID)
+      }
+    }
+  }
+
+  private func cancelWaiter(id: UUID) {
+    guard let index = waiters.firstIndex(where: { $0.id == id }) else { return }
+    let waiter = waiters.remove(at: index)
+    waiter.continuation.resume(throwing: CancellationError())
+  }
+
+  private func release(repoKey: String) {
+    runningGlobal = max(0, runningGlobal - 1)
+    let repoRunning = max(0, (runningByRepository[repoKey] ?? 0) - 1)
+    if repoRunning == 0 {
+      runningByRepository[repoKey] = nil
+    } else {
+      runningByRepository[repoKey] = repoRunning
+    }
+
+    scheduleWaiters()
+  }
+
+  private func scheduleWaiters() {
+    while let index = waiters.firstIndex(where: { canStart(repoKey: $0.repoKey) }) {
+      let waiter = waiters.remove(at: index)
+      markStarted(repoKey: waiter.repoKey)
+      waiter.continuation.resume()
+    }
+  }
+
+  private func canStart(repoKey: String) -> Bool {
+    runningGlobal < maxConcurrentGlobally
+      && (runningByRepository[repoKey] ?? 0) < maxConcurrentPerRepository
+  }
+
+  private func markStarted(repoKey: String) {
+    runningGlobal += 1
+    runningByRepository[repoKey, default: 0] += 1
+  }
+}

--- a/app/modules/AgentHubCLI/Sources/AgentHubCLIKit/WorktreeManagementService.swift
+++ b/app/modules/AgentHubCLI/Sources/AgentHubCLIKit/WorktreeManagementService.swift
@@ -66,6 +66,10 @@ public extension WorktreeManagementServiceProtocol {
 public actor WorktreeManagementService: WorktreeManagementServiceProtocol {
   private static let gitCommandTimeout: TimeInterval = 10.0
   private static let gitWorktreeTimeout: TimeInterval = 300.0
+  private static let creationQueue = WorktreeCreationQueue(
+    maxConcurrentGlobally: 2,
+    maxConcurrentPerRepository: 1
+  )
   private static let updatingFilesPattern = #/Updating files:\s+\d+%\s+\((\d+)/(\d+)\)/#
 
   private var gitRootCache: [String: String] = [:]
@@ -153,16 +157,19 @@ public actor WorktreeManagementService: WorktreeManagementServiceProtocol {
     branch: String,
     directoryName: String
   ) async throws -> String {
-    let sourceRoot = try await findGitRoot(at: repoPath)
-    let worktreePath = try await prepareWorktreePath(repoPath: repoPath, directoryName: directoryName)
+    let repoKey = try await findMainRepositoryRoot(at: repoPath)
+    return try await Self.creationQueue.withPermit(repoKey: repoKey) { [self] in
+      let sourceRoot = try await findGitRoot(at: repoPath)
+      let worktreePath = try await prepareWorktreePath(repoPath: repoPath, directoryName: directoryName)
 
-    try await runGitCommand(
-      ["worktree", "add", worktreePath, branch],
-      at: sourceRoot,
-      timeout: Self.gitWorktreeTimeout
-    )
+      try await runGitCommand(
+        ["worktree", "add", worktreePath, branch],
+        at: sourceRoot,
+        timeout: Self.gitWorktreeTimeout
+      )
 
-    return worktreePath
+      return worktreePath
+    }
   }
 
   public func checkoutWorktree(
@@ -188,16 +195,19 @@ public actor WorktreeManagementService: WorktreeManagementServiceProtocol {
     directoryName: String,
     startPoint: String? = nil
   ) async throws -> String {
-    let sourceRoot = try await findGitRoot(at: repoPath)
-    let worktreePath = try await prepareWorktreePath(repoPath: repoPath, directoryName: directoryName)
+    let repoKey = try await findMainRepositoryRoot(at: repoPath)
+    return try await Self.creationQueue.withPermit(repoKey: repoKey) { [self] in
+      let sourceRoot = try await findGitRoot(at: repoPath)
+      let worktreePath = try await prepareWorktreePath(repoPath: repoPath, directoryName: directoryName)
 
-    var args = ["worktree", "add", "-b", newBranchName, worktreePath]
-    if let startPoint {
-      args.append(startPoint)
+      var args = ["worktree", "add", "-b", newBranchName, worktreePath]
+      if let startPoint {
+        args.append(startPoint)
+      }
+
+      try await runGitCommand(args, at: sourceRoot, timeout: Self.gitWorktreeTimeout)
+      return worktreePath
     }
-
-    try await runGitCommand(args, at: sourceRoot, timeout: Self.gitWorktreeTimeout)
-    return worktreePath
   }
 
   public func createWorktreeWithNewBranch(
@@ -208,32 +218,44 @@ public actor WorktreeManagementService: WorktreeManagementServiceProtocol {
     operationID: WorktreeOperationID,
     onProgress: @escaping @Sendable (WorktreeCreationProgress) async -> Void
   ) async throws -> String {
-    if cancelledWorktreeOperations.contains(operationID) {
+    if consumeCancellation(for: operationID) {
       await onProgress(.cancelled(message: "Cancelled before worktree creation began"))
-      cancelledWorktreeOperations.remove(operationID)
       throw WorktreeManagementError.cancelled
     }
 
-    await onProgress(.preparing(message: "Preparing worktree..."))
+    let repoKey = try await findMainRepositoryRoot(at: repoPath)
+    return try await Self.creationQueue.withPermit(
+      repoKey: repoKey,
+      onQueued: {
+        await onProgress(.queued(message: "Queued behind another worktree for this repository"))
+      }
+    ) { [self] in
+      if await consumeCancellation(for: operationID) {
+        await onProgress(.cancelled(message: "Cancelled before worktree creation began"))
+        throw WorktreeManagementError.cancelled
+      }
 
-    let sourceRoot = try await findGitRoot(at: repoPath)
-    let worktreePath = try await prepareWorktreePath(repoPath: repoPath, directoryName: directoryName)
+      await onProgress(.preparing(message: "Preparing worktree..."))
 
-    var args = ["worktree", "add", "-b", newBranchName, worktreePath]
-    if let startPoint {
-      args.append(startPoint)
+      let sourceRoot = try await findGitRoot(at: repoPath)
+      let worktreePath = try await prepareWorktreePath(repoPath: repoPath, directoryName: directoryName)
+
+      var args = ["worktree", "add", "-b", newBranchName, worktreePath]
+      if let startPoint {
+        args.append(startPoint)
+      }
+
+      try await runGitCommandWithProgress(
+        args,
+        at: sourceRoot,
+        timeout: Self.gitWorktreeTimeout,
+        operationID: operationID,
+        onProgress: onProgress
+      )
+
+      await onProgress(.completed(path: worktreePath))
+      return worktreePath
     }
-
-    try await runGitCommandWithProgress(
-      args,
-      at: sourceRoot,
-      timeout: Self.gitWorktreeTimeout,
-      operationID: operationID,
-      onProgress: onProgress
-    )
-
-    await onProgress(.completed(path: worktreePath))
-    return worktreePath
   }
 
   public func cancelWorktreeCreation(_ operationID: WorktreeOperationID) async {
@@ -241,6 +263,12 @@ public actor WorktreeManagementService: WorktreeManagementServiceProtocol {
     if let process = activeWorktreeProcesses[operationID] {
       Self.terminateIfRunning(process)
     }
+  }
+
+  private func consumeCancellation(for operationID: WorktreeOperationID) -> Bool {
+    guard cancelledWorktreeOperations.contains(operationID) else { return false }
+    cancelledWorktreeOperations.remove(operationID)
+    return true
   }
 
   public func cleanupCancelledWorktreeCreation(

--- a/app/modules/AgentHubCLI/Sources/AgentHubCLIKit/WorktreeModels.swift
+++ b/app/modules/AgentHubCLI/Sources/AgentHubCLIKit/WorktreeModels.swift
@@ -119,6 +119,7 @@ public struct WorktreeInfo: Codable, Equatable, Identifiable, Sendable {
 
 public enum WorktreeCreationProgress: Equatable, Sendable, Codable {
   case idle
+  case queued(message: String)
   case preparing(message: String)
   case updatingFiles(current: Int, total: Int)
   case completed(path: String)
@@ -128,6 +129,8 @@ public enum WorktreeCreationProgress: Equatable, Sendable, Codable {
   public var progressValue: Double {
     switch self {
     case .idle:
+      return 0
+    case .queued:
       return 0
     case .preparing:
       return 0.05
@@ -144,6 +147,8 @@ public enum WorktreeCreationProgress: Equatable, Sendable, Codable {
     switch self {
     case .idle:
       return ""
+    case .queued(let message):
+      return message
     case .preparing(let message):
       return message
     case .updatingFiles(let current, let total):
@@ -159,7 +164,7 @@ public enum WorktreeCreationProgress: Equatable, Sendable, Codable {
 
   public var isInProgress: Bool {
     switch self {
-    case .preparing, .updatingFiles:
+    case .queued, .preparing, .updatingFiles:
       return true
     case .idle, .completed, .cancelled, .failed:
       return false
@@ -170,6 +175,8 @@ public enum WorktreeCreationProgress: Equatable, Sendable, Codable {
     switch self {
     case .idle:
       return "circle"
+    case .queued:
+      return "clock"
     case .preparing:
       return "arrow.triangle.branch"
     case .updatingFiles:

--- a/app/modules/AgentHubCLI/Tests/AgentHubCLIKitTests/WorktreeManagementServiceTests.swift
+++ b/app/modules/AgentHubCLI/Tests/AgentHubCLIKitTests/WorktreeManagementServiceTests.swift
@@ -194,6 +194,91 @@ struct WorktreeConventionTests {
   }
 }
 
+@Suite("WorktreeManagementService creation queue")
+struct WorktreeCreationQueueTests {
+  private actor EventRecorder {
+    private var events: [String] = []
+
+    func record(_ event: String) {
+      events.append(event)
+    }
+
+    func recordedEvents() -> [String] {
+      events
+    }
+  }
+
+  @Test("Serializes same-repository worktree creation and reports queued state")
+  func serializesSameRepositoryCreation() async throws {
+    let queue = WorktreeCreationQueue(maxConcurrentGlobally: 2, maxConcurrentPerRepository: 1)
+    let recorder = EventRecorder()
+    let firstTask = Task {
+      try await queue.withPermit(repoKey: "repo-a") {
+        await recorder.record("first-start")
+        try await Task.sleep(for: .milliseconds(250))
+        await recorder.record("first-end")
+      }
+    }
+
+    try await Task.sleep(for: .milliseconds(50))
+
+    let secondTask = Task {
+      try await queue.withPermit(
+        repoKey: "repo-a",
+        onQueued: {
+          await recorder.record("second-queued")
+        }
+      ) {
+        await recorder.record("second-start")
+      }
+    }
+
+    try await Task.sleep(for: .milliseconds(50))
+
+    let earlyEvents = await recorder.recordedEvents()
+    #expect(earlyEvents.contains("second-queued"))
+    #expect(!earlyEvents.contains("second-start"))
+
+    try await firstTask.value
+    try await secondTask.value
+
+    let events = await recorder.recordedEvents()
+    let firstEndIndex = try #require(events.firstIndex(of: "first-end"))
+    let secondStartIndex = try #require(events.firstIndex(of: "second-start"))
+
+    #expect(firstEndIndex < secondStartIndex)
+  }
+
+  @Test("Allows different repositories to run concurrently")
+  func allowsDifferentRepositoriesToRunConcurrently() async throws {
+    let queue = WorktreeCreationQueue(maxConcurrentGlobally: 2, maxConcurrentPerRepository: 1)
+    let recorder = EventRecorder()
+
+    let firstTask = Task {
+      try await queue.withPermit(repoKey: "repo-a") {
+        await recorder.record("first-start")
+        try await Task.sleep(for: .milliseconds(250))
+        await recorder.record("first-end")
+      }
+    }
+
+    try await Task.sleep(for: .milliseconds(50))
+
+    let secondTask = Task {
+      try await queue.withPermit(repoKey: "repo-b") {
+        await recorder.record("second-start")
+      }
+    }
+
+    try await secondTask.value
+    let earlyEvents = await recorder.recordedEvents()
+    #expect(earlyEvents.contains("second-start"))
+    #expect(!earlyEvents.contains("first-end"))
+
+    try await firstTask.value
+  }
+}
+
 @Suite("WorktreeManagementService removal and cancellation")
 struct WorktreeRemovalTests {
   @Test("Prunes stale reference when worktree directory is missing")

--- a/app/modules/AgentHubCLI/Tests/AgentHubCLIKitTests/WorktreeProgressQueueTests.swift
+++ b/app/modules/AgentHubCLI/Tests/AgentHubCLIKitTests/WorktreeProgressQueueTests.swift
@@ -75,6 +75,7 @@ struct WorktreeProgressQueueTests {
   func progressCodableRoundTrip() throws {
     let cases: [WorktreeCreationProgress] = [
       .idle,
+      .queued(message: "Waiting for another worktree"),
       .preparing(message: "Preparing worktree…"),
       .updatingFiles(current: 84, total: 194),
       .completed(path: "/tmp/repo/.worktrees/feature"),

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
@@ -123,6 +123,11 @@ private struct WorktreeCreateContext: Identifiable {
   let repository: SelectedRepository
 }
 
+private struct StartSessionSheetContext: Identifiable {
+  let id = UUID()
+  let launchViewModel: MultiSessionLaunchViewModel
+}
+
 public struct MultiProviderSessionsListView: View {
   @Bindable var claudeViewModel: CLISessionsViewModel
   @Bindable var codexViewModel: CLISessionsViewModel
@@ -143,13 +148,13 @@ public struct MultiProviderSessionsListView: View {
   @State private var scrollToSessionId: String?
   @State private var launchExpandRequestID = 0
   @State private var createWorktreeContext: WorktreeCreateContext?
+  @State private var startSessionSheetContext: StartSessionSheetContext?
   @State private var gitHubSheetItem: GitHubSheetItem?
   @State private var archiveConfirmation: ArchiveConfirmation?
   @State private var removeConfirmation: RemoveConfirmation?
   @State private var worktreeModuleDeleteConfirmation: WorktreeModuleDeleteConfirmation?
   @State private var selectedModuleLandingPath: String?
   @State private var pendingAddedModulePaths: [String] = []
-  @State private var isStartSessionSheetPresented = false
   @State private var isRefreshingGitHubStates = false
   @State private var didScheduleInitialGitHubStateRefresh = false
 
@@ -247,13 +252,7 @@ public struct MultiProviderSessionsListView: View {
     }
     .onAppear {
       if multiLaunchViewModel == nil {
-        multiLaunchViewModel = MultiSessionLaunchViewModel(
-          claudeViewModel: claudeViewModel,
-          codexViewModel: codexViewModel,
-          intelligenceViewModel: intelligenceViewModel,
-          worktreeBranchNamingService: worktreeBranchNamingService,
-          worktreeSuccessSoundService: worktreeSuccessSoundService
-        )
+        multiLaunchViewModel = makeLaunchViewModel()
       }
       ensurePrimarySelection()
       scheduleInitialGitHubStateRefreshIfNeeded()
@@ -447,14 +446,12 @@ public struct MultiProviderSessionsListView: View {
         }
       )
     }
-    .sheet(isPresented: $isStartSessionSheetPresented) {
-      if let multiLaunchViewModel {
-        StartSessionSheet(
-          launchViewModel: multiLaunchViewModel,
-          intelligenceViewModel: intelligenceViewModel,
-          onDismiss: { isStartSessionSheetPresented = false }
-        )
-      }
+    .sheet(item: $startSessionSheetContext) { context in
+      StartSessionSheet(
+        launchViewModel: context.launchViewModel,
+        intelligenceViewModel: intelligenceViewModel,
+        onDismiss: { startSessionSheetContext = nil }
+      )
     }
     .modifier(ArchiveConfirmationAlert(confirmation: $archiveConfirmation))
     .modifier(RemoveConfirmationAlert(confirmation: $removeConfirmation))
@@ -1091,12 +1088,13 @@ public struct MultiProviderSessionsListView: View {
       SessionsSectionHeader(
         groupMode: $sidebarGroupMode,
         repos: orderedTrackedRepos,
-        launchViewModel: multiLaunchViewModel,
-        intelligenceViewModel: intelligenceViewModel,
         isRefreshingGitHubStates: isRefreshingGitHubStates,
         canRefreshGitHubStates: canRefreshGitHubStates,
         onRefreshGitHubStates: refreshGitHubStates,
-        onAddFolder: { showAddRepositoryPicker() }
+        onAddFolder: { showAddRepositoryPicker() },
+        onStartSession: { repoPath in
+          triggerNewSessionFlow(preferredRepositoryPath: repoPath)
+        }
       )
 
       let pendingModules = pendingModulePaths
@@ -1909,6 +1907,16 @@ public struct MultiProviderSessionsListView: View {
     )
   }
 
+  private func makeLaunchViewModel() -> MultiSessionLaunchViewModel {
+    MultiSessionLaunchViewModel(
+      claudeViewModel: claudeViewModel,
+      codexViewModel: codexViewModel,
+      intelligenceViewModel: intelligenceViewModel,
+      worktreeBranchNamingService: worktreeBranchNamingService,
+      worktreeSuccessSoundService: worktreeSuccessSoundService
+    )
+  }
+
   private func triggerFocusedNewSessionFlow() {
     guard let focusedSessionLaunchPath else { return }
     triggerNewSessionFlow(
@@ -1921,36 +1929,35 @@ public struct MultiProviderSessionsListView: View {
     preferredRepositoryPath: String? = nil,
     fallsBackToRepositoryPicker: Bool = true
   ) {
-    guard let multiLaunchViewModel else { return }
-    multiLaunchViewModel.reset()
+    let launchViewModel = makeLaunchViewModel()
 
     guard let preferredRepositoryPath else {
-      isStartSessionSheetPresented = true
-      multiLaunchViewModel.selectRepository()
+      startSessionSheetContext = StartSessionSheetContext(launchViewModel: launchViewModel)
+      launchViewModel.selectRepository()
       return
     }
 
     Task { @MainActor in
-      let didPreselect = await multiLaunchViewModel.preselectRepository(path: preferredRepositoryPath)
+      let didPreselect = await launchViewModel.preselectRepository(path: preferredRepositoryPath)
       if didPreselect {
-        isStartSessionSheetPresented = true
+        startSessionSheetContext = StartSessionSheetContext(launchViewModel: launchViewModel)
       } else if fallsBackToRepositoryPicker {
-        isStartSessionSheetPresented = true
-        multiLaunchViewModel.selectRepository()
+        startSessionSheetContext = StartSessionSheetContext(launchViewModel: launchViewModel)
+        launchViewModel.selectRepository()
       }
     }
   }
 
   private func triggerForkSessionFlow(session: CLISession, targetProvider: SessionProviderKind) {
-    guard let multiLaunchViewModel else { return }
+    let launchViewModel = makeLaunchViewModel()
 
     Task { @MainActor in
-      let didConfigure = await multiLaunchViewModel.configureForFork(
+      let didConfigure = await launchViewModel.configureForFork(
         from: session,
         targetProvider: targetProvider
       )
       if didConfigure {
-        isStartSessionSheetPresented = true
+        startSessionSheetContext = StartSessionSheetContext(launchViewModel: launchViewModel)
       }
     }
   }
@@ -2287,15 +2294,13 @@ private struct StartSessionSheet: View {
 private struct SessionsSectionHeader: View {
   @Binding var groupMode: SidebarGroupMode
   let repos: [SelectedRepository]
-  let launchViewModel: MultiSessionLaunchViewModel?
-  let intelligenceViewModel: IntelligenceViewModel?
   let isRefreshingGitHubStates: Bool
   let canRefreshGitHubStates: Bool
   let onRefreshGitHubStates: () -> Void
   let onAddFolder: () -> Void
+  let onStartSession: (String) -> Void
 
   @State private var showGroupPopover = false
-  @State private var showStartSheet = false
 
   var body: some View {
     VStack(spacing: 0) {
@@ -2336,27 +2341,13 @@ private struct SessionsSectionHeader: View {
           ) {
             ForEach(repos, id: \.path) { repo in
               Button {
-                guard let vm = launchViewModel else { return }
-                Task { @MainActor in
-                  vm.reset()
-                  _ = await vm.preselectRepository(path: repo.path)
-                  showStartSheet = true
-                }
+                onStartSession(repo.path)
               } label: {
                 Label(
                   URL(fileURLWithPath: repo.path).lastPathComponent,
                   systemImage: "folder"
                 )
               }
-            }
-          }
-          .sheet(isPresented: $showStartSheet) {
-            if let vm = launchViewModel {
-              StartSessionSheet(
-                launchViewModel: vm,
-                intelligenceViewModel: intelligenceViewModel,
-                onDismiss: { showStartSheet = false }
-              )
             }
           }
         }

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/WorktreeGenerationProgressBar.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/WorktreeGenerationProgressBar.swift
@@ -245,7 +245,7 @@ public struct WorktreeGenerationProgressBar: View {
       return (op.branchName.isEmpty ? "Creation failed" : op.branchName, error)
     case .cancelled:
       return (op.branchName.isEmpty ? "Cancelled" : op.branchName, "Cancelled")
-    case .idle, .preparing, .updatingFiles:
+    case .idle, .queued, .preparing, .updatingFiles:
       let title = op.branchName.isEmpty ? "Creating worktree" : op.branchName
       let subtitle = op.progress.statusMessage.isEmpty ? op.repoName : op.progress.statusMessage
       return (title, subtitle)
@@ -350,7 +350,7 @@ private struct WorktreeGenerationOperationRow: View {
     case .completed: return .green
     case .failed: return .red
     case .cancelled: return .secondary
-    case .idle, .preparing, .updatingFiles: return .brandPrimary
+    case .idle, .queued, .preparing, .updatingFiles: return .brandPrimary
     }
   }
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/MultiSessionLaunchViewModel.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/MultiSessionLaunchViewModel.swift
@@ -915,6 +915,8 @@ public final class MultiSessionLaunchViewModel {
     carrySourceChangesPath = nil
     availableBranches = []
     currentBranchName = ""
+    isLoadingBranches = false
+    isLoadingCurrentBranch = false
     launchMode = .manual
     workMode = .local
     worktreeNamingMode = .automatic
@@ -933,6 +935,7 @@ public final class MultiSessionLaunchViewModel {
     claudeProgress = .idle
     codexProgress = .idle
     resetBranchNamingProgress()
+    isLaunching = false
     launchError = nil
     lastLaunchEndedByCancellation = false
     smartPhase = .idle

--- a/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/WorktreeGenerationProgressCoordinator.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/WorktreeGenerationProgressCoordinator.swift
@@ -346,7 +346,7 @@ public final class WorktreeGenerationProgressCoordinator {
       scheduleClear(id: op.id, delay: Self.failureClearDelay)
     case .cancelled:
       scheduleClear(id: op.id, delay: op.isNaming ? Self.namingClearDelay : Self.successClearDelay)
-    case .idle, .preparing, .updatingFiles:
+    case .idle, .queued, .preparing, .updatingFiles:
       break
     }
   }


### PR DESCRIPTION
## Summary
- create a fresh Start Session launch view model per sheet so in-flight worktree launches do not leak Cancel-only state into other repos
- add an in-process worktree creation queue with one running worktree per repository and two globally
- surface queued worktree progress in the existing progress UI and cover queue/codable/reset behavior with tests

## Root Cause
The Start Session sheet reused one launch view model across repositories, so an active launch kept later sheets in the launching state. Worktree creation also started immediately from multiple entry points without an admission point around `git worktree add`.

## Validation
- `git diff --check`
- `swift test --package-path app/modules/AgentHubCLI --filter WorktreeCreationQueueTests`
- `swift test --package-path app/modules/AgentHubCLI --filter WorktreeProgressQueueTests/progressCodableRoundTrip`
- `xcodebuild build -project app/AgentHub.xcodeproj -scheme AgentHub -destination 'platform=macOS'`

## Notes
- Full `swift test --package-path app/modules/AgentHubCLI` timed out in the existing git integration test runner after build; focused queue tests passed.
- Queueing is process-local. A cross-process repo lock would be needed if app-created and external CLI-created worktrees must coordinate with each other.