### PR TITLE
[codex] Bundle llhttp with libgit2 runtime

### DIFF
--- a/app/scripts/bundle-libgit2.sh
+++ b/app/scripts/bundle-libgit2.sh
@@ -25,11 +25,12 @@ libgit2="${brew_prefix}/opt/libgit2/lib/libgit2.1.9.dylib"
 libssh2="${brew_prefix}/opt/libssh2/lib/libssh2.1.dylib"
 libssl="${brew_prefix}/opt/openssl@3/lib/libssl.3.dylib"
 libcrypto="${brew_prefix}/opt/openssl@3/lib/libcrypto.3.dylib"
+libllhttp="${brew_prefix}/opt/llhttp/lib/libllhttp.9.4.dylib"
 
-for lib in "${libgit2}" "${libssh2}" "${libssl}" "${libcrypto}"; do
+for lib in "${libgit2}" "${libssh2}" "${libssl}" "${libcrypto}" "${libllhttp}"; do
   if [ ! -f "${lib}" ]; then
     echo "error: required libgit2 runtime dependency missing: ${lib}"
-    echo "Install dependencies with: brew install libgit2 libssh2 openssl@3"
+    echo "Install dependencies with: brew install libgit2 libssh2 openssl@3 llhttp"
     exit 1
   fi
 done
@@ -49,6 +50,7 @@ copy_lib "${libgit2}" "libgit2.1.9.dylib"
 copy_lib "${libssh2}" "libssh2.1.dylib"
 copy_lib "${libssl}" "libssl.3.dylib"
 copy_lib "${libcrypto}" "libcrypto.3.dylib"
+copy_lib "${libllhttp}" "libllhttp.9.4.dylib"
 
 rewrite_dependency() {
   target="$1"
@@ -73,7 +75,9 @@ install_name_tool -id "@rpath/libgit2.1.9.dylib" "${frameworks_dir}/libgit2.1.9.
 install_name_tool -id "@rpath/libssh2.1.dylib" "${frameworks_dir}/libssh2.1.dylib"
 install_name_tool -id "@rpath/libssl.3.dylib" "${frameworks_dir}/libssl.3.dylib"
 install_name_tool -id "@rpath/libcrypto.3.dylib" "${frameworks_dir}/libcrypto.3.dylib"
+install_name_tool -id "@rpath/libllhttp.9.4.dylib" "${frameworks_dir}/libllhttp.9.4.dylib"
 
+rewrite_dependency "${frameworks_dir}/libgit2.1.9.dylib" "libllhttp" "@rpath/libllhttp.9.4.dylib"
 rewrite_dependency "${frameworks_dir}/libgit2.1.9.dylib" "libssh2" "@rpath/libssh2.1.dylib"
 rewrite_dependency "${frameworks_dir}/libssh2.1.dylib" "libssl" "@rpath/libssl.3.dylib"
 rewrite_dependency "${frameworks_dir}/libssh2.1.dylib" "libcrypto" "@rpath/libcrypto.3.dylib"
@@ -96,6 +100,7 @@ if [ "${CODE_SIGNING_ALLOWED:-YES}" != "NO" ]; then
   for lib in \
     "${frameworks_dir}/libcrypto.3.dylib" \
     "${frameworks_dir}/libssl.3.dylib" \
+    "${frameworks_dir}/libllhttp.9.4.dylib" \
     "${frameworks_dir}/libssh2.1.dylib" \
     "${frameworks_dir}/libgit2.1.9.dylib"; do
     codesign --force --sign "${signing_identity}" --timestamp=none "${lib}"


### PR DESCRIPTION
## Summary

Fixes a launch crash for developers building AgentHub from source with current Homebrew libgit2 1.9 by bundling libgit2's new `llhttp` runtime dependency.

## Root Cause

Homebrew libgit2 1.9 links against `libllhttp.9.4.dylib` for HTTP parsing, but `app/scripts/bundle-libgit2.sh` only copied, rewrote, and signed `libgit2`, `libssh2`, `libssl`, and `libcrypto`. The app could therefore launch with a raw Homebrew `llhttp` path instead of a bundled dylib, causing dyld to reject the library because its code signing identity did not match the app process.

## Changes

- Resolves `libllhttp.9.4.dylib` from the Homebrew prefix alongside the existing libgit2 runtime dependencies.
- Includes `llhttp` in the required dependency check and install guidance.
- Copies `libllhttp.9.4.dylib` into `Contents/Frameworks` during the build.
- Rewrites the `llhttp` install name and libgit2 dependency reference to use `@rpath`.
- Codesigns the bundled `llhttp` dylib with the same identity as the other bundled libraries.

## Validation

- `sh -n app/scripts/bundle-libgit2.sh`
- `git diff --check`

Not run: full Xcode clean build or app launch verification in this session.