### PR TITLE
[codex] Show diff tab for git repositories

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringEditorState.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringEditorState.swift
@@ -84,7 +84,7 @@ enum MonitoringEditorStateStore {
   ) -> [MonitoringCardContentMode] {
     var modes: [MonitoringCardContentMode] = [.terminal, .editor]
     if diffDisplayMode == .inline,
-       diffAvailabilityStatus?.isAvailable == true {
+       diffAvailabilityStatus?.canShowDiffViewer == true {
       modes.append(.diffs)
     }
     return modes

--- a/app/modules/AgentHubCore/Sources/AgentHubGitDiff/Services/DiffAvailabilityService.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHubGitDiff/Services/DiffAvailabilityService.swift
@@ -14,6 +14,15 @@ public enum DiffAvailabilityStatus: Equatable, Sendable {
     self == .available
   }
 
+  public var canShowDiffViewer: Bool {
+    switch self {
+    case .checking, .available:
+      return true
+    case .unavailable:
+      return false
+    }
+  }
+
   public var isChecking: Bool {
     self == .checking
   }
@@ -119,23 +128,14 @@ public actor DiffAvailabilityService: DiffAvailabilityServiceProtocol {
   }
 
   private nonisolated static func evaluateGitDiffAvailability(projectPath: String) async -> DiffAvailabilityStatus {
-    // Small worktrees: keep the fast single-open libgit2 availability check unchanged.
-    if !LibGit2DiffBackend.isLargeWorktree(
-      atGitRoot: projectPath,
-      thresholdBytes: GitDiffService.defaultLargeWorktreeIndexByteThreshold
-    ) {
-      return (try? LibGit2DiffBackend.diffAvailability(at: projectPath)) ?? .unavailable
+    if (try? LibGit2DiffBackend.findGitRoot(at: projectPath)) != nil {
+      return .available
     }
-    // Large worktrees: avoid libgit2's full index→workdir scan. Check cheap tree comparisons
-    // first (branch, then staged), expensive workdir scan last; route through GitDiffService
-    // so unstaged/staged use the native-git large-worktree gate.
-    let service = GitDiffService()
-    for mode in [DiffMode.branch, .staged, .unstaged] {
-      if let state = try? await service.changedFiles(at: projectPath, mode: mode, baseBranch: nil),
-         !state.files.isEmpty {
-        return .available
-      }
+
+    if (try? await GitDiffService().findGitRoot(at: projectPath)) != nil {
+      return .available
     }
+
     return .unavailable
   }
 }

--- a/app/modules/AgentHubCore/Sources/AgentHubGitDiff/Services/LibGit2DiffBackend.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHubGitDiff/Services/LibGit2DiffBackend.swift
@@ -65,16 +65,7 @@ enum LibGit2DiffBackend {
     let repo = try openRepository(at: path)
     defer { git_repository_free(repo) }
 
-    if try hasChanges(repo: repo, mode: .unstaged, baseBranch: nil) {
-      return .available
-    }
-
-    if try hasChanges(repo: repo, mode: .staged, baseBranch: nil) {
-      return .available
-    }
-
-    guard let baseBranch = try? detectBaseBranch(in: repo),
-          try hasChanges(repo: repo, mode: .branch, baseBranch: baseBranch) else {
+    guard git_repository_workdir(repo) != nil else {
       return .unavailable
     }
 

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/DiffAvailabilityServiceTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/DiffAvailabilityServiceTests.swift
@@ -194,14 +194,14 @@ private actor DiffStubFileWatcher: SessionFileWatcherProtocol {
 
 @Suite("DiffAvailabilityService")
 struct DiffAvailabilityServiceTests {
-  @Test("Clean repository is unavailable")
-  func cleanRepositoryIsUnavailable() async throws {
+  @Test("Clean repository is available")
+  func cleanRepositoryIsAvailable() async throws {
     let fixture = try GitRepoFixture.create()
     defer { fixture.cleanup() }
 
     let status = await DiffAvailabilityService().availability(for: fixture.repoPath)
 
-    #expect(status == .unavailable)
+    #expect(status == .available)
   }
 
   @Test("Unstaged changes are available")
@@ -252,8 +252,8 @@ struct DiffAvailabilityServiceTests {
     #expect(status == .available)
   }
 
-  @Test("Parent repository changes do not make a clean worktree available")
-  func parentRepositoryChangesDoNotMakeCleanWorktreeAvailable() async throws {
+  @Test("Clean git worktree is available")
+  func cleanGitWorktreeIsAvailable() async throws {
     let fixture = try GitRepoFixture.create()
     defer { fixture.cleanup() }
     let worktreePath = try fixture.addWorktree(branch: "feature-clean-worktree")
@@ -261,7 +261,7 @@ struct DiffAvailabilityServiceTests {
 
     let status = await DiffAvailabilityService().availability(for: worktreePath)
 
-    #expect(status == .unavailable)
+    #expect(status == .available)
   }
 
   @Test("Worktree branch changes are available from that worktree")

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/MonitoringEditorStateTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/MonitoringEditorStateTests.swift
@@ -146,11 +146,15 @@ struct MonitoringEditorStateTests {
     ) == .terminal)
   }
 
-  @Test("Inline available modes include diffs only when available")
-  func inlineAvailableModesIncludeDiffsOnlyWhenAvailable() {
+  @Test("Inline available modes include diffs while checking or available")
+  func inlineAvailableModesIncludeDiffsWhileCheckingOrAvailable() {
     let availableItems = MonitoringCardContentModeItems.items(
       diffDisplayMode: .inline,
       diffAvailabilityStatus: .available
+    )
+    let checkingItems = MonitoringCardContentModeItems.items(
+      diffDisplayMode: .inline,
+      diffAvailabilityStatus: .checking
     )
     let unavailableItems = MonitoringCardContentModeItems.items(
       diffDisplayMode: .inline,
@@ -162,6 +166,7 @@ struct MonitoringEditorStateTests {
     )
 
     #expect(availableItems.map(\.value) == [.terminal, .editor, .diffs])
+    #expect(checkingItems.map(\.value) == [.terminal, .editor, .diffs])
     #expect(unavailableItems.map(\.value) == [.terminal, .editor])
     #expect(sidePanelItems.map(\.value) == [.terminal, .editor])
   }


### PR DESCRIPTION
## Summary

Show the inline Diffs option as soon as AgentHub can confirm the session path belongs to a Git worktree, instead of waiting for changed-file detection.

## Why

The Terminal / Files / Diffs selector was gated on whether there were current diff changes. That delayed or hid the Diffs option for valid Git repositories until change scanning completed, and clean repositories had no inline path into the diff viewer.

## Changes

- Treat diff availability as Git repository/worktree capability rather than changed-file presence.
- Keep the Diffs segment visible while availability is checking, then hide it only for confirmed non-Git paths.
- Update focused tests for clean repositories, clean worktrees, and checking-state selector visibility.

## Validation

- `swift build --package-path app/modules/AgentHubCore --target AgentHubGitDiff`
- `xcodebuild build -quiet -project app/AgentHub.xcodeproj -scheme AgentHubCore -destination 'platform=macOS'`

Note: targeted `swift test --package-path app/modules/AgentHubCore --filter 'DiffAvailabilityService|MonitoringEditorState'` is blocked by an existing SwiftPM `CodeEditSymbols` `Bundle.module` compile failure. The Xcode schemes in this project are not configured for the test action.