### PR TITLE
[codex] Add CLI extra arguments handoff

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubDefaults.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubDefaults.swift
@@ -73,6 +73,14 @@ public enum AgentHubDefaults {
   /// Type: Data (JSON-encoded [CLIEnvironmentVariable])
   public static let cliEnvironmentVariables = "\(keyPrefix)cli.environmentVariables"
 
+  /// Extra CLI arguments applied to Claude command invocations
+  /// Type: String (shell-style arguments, default: "")
+  public static let claudeCommandArgs = "\(keyPrefix)cli.claudeCommandArgs"
+
+  /// Extra CLI arguments applied to Codex command invocations
+  /// Type: String (shell-style arguments, default: "")
+  public static let codexCommandArgs = "\(keyPrefix)cli.codexCommandArgs"
+
   /// Selected provider in side panel segmented control
   /// Type: String (default: "Claude")
   public static let selectedSidePanelProvider = "\(keyPrefix)sidepanel.selectedProvider"

--- a/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubProvider.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubProvider.swift
@@ -359,19 +359,23 @@ public final class AgentHubProvider {
     case .claude:
       let command = defaults.string(forKey: AgentHubDefaults.claudeCommand)
         ?? configuration.cliCommand
+      let claudeArgString = defaults.string(forKey: AgentHubDefaults.claudeCommandArgs) ?? ""
       cliConfiguration = CLICommandConfiguration(
         command: command,
         additionalPaths: ClaudeCodePathResolver.searchPaths(additionalPaths: configuration.additionalCLIPaths),
-        mode: .claude
+        mode: .claude,
+        extraArgs: CLICommandConfiguration.parseArgumentString(claudeArgString)
       )
     case .codex:
       let userCommand = defaults.string(forKey: AgentHubDefaults.codexCommand) ?? configuration.codexCommand
+      let codexArgString = defaults.string(forKey: AgentHubDefaults.codexCommandArgs) ?? ""
       // Store the user's configured command string as-is (e.g. "airchat codex")
       // Executable resolution happens at launch time using executableName
       cliConfiguration = CLICommandConfiguration(
         command: userCommand,
         additionalPaths: CLIPathResolver.codexPaths(additionalPaths: configuration.additionalCLIPaths),
-        mode: .codex
+        mode: .codex,
+        extraArgs: CLICommandConfiguration.parseArgumentString(codexArgString)
       )
     }
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/Configuration/CLICommandConfiguration.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Configuration/CLICommandConfiguration.swift
@@ -16,27 +16,48 @@ public struct CLICommandConfiguration: Codable, Sendable {
   public var command: String
   public var additionalPaths: [String]
   public var mode: CLICommandMode
+  /// Extra arguments configured by the user for each CLI invocation.
+  public var extraArgs: [String]
 
   public init(
     command: String,
     additionalPaths: [String] = [],
-    mode: CLICommandMode
+    mode: CLICommandMode,
+    extraArgs: [String] = []
   ) {
     self.command = command
     self.additionalPaths = additionalPaths
     self.mode = mode
+    self.extraArgs = extraArgs
+  }
+
+  private enum CodingKeys: String, CodingKey {
+    case command
+    case additionalPaths
+    case mode
+    case extraArgs
+  }
+
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    command = try container.decode(String.self, forKey: .command)
+    additionalPaths = try container.decode([String].self, forKey: .additionalPaths)
+    mode = try container.decode(CLICommandMode.self, forKey: .mode)
+    extraArgs = try container.decodeIfPresent([String].self, forKey: .extraArgs) ?? []
   }
 
   /// The executable name (first word of command). e.g. "airchat" from "airchat codex"
   public var executableName: String {
-    String(command.split(separator: " ", maxSplits: 1).first ?? Substring(command))
+    commandParts.first ?? command
   }
 
   /// Subcommand arguments (remaining words after executable). e.g. ["codex"] from "airchat codex"
   public var subcommandArgs: [String] {
-    let parts = command.split(separator: " ", maxSplits: 1)
-    guard parts.count > 1 else { return [] }
-    return [String(parts[1])]
+    Array(commandParts.dropFirst())
+  }
+
+  private var commandParts: [String] {
+    Self.parseArgumentString(command)
   }
 
   public static var claudeDefault: CLICommandConfiguration {
@@ -60,103 +81,200 @@ public struct CLICommandConfiguration: Codable, Sendable {
     disallowedTools: [String]? = nil,
     codexApprovalPolicy: String? = nil
   ) -> [String] {
-    let prefix = subcommandArgs
+    let prefix = normalizedPrefixArguments()
 
     switch mode {
     case .claude:
-      var args: [String] = []
+      var providerArgs: [String] = []
 
       let isNewSession = sessionId == nil || sessionId?.isEmpty == true || sessionId?.hasPrefix("pending-") == true
 
       if let agentHubMCPServerPath, !agentHubMCPServerPath.isEmpty {
-        args += ["--mcp-config", claudeMCPConfig(agentHubCLIPath: agentHubMCPServerPath)]
-        args += ["--append-system-prompt", Self.agentHubMCPRoutingInstructions]
+        providerArgs += ["--mcp-config", claudeMCPConfig(agentHubCLIPath: agentHubMCPServerPath)]
+        providerArgs += ["--append-system-prompt", Self.agentHubMCPRoutingInstructions]
       }
 
       // Add flags only for NEW sessions (not resume)
       if isNewSession {
         if permissionModePlan {
           // --permission-mode plan takes precedence; mutually exclusive with dangerously-skip-permissions
-          args += ["--permission-mode", "plan"]
+          providerArgs += ["--permission-mode", "plan"]
         } else if dangerouslySkipPermissions {
-          args.append("--dangerously-skip-permissions")
+          providerArgs.append("--dangerously-skip-permissions")
         }
         if let name = worktreeName {
           if name.isEmpty {
-            args.append("--worktree")
+            providerArgs.append("--worktree")
           } else {
-            args += ["--worktree", name]
+            providerArgs += ["--worktree", name]
           }
         }
 
         // AI configuration flags
         if let model, !model.isEmpty {
-          args += ["--model", model]
+          providerArgs += ["--model", model]
         }
         if let effortLevel, !effortLevel.isEmpty {
-          args += ["--effort", effortLevel]
+          providerArgs += ["--effort", effortLevel]
         }
         if let allowedTools, !allowedTools.isEmpty {
-          args.append("--allowedTools")
-          args.append(contentsOf: allowedTools)
+          providerArgs.append("--allowedTools")
+          providerArgs.append(contentsOf: allowedTools)
         }
         if let disallowedTools, !disallowedTools.isEmpty {
-          args.append("--disallowedTools")
-          args.append(contentsOf: disallowedTools)
+          providerArgs.append("--disallowedTools")
+          providerArgs.append(contentsOf: disallowedTools)
         }
       }
 
       if let sessionId, !sessionId.isEmpty, !sessionId.hasPrefix("pending-") {
+        var trailingArgs = ["-r", sessionId]
         if let prompt, !prompt.isEmpty {
-          return prefix + args + ["-r", sessionId, prompt]
+          trailingArgs.append(prompt)
         }
-        return prefix + args + ["-r", sessionId]
+        return assembleArguments(prefix: prefix, providerArgs: providerArgs, trailingArgs: trailingArgs)
       }
+      var trailingArgs: [String] = []
       if let prompt, !prompt.isEmpty {
-        return prefix + args + [prompt]
+        trailingArgs.append(prompt)
       }
-      return prefix + args
+      return assembleArguments(prefix: prefix, providerArgs: providerArgs, trailingArgs: trailingArgs)
 
     case .codex:
       if let sessionId, !sessionId.isEmpty, !sessionId.hasPrefix("pending-") {
         // Codex CLI resume: codex resume <SESSION_ID>
-        var args: [String] = []
+        var providerArgs: [String] = []
         if let agentHubMCPServerPath, !agentHubMCPServerPath.isEmpty {
-          args += codexMCPConfigArgs(agentHubCLIPath: agentHubMCPServerPath)
+          providerArgs += codexMCPConfigArgs(agentHubCLIPath: agentHubMCPServerPath)
         }
-        return prefix + args + ["resume", sessionId]
+        return assembleArguments(prefix: prefix, providerArgs: providerArgs, trailingArgs: ["resume", sessionId])
       }
 
       // AI configuration flags for new Codex sessions
-      var args: [String] = []
+      var providerArgs: [String] = []
       if let agentHubMCPServerPath, !agentHubMCPServerPath.isEmpty {
-        args += codexMCPConfigArgs(agentHubCLIPath: agentHubMCPServerPath)
+        providerArgs += codexMCPConfigArgs(agentHubCLIPath: agentHubMCPServerPath)
       }
       if let model, !model.isEmpty {
-        args += ["--model", model]
+        providerArgs += ["--model", model]
       }
       if let codexApprovalPolicy {
         switch codexApprovalPolicy {
         case "full-auto":
-          args += ["--sandbox", "workspace-write"]
+          providerArgs += ["--sandbox", "workspace-write"]
         case "untrusted", "on-request", "never":
-          args += ["-a", codexApprovalPolicy]
+          providerArgs += ["-a", codexApprovalPolicy]
         default:
           break
         }
       }
       if let effortLevel, !effortLevel.isEmpty {
-        args += ["-c", "model_reasoning_effort=\"\(effortLevel)\""]
+        providerArgs += ["-c", "model_reasoning_effort=\"\(effortLevel)\""]
       }
 
       // Start a new Codex session.
       // NOTE: Codex plan mode (ModeKind::Plan) is TUI-only and cannot be activated
       // via CLI flags. The UI layer disables the Codex pill when plan mode is on.
+      var trailingArgs: [String] = []
       if let prompt, !prompt.isEmpty {
-        return prefix + args + [prompt]
+        trailingArgs.append(prompt)
       }
-      return prefix + args
+      return assembleArguments(prefix: prefix, providerArgs: providerArgs, trailingArgs: trailingArgs)
     }
+  }
+
+  public static func parseArgumentString(_ value: String) -> [String] {
+    var arguments: [String] = []
+    var current = ""
+    var quote: Character?
+    var escaping = false
+    var hasCurrentArgument = false
+
+    for character in value {
+      if escaping {
+        current.append(character)
+        hasCurrentArgument = true
+        escaping = false
+        continue
+      }
+
+      if character == "\\" {
+        escaping = true
+        hasCurrentArgument = true
+        continue
+      }
+
+      if let activeQuote = quote {
+        if character == activeQuote {
+          quote = nil
+        } else {
+          current.append(character)
+          hasCurrentArgument = true
+        }
+        continue
+      }
+
+      if character == "'" || character == "\"" {
+        quote = character
+        hasCurrentArgument = true
+        continue
+      }
+
+      if character.isWhitespace {
+        if hasCurrentArgument {
+          arguments.append(current)
+          current = ""
+          hasCurrentArgument = false
+        }
+        continue
+      }
+
+      current.append(character)
+      hasCurrentArgument = true
+    }
+
+    if escaping {
+      current.append("\\")
+    }
+    if hasCurrentArgument {
+      arguments.append(current)
+    }
+    return arguments
+  }
+
+  private func normalizedPrefixArguments() -> [String] {
+    var prefix = subcommandArgs
+    guard isAirChatExecutable else { return prefix }
+
+    let providerSubcommand: String
+    switch mode {
+    case .claude:
+      providerSubcommand = "claude"
+    case .codex:
+      providerSubcommand = "codex"
+    }
+
+    if !prefix.contains("claude"), !prefix.contains("codex") {
+      prefix.append(providerSubcommand)
+    }
+    return prefix
+  }
+
+  private func assembleArguments(prefix: [String], providerArgs: [String], trailingArgs: [String]) -> [String] {
+    guard isAirChatExecutable else {
+      return prefix + providerArgs + extraArgs + trailingArgs
+    }
+
+    let directProviderArgs = providerArgs + trailingArgs
+    guard !directProviderArgs.isEmpty else {
+      return prefix + extraArgs
+    }
+
+    return prefix + extraArgs + ["--"] + directProviderArgs
+  }
+
+  private var isAirChatExecutable: Bool {
+    URL(fileURLWithPath: executableName).lastPathComponent == "airchat"
   }
 
   private func claudeMCPConfig(agentHubCLIPath: String) -> String {

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringCardView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringCardView.swift
@@ -852,7 +852,7 @@ public struct MonitoringCardView: View {
       terminalKey: terminalKey ?? session.id,
       sessionId: session.id,
       projectPath: session.projectPath,
-      cliConfiguration: viewModel?.cliConfiguration ?? .claudeDefault,
+      cliConfiguration: liveCLIConfiguration,
       initialPrompt: initialPrompt,
       initialInputText: initialInputText,
       viewModel: viewModel,
@@ -885,7 +885,7 @@ public struct MonitoringCardView: View {
       session: session,
       projectPath: session.projectPath,
       onDismiss: { contentMode = .terminal },
-      cliConfiguration: viewModel?.cliConfiguration,
+      cliConfiguration: liveCLIConfiguration,
       providerKind: providerKind,
       onInlineRequestSubmit: { prompt, sess in
         contentMode = .terminal
@@ -899,6 +899,12 @@ public struct MonitoringCardView: View {
     )
     .frame(maxWidth: .infinity, minHeight: 300, maxHeight: .infinity)
     .id("diffs-\(session.id)")
+  }
+
+  private var liveCLIConfiguration: CLICommandConfiguration {
+    viewModel?.cliConfiguration(for: providerKind)
+      ?? cliConfiguration
+      ?? (providerKind == .claude ? .claudeDefault : .codexDefault)
   }
 
   private var previewContextBadge: some View {

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringPanelView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringPanelView.swift
@@ -169,7 +169,7 @@ public struct MonitoringPanelView: View {
         MonitoringCardView(
           session: pending.placeholderSession,
           state: nil,
-          cliConfiguration: viewModel.cliConfiguration,
+          cliConfiguration: viewModel.cliConfiguration(for: viewModel.providerKind),
           providerKind: viewModel.providerKind,
           initialPrompt: pending.initialPrompt,
           initialInputText: pending.initialInputText,
@@ -206,7 +206,7 @@ public struct MonitoringPanelView: View {
           session: session,
           state: state,
           planState: planState,
-          cliConfiguration: viewModel.cliConfiguration,
+          cliConfiguration: viewModel.cliConfiguration(for: viewModel.providerKind),
           providerKind: viewModel.providerKind,
           initialPrompt: initialPrompt,
           terminalKey: session.id,

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderMonitoringPanelView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderMonitoringPanelView.swift
@@ -508,7 +508,7 @@ public struct MultiProviderMonitoringPanelView: View {
           MonitoringCardView(
             session: pending.placeholderSession,
             state: nil,
-            cliConfiguration: viewModel.cliConfiguration,
+            cliConfiguration: viewModel.cliConfiguration(for: item.providerKind),
             providerKind: item.providerKind,
             initialPrompt: pending.initialPrompt,
             initialInputText: pending.initialInputText,
@@ -577,7 +577,7 @@ public struct MultiProviderMonitoringPanelView: View {
             session: session,
             state: state,
             planState: planState,
-            cliConfiguration: viewModel.cliConfiguration,
+            cliConfiguration: viewModel.cliConfiguration(for: item.providerKind),
             providerKind: item.providerKind,
             initialPrompt: initialPrompt,
             terminalKey: session.id,
@@ -886,7 +886,7 @@ public struct MultiProviderMonitoringPanelView: View {
         session: session,
         projectPath: projectPath,
         onDismiss: closeEmbeddedSidePanel,
-        cliConfiguration: viewModel.cliConfiguration,
+        cliConfiguration: viewModel.cliConfiguration(for: payload.providerKind),
         providerKind: payload.providerKind,
         onInlineRequestSubmit: { prompt, sess in
           closeEmbeddedSidePanel()

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/SettingsView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/SettingsView.swift
@@ -72,6 +72,12 @@ public struct SettingsView: View {
   @AppStorage(AgentHubDefaults.codexCommandLockedByDeveloper)
   private var codexCommandLocked: Bool = false
 
+  @AppStorage(AgentHubDefaults.claudeCommandArgs)
+  private var claudeCommandArgs: String = ""
+
+  @AppStorage(AgentHubDefaults.codexCommandArgs)
+  private var codexCommandArgs: String = ""
+
   @AppStorage(AgentHubDefaults.webPreviewInspectorDataLevel)
   private var webPreviewInspectorDataLevelRawValue: String = ElementInspectorDataLevel.regular.rawValue
 
@@ -240,6 +246,7 @@ public struct SettingsView: View {
           provider: .claude,
           isExpanded: $isClaudeConfigurationExpanded,
           command: $claudeCommand,
+          commandArgs: $claudeCommandArgs,
           locked: claudeCommandLocked,
           installed: CLIDetectionService.isClaudeInstalled()
         ) {
@@ -251,6 +258,7 @@ public struct SettingsView: View {
           provider: .codex,
           isExpanded: $isCodexConfigurationExpanded,
           command: $codexCommand,
+          commandArgs: $codexCommandArgs,
           locked: codexCommandLocked,
           installed: CLIDetectionService.isCodexInstalled()
         ) {
@@ -418,6 +426,7 @@ public struct SettingsView: View {
     provider: SessionProviderKind,
     isExpanded: Binding<Bool>,
     command: Binding<String>,
+    commandArgs: Binding<String>,
     locked: Bool,
     installed: Bool,
     @ViewBuilder content: @escaping () -> Content
@@ -471,6 +480,19 @@ public struct SettingsView: View {
                   .font(.caption)
               }
             }
+          }
+
+          VStack(alignment: .leading, spacing: 6) {
+            Text("Extra arguments")
+              .font(.caption)
+              .foregroundColor(.secondary)
+
+            TextField("e.g. --api-mode enterprise", text: commandArgs)
+              .textFieldStyle(.roundedBorder)
+
+            Text("Arguments applied to each CLI launch.")
+              .font(.caption)
+              .foregroundColor(.secondary)
           }
 
           content()

--- a/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/CLISessionsViewModel.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/CLISessionsViewModel.swift
@@ -439,12 +439,26 @@ public final class CLISessionsViewModel {
     }
   }
 
-  /// Returns a CLI configuration with the current command from UserDefaults
+  private var currentCLIExtraArgs: [String] {
+    let defaults = UserDefaults.standard
+    let rawArgs: String?
+    switch providerKind {
+    case .claude:
+      rawArgs = defaults.string(forKey: AgentHubDefaults.claudeCommandArgs)
+    case .codex:
+      rawArgs = defaults.string(forKey: AgentHubDefaults.codexCommandArgs)
+    }
+    guard let rawArgs else { return cliConfiguration.extraArgs }
+    return CLICommandConfiguration.parseArgumentString(rawArgs)
+  }
+
+  /// Returns a CLI configuration with the current command and extra arguments from UserDefaults.
   private var currentCLIConfiguration: CLICommandConfiguration {
     CLICommandConfiguration(
       command: currentCLICommand,
       additionalPaths: cliConfiguration.additionalPaths,
-      mode: cliConfiguration.mode
+      mode: cliConfiguration.mode,
+      extraArgs: currentCLIExtraArgs
     )
   }
 
@@ -2441,7 +2455,7 @@ public final class CLISessionsViewModel {
     }
     return TerminalLauncher.launchTerminalWithSession(
       session.id,
-      cliConfiguration: cliConfiguration,
+      cliConfiguration: currentCLIConfiguration,
       projectPath: session.projectPath
     )
   }
@@ -2465,7 +2479,7 @@ public final class CLISessionsViewModel {
       branchName: worktree.name,
       isWorktree: worktree.isWorktree,
       skipCheckout: skipCheckout,
-      cliConfiguration: cliConfiguration,
+      cliConfiguration: currentCLIConfiguration,
       dangerouslySkipPermissions: dangerouslySkipPermissions
     )
   }

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/AIConfigSettingsTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/AIConfigSettingsTests.swift
@@ -9,6 +9,127 @@ import Foundation
 import Testing
 @testable import AgentHubCore
 
+@Suite("CLICommandConfiguration — command and extra argument handling")
+struct CLICommandConfigurationArgumentHandlingTests {
+
+  @Test("Parses quoted command argument strings")
+  func parsesQuotedArgumentStrings() {
+    let args = CLICommandConfiguration.parseArgumentString("--api-mode enterprise --as-user 'Jane Doe' \"two words\"")
+
+    #expect(args == ["--api-mode", "enterprise", "--as-user", "Jane Doe", "two words"])
+  }
+
+  @Test("Parses empty quoted command arguments")
+  func parsesEmptyQuotedArgumentStrings() {
+    let args = CLICommandConfiguration.parseArgumentString("--name '' --label \"\"")
+
+    #expect(args == ["--name", "", "--label", ""])
+  }
+
+  @Test("AirChat Claude wrapper passes wrapper args before Claude direct args")
+  func airChatClaudeWrapperUsesDirectArgumentSeparator() {
+    let config = CLICommandConfiguration(
+      command: "airchat",
+      mode: .claude,
+      extraArgs: ["--api-mode", "enterprise"]
+    )
+
+    let args = config.argumentsForSession(
+      sessionId: nil,
+      prompt: "Start work",
+      agentHubMCPServerPath: "/Applications/AgentHub.app/Contents/Helpers/agenthub"
+    )
+
+    #expect(Array(args.prefix(4)) == ["claude", "--api-mode", "enterprise", "--"])
+
+    guard let separatorIndex = args.firstIndex(of: "--"),
+          let mcpConfigIndex = args.firstIndex(of: "--mcp-config") else {
+      Issue.record("Expected AirChat direct-argument separator and Claude MCP flag")
+      return
+    }
+
+    #expect(mcpConfigIndex > separatorIndex)
+    #expect(args.last == "Start work")
+  }
+
+  @Test("AirChat Claude command does not duplicate explicit provider subcommand")
+  func airChatClaudeWrapperDoesNotDuplicateExplicitSubcommand() {
+    let config = CLICommandConfiguration(
+      command: "airchat claude",
+      mode: .claude,
+      extraArgs: ["--api-mode", "enterprise"]
+    )
+
+    let args = config.argumentsForSession(
+      sessionId: nil,
+      prompt: nil,
+      agentHubMCPServerPath: "/Applications/AgentHub.app/Contents/Helpers/agenthub"
+    )
+
+    #expect(args.first == "claude")
+    #expect(args.filter { $0 == "claude" }.count == 1)
+    #expect(args.prefix(4).contains("--api-mode"))
+  }
+
+  @Test("AirChat Codex wrapper passes Codex config overrides after separator")
+  func airChatCodexWrapperUsesDirectArgumentSeparator() {
+    let config = CLICommandConfiguration(
+      command: "airchat codex",
+      mode: .codex,
+      extraArgs: ["--no-banner"]
+    )
+
+    let args = config.argumentsForSession(
+      sessionId: nil,
+      prompt: "Start work",
+      agentHubMCPServerPath: "/Applications/AgentHub.app/Contents/Helpers/agenthub",
+      effortLevel: "high"
+    )
+
+    #expect(Array(args.prefix(3)) == ["codex", "--no-banner", "--"])
+
+    guard let separatorIndex = args.firstIndex(of: "--"),
+          let configIndex = args.firstIndex(of: "-c") else {
+      Issue.record("Expected AirChat direct-argument separator and Codex config flag")
+      return
+    }
+
+    #expect(configIndex > separatorIndex)
+    #expect(args.last == "Start work")
+  }
+
+  @Test("Direct CLI keeps extra args before prompt")
+  func directCLIKeepsExtraArgsBeforePrompt() {
+    let config = CLICommandConfiguration(
+      command: "claude",
+      mode: .claude,
+      extraArgs: ["--debug"]
+    )
+
+    let args = config.argumentsForSession(
+      sessionId: nil,
+      prompt: "Start work"
+    )
+
+    #expect(Array(args.suffix(2)) == ["--debug", "Start work"])
+  }
+
+  @Test("Decodes previous CLI configuration payloads without extra args")
+  func decodesLegacyConfigurationWithoutExtraArgs() throws {
+    let data = Data("""
+    {
+      "command": "airchat claude",
+      "additionalPaths": [],
+      "mode": "claude"
+    }
+    """.utf8)
+
+    let config = try JSONDecoder().decode(CLICommandConfiguration.self, from: data)
+
+    #expect(config.extraArgs.isEmpty)
+  }
+}
+
 @Suite("CLICommandConfiguration — Claude AI config flags")
 struct ClaudeAIConfigArgumentTests {
 


### PR DESCRIPTION
## Summary

- Add persisted Claude and Codex extra CLI argument settings and Settings UI fields.
- Parse shell-style command and extra-argument strings, including quoted arguments.
- Assemble AirChat wrapper launches so wrapper flags stay before `--` and Claude/Codex-native flags go after it.
- Use live CLI configuration for new embedded terminals, inline prompt launches, accessory sessions, refreshes, and external Claude launches.
- Add focused argument-ordering and parser tests for direct CLI, AirChat Claude, and AirChat Codex paths.

## Root Cause

Settings changes for CLI commands were persisted, but several new launch paths still used the `CLISessionsViewModel.cliConfiguration` startup snapshot. That meant newly created sessions could keep using stale command arguments until app relaunch. AirChat also needed different argument placement because `--api-mode enterprise` is an AirChat wrapper flag, while AgentHub's MCP/config flags are provider-native Claude/Codex flags.

## Validation

- `xcodebuild build -project app/AgentHub.xcodeproj -scheme AgentHub -destination 'platform=macOS' -quiet` succeeded.
- `swiftc app/modules/AgentHubCore/Sources/AgentHub/Configuration/CLICommandConfiguration.swift -o /tmp/cli-config-compile-check && /tmp/cli-config-compile-check` succeeded.
- A direct Swift runtime check confirmed `airchat claude --api-mode enterprise -- --mcp-config ...` ordering.
- `xcodebuild test -project app/AgentHub.xcodeproj -scheme AgentHub -destination 'platform=macOS' -only-testing:AgentHubTests/CLICommandConfigurationArgumentHandlingTests -quiet` could not run because the `AgentHub` scheme is not configured for the test action.
- `swift test --package-path app/modules/AgentHubCore --filter CLICommandConfigurationArgumentHandlingTests` could not reach AgentHub tests because the checkout still fails first in `CodeEditSymbols` with `Bundle.module` errors.