### PR TITLE
[codex] Refine worktree module grouping

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ Toggle between modes in the app settings.
 
 ### Worktree Grouping
 
-Worktree sessions are grouped under their parent module by default, so `ModuleA` shows its regular sessions plus AgentHub-owned worktree sessions. The Worktrees settings tab can switch to separate modules, where each AgentHub-owned worktree appears as its own module section.
+Worktree sessions are grouped under their parent module by default, so `ModuleA` shows its regular sessions plus AgentHub-owned worktree sessions. The Worktrees settings tab can switch to separate modules, where the root module and its AgentHub-owned worktrees appear as sibling module rows grouped by repository.
 
 AgentHub creates new worktrees as sibling directories beside the main repository, using the generated or manual directory name directly under the repository's parent directory. It no longer creates a repo-local `.worktrees` folder or adds `.worktrees/` to Git's exclude file.
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/Models/WorktreeDisplayMode.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Models/WorktreeDisplayMode.swift
@@ -25,7 +25,7 @@ public enum WorktreeDisplayMode: String, CaseIterable, Identifiable, Sendable, C
     case .parent:
       return "Worktree sessions appear under their parent module."
     case .separateModules:
-      return "Worktrees appear as separate module sections without adding them as saved repositories."
+      return "Root modules and worktree modules appear as siblings grouped by repository."
     }
   }
 }

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderMonitoringPanelView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderMonitoringPanelView.swift
@@ -432,6 +432,7 @@ public struct MultiProviderMonitoringPanelView: View {
     if let modulePath = activeModuleLandingPath(snapshot: snapshot) {
       ModuleLandingView(
         modulePath: modulePath,
+        rootRepositoryPath: rootRepositoryPath(for: modulePath),
         onStartSession: { onRequestStartSession(modulePath) }
       )
     } else if !snapshot.allItems.isEmpty {
@@ -1078,6 +1079,13 @@ public struct MultiProviderMonitoringPanelView: View {
     )
   }
 
+  private func rootRepositoryPath(for modulePath: String) -> String {
+    WorktreeModuleResolver.bestMatch(for: modulePath, repositories: allSelectedRepositories)?
+      .repository
+      .path
+      ?? modulePath
+  }
+
   private func openSessionFile(for session: CLISession, viewModel: CLISessionsViewModel) {
     guard let fileURL = viewModel.sessionFileURL(for: session),
           let data = FileManager.default.contents(atPath: fileURL.path),
@@ -1379,6 +1387,7 @@ public struct MultiProviderMonitoringPanelView: View {
 
 private struct ModuleLandingView: View {
   let modulePath: String
+  let rootRepositoryPath: String
   let onStartSession: () -> Void
 
   @Environment(\.colorScheme) private var colorScheme
@@ -1396,6 +1405,13 @@ private struct ModuleLandingView: View {
         .lineLimit(nil)
         .minimumScaleFactor(0.65)
         .fixedSize(horizontal: false, vertical: true)
+
+      Text(rootRepositoryPath)
+        .font(.system(size: 13, weight: .medium, design: .monospaced))
+        .foregroundStyle(.secondary)
+        .lineLimit(1)
+        .truncationMode(.middle)
+        .frame(maxWidth: .infinity)
 
       Button(action: onStartSession) {
         HStack(spacing: 8) {

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
@@ -902,10 +902,8 @@ public struct MultiProviderSessionsListView: View {
     )
   }
 
-  /// Groups built from tracked repos first (even empty), then an orphan bucket
-  /// for sessions whose path doesn't belong to any tracked repo.
-  private var groupedSelectedSessions: [SidebarSessionGroup<SelectedSessionItem>] {
-    SidebarSessionOrdering.moduleGroups(
+  private var groupedSelectedSessionSections: [SidebarRepositoryModuleSection<SelectedSessionItem>] {
+    SidebarSessionOrdering.repositoryModuleSections(
       from: selectedSessionItems,
       repositories: Array(orderedTrackedRepos),
       worktreeDisplayMode: worktreeDisplayMode,
@@ -1129,78 +1127,84 @@ public struct MultiProviderSessionsListView: View {
 
       switch sidebarGroupMode {
       case .repo:
-        let groups = groupedSelectedSessions
-        if !groups.isEmpty {
-          ForEach(groups) { group in
-            let isExpanded = !collapsedProjectGroups.contains(group.id)
-            let worktreeModule = worktreeModule(for: group.id)
-            let worktreeSessionCount = worktreeModule.map {
-              focusedSessionCount(inWorktreePath: $0.path)
-            } ?? 0
+        let sections = groupedSelectedSessionSections
+        if !sections.isEmpty {
+          ForEach(sections) { section in
+            ForEach(section.groups) { group in
+              let isExpanded = !collapsedProjectGroups.contains(group.id)
+              let worktreeModule = worktreeModule(for: group.id)
+              let worktreeSessionCount = worktreeModule.map {
+                focusedSessionCount(inWorktreePath: $0.path)
+              } ?? 0
 
-            ProjectGroupHeader(
-              name: group.displayName,
-              isExpanded: isExpanded,
-              canToggle: !group.items.isEmpty,
-              isSelected: selectedModuleLandingPath == group.id && group.items.isEmpty,
-              onToggle: {
-                withAnimation(.easeInOut(duration: 0.25)) {
-                  if isExpanded {
-                    collapsedProjectGroups.insert(group.id)
-                  } else {
-                    collapsedProjectGroups.remove(group.id)
-                  }
-                }
-              },
-              onSelectEmptyModule: {
-                selectEmptyModule(group.id)
-              },
-              repoPath: group.id,
-              onStartSession: {
-                triggerNewSessionFlow(preferredRepositoryPath: group.id)
-              },
-              onOpenInFinder: {
-                NSWorkspace.shared.selectFile(nil, inFileViewerRootedAtPath: group.id)
-              },
-              onOpenGitHub: {
-                gitHubSheetItem = GitHubSheetItem(projectPath: group.id)
-              },
-              onArchiveSessions: group.items.isEmpty ? nil : {
-                let items = group.items
-                archiveConfirmation = ArchiveConfirmation(
-                  repoName: group.displayName,
-                  count: items.count
-                ) {
+              ProjectGroupHeader(
+                name: group.displayName,
+                isExpanded: isExpanded,
+                canToggle: !group.items.isEmpty,
+                isSelected: selectedModuleLandingPath == group.id && group.items.isEmpty,
+                onToggle: {
                   withAnimation(.easeInOut(duration: 0.25)) {
-                    for item in items where !item.isPending {
-                      switch item.providerKind {
-                      case .claude: claudeViewModel.stopMonitoring(session: item.session)
-                      case .codex: codexViewModel.stopMonitoring(session: item.session)
+                    if isExpanded {
+                      collapsedProjectGroups.insert(group.id)
+                    } else {
+                      collapsedProjectGroups.remove(group.id)
+                    }
+                  }
+                },
+                onSelectEmptyModule: {
+                  selectEmptyModule(group.id)
+                },
+                repoPath: group.id,
+                onStartSession: {
+                  triggerNewSessionFlow(preferredRepositoryPath: group.id)
+                },
+                onOpenInFinder: {
+                  NSWorkspace.shared.selectFile(nil, inFileViewerRootedAtPath: group.id)
+                },
+                onOpenGitHub: {
+                  gitHubSheetItem = GitHubSheetItem(projectPath: group.id)
+                },
+                onArchiveSessions: group.items.isEmpty ? nil : {
+                  let items = group.items
+                  archiveConfirmation = ArchiveConfirmation(
+                    repoName: group.displayName,
+                    count: items.count
+                  ) {
+                    withAnimation(.easeInOut(duration: 0.25)) {
+                      for item in items where !item.isPending {
+                        switch item.providerKind {
+                        case .claude: claudeViewModel.stopMonitoring(session: item.session)
+                        case .codex: codexViewModel.stopMonitoring(session: item.session)
+                        }
                       }
                     }
                   }
+                },
+                removeTitle: worktreeModule == nil ? "Remove" : "Remove from AgentHub",
+                onRemove: removeAction(
+                  for: group,
+                  worktreeModule: worktreeModule,
+                  worktreeSessionCount: worktreeSessionCount
+                ),
+                onDeleteWorktree: worktreeModule.map { worktree in
+                  {
+                    worktreeModuleDeleteConfirmation = WorktreeModuleDeleteConfirmation(
+                      worktree: worktree,
+                      displayName: group.displayName,
+                      sessionCount: worktreeSessionCount,
+                      providerKind: providerKindForWorktreeModule(worktree, items: group.items)
+                    )
+                  }
                 }
-              },
-              removeTitle: worktreeModule == nil ? "Remove" : "Remove from AgentHub",
-              onRemove: removeAction(
-                for: group,
-                worktreeModule: worktreeModule,
-                worktreeSessionCount: worktreeSessionCount
-              ),
-              onDeleteWorktree: worktreeModule.map { worktree in
-                {
-                  worktreeModuleDeleteConfirmation = WorktreeModuleDeleteConfirmation(
-                    worktree: worktree,
-                    displayName: group.displayName,
-                    sessionCount: worktreeSessionCount,
-                    providerKind: providerKindForWorktreeModule(worktree, items: group.items)
-                  )
-                }
-              }
-            )
+              )
 
-            if isExpanded {
-              sessionRows(for: group.items)
+              if isExpanded {
+                sessionRows(for: group.items)
+              }
+            }
+
+            if worktreeDisplayMode == .separateModules {
+              RepositoryModuleSectionDivider()
             }
           }
         }
@@ -2031,6 +2035,17 @@ private struct PendingModuleRow: View {
     .padding(.top, 2)
     .accessibilityElement(children: .combine)
     .accessibilityLabel("Adding \(name)")
+  }
+}
+
+// MARK: - RepositoryModuleSectionDivider
+
+private struct RepositoryModuleSectionDivider: View {
+  var body: some View {
+    RoundedRectangle(cornerRadius: 1.5, style: .continuous)
+      .fill(Color.borderSubtle.opacity(0.9))
+      .frame(height: 3)
+      .padding(.vertical, 8)
   }
 }
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/SessionsBrowserPanel.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/SessionsBrowserPanel.swift
@@ -43,11 +43,17 @@ public struct SessionsBrowserPanel: View {
       } else {
         ScrollView(showsIndicators: false) {
           LazyVStack(spacing: 12, pinnedViews: [.sectionHeaders]) {
-            ForEach(groupedByModule, id: \.modulePath) { group in
-              Section(header: moduleSectionHeader(name: group.modulePath, count: group.items.count)) {
+            ForEach(groupedByRepository) { section in
+              ForEach(section.groups) { group in
+                moduleSectionHeader(name: group.displayName, count: group.items.count)
+
                 ForEach(group.items) { item in
                   sessionRow(for: item)
                 }
+              }
+
+              if worktreeDisplayMode == .separateModules {
+                repositorySectionDivider()
               }
             }
           }
@@ -81,9 +87,16 @@ public struct SessionsBrowserPanel: View {
 
   // MARK: - Section Header
 
+  private func repositorySectionDivider() -> some View {
+    RoundedRectangle(cornerRadius: 1.5, style: .continuous)
+      .fill(Color.borderSubtle.opacity(0.9))
+      .frame(height: 3)
+      .padding(.vertical, 8)
+  }
+
   private func moduleSectionHeader(name: String, count: Int) -> some View {
     HStack {
-      Text(URL(fileURLWithPath: name).lastPathComponent)
+      Text(name)
         .font(.caption.weight(.semibold))
         .foregroundColor(.secondary)
       Spacer()
@@ -179,24 +192,31 @@ public struct SessionsBrowserPanel: View {
     return claudePending + codexPending + claudeMonitored + codexMonitored
   }
 
-  private var groupedByModule: [(modulePath: String, items: [ProviderMonitoringItem])] {
-    let grouped = Dictionary(grouping: allMonitoredItems) { findModulePath(for: $0) }
-    return grouped.sorted { $0.key < $1.key }
-      .map { (modulePath: $0.key, items: $0.value.sorted { $0.timestamp > $1.timestamp }) }
+  private var groupedByRepository: [SidebarRepositoryModuleSection<ProviderMonitoringItem>] {
+    SidebarSessionOrdering.repositoryModuleSections(
+      from: allMonitoredItems,
+      repositories: allSelectedRepositories,
+      worktreeDisplayMode: worktreeDisplayMode,
+      isPinned: { _ in false },
+      projectPath: { $0.projectPath },
+      timestamp: { $0.timestamp },
+      id: { $0.id }
+    )
+    .compactMap { section in
+      let groups = section.groups.filter { !$0.items.isEmpty }
+      guard !groups.isEmpty else { return nil }
+      return SidebarRepositoryModuleSection(
+        id: section.id,
+        displayName: section.displayName,
+        groups: groups
+      )
+    }
   }
 
   private var allSelectedRepositories: [SelectedRepository] {
     WorktreeModuleResolver.mergedRepositories(
       claudeViewModel.selectedRepositories + codexViewModel.selectedRepositories
     ).sorted { $0.path < $1.path }
-  }
-
-  private func findModulePath(for item: ProviderMonitoringItem) -> String {
-    WorktreeModuleResolver.modulePath(
-      for: item.projectPath,
-      repositories: allSelectedRepositories,
-      mode: worktreeDisplayMode
-    )
   }
 
   private var worktreeDisplayMode: WorktreeDisplayMode {

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/SidebarSessionOrdering.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/SidebarSessionOrdering.swift
@@ -43,6 +43,12 @@ struct SidebarSessionGroup<Item>: Identifiable {
   let items: [Item]
 }
 
+struct SidebarRepositoryModuleSection<Item>: Identifiable {
+  let id: String
+  let displayName: String
+  let groups: [SidebarSessionGroup<Item>]
+}
+
 enum SidebarSessionOrdering {
   static func pinnedItems<Item>(
     from items: [Item],
@@ -101,6 +107,57 @@ enum SidebarSessionOrdering {
     }
 
     return groups
+  }
+
+  static func repositoryModuleSections<Item>(
+    from items: [Item],
+    repositories: [SelectedRepository],
+    worktreeDisplayMode: WorktreeDisplayMode,
+    isPinned: (Item) -> Bool,
+    projectPath: (Item) -> String,
+    timestamp: (Item) -> Date,
+    id: (Item) -> String
+  ) -> [SidebarRepositoryModuleSection<Item>] {
+    let groups = moduleGroups(
+      from: items,
+      repositories: repositories,
+      worktreeDisplayMode: worktreeDisplayMode,
+      isPinned: isPinned,
+      projectPath: projectPath,
+      timestamp: timestamp,
+      id: id
+    )
+    let groupsByID = Dictionary(uniqueKeysWithValues: groups.map { ($0.id, $0) })
+    var handledGroupIDs: Set<String> = []
+    var sections: [SidebarRepositoryModuleSection<Item>] = []
+
+    for repository in WorktreeModuleResolver.mergedRepositories(repositories) {
+      let repositoryPath = WorktreeModuleResolver.normalizedDirectoryPath(repository.path)
+      let modulePaths = WorktreeModuleResolver.modulePaths(
+        for: [repository],
+        mode: worktreeDisplayMode
+      )
+      let sectionGroups = modulePaths.compactMap { groupsByID[$0] }
+      guard !sectionGroups.isEmpty else { continue }
+
+      handledGroupIDs.formUnion(sectionGroups.map(\.id))
+      sections.append(SidebarRepositoryModuleSection(
+        id: repositoryPath,
+        displayName: URL(fileURLWithPath: repositoryPath).lastPathComponent,
+        groups: sectionGroups
+      ))
+    }
+
+    let orphanGroups = groups.filter { !handledGroupIDs.contains($0.id) }
+    for group in orphanGroups {
+      sections.append(SidebarRepositoryModuleSection(
+        id: group.id,
+        displayName: group.displayName,
+        groups: [group]
+      ))
+    }
+
+    return sections
   }
 
   static func statusGroups<Item>(

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/SidebarSessionOrderingTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/SidebarSessionOrderingTests.swift
@@ -59,6 +59,36 @@ struct SidebarSessionOrderingTests {
     #expect(ids == ["a-main", "a-worktree", "b-newest"])
   }
 
+  @Test("Repository sections keep root and worktree modules as siblings")
+  func repositorySectionsKeepRootAndWorktreeModulesAsSiblings() {
+    let repoA = SelectedRepository(
+      path: "/tmp/RepoA",
+      worktrees: [
+        WorktreeBranch(name: "main", path: "/tmp/RepoA", isWorktree: false),
+        WorktreeBranch(name: "feature", path: "/tmp/RepoA-feature", isWorktree: true)
+      ]
+    )
+    let repoB = SelectedRepository(path: "/tmp/RepoB")
+
+    let sections = SidebarSessionOrdering.repositoryModuleSections(
+      from: [
+        item("b", projectPath: "/tmp/RepoB", timestamp: 300),
+        item("a-worktree", projectPath: "/tmp/RepoA-feature", timestamp: 200),
+        item("a-main", projectPath: "/tmp/RepoA", timestamp: 100)
+      ],
+      repositories: [repoA, repoB],
+      worktreeDisplayMode: .separateModules,
+      isPinned: { $0.isPinned },
+      projectPath: { $0.projectPath },
+      timestamp: { $0.timestamp },
+      id: { $0.id }
+    )
+
+    #expect(sections.map(\.id) == ["/tmp/RepoA", "/tmp/RepoB"])
+    #expect(sections[0].groups.map(\.id) == ["/tmp/RepoA", "/tmp/RepoA-feature"])
+    #expect(sections[1].groups.map(\.id) == ["/tmp/RepoB"])
+  }
+
   @Test("Status grouping flattens by status section order")
   func statusGroupingFlattensByStatusOrder() {
     let items = [


### PR DESCRIPTION
## Summary

- Group root modules and AgentHub-owned worktree modules into repository sections when `Show worktrees as modules` is enabled.
- Keep sessions directly under their owning module/worktree while separating repository sections with a subtle bottom divider.
- Show the resolved root repository path on the empty module landing view between the prompt and Start Session button.
- Update Worktrees settings copy and README wording for the revised grouping behavior.

## Why

The previous nested presentation made worktree modules feel detached from the root repo and could separate sessions from their owning module. This keeps modules/worktrees as peers while preserving clear repository boundaries.

## Validation

- `git diff --check`
- Attempted `swift test --package-path app/modules/AgentHubCore --filter SidebarSessionOrderingTests --disable-sandbox`, but the build is blocked before AgentHub tests compile by the existing `CodeEditSymbols` checkout error: `Bundle.module` has no member.