### PR TITLE
Bump SwiftTerm to 1.13.0-agenthub.6 (sync-output snapshot perf fix)

### DIFF
--- a/app/AgentHub.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/app/AgentHub.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -177,8 +177,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/jamesrochabrun/SwiftTerm",
       "state" : {
-        "revision" : "46d4c1a9b5bf981b9d9e376447be7f81f456837a",
-        "version" : "1.13.0-agenthub.5"
+        "revision" : "0b645ef4019486ee7ce554c1e0309ff647e3ecc9",
+        "version" : "1.13.0-agenthub.6"
       }
     },
     {

--- a/app/modules/AgentHubCore/Package.swift
+++ b/app/modules/AgentHubCore/Package.swift
@@ -35,7 +35,7 @@ let package = Package(
     .package(path: "../Storybook"),
     .package(url: "https://github.com/jamesrochabrun/Canvas", exact: "1.2.1"),
     .package(url: "https://github.com/jamesrochabrun/PierreDiffsSwift", exact: "1.1.7"),
-    .package(url: "https://github.com/jamesrochabrun/SwiftTerm", exact: "1.13.0-agenthub.5"),
+    .package(url: "https://github.com/jamesrochabrun/SwiftTerm", exact: "1.13.0-agenthub.6"),
     .package(url: "https://github.com/gonzalezreal/swift-markdown-ui", from: "2.0.0"),
     .package(url: "https://github.com/groue/GRDB.swift", from: "6.24.0"),
     .package(url: "https://github.com/appstefan/HighlightSwift", from: "1.1.0"),


### PR DESCRIPTION
## What

Bumps the SwiftTerm dependency from `1.13.0-agenthub.5` → `1.13.0-agenthub.6`.

## Why

`.6` ships [jamesrochabrun/SwiftTerm#5](https://github.com/jamesrochabrun/SwiftTerm/pull/5), a performance fix for synchronized output.

Previously, `Terminal.snapshotBuffer()` deep-copied **every line including the entire scrollback** each time a program entered synchronized output (`CSI ? 2026 h`). TUIs that pair `2026h`/`2026l` once per frame — e.g. coding agents (Claude Code, Codex) rendering **inline** in the embedded terminal — made this **O(scrollback) per frame**, allocating and copying thousands of `BufferLine`s many times a second. That pinned a CPU core and spun up the fan.

`.6` deep-copies only the active on-screen rows (`yBase ..< yBase + rows`) and shares scrollback `BufferLine` objects by reference (ARC). The displayed frame stays tear-free and `displayBuffer.lines.count` is unchanged, so search / selection / scrollbar are unaffected. Per-frame snapshot cost drops from O(scrollback) to O(rows).

## Diff

- `app/modules/AgentHubCore/Package.swift` — pin → `1.13.0-agenthub.6`
- `Package.resolved` — revision `0b645ef`, version `1.13.0-agenthub.6`

## Testing

- Verified locally against the fix via a temporary local-path override: profiling showed the `snapshotBuffer` / `BufferLine.init(from:)` hot path no longer dominates during heavy inline TUI rendering, and CPU/fan dropped noticeably. This PR restores the proper pinned-URL dependency at the released tag.
