### PR TITLE
[codex] Fix dynamic libgit2 llhttp bundling

### DIFF
--- a/app/AgentHub.xcodeproj/project.pbxproj
+++ b/app/AgentHub.xcodeproj/project.pbxproj
@@ -266,6 +266,7 @@
 				"$(TARGET_BUILD_DIR)/$(FRAMEWORKS_FOLDER_PATH)/libssh2.1.dylib",
 				"$(TARGET_BUILD_DIR)/$(FRAMEWORKS_FOLDER_PATH)/libssl.3.dylib",
 				"$(TARGET_BUILD_DIR)/$(FRAMEWORKS_FOLDER_PATH)/libcrypto.3.dylib",
+				"$(TARGET_BUILD_DIR)/$(FRAMEWORKS_FOLDER_PATH)/libllhttp.9.4.dylib",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/app/scripts/bundle-libgit2.sh
+++ b/app/scripts/bundle-libgit2.sh
@@ -25,15 +25,29 @@ libgit2="${brew_prefix}/opt/libgit2/lib/libgit2.1.9.dylib"
 libssh2="${brew_prefix}/opt/libssh2/lib/libssh2.1.dylib"
 libssl="${brew_prefix}/opt/openssl@3/lib/libssl.3.dylib"
 libcrypto="${brew_prefix}/opt/openssl@3/lib/libcrypto.3.dylib"
-libllhttp="${brew_prefix}/opt/llhttp/lib/libllhttp.9.4.dylib"
 
-for lib in "${libgit2}" "${libssh2}" "${libssl}" "${libcrypto}" "${libllhttp}"; do
+for lib in "${libgit2}" "${libssh2}" "${libssl}" "${libcrypto}"; do
   if [ ! -f "${lib}" ]; then
     echo "error: required libgit2 runtime dependency missing: ${lib}"
-    echo "Install dependencies with: brew install libgit2 libssh2 openssl@3 llhttp"
+    echo "Install dependencies with: brew install libgit2 libssh2 openssl@3"
     exit 1
   fi
 done
+
+libllhttp="$(otool -L "${libgit2}" | awk '$1 ~ /libllhttp/ { print $1; exit }')"
+if [ -n "${libllhttp}" ]; then
+  if [ ! -f "${libllhttp}" ]; then
+    libllhttp_candidate="${brew_prefix}/opt/llhttp/lib/$(basename "${libllhttp}")"
+    if [ -f "${libllhttp_candidate}" ]; then
+      libllhttp="${libllhttp_candidate}"
+    else
+      echo "error: required libgit2 runtime dependency missing: ${libllhttp}"
+      echo "Install dependencies with: brew install libgit2 libssh2 openssl@3 llhttp"
+      exit 1
+    fi
+  fi
+  libllhttp_name="$(basename "${libllhttp}")"
+fi
 
 frameworks_dir="${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}"
 mkdir -p "${frameworks_dir}"
@@ -50,7 +64,9 @@ copy_lib "${libgit2}" "libgit2.1.9.dylib"
 copy_lib "${libssh2}" "libssh2.1.dylib"
 copy_lib "${libssl}" "libssl.3.dylib"
 copy_lib "${libcrypto}" "libcrypto.3.dylib"
-copy_lib "${libllhttp}" "libllhttp.9.4.dylib"
+if [ -n "${libllhttp}" ]; then
+  copy_lib "${libllhttp}" "${libllhttp_name}"
+fi
 
 rewrite_dependency() {
   target="$1"
@@ -75,9 +91,13 @@ install_name_tool -id "@rpath/libgit2.1.9.dylib" "${frameworks_dir}/libgit2.1.9.
 install_name_tool -id "@rpath/libssh2.1.dylib" "${frameworks_dir}/libssh2.1.dylib"
 install_name_tool -id "@rpath/libssl.3.dylib" "${frameworks_dir}/libssl.3.dylib"
 install_name_tool -id "@rpath/libcrypto.3.dylib" "${frameworks_dir}/libcrypto.3.dylib"
-install_name_tool -id "@rpath/libllhttp.9.4.dylib" "${frameworks_dir}/libllhttp.9.4.dylib"
+if [ -n "${libllhttp}" ]; then
+  install_name_tool -id "@rpath/${libllhttp_name}" "${frameworks_dir}/${libllhttp_name}"
+fi
 
-rewrite_dependency "${frameworks_dir}/libgit2.1.9.dylib" "libllhttp" "@rpath/libllhttp.9.4.dylib"
+if [ -n "${libllhttp}" ]; then
+  rewrite_dependency "${frameworks_dir}/libgit2.1.9.dylib" "libllhttp" "@rpath/${libllhttp_name}"
+fi
 rewrite_dependency "${frameworks_dir}/libgit2.1.9.dylib" "libssh2" "@rpath/libssh2.1.dylib"
 rewrite_dependency "${frameworks_dir}/libssh2.1.dylib" "libssl" "@rpath/libssl.3.dylib"
 rewrite_dependency "${frameworks_dir}/libssh2.1.dylib" "libcrypto" "@rpath/libcrypto.3.dylib"
@@ -100,9 +120,12 @@ if [ "${CODE_SIGNING_ALLOWED:-YES}" != "NO" ]; then
   for lib in \
     "${frameworks_dir}/libcrypto.3.dylib" \
     "${frameworks_dir}/libssl.3.dylib" \
-    "${frameworks_dir}/libllhttp.9.4.dylib" \
+    "${frameworks_dir}/${libllhttp_name:-libllhttp.dylib}" \
     "${frameworks_dir}/libssh2.1.dylib" \
     "${frameworks_dir}/libgit2.1.9.dylib"; do
+    if [ ! -f "${lib}" ]; then
+      continue
+    fi
     codesign --force --sign "${signing_identity}" --timestamp=none "${lib}"
   done
 fi


### PR DESCRIPTION
## Summary

Fixes the Homebrew libgit2 bundling script so source builds do not fail when the installed libgit2 version differs in its llhttp runtime dependency.

## What changed

- Detect `libllhttp` from the selected `libgit2` binary with `otool -L` instead of hardcoding `libllhttp.9.4.dylib` as an unconditional dependency.
- Only require, copy, rewrite, and sign `libllhttp` when the installed `libgit2` actually links it.
- Preserve the detected llhttp dylib basename so newer Homebrew names continue to bundle correctly.
- Add the current llhttp output path to the Xcode build phase output list.

## Why

PR #349 fixed the launch crash for current Homebrew libgit2 builds by adding `llhttp`, but it made one exact llhttp version mandatory. That regressed developers with older valid libgit2 1.9 kegs that do not link `llhttp` at all. This keeps newer Homebrew builds fixed while allowing older compatible installs to build.

## Validation

- `/bin/sh -n app/scripts/bundle-libgit2.sh`
- Isolated script run against this machine's Homebrew libgit2 install without llhttp linkage
- Synthetic Homebrew-prefix test with `libgit2 -> libllhttp.10.dylib`, confirming copy and `@rpath` rewrite
- `xcodebuild -project app/AgentHub.xcodeproj -scheme AgentHub -configuration Debug -derivedDataPath /tmp/AgentHubDerivedData-libgit2 -quiet CODE_SIGNING_ALLOWED=NO build`