### PR TITLE
[codex] Add project path open menu

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringCardView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringCardView.swift
@@ -968,18 +968,10 @@ private struct MonitoringCardPathRow: View {
 
   var body: some View {
     HStack(spacing: 8) {
-      HStack(spacing: 4) {
-        Image(systemName: "folder")
-          .font(.caption)
-          .foregroundStyle(.secondary)
+      projectPathLabel
+        .layoutPriority(1)
 
-        Text(session.projectPath)
-          .font(.primaryCaption)
-          .foregroundStyle(.secondary)
-          .lineLimit(1)
-          .truncationMode(.middle)
-      }
-      .layoutPriority(1)
+      projectPathActionsMenu
 
       if let branch = session.branchName {
         Text(branch)
@@ -1000,6 +992,53 @@ private struct MonitoringCardPathRow: View {
       .help("Switch session content")
     }
     .frame(minHeight: 24)
+  }
+
+  private var projectPathLabel: some View {
+    HStack(spacing: 4) {
+      Image(systemName: "folder")
+        .font(.caption)
+        .foregroundStyle(.secondary)
+
+      Text(session.projectPath)
+        .font(.primaryCaption)
+        .foregroundStyle(.secondary)
+        .lineLimit(1)
+        .truncationMode(.middle)
+    }
+  }
+
+  private var projectPathActionsMenu: some View {
+    Menu {
+      Section("Open with") {
+        ForEach(ProjectPathOpenTarget.allCases) { target in
+          Button {
+            target.open(path: session.projectPath)
+          } label: {
+            Label(target.label, systemImage: target.systemImage)
+          }
+          .disabled(!target.isInstalled)
+        }
+      }
+
+      Divider()
+
+      Button {
+        ProjectPathOpenTarget.copyPath(session.projectPath)
+      } label: {
+        Label("Copy path", systemImage: "doc.on.doc")
+      }
+    } label: {
+      Image(systemName: "arrow.forward.circle")
+        .font(.system(size: 11, weight: .medium))
+        .foregroundStyle(.secondary)
+        .contentShape(Rectangle())
+    }
+    .menuStyle(.borderlessButton)
+    .menuIndicator(.hidden)
+    .buttonStyle(.plain)
+    .fixedSize()
+    .help("Open project path menu")
   }
 }
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/Utils/ProjectPathOpenTarget.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Utils/ProjectPathOpenTarget.swift
@@ -1,0 +1,106 @@
+//
+//  ProjectPathOpenTarget.swift
+//  AgentHub
+//
+//  Targets for opening a project folder from monitoring card path menus.
+//
+
+import AppKit
+import Foundation
+
+enum ProjectPathOpenTarget: String, CaseIterable, Identifiable {
+  case finder
+  case cursor
+  case visualStudioCode
+  case sublimeText
+  case xcode
+  case ghostty
+  case terminal
+
+  var id: String { rawValue }
+
+  var label: String {
+    switch self {
+    case .finder: return "Finder"
+    case .cursor: return "Cursor"
+    case .visualStudioCode: return "VS Code"
+    case .sublimeText: return "Sublime Text"
+    case .xcode: return "Xcode"
+    case .ghostty: return "Ghostty"
+    case .terminal: return "Terminal"
+    }
+  }
+
+  var systemImage: String {
+    switch self {
+    case .finder: return "face.smiling"
+    case .cursor: return "cursorarrow"
+    case .visualStudioCode: return "chevron.left.forwardslash.chevron.right"
+    case .sublimeText: return "textformat"
+    case .xcode: return "hammer"
+    case .ghostty: return "terminal.fill"
+    case .terminal: return "terminal"
+    }
+  }
+
+  var bundleIdentifier: String {
+    bundleIdentifiers[0]
+  }
+
+  var bundleIdentifiers: [String] {
+    switch self {
+    case .finder: return ["com.apple.finder"]
+    case .cursor: return ["com.todesktop.230313mzl4w4u92"]
+    case .visualStudioCode: return ["com.microsoft.VSCode"]
+    case .sublimeText: return ["com.sublimetext.4", "com.sublimetext.3"]
+    case .xcode: return ["com.apple.dt.Xcode"]
+    case .ghostty: return ["com.mitchellh.ghostty"]
+    case .terminal: return ["com.apple.Terminal"]
+    }
+  }
+
+  var isInstalled: Bool {
+    isInstalled { bundleIdentifier in
+      NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleIdentifier)
+    }
+  }
+
+  func isInstalled(applicationURL: (String) -> URL?) -> Bool {
+    resolvedApplicationURL(applicationURL: applicationURL) != nil
+  }
+
+  func open(path: String) {
+    if self == .finder {
+      NSWorkspace.shared.selectFile(nil, inFileViewerRootedAtPath: path)
+      return
+    }
+
+    guard let applicationURL = resolvedApplicationURL(applicationURL: { bundleIdentifier in
+      NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleIdentifier)
+    }) else {
+      return
+    }
+
+    let configuration = NSWorkspace.OpenConfiguration()
+    NSWorkspace.shared.open(
+      [URL(fileURLWithPath: path, isDirectory: true)],
+      withApplicationAt: applicationURL,
+      configuration: configuration
+    )
+  }
+
+  static func copyPath(_ path: String) {
+    let pasteboard = NSPasteboard.general
+    pasteboard.clearContents()
+    pasteboard.setString(path, forType: .string)
+  }
+
+  private func resolvedApplicationURL(applicationURL: (String) -> URL?) -> URL? {
+    for bundleIdentifier in bundleIdentifiers {
+      if let url = applicationURL(bundleIdentifier) {
+        return url
+      }
+    }
+    return nil
+  }
+}

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/ProjectPathOpenTargetTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/ProjectPathOpenTargetTests.swift
@@ -1,0 +1,41 @@
+import Foundation
+import Testing
+@testable import AgentHubCore
+
+@Suite("ProjectPathOpenTarget")
+struct ProjectPathOpenTargetTests {
+  @Test func exposesExpectedBundleIdentifiers() {
+    #expect(ProjectPathOpenTarget.finder.bundleIdentifier == "com.apple.finder")
+    #expect(ProjectPathOpenTarget.cursor.bundleIdentifier == "com.todesktop.230313mzl4w4u92")
+    #expect(ProjectPathOpenTarget.visualStudioCode.bundleIdentifier == "com.microsoft.VSCode")
+    #expect(ProjectPathOpenTarget.sublimeText.bundleIdentifiers == ["com.sublimetext.4", "com.sublimetext.3"])
+    #expect(ProjectPathOpenTarget.xcode.bundleIdentifier == "com.apple.dt.Xcode")
+    #expect(ProjectPathOpenTarget.ghostty.bundleIdentifier == "com.mitchellh.ghostty")
+    #expect(ProjectPathOpenTarget.terminal.bundleIdentifier == "com.apple.Terminal")
+  }
+
+  @Test func resolvesAvailabilityFromInjectedApplicationLookup() {
+    let installed: Set<String> = [
+      ProjectPathOpenTarget.finder.bundleIdentifier,
+      ProjectPathOpenTarget.cursor.bundleIdentifier,
+      ProjectPathOpenTarget.visualStudioCode.bundleIdentifier,
+      "com.sublimetext.3",
+      ProjectPathOpenTarget.ghostty.bundleIdentifier,
+      ProjectPathOpenTarget.terminal.bundleIdentifier
+    ]
+
+    func applicationURL(for bundleIdentifier: String) -> URL? {
+      installed.contains(bundleIdentifier)
+        ? URL(fileURLWithPath: "/Applications/\(bundleIdentifier).app")
+        : nil
+    }
+
+    #expect(ProjectPathOpenTarget.finder.isInstalled(applicationURL: applicationURL))
+    #expect(ProjectPathOpenTarget.cursor.isInstalled(applicationURL: applicationURL))
+    #expect(ProjectPathOpenTarget.visualStudioCode.isInstalled(applicationURL: applicationURL))
+    #expect(ProjectPathOpenTarget.sublimeText.isInstalled(applicationURL: applicationURL))
+    #expect(!ProjectPathOpenTarget.xcode.isInstalled(applicationURL: applicationURL))
+    #expect(ProjectPathOpenTarget.ghostty.isInstalled(applicationURL: applicationURL))
+    #expect(ProjectPathOpenTarget.terminal.isInstalled(applicationURL: applicationURL))
+  }
+}


### PR DESCRIPTION
## Summary

Adds a visible project path action menu in monitoring cards. The path remains plain text, with a small `arrow.forward.circle` trigger beside it.

The menu supports opening the project folder in Finder, Cursor, VS Code, Sublime Text, Xcode, Ghostty, or Terminal when those apps are installed, and includes a Copy path action.

## Impact

This makes the project path row discoverable and gives users quick access to common editors and terminals without overloading the path text itself.

## Validation

- `xcrun swiftc -parse app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringCardView.swift app/modules/AgentHubCore/Sources/AgentHub/Utils/ProjectPathOpenTarget.swift`
- `xcodebuild -project app/AgentHub.xcodeproj -scheme AgentHub -destination 'platform=macOS' -quiet build`