### PR TITLE
[codex] Fix worktree progress regression

### DIFF
--- a/app/modules/AgentHubCLI/Sources/AgentHubCLIKit/WorktreeManagementService.swift
+++ b/app/modules/AgentHubCLI/Sources/AgentHubCLIKit/WorktreeManagementService.swift
@@ -891,6 +891,7 @@ private extension WorktreeManagementService {
     process.standardError = errorPipe
 
     let stderrCollector = GitStderrCollector()
+    let progressForwarder = WorktreeProgressForwarder(onProgress: onProgress)
     errorPipe.fileHandleForReading.readabilityHandler = { handle in
       let data = handle.availableData
       guard !data.isEmpty,
@@ -900,15 +901,7 @@ private extension WorktreeManagementService {
 
       let lines = stderrCollector.append(chunk)
       for line in lines {
-        if let progress = Self.parseUpdatingFilesProgress(from: line) {
-          Task {
-            await onProgress(.updatingFiles(current: progress.current, total: progress.total))
-          }
-        } else if line.contains("Preparing worktree") {
-          Task {
-            await onProgress(.preparing(message: "Preparing worktree..."))
-          }
-        }
+        Self.forwardGitProgress(from: line, using: progressForwarder)
       }
     }
 
@@ -963,10 +956,16 @@ private extension WorktreeManagementService {
     let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
     errorPipe.fileHandleForReading.readabilityHandler = nil
     let remainingErrorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
+    var remainingLines: [String] = []
     if let remainingError = String(data: remainingErrorData, encoding: .utf8),
        !remainingError.isEmpty {
-      _ = stderrCollector.append(remainingError)
+      remainingLines.append(contentsOf: stderrCollector.append(remainingError))
     }
+    remainingLines.append(contentsOf: stderrCollector.drainPartialLine())
+    for line in remainingLines {
+      Self.forwardGitProgress(from: line, using: progressForwarder)
+    }
+    await progressForwarder.waitForAll()
 
     let output = String(data: outputData, encoding: .utf8) ?? ""
     let wasCancelled = cancelledWorktreeOperations.remove(operationID) != nil || Task.isCancelled
@@ -998,10 +997,67 @@ private extension WorktreeManagementService {
     return (current, total)
   }
 
+  static func forwardGitProgress(
+    from line: String,
+    using forwarder: WorktreeProgressForwarder
+  ) {
+    if let progress = parseUpdatingFilesProgress(from: line) {
+      forwarder.enqueue(.updatingFiles(current: progress.current, total: progress.total))
+    } else if line.contains("Preparing worktree") {
+      forwarder.enqueue(.preparing(message: "Preparing worktree..."))
+    }
+  }
+
   static func terminateIfRunning(_ process: Process) {
     if process.isRunning {
       process.terminate()
     }
+  }
+}
+
+private final class WorktreeProgressForwarder: @unchecked Sendable {
+  private let lock = NSLock()
+  private var tailTask: Task<Void, Never>?
+  private var generation = 0
+  private let onProgress: @Sendable (WorktreeCreationProgress) async -> Void
+
+  init(onProgress: @escaping @Sendable (WorktreeCreationProgress) async -> Void) {
+    self.onProgress = onProgress
+  }
+
+  func enqueue(_ progress: WorktreeCreationProgress) {
+    lock.lock()
+    defer { lock.unlock() }
+    let previousTask = tailTask
+    generation += 1
+    tailTask = Task {
+      await previousTask?.value
+      await onProgress(progress)
+    }
+  }
+
+  func waitForAll() async {
+    while true {
+      let (task, targetGeneration) = currentTail()
+
+      await task?.value
+
+      if isCurrentGeneration(targetGeneration) {
+        return
+      }
+    }
+  }
+
+  private func currentTail() -> (Task<Void, Never>?, Int) {
+    lock.lock()
+    defer { lock.unlock() }
+    return (tailTask, generation)
+  }
+
+  private func isCurrentGeneration(_ targetGeneration: Int) -> Bool {
+    lock.lock()
+    defer { lock.unlock() }
+    return generation == targetGeneration
   }
 }
 
@@ -1030,5 +1086,16 @@ private final class GitStderrCollector: @unchecked Sendable {
       output.append(partialLine)
     }
     return output.joined(separator: "\n")
+  }
+
+  func drainPartialLine() -> [String] {
+    lock.lock()
+    defer { lock.unlock() }
+
+    guard !partialLine.isEmpty else { return [] }
+    let line = partialLine
+    lines.append(line)
+    partialLine = ""
+    return [line]
   }
 }

--- a/app/modules/AgentHubCLI/Tests/AgentHubCLIKitTests/WorktreeManagementServiceTests.swift
+++ b/app/modules/AgentHubCLI/Tests/AgentHubCLIKitTests/WorktreeManagementServiceTests.swift
@@ -89,6 +89,18 @@ enum GitFixtureError: Error {
   case commandFailed(command: String, output: String, error: String)
 }
 
+private actor WorktreeProgressRecorder {
+  private var values: [WorktreeCreationProgress] = []
+
+  func record(_ progress: WorktreeCreationProgress) {
+    values.append(progress)
+  }
+
+  func recordedValues() -> [WorktreeCreationProgress] {
+    values
+  }
+}
+
 @Suite("WorktreeManagementService sibling worktree convention")
 struct WorktreeConventionTests {
   @Test("Creates new branch worktrees beside the main repository")
@@ -165,6 +177,45 @@ struct WorktreeConventionTests {
     )
 
     #expect(FileManager.default.fileExists(atPath: path + "/BASE.md"))
+  }
+
+  @Test("Progress-enabled creation leaves completed as the final update")
+  func progressEnabledCreationLeavesCompletedFinal() async throws {
+    let fixture = try GitRepoFixture.create()
+    defer { fixture.cleanup() }
+
+    let hookPath = fixture.repoPath + "/.git/hooks/post-checkout"
+    let hook = """
+    #!/bin/sh
+    echo "Preparing worktree from hook" >&2
+    """
+    try hook.write(toFile: hookPath, atomically: true, encoding: .utf8)
+    try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: hookPath)
+
+    let service = WorktreeManagementService()
+    let recorder = WorktreeProgressRecorder()
+
+    _ = try await service.createWorktreeWithNewBranch(
+      at: fixture.repoPath,
+      newBranchName: "feature/progress-order",
+      directoryName: "feature-progress-order",
+      operationID: WorktreeOperationID()
+    ) { progress in
+      if case .preparing = progress {
+        try? await Task.sleep(for: .milliseconds(150))
+      }
+      await recorder.record(progress)
+    }
+
+    try await Task.sleep(for: .milliseconds(250))
+    let progressUpdates = await recorder.recordedValues()
+    let completedIndex = try #require(progressUpdates.lastIndex(where: { progress in
+      if case .completed = progress { return true }
+      return false
+    }))
+
+    #expect(completedIndex == progressUpdates.indices.last)
+    #expect(!progressUpdates.dropFirst(completedIndex + 1).contains { $0.isInProgress })
   }
 
   @Test("Applies tracked and untracked source changes to another worktree")

--- a/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/WorktreeGenerationProgressCoordinator.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/WorktreeGenerationProgressCoordinator.swift
@@ -315,6 +315,8 @@ public final class WorktreeGenerationProgressCoordinator {
 
   private func ingest(_ progress: WorktreeCreationProgress, for id: String) {
     guard let idx = operations.firstIndex(where: { $0.id == id }) else { return }
+    // Git stderr callbacks can arrive after the terminal sidecar snapshot; terminal states are final.
+    guard operations[idx].progress.isInProgress else { return }
     guard operations[idx].progress != progress else { return }
     operations[idx].progress = progress
     if !progress.isInProgress {

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/WorktreeGenerationProgressCoordinatorTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/WorktreeGenerationProgressCoordinatorTests.swift
@@ -72,6 +72,22 @@ struct WorktreeGenerationProgressCoordinatorTests {
     #expect(notif.calls == [["add-logging"]])
   }
 
+  @Test("Terminal MCP progress does not regress to preparing")
+  func terminalMCPProgressDoesNotRegressToPreparing() async {
+    let watcher = MockProgressWatcher()
+    let coord = WorktreeGenerationProgressCoordinator(soundService: MockSound(), notificationService: MockNotifier())
+    coord.startObservingMCP(watcher: watcher)
+
+    watcher.send(snapshot("mcp-1", "mcp-opt-in", .completed(path: "/tmp/mcp-opt-in"), at: 1))
+    await settle()
+    watcher.send(snapshot("mcp-1", "mcp-opt-in", .preparing(message: "Preparing worktree..."), at: 2))
+    await settle()
+
+    #expect(coord.operations.count == 1)
+    #expect(coord.inFlightCount == 0)
+    #expect(coord.operations.first?.progress == .completed(path: "/tmp/mcp-opt-in"))
+  }
+
   @Test("Branch naming shows a transient row that never announces ready")
   func namingDoesNotFireReady() async {
     UserDefaults.standard.set(true, forKey: AgentHubDefaults.notificationSoundsEnabled)


### PR DESCRIPTION
## Summary
- serialize git worktree progress forwarding so stderr-derived updates cannot arrive after completion
- keep terminal worktree progress states final in the app-wide coordinator
- add regression coverage for completed progress staying terminal

## Root Cause
PR #339 added queued worktree creation and progress surfaced through the shared top-bar coordinator. The git stderr progress path forwarded updates through unstructured `Task` callbacks, while completion was emitted synchronously after `git worktree add` returned. A late `Preparing worktree...` callback could therefore arrive after `.completed` and move the operation back to the 5% preparing state.

## Validation
- `git diff --check`
- `swift test --package-path app/modules/AgentHubCLI --filter progressEnabledCreationLeavesCompletedFinal`
- `swift test --package-path app/modules/AgentHubCLI --filter cancelsWorktreeCreationAndCleansUp`
- `swift test --package-path app/modules/AgentHubCLI --filter WorktreeProgressQueueTests`
- `xcodebuild build -project app/AgentHub.xcodeproj -scheme AgentHub -destination 'platform=macOS'`

## Notes
- The app build succeeded. Xcode still prints SwiftLint plugin failure summaries for third-party package lint phases despite the successful build exit.
- Direct AgentHubCore test execution is blocked in this checkout: the app/package schemes are not configured for test action, and SwiftPM AgentHubCore currently fails in `CodeEditSymbols` on `Bundle.module`.