### PR TITLE
[codex] Use sibling directories for worktrees

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -164,6 +164,7 @@ xcodebuild -workspace app/AgentHub.xcodeproj/project.xcworkspace -scheme AgentHu
 - Combine publishers bridge actor-isolated services to `@MainActor` ViewModels
 - `Task.detached` is used for file I/O off the actor's isolation context
 - `withTaskGroup` for parallel worktree detection and metadata reading
+- AgentHub-created worktrees are sibling directories beside the main repository. Do not create a repo-local `.worktrees` folder or write `.worktrees/` into `.git/info/exclude`.
 - Terminal PTY state is preserved across pending-to-real session transitions
 - `TerminalProcessRegistry` tracks child PIDs for cleanup on app termination
 - Theme system: built-in themes (Claude, Codex, Bat, Xcode) + YAML hot-reload via `ThemeFileWatcher`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,7 @@ Concrete types: `CLISessionMonitorService` / `CodexSessionMonitorService`, `Sess
 
 - Read `AccessorySessions.md` before editing accessory terminal panes, sub-session launch/detection, terminal workspace linked-session restore, or `session_relationships`.
 - AI override flags are applied only when starting a new CLI session, never when resuming an existing one
+- AgentHub-created worktrees live as sibling directories beside the main repository. Do not create a repo-local `.worktrees` folder or add `.worktrees/` to `.git/info/exclude`.
 - Empty or unsupported saved provider settings must fall back to the CLI's own defaults instead of emitting override flags
 - UserDefaults is only for app/UI preferences. Session/workspace management state must live in SQLite via `SessionMetadataStore`.
 - Never add `AgentHubDefaults` keys for selected repositories, monitored session IDs, session restore state, repo mappings, terminal workspace state, or terminal/dev-server process cleanup state.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -295,6 +295,7 @@ The short version: GitHub observation is a shared actor service in `AgentHubGitH
 - Combine publishers bridge actor-isolated services to `@MainActor` ViewModels
 - `Task.detached` is used for file I/O off the actor's isolation context
 - `withTaskGroup` for parallel worktree detection and metadata reading
+- AgentHub-created worktrees are sibling directories beside the main repository. Do not create a repo-local `.worktrees` folder or write `.worktrees/` into `.git/info/exclude`.
 - Terminal PTY state is preserved across pending-to-real session transitions
 - `TerminalProcessRegistry` tracks child PIDs for cleanup on app termination
 - Theme system: built-in themes (Claude, Codex, Bat, Xcode) + YAML hot-reload via `ThemeFileWatcher`

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 - **GitHub support** — Browse pull requests and issues for the current repository, inspect PR diffs and CI checks, monitor current-branch PR status f![Uploading Screenshot 2026-05-26 at 4.23.24 PM.png…]()
 rom session rows, and send GitHub context back into a session
 - **File explorer and built-in editor** — Browse the project tree, jump to files with Cmd+P, edit files in-app with syntax highlighting, and save changes without leaving AgentHub
-- **Git worktree management** — Create and delete worktrees from the UI, launch sessions on new branches, and choose whether AgentHub-owned worktree sessions appear under the parent module or as separate modules
+- **Git worktree management** — Create and delete sibling worktrees from the UI, launch sessions on new branches, and choose whether AgentHub-owned worktree sessions appear under the parent module or as separate modules
 - **Remix with provider picker** — Branch any session into an isolated git worktree and continue it in Claude or Codex; the original session's transcript is passed as context to the new session
 - **Multi-session launcher** — Launch parallel sessions across Claude and Codex with manual prompts or AI-planned orchestration (Smart mode)
 - **Mermaid diagrams** — Detects Mermaid diagram syntax in session output and renders it natively; diagrams can be exported as images
@@ -244,6 +244,8 @@ Toggle between modes in the app settings.
 ### Worktree Grouping
 
 Worktree sessions are grouped under their parent module by default, so `ModuleA` shows its regular sessions plus AgentHub-owned worktree sessions. The Worktrees settings tab can switch to separate modules, where each AgentHub-owned worktree appears as its own module section.
+
+AgentHub creates new worktrees as sibling directories beside the main repository, using the generated or manual directory name directly under the repository's parent directory. It no longer creates a repo-local `.worktrees` folder or adds `.worktrees/` to Git's exclude file.
 
 AgentHub only treats worktrees it created, explicitly added, or focused through monitored sessions as owned. External Git worktrees discovered from the repository are ignored for session grouping, which keeps large local worktree setups from flooding the session list. The Worktrees settings inventory still lists all Git worktrees for tracked repositories: focused rows participate in AgentHub grouping, while external rows can be deleted without becoming focused.
 

--- a/app/AgentHubTests/GitWorktreeServiceTests.swift
+++ b/app/AgentHubTests/GitWorktreeServiceTests.swift
@@ -189,7 +189,7 @@ struct GitWorktreeServiceCancellationTests {
 
     #expect(cleanup.removedWorktree || cleanup.removedBranch || !cleanup.notes.isEmpty)
     #expect(try fixture.localBranchExists(branchName) == false)
-    #expect(FileManager.default.fileExists(atPath: fixture.repoPath + "/.worktrees/\(directoryName)") == false)
+    #expect(FileManager.default.fileExists(atPath: fixture.parentDir + "/\(directoryName)") == false)
   }
 }
 

--- a/app/modules/AgentHubCLI/Sources/AgentHubCLIKit/WorktreeManagementService.swift
+++ b/app/modules/AgentHubCLI/Sources/AgentHubCLIKit/WorktreeManagementService.swift
@@ -109,7 +109,7 @@ public actor WorktreeManagementService: WorktreeManagementServiceProtocol {
 
   public func worktreesDirectory(at repoPath: String) async throws -> String {
     let mainRoot = try await findMainRepositoryRoot(at: repoPath)
-    return (mainRoot as NSString).appendingPathComponent(".worktrees")
+    return siblingWorktreeDirectory(mainRoot: mainRoot)
   }
 
   public func listWorktrees(at repoPath: String) async throws -> [WorktreeInfo] {
@@ -168,7 +168,11 @@ public actor WorktreeManagementService: WorktreeManagementServiceProtocol {
         timeout: Self.gitWorktreeTimeout
       )
 
-      return worktreePath
+      return await resolveCreatedWorktreePath(
+        requestedPath: worktreePath,
+        branch: branch,
+        repoPath: sourceRoot
+      )
     }
   }
 
@@ -206,7 +210,11 @@ public actor WorktreeManagementService: WorktreeManagementServiceProtocol {
       }
 
       try await runGitCommand(args, at: sourceRoot, timeout: Self.gitWorktreeTimeout)
-      return worktreePath
+      return await resolveCreatedWorktreePath(
+        requestedPath: worktreePath,
+        branch: newBranchName,
+        repoPath: sourceRoot
+      )
     }
   }
 
@@ -253,8 +261,13 @@ public actor WorktreeManagementService: WorktreeManagementServiceProtocol {
         onProgress: onProgress
       )
 
-      await onProgress(.completed(path: worktreePath))
-      return worktreePath
+      let resolvedWorktreePath = await resolveCreatedWorktreePath(
+        requestedPath: worktreePath,
+        branch: newBranchName,
+        repoPath: sourceRoot
+      )
+      await onProgress(.completed(path: resolvedWorktreePath))
+      return resolvedWorktreePath
     }
   }
 
@@ -283,8 +296,7 @@ public actor WorktreeManagementService: WorktreeManagementServiceProtocol {
     do {
       let sourceRoot = try await findGitRoot(at: repoPath)
       let mainRoot = try await findMainRepositoryRoot(at: repoPath)
-      let worktreesDirectory = (mainRoot as NSString).appendingPathComponent(".worktrees")
-      let worktreePath = (worktreesDirectory as NSString).appendingPathComponent(directoryName)
+      let worktreePath = siblingWorktreePath(mainRoot: mainRoot, directoryName: directoryName)
 
       let fileManager = FileManager.default
 
@@ -508,8 +520,7 @@ public actor WorktreeManagementService: WorktreeManagementServiceProtocol {
     } else {
       let mainRoot = try await findMainRepositoryRoot(at: repoPath)
       let directoryName = WorktreeNaming.worktreeDirectoryName(for: branchOrPath)
-      let worktreesDirectory = (mainRoot as NSString).appendingPathComponent(".worktrees")
-      targetPath = (worktreesDirectory as NSString).appendingPathComponent(directoryName)
+      targetPath = siblingWorktreePath(mainRoot: mainRoot, directoryName: directoryName)
     }
 
     let mainRoot = try await findMainRepositoryRoot(at: repoPath)
@@ -561,16 +572,49 @@ public actor WorktreeManagementService: WorktreeManagementServiceProtocol {
 private extension WorktreeManagementService {
   func prepareWorktreePath(repoPath: String, directoryName: String) async throws -> String {
     let mainRoot = try await findMainRepositoryRoot(at: repoPath)
-    try ensureWorktreesDirectory(mainRoot: mainRoot, repoPath: repoPath)
-
-    let worktreesDirectory = (mainRoot as NSString).appendingPathComponent(".worktrees")
-    let worktreePath = (worktreesDirectory as NSString).appendingPathComponent(directoryName)
+    let worktreePath = siblingWorktreePath(mainRoot: mainRoot, directoryName: directoryName)
 
     if FileManager.default.fileExists(atPath: worktreePath) {
       throw WorktreeManagementError.directoryAlreadyExists(worktreePath)
     }
 
     return worktreePath
+  }
+
+  nonisolated func siblingWorktreeDirectory(mainRoot: String) -> String {
+    (mainRoot as NSString).deletingLastPathComponent
+  }
+
+  nonisolated func siblingWorktreePath(mainRoot: String, directoryName: String) -> String {
+    (siblingWorktreeDirectory(mainRoot: mainRoot) as NSString).appendingPathComponent(directoryName)
+  }
+
+  func resolveCreatedWorktreePath(
+    requestedPath: String,
+    branch: String,
+    repoPath: String
+  ) async -> String {
+    let normalizedRequestedPath = normalizedExistingPath(requestedPath)
+    if let worktrees = try? await listWorktrees(at: repoPath),
+       let gitRegisteredPath = worktrees.first(where: { worktree in
+         worktree.branch == branch
+           || normalizedExistingPath(worktree.path) == normalizedRequestedPath
+       })?.path {
+      return gitRegisteredPath
+    }
+
+    if let gitRoot = try? await findGitRoot(at: requestedPath), !gitRoot.isEmpty {
+      return gitRoot
+    }
+
+    return normalizedRequestedPath
+  }
+
+  nonisolated func normalizedExistingPath(_ path: String) -> String {
+    URL(fileURLWithPath: path)
+      .standardizedFileURL
+      .resolvingSymlinksInPath()
+      .path
   }
 
   func copyUntrackedFiles(
@@ -606,33 +650,6 @@ private extension WorktreeManagementService {
     }
 
     return (root as NSString).appendingPathComponent(relativePath)
-  }
-
-  func ensureWorktreesDirectory(mainRoot: String, repoPath: String) throws {
-    let worktreesDirectory = (mainRoot as NSString).appendingPathComponent(".worktrees")
-    try FileManager.default.createDirectory(
-      atPath: worktreesDirectory,
-      withIntermediateDirectories: true
-    )
-
-    let commonDirOutput = try runGitCommandSync(
-      ["rev-parse", "--path-format=absolute", "--git-common-dir"],
-      at: repoPath
-    )
-    let commonDir = commonDirOutput.trimmingCharacters(in: .whitespacesAndNewlines)
-    guard !commonDir.isEmpty else { return }
-
-    let infoDirectory = (commonDir as NSString).appendingPathComponent("info")
-    try FileManager.default.createDirectory(atPath: infoDirectory, withIntermediateDirectories: true)
-    let excludeFile = (infoDirectory as NSString).appendingPathComponent("exclude")
-
-    let existing = (try? String(contentsOfFile: excludeFile, encoding: .utf8)) ?? ""
-    let lines = existing.components(separatedBy: .newlines)
-    guard !lines.contains(".worktrees/") else { return }
-
-    let prefix = existing.isEmpty || existing.hasSuffix("\n") ? "" : "\n"
-    let updated = existing + prefix + ".worktrees/\n"
-    try updated.write(toFile: excludeFile, atomically: true, encoding: .utf8)
   }
 
   func branchExists(_ branchName: String, at repoPath: String) async throws -> Bool {

--- a/app/modules/AgentHubCLI/Tests/AgentHubCLIKitTests/WorktreeManagementServiceTests.swift
+++ b/app/modules/AgentHubCLI/Tests/AgentHubCLIKitTests/WorktreeManagementServiceTests.swift
@@ -89,10 +89,10 @@ enum GitFixtureError: Error {
   case commandFailed(command: String, output: String, error: String)
 }
 
-@Suite("WorktreeManagementService .worktrees convention")
+@Suite("WorktreeManagementService sibling worktree convention")
 struct WorktreeConventionTests {
-  @Test("Creates new branch worktrees under repo-local .worktrees")
-  func createsWorktreeUnderRepoLocalDirectory() async throws {
+  @Test("Creates new branch worktrees beside the main repository")
+  func createsWorktreeBesideMainRepository() async throws {
     let fixture = try GitRepoFixture.create()
     defer { fixture.cleanup() }
 
@@ -103,11 +103,11 @@ struct WorktreeConventionTests {
       directoryName: WorktreeNaming.worktreeDirectoryName(for: "feature/example")
     )
 
-    #expect(path == fixture.repoPath + "/.worktrees/feature-example")
+    #expect(path == fixture.parentDir + "/feature-example")
     #expect(FileManager.default.fileExists(atPath: path))
-
-    let exclude = try String(contentsOfFile: fixture.repoPath + "/.git/info/exclude", encoding: .utf8)
-    #expect(exclude.components(separatedBy: .newlines).contains(".worktrees/"))
+    let worktrees = try await service.listWorktrees(at: fixture.repoPath)
+    let registeredWorktree = try #require(worktrees.first { $0.branch == "feature/example" })
+    #expect(path == registeredWorktree.path)
   }
 
   @Test("Creates from a linked worktree but stores under the main repository")
@@ -124,7 +124,7 @@ struct WorktreeConventionTests {
       directoryName: "feature-from-linked"
     )
 
-    #expect(path == fixture.repoPath + "/.worktrees/feature-from-linked")
+    #expect(path == fixture.parentDir + "/feature-from-linked")
     #expect(FileManager.default.fileExists(atPath: path))
   }
 
@@ -332,6 +332,6 @@ struct WorktreeRemovalTests {
 
     #expect(cleanup.removedWorktree || cleanup.removedBranch || !cleanup.notes.isEmpty)
     #expect(try fixture.localBranchExists(branchName) == false)
-    #expect(FileManager.default.fileExists(atPath: fixture.repoPath + "/.worktrees/\(directoryName)") == false)
+    #expect(FileManager.default.fileExists(atPath: fixture.parentDir + "/\(directoryName)") == false)
   }
 }

--- a/app/modules/AgentHubCore/Package.resolved
+++ b/app/modules/AgentHubCore/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "c072eabf83c0a2633edfa8b6bf5f64b80407f109991906438cba79188553eb55",
+  "originHash" : "34e0a7572cf74c09722f7d9c1a5bc28acc1dc417040a7c7e591c0babc7432e52",
   "pins" : [
     {
       "identity" : "beautiful-mermaid-swift",
@@ -159,8 +159,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/jamesrochabrun/SwiftTerm",
       "state" : {
-        "revision" : "46d4c1a9b5bf981b9d9e376447be7f81f456837a",
-        "version" : "1.13.0-agenthub.5"
+        "revision" : "0b645ef4019486ee7ce554c1e0309ff647e3ecc9",
+        "version" : "1.13.0-agenthub.6"
       }
     },
     {

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/FileIndexService.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/FileIndexService.swift
@@ -416,8 +416,7 @@ public actor FileIndexService {
   }
 
   /// Searches files using Spotlight first, then falls back to a local index if
-  /// Spotlight has no usable results for the project. Git worktrees use the local
-  /// Git-backed index first because Spotlight often lags or misses them entirely.
+  /// Spotlight has no usable results for the project.
   /// Ranking uses a strict 3-tier approach:
   /// 1. Filename starts with query → highest score
   /// 2. Filename contains query as substring → high score
@@ -442,49 +441,44 @@ public actor FileIndexService {
 
     let resolvedProjectPath = Self.resolvedURL(for: projectPath).path
     let localStatusBeforeFallback = searchIndexStatus(resolvedProjectPath: resolvedProjectPath)
-    let usesWorktreeLocalIndexFirst = projectFileEnumerator.gitProjectKind(at: resolvedProjectPath) == .gitWorktree
 
-    var spotlightCandidateCount = 0
-    var spotlightElapsedSeconds: TimeInterval = 0
-    if !usesWorktreeLocalIndexFirst {
-      let spotlightResponse = await projectFileSearchService.searchWithDiagnostics(
-        query: query,
-        in: resolvedProjectPath,
-        limit: Self.maxSearchResults * 10
-      )
-      spotlightCandidateCount = spotlightResponse.candidateCount
-      spotlightElapsedSeconds = spotlightResponse.elapsedSeconds
+    let spotlightResponse = await projectFileSearchService.searchWithDiagnostics(
+      query: query,
+      in: resolvedProjectPath,
+      limit: Self.maxSearchResults * 10
+    )
+    let spotlightCandidateCount = spotlightResponse.candidateCount
+    let spotlightElapsedSeconds = spotlightResponse.elapsedSeconds
 
-      let filteredSpotlightResults = spotlightResponse.results
-        .compactMap { spotlightResult -> FileSearchResult? in
-          let absolutePath = Self.resolvedURL(for: spotlightResult.absolutePath).path
-          guard shouldIncludeSearchResultCached(at: absolutePath, rootPath: resolvedProjectPath) else {
-            return nil
-          }
-          let relativePath = Self.projectRelativePath(for: absolutePath, relativeTo: resolvedProjectPath)
-          let name = URL(fileURLWithPath: absolutePath).lastPathComponent
-
-          return FileSearchResult(
-            id: absolutePath,
-            name: name,
-            relativePath: relativePath,
-            absolutePath: absolutePath,
-            score: spotlightResult.score
-          )
+    let filteredSpotlightResults = spotlightResponse.results
+      .compactMap { spotlightResult -> FileSearchResult? in
+        let absolutePath = Self.resolvedURL(for: spotlightResult.absolutePath).path
+        guard shouldIncludeSearchResultCached(at: absolutePath, rootPath: resolvedProjectPath) else {
+          return nil
         }
-        .sortedBySearchScore()
+        let relativePath = Self.projectRelativePath(for: absolutePath, relativeTo: resolvedProjectPath)
+        let name = URL(fileURLWithPath: absolutePath).lastPathComponent
 
-      if !filteredSpotlightResults.isEmpty {
-        return FileSearchDiagnostics(
-          results: Array(filteredSpotlightResults.prefix(Self.maxSearchResults)),
-          source: .spotlight,
-          spotlightCandidateCount: spotlightCandidateCount,
-          spotlightElapsedSeconds: spotlightElapsedSeconds,
-          localIndexStatusBeforeFallback: localStatusBeforeFallback,
-          localIndexedFileCount: searchCache[resolvedProjectPath]?.files.count ?? 0,
-          localIndexElapsedSeconds: nil
+        return FileSearchResult(
+          id: absolutePath,
+          name: name,
+          relativePath: relativePath,
+          absolutePath: absolutePath,
+          score: spotlightResult.score
         )
       }
+      .sortedBySearchScore()
+
+    if !filteredSpotlightResults.isEmpty {
+      return FileSearchDiagnostics(
+        results: Array(filteredSpotlightResults.prefix(Self.maxSearchResults)),
+        source: .spotlight,
+        spotlightCandidateCount: spotlightCandidateCount,
+        spotlightElapsedSeconds: spotlightElapsedSeconds,
+        localIndexStatusBeforeFallback: localStatusBeforeFallback,
+        localIndexedFileCount: searchCache[resolvedProjectPath]?.files.count ?? 0,
+        localIndexElapsedSeconds: nil
+      )
     }
 
     let localIndexStart = Date()

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/CreateWorktreeSheet.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/CreateWorktreeSheet.swift
@@ -259,7 +259,7 @@ public struct CreateWorktreeSheet: View {
   // MARK: - Computed Properties
 
   private var parentDirectory: String {
-    (repositoryPath as NSString).appendingPathComponent(".worktrees")
+    (repositoryPath as NSString).deletingLastPathComponent
   }
 
   private var isValid: Bool {

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/FileExplorerView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/FileExplorerView.swift
@@ -41,7 +41,7 @@ public struct FileExplorerView: View {
   @State private var expandedPaths: Set<String> = []
   @State private var loadingDirectories: Set<String> = []
   @State private var scrollToPath: String?
-  @State private var hasLoadedTreeRoot = false
+  @State private var loadedTreeRootPath: String?
   @State private var editorDisplayMode: EditorDisplayMode = .highlighted
   @State private var editorDocumentID = UUID()
 
@@ -121,7 +121,10 @@ public struct FileExplorerView: View {
       maxHeight: .infinity
     )
     .task(id: loadTaskID) {
-      guard navigationRequest == nil else { return }
+      guard navigationRequest == nil else {
+        await ensureFileTreeLoaded()
+        return
+      }
       if let initialPath = selectedFilePath {
         await navigateToFile(at: initialPath)
       } else {
@@ -378,7 +381,7 @@ public struct FileExplorerView: View {
     loadingDirectories.removeAll()
     expandedPaths.removeAll()
     treeNodes = await FileIndexService.shared.rootNodes(projectPath: normalizedProjectPath)
-    hasLoadedTreeRoot = true
+    loadedTreeRootPath = normalizedProjectPath
     isLoading = false
   }
 
@@ -437,6 +440,7 @@ public struct FileExplorerView: View {
       .resolvingSymlinksInPath()
       .path
     await openFile(at: resolvedPath)
+    await ensureFileTreeLoaded()
     await expandToFile(resolvedPath)
     try? await Task.sleep(for: .milliseconds(100))
     scrollToPath = resolvedPath
@@ -500,11 +504,14 @@ public struct FileExplorerView: View {
     }
   }
 
+  private func ensureFileTreeLoaded() async {
+    guard loadedTreeRootPath != normalizedProjectPath else { return }
+    await loadFileTree()
+  }
+
   private func ensureDirectoryLoaded(_ directoryPath: String) async {
     if directoryPath == normalizedProjectPath {
-      if !hasLoadedTreeRoot {
-        await loadFileTree()
-      }
+      await ensureFileTreeLoaded()
       return
     }
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderMonitoringPanelView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderMonitoringPanelView.swift
@@ -296,15 +296,16 @@ public struct MultiProviderMonitoringPanelView: View {
     }
     .floatingPanel(isPresented: $showQuickFilePicker, defaultSize: CGSize(width: 680, height: 640)) {
       if let primaryItem = snapshot.effectivePrimaryItem {
+        let projectPath = defaultEditorProjectPath(for: primaryItem)
         QuickFilePickerView(
           isPresented: $showQuickFilePicker,
-          projectPath: editorState(for: primaryItem).projectPath,
+          projectPath: projectPath,
           onFileSelected: { path in
             showQuickFilePicker = false
             openFileInEditor(
               for: primaryItem.id,
               filePath: path,
-              projectPath: editorState(for: primaryItem).projectPath,
+              projectPath: projectPath,
               lineNumber: nil,
               makePrimary: false
             )
@@ -1233,11 +1234,36 @@ public struct MultiProviderMonitoringPanelView: View {
   }
 
   private func editorState(for item: ProviderMonitoringItem) -> MonitoringEditorState {
-    MonitoringEditorStateStore.state(
+    let defaultProjectPath = defaultEditorProjectPath(for: item)
+    var state = MonitoringEditorStateStore.state(
       for: item.id,
-      defaultProjectPath: item.projectPath,
+      defaultProjectPath: defaultProjectPath,
       in: editorStates
     )
+
+    if state.projectPath != defaultProjectPath {
+      state.projectPath = defaultProjectPath
+    }
+    if let selectedFilePath = state.selectedFilePath,
+       !Self.isPath(selectedFilePath, within: state.projectPath) {
+      state.selectedFilePath = nil
+      state.navigationRequest = nil
+    }
+
+    return state
+  }
+
+  private func defaultEditorProjectPath(for item: ProviderMonitoringItem) -> String {
+    WorktreeModuleResolver.bestMatch(for: item.projectPath, repositories: allSelectedRepositories)?
+      .worktree
+      .path
+      ?? item.projectPath
+  }
+
+  private static func isPath(_ path: String, within rootPath: String) -> Bool {
+    let normalizedPath = WorktreeModuleResolver.normalizedDirectoryPath(path)
+    let normalizedRootPath = WorktreeModuleResolver.normalizedDirectoryPath(rootPath)
+    return normalizedPath == normalizedRootPath || normalizedPath.hasPrefix(normalizedRootPath + "/")
   }
 
   private func editorContentModeBinding(for item: ProviderMonitoringItem) -> Binding<MonitoringCardContentMode> {

--- a/app/modules/AgentHubCore/Sources/AgentHub/Utils/TerminalFileOpenProjectResolver.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Utils/TerminalFileOpenProjectResolver.swift
@@ -18,15 +18,15 @@ enum TerminalFileOpenProjectResolver {
     let resolvedFilePath = normalize(filePath)
     let resolvedSessionProjectPath = normalize(sessionProjectPath)
 
-    if isPath(resolvedFilePath, within: resolvedSessionProjectPath) {
-      return resolvedSessionProjectPath
-    }
-
     if let selectedRoot = selectedProjectRoot(
       containing: resolvedFilePath,
       repositories: repositories
     ) {
       return selectedRoot
+    }
+
+    if isPath(resolvedFilePath, within: resolvedSessionProjectPath) {
+      return resolvedSessionProjectPath
     }
 
     if let gitRoot = gitRoot(containing: resolvedFilePath, fileManager: fileManager) {

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/FileIndexServiceTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/FileIndexServiceTests.swift
@@ -389,8 +389,8 @@ struct FileIndexServicePrivacyTests {
     #expect(!relativePaths.contains("ignored/IgnoredSearchTarget.swift"))
   }
 
-  @Test("Worktree search uses local Git index before Spotlight")
-  func worktreeSearchSkipsSpotlight() async throws {
+  @Test("Worktree search checks Spotlight before local fallback")
+  func worktreeSearchChecksSpotlightBeforeLocalFallback() async throws {
     let fixture = try FileIndexFixture.create()
     defer { fixture.cleanup() }
 
@@ -417,9 +417,9 @@ struct FileIndexServicePrivacyTests {
 
     let diagnostics = await service.searchWithDiagnostics(query: "only", in: fixture.projectPath)
 
-    #expect(diagnostics.source == .localIndex)
-    #expect(diagnostics.spotlightCandidateCount == 0)
-    #expect(diagnostics.results.map(\.relativePath) == ["LocalOnly.swift"])
+    #expect(diagnostics.source == .spotlight)
+    #expect(diagnostics.spotlightCandidateCount == 1)
+    #expect(diagnostics.results.map(\.relativePath) == ["SpotlightOnly.swift"])
   }
 
   @Test("Non-Git folders fall back to recursive indexing")

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/GitWorktreeServiceTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/GitWorktreeServiceTests.swift
@@ -213,7 +213,7 @@ struct GitWorktreeServiceCancellationTests {
 
     #expect(cleanup.removedWorktree || cleanup.removedBranch || !cleanup.notes.isEmpty)
     #expect(try fixture.localBranchExists(branchName) == false)
-    #expect(FileManager.default.fileExists(atPath: fixture.repoPath + "/.worktrees/\(directoryName)") == false)
+    #expect(FileManager.default.fileExists(atPath: fixture.parentDir + "/\(directoryName)") == false)
   }
 }
 

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/TerminalFileOpenProjectResolverTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/TerminalFileOpenProjectResolverTests.swift
@@ -48,6 +48,32 @@ struct TerminalFileOpenProjectResolverTests {
     #expect(resolved == worktreePath)
   }
 
+  @Test func prefersSelectedWorktreeRootOverNestedSessionProject() {
+    let worktreePath = "/tmp/AgentHubResolver/agenthub-buenos-aires-692130"
+    let sessionProjectPath = worktreePath + "/android"
+    let filePath = sessionProjectPath + "/app/src/main/java/MainActivity.kt"
+    let repositories = [
+      SelectedRepository(
+        path: "/tmp/AgentHubResolver/agenthub",
+        worktrees: [
+          WorktreeBranch(
+            name: "agenthub-buenos-aires-692130",
+            path: worktreePath,
+            isWorktree: true
+          )
+        ]
+      )
+    ]
+
+    let resolved = TerminalFileOpenProjectResolver.projectPath(
+      forFile: filePath,
+      sessionProjectPath: sessionProjectPath,
+      repositories: repositories
+    )
+
+    #expect(resolved == worktreePath)
+  }
+
   @Test func fallsBackToNearestGitRootForUntrackedProject() throws {
     let root = try makeTemporaryDirectory()
     let gitDirectory = root.appendingPathComponent(".git", isDirectory: true)


### PR DESCRIPTION
## Summary

- Create AgentHub-managed worktrees as sibling directories beside the main repository instead of under a repo-local `.worktrees` folder.
- Remove `.worktrees/` exclude-file management and update cleanup/removal fallbacks to use the sibling path convention.
- Keep editor, quick picker, file search, and terminal file-open project resolution aligned with selected worktree roots.
- Update tests and docs for the new convention, and bump AgentHubCore's SwiftTerm pin to `1.13.0-agenthub.6`.

## Validation

- `git diff --check`
- `swift test --filter WorktreeConventionTests.createsWorktreeBesideMainRepository`
- `swift test --filter WorktreeConventionTests.linkedWorktreeInvocationUsesMainRepositoryStorage`
- `swift test --filter WorktreeRemovalTests.cancelsWorktreeCreationAndCleansUp`
- `xcodebuild build -quiet -project app/AgentHub.xcodeproj -scheme AgentHub -destination 'platform=macOS'`

## Notes

AgentHubCore SwiftPM tests were not run because the package build fails in the external `CodeEditSymbols` checkout before AgentHubCore tests compile (`Bundle.module` is unavailable in that target under bare SwiftPM). The Xcode app build passes.