### PR TITLE
[codex] Load GitHub panel counts asynchronously

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/GitHubPanelView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/GitHubPanelView.swift
@@ -64,10 +64,7 @@ public struct GitHubPanelView: View {
         await viewModel.setup(repoPath: projectPath, branchName: branchName)
       }
       if viewModel.setupState == .ready {
-        if viewModel.pullRequests.isEmpty {
-          await viewModel.loadPullRequests()
-        }
-        await viewModel.loadCurrentBranchPR()
+        await viewModel.loadPanelOverview()
       }
     }
     .alert("Error", isPresented: .init(
@@ -159,13 +156,13 @@ public struct GitHubPanelView: View {
         title: { $0.rawValue },
         badge: { tab in
           switch tab {
-          case .pullRequests: return viewModel.pullRequests.isEmpty ? nil : viewModel.pullRequests.count
-          case .issues: return viewModel.issues.isEmpty ? nil : viewModel.issues.count
+          case .pullRequests: return viewModel.pullRequestTabBadgeCount
+          case .issues: return viewModel.issueTabBadgeCount
           }
         },
         onSelect: { tab in
-          if tab == .issues && viewModel.issues.isEmpty {
-            Task { await viewModel.loadIssues() }
+          if tab == .issues {
+            Task { await viewModel.loadIssuesIfNeeded() }
           }
         },
         trailing: {
@@ -173,8 +170,8 @@ public struct GitHubPanelView: View {
             Button {
               Task {
                 switch viewModel.selectedTab {
-                case .pullRequests: await viewModel.loadPullRequests()
-                case .issues: await viewModel.loadIssues()
+                case .pullRequests: await viewModel.reloadPullRequestsAndCounts()
+                case .issues: await viewModel.reloadIssuesAndCounts()
                 }
               }
             } label: {
@@ -266,21 +263,39 @@ public struct GitHubPanelView: View {
         filterMenu
       }
 
-      // Active label chips
-      if !viewModel.selectedLabels.isEmpty {
+      // Active filter chips
+      if viewModel.showOnlyMyPRs || !viewModel.selectedLabels.isEmpty {
         ScrollView(.horizontal, showsIndicators: false) {
           HStack(spacing: 4) {
+            if viewModel.showOnlyMyPRs {
+              HStack(spacing: 3) {
+                Text("Only my pull requests")
+                  .font(GitHubTypography.badge)
+                Button("Show pull requests from all authors", systemImage: "xmark") {
+                  viewModel.showOnlyMyPRs = false
+                  Task { await viewModel.reloadPullRequestsAndCounts() }
+                }
+                .font(.system(size: 8, weight: .bold))
+                .labelStyle(.iconOnly)
+                .buttonStyle(.plain)
+                .help("Show pull requests from all authors")
+              }
+              .padding(.horizontal, 6)
+              .padding(.vertical, 2)
+              .background(accent.opacity(0.12))
+              .clipShape(Capsule())
+            }
+
             ForEach(viewModel.selectedLabels.sorted(), id: \.self) { label in
               HStack(spacing: 3) {
                 Text(label)
                   .font(GitHubTypography.badge)
-                Button {
+                Button("Remove \(label) label filter", systemImage: "xmark") {
                   viewModel.selectedLabels.remove(label)
-                  Task { await viewModel.loadPullRequests() }
-                } label: {
-                  Image(systemName: "xmark")
-                    .font(.system(size: 8, weight: .bold))
+                  Task { await viewModel.reloadPullRequestsAndCounts() }
                 }
+                .font(.system(size: 8, weight: .bold))
+                .labelStyle(.iconOnly)
                 .buttonStyle(.plain)
               }
               .padding(.horizontal, 6)
@@ -301,7 +316,7 @@ public struct GitHubPanelView: View {
       Section("Scope") {
         Button {
           viewModel.showOnlyMyPRs.toggle()
-          Task { await viewModel.loadPullRequests() }
+          Task { await viewModel.reloadPullRequestsAndCounts() }
         } label: {
           HStack {
             Text("Only my pull requests")
@@ -319,7 +334,7 @@ public struct GitHubPanelView: View {
               } else {
                 viewModel.selectedLabels.insert(label.name)
               }
-              Task { await viewModel.loadPullRequests() }
+              Task { await viewModel.reloadPullRequestsAndCounts() }
             } label: {
               HStack {
                 Text(label.name)
@@ -333,7 +348,7 @@ public struct GitHubPanelView: View {
             Divider()
             Button("Clear all labels") {
               viewModel.selectedLabels.removeAll()
-              Task { await viewModel.loadPullRequests() }
+              Task { await viewModel.reloadPullRequestsAndCounts() }
             }
           }
         }
@@ -471,7 +486,7 @@ public struct GitHubPanelView: View {
         ForEach(GitHubIssueFilter.allCases) { filter in
           FilterChipWithCount(
             title: filter.rawValue,
-            count: filter == viewModel.issueFilter ? viewModel.issues.count : 0,
+            count: viewModel.issueFilterCount(filter),
             isActive: viewModel.issueFilter == filter,
             accent: accent
           ) {
@@ -673,17 +688,11 @@ struct FilterChipWithCount: View {
   }
 
   private var chipContent: some View {
-    ViewThatFits(in: .horizontal) {
-      HStack(spacing: 5) {
-        titleLabel
-        countBadge
-      }
-
-      VStack(spacing: 2) {
-        titleLabel
-        countBadge
-      }
+    VStack(spacing: 2) {
+      titleLabel
+      countBadge
     }
+    .frame(minHeight: 36)
   }
 
   private var titleLabel: some View {
@@ -707,6 +716,14 @@ struct FilterChipWithCount: View {
           (isActive ? accent : Color.secondary).opacity(colorScheme == .dark ? 0.18 : 0.14)
         )
         .clipShape(Capsule())
+        .fixedSize(horizontal: true, vertical: false)
+    } else {
+      Text("0")
+        .font(GitHubTypography.monoCaption)
+        .lineLimit(1)
+        .padding(.horizontal, 5)
+        .padding(.vertical, 1)
+        .hidden()
         .fixedSize(horizontal: true, vertical: false)
     }
   }

--- a/app/modules/AgentHubGitHub/Sources/AgentHubGitHub/ViewModels/GitHubViewModel.swift
+++ b/app/modules/AgentHubGitHub/Sources/AgentHubGitHub/ViewModels/GitHubViewModel.swift
@@ -27,7 +27,7 @@ public enum GitHubTab: String, CaseIterable, Identifiable, Sendable {
 // MARK: - PR Filter
 
 /// Filter for PR list state
-public enum GitHubPRFilter: String, CaseIterable, Identifiable, Sendable {
+public enum GitHubPRFilter: String, CaseIterable, Hashable, Identifiable, Sendable {
   case open = "Open"
   case draft = "Draft"
   case merged = "Merged"
@@ -49,7 +49,7 @@ public enum GitHubPRFilter: String, CaseIterable, Identifiable, Sendable {
 
 // MARK: - Issue Filter
 
-public enum GitHubIssueFilter: String, CaseIterable, Identifiable, Sendable {
+public enum GitHubIssueFilter: String, CaseIterable, Hashable, Identifiable, Sendable {
   case open = "Open"
   case closed = "Closed"
   case all = "All"
@@ -119,6 +119,7 @@ public final class GitHubViewModel {
   public var pullRequests: [GitHubPullRequest] = []
   public var prFilter: GitHubPRFilter = .open
   public var prLoadingState: GitHubLoadingState = .idle
+  public var prFilterCounts: [GitHubPRFilter: Int] = [:]
 
   /// Selected PR for detail view
   public var selectedPR: GitHubPullRequest?
@@ -137,13 +138,14 @@ public final class GitHubViewModel {
   public var issues: [GitHubIssue] = []
   public var issueFilter: GitHubIssueFilter = .open
   public var issueLoadingState: GitHubLoadingState = .idle
+  public var issueFilterCounts: [GitHubIssueFilter: Int] = [:]
 
   /// Selected issue for detail view
   public var selectedIssue: GitHubIssue?
   public var issueDetailLoadingState: GitHubLoadingState = .idle
 
   /// PR filter: show only my PRs
-  public var showOnlyMyPRs: Bool = false
+  public var showOnlyMyPRs: Bool = true
 
   /// PR filter: selected labels
   public var selectedLabels: Set<String> = []
@@ -185,6 +187,8 @@ public final class GitHubViewModel {
   private var selectedPRObservationTask: Task<Void, Never>?
   private var currentBranchSubscriptionID: UUID?
   private var selectedPRSubscriptionID: UUID?
+  private var prFilterCountsRequestID: UUID?
+  private var issueFilterCountsRequestID: UUID?
 
   // MARK: - Init
 
@@ -247,6 +251,32 @@ public final class GitHubViewModel {
     currentRepoPath == repoPath && currentBranchName == branchName && setupState != .checking
   }
 
+  public func loadPanelOverview() async {
+    guard currentRepoPath != nil else { return }
+
+    async let pullRequestList: Void = loadPullRequestsIfNeeded()
+    async let issueList: Void = loadIssuesIfNeeded()
+    async let currentBranch: Void = loadCurrentBranchPR()
+    async let pullRequestCounts: Void = loadPRFilterCountsIfNeeded()
+    async let issueCounts: Void = loadIssueFilterCountsIfNeeded()
+
+    _ = await (pullRequestList, issueList, currentBranch, pullRequestCounts, issueCounts)
+  }
+
+  public func reloadPullRequestsAndCounts() async {
+    async let pullRequestList: Void = loadPullRequests()
+    async let pullRequestCounts: Void = refreshPRFilterCounts()
+
+    _ = await (pullRequestList, pullRequestCounts)
+  }
+
+  public func reloadIssuesAndCounts() async {
+    async let issueList: Void = loadIssues()
+    async let issueCounts: Void = refreshIssueFilterCounts()
+
+    _ = await (issueList, issueCounts)
+  }
+
   // MARK: - Pull Requests
 
   /// Loads the list of pull requests
@@ -263,11 +293,17 @@ public final class GitHubViewModel {
         labels: Array(selectedLabels)
       )
       pullRequests = applyClientSideFilter(raw, filter: prFilter)
+      prFilterCounts[prFilter] = pullRequests.count
       prLoadingState = .loaded
     } catch {
       prLoadingState = .error(error.localizedDescription)
       GitHubLogger.github.error("Failed to load PRs: \(error.localizedDescription)")
     }
+  }
+
+  public func loadPullRequestsIfNeeded() async {
+    guard pullRequests.isEmpty, prLoadingState != .loading else { return }
+    await loadPullRequests()
   }
 
   /// Refines the raw list returned by `gh` for filters that can't be expressed in the query.
@@ -281,18 +317,57 @@ public final class GitHubViewModel {
     filter: GitHubPRFilter
   ) -> [GitHubPullRequest] {
     switch filter {
-    case .draft:  return prs.filter { $0.isDraft }
-    case .open:   return prs.filter { !$0.isDraft }
+    case .draft:  return prs.filter { $0.stateKind == .open && $0.isDraft }
+    case .open:   return prs.filter { $0.stateKind == .open && !$0.isDraft }
     case .merged: return prs.filter { $0.stateKind == .merged }
     case .closed: return prs.filter { $0.stateKind == .closed }
     case .all:    return prs
     }
   }
 
-  /// Count of loaded PRs that fall into a given filter. Used for the filter chip badges.
-  /// Note: counts reflect the currently loaded set, not the full remote state.
+  /// Count of PRs that fall into a given filter. Used for the filter chip badges.
   public func filterCount(_ filter: GitHubPRFilter) -> Int {
-    applyClientSideFilter(pullRequests, filter: filter).count
+    prFilterCounts[filter] ?? (filter == prFilter ? pullRequests.count : 0)
+  }
+
+  public var pullRequestTabBadgeCount: Int? {
+    let count = filterCount(prFilter)
+    return count > 0 ? count : nil
+  }
+
+  public func loadPRFilterCountsIfNeeded() async {
+    guard prFilterCounts.isEmpty else { return }
+    await refreshPRFilterCounts()
+  }
+
+  public func refreshPRFilterCounts() async {
+    guard let repoPath = currentRepoPath else { return }
+
+    let requestID = UUID()
+    let authoredByMe = showOnlyMyPRs
+    let labels = Array(selectedLabels)
+    prFilterCountsRequestID = requestID
+    prFilterCounts = [:]
+
+    do {
+      let raw = try await service.listPullRequests(
+        at: repoPath,
+        state: GitHubPRFilter.all.ghState,
+        limit: 200,
+        authoredByMe: authoredByMe,
+        labels: labels
+      )
+      guard prFilterCountsRequestID == requestID else { return }
+
+      prFilterCounts = Dictionary(
+        uniqueKeysWithValues: GitHubPRFilter.allCases.map { filter in
+          (filter, applyClientSideFilter(raw, filter: filter).count)
+        }
+      )
+    } catch {
+      guard prFilterCountsRequestID == requestID else { return }
+      GitHubLogger.github.error("Failed to load PR filter counts: \(error.localizedDescription)")
+    }
   }
 
   /// Loads repository labels if not already loaded
@@ -435,10 +510,67 @@ public final class GitHubViewModel {
 
     do {
       issues = try await service.listIssues(at: repoPath, state: issueFilter.ghState, limit: 30)
+      issueFilterCounts[issueFilter] = issues.count
       issueLoadingState = .loaded
     } catch {
       issueLoadingState = .error(error.localizedDescription)
       GitHubLogger.github.error("Failed to load issues: \(error.localizedDescription)")
+    }
+  }
+
+  public func loadIssuesIfNeeded() async {
+    guard issues.isEmpty, issueLoadingState != .loading else { return }
+    await loadIssues()
+  }
+
+  public func issueFilterCount(_ filter: GitHubIssueFilter) -> Int {
+    issueFilterCounts[filter] ?? (filter == issueFilter ? issues.count : 0)
+  }
+
+  public var issueTabBadgeCount: Int? {
+    let count = issueFilterCount(issueFilter)
+    return count > 0 ? count : nil
+  }
+
+  public func loadIssueFilterCountsIfNeeded() async {
+    guard issueFilterCounts.isEmpty else { return }
+    await refreshIssueFilterCounts()
+  }
+
+  public func refreshIssueFilterCounts() async {
+    guard let repoPath = currentRepoPath else { return }
+
+    let requestID = UUID()
+    issueFilterCountsRequestID = requestID
+    issueFilterCounts = [:]
+
+    do {
+      let raw = try await service.listIssues(
+        at: repoPath,
+        state: GitHubIssueFilter.all.ghState,
+        limit: 200
+      )
+      guard issueFilterCountsRequestID == requestID else { return }
+
+      issueFilterCounts = Dictionary(
+        uniqueKeysWithValues: GitHubIssueFilter.allCases.map { filter in
+          (filter, applyClientSideIssueFilter(raw, filter: filter).count)
+        }
+      )
+    } catch {
+      guard issueFilterCountsRequestID == requestID else { return }
+      GitHubLogger.github.error("Failed to load issue filter counts: \(error.localizedDescription)")
+    }
+  }
+
+  private func applyClientSideIssueFilter(
+    _ issues: [GitHubIssue],
+    filter: GitHubIssueFilter
+  ) -> [GitHubIssue] {
+    switch filter {
+    case .open: return issues.filter { $0.stateKind == .open }
+    case .closed: return issues.filter { $0.stateKind == .closed }
+    case .all: return issues
     }
   }
 

--- a/app/modules/AgentHubGitHub/Tests/AgentHubGitHubTests/GitHubViewModelTests.swift
+++ b/app/modules/AgentHubGitHub/Tests/AgentHubGitHubTests/GitHubViewModelTests.swift
@@ -176,6 +176,32 @@ struct GitHubViewModelPRTests {
     #expect(mock.listPullRequestsLimit == 30)
   }
 
+  @Test("loadPanelOverview starts pull request and issue loading")
+  @MainActor
+  func loadPanelOverviewStartsPullRequestAndIssueLoading() async {
+    let mock = MockGitHubCLIService()
+    mock.repoInfoResult = makeRepoInfo()
+    mock.pullRequestsResultsByState = [
+      "open": [makePR(number: 1)],
+      "all": [makePR(number: 1), makePR(number: 2, state: "MERGED")]
+    ]
+    mock.issuesResultsByState = [
+      "open": [makeIssue(number: 1)],
+      "all": [makeIssue(number: 1), makeIssue(number: 2, state: "CLOSED")]
+    ]
+    let vm = GitHubViewModel(service: mock)
+    await vm.setup(repoPath: "/tmp/repo")
+
+    await vm.loadPanelOverview()
+
+    #expect(vm.pullRequests.map(\.number) == [1])
+    #expect(vm.issues.map(\.number) == [1])
+    #expect(mock.listPullRequestsStates.contains("open"))
+    #expect(mock.listPullRequestsStates.contains("all"))
+    #expect(mock.listIssuesStates.contains("open"))
+    #expect(mock.listIssuesStates.contains("all"))
+  }
+
   @Test("loadPullRequests sets error state on failure")
   @MainActor
   func loadPullRequestsError() async {
@@ -547,6 +573,69 @@ struct GitHubViewModelFilterTests {
     await vm.loadPullRequests()
 
     #expect(mock.listPullRequestsState == "all")
+  }
+
+  @Test("PR list defaults to only my pull requests")
+  @MainActor
+  func prListDefaultsToOnlyMyPullRequests() async {
+    let mock = MockGitHubCLIService()
+    mock.repoInfoResult = makeRepoInfo()
+    let vm = GitHubViewModel(service: mock)
+    await vm.setup(repoPath: "/tmp/repo")
+
+    await vm.loadPullRequests()
+
+    #expect(vm.showOnlyMyPRs)
+    #expect(mock.listPullRequestsAuthoredByMe == true)
+  }
+
+  @Test("PR filter counts load from all pull requests")
+  @MainActor
+  func prFilterCountsLoadFromAllPullRequests() async {
+    let mock = MockGitHubCLIService()
+    mock.repoInfoResult = makeRepoInfo()
+    mock.pullRequestsResultsByState = [
+      "all": [
+        makePR(number: 1),
+        makePR(number: 2, isDraft: true),
+        makePR(number: 3, state: "MERGED"),
+        makePR(number: 4, state: "CLOSED")
+      ]
+    ]
+    let vm = GitHubViewModel(service: mock)
+    await vm.setup(repoPath: "/tmp/repo")
+
+    await vm.refreshPRFilterCounts()
+
+    #expect(mock.listPullRequestsState == "all")
+    #expect(mock.listPullRequestsAuthoredByMe == true)
+    #expect(vm.filterCount(.open) == 1)
+    #expect(vm.filterCount(.draft) == 1)
+    #expect(vm.filterCount(.merged) == 1)
+    #expect(vm.filterCount(.closed) == 1)
+    #expect(vm.filterCount(.all) == 4)
+  }
+
+  @Test("Issue filter counts load from all issues")
+  @MainActor
+  func issueFilterCountsLoadFromAllIssues() async {
+    let mock = MockGitHubCLIService()
+    mock.repoInfoResult = makeRepoInfo()
+    mock.issuesResultsByState = [
+      "all": [
+        makeIssue(number: 1),
+        makeIssue(number: 2, state: "CLOSED")
+      ]
+    ]
+    let vm = GitHubViewModel(service: mock)
+    await vm.setup(repoPath: "/tmp/repo")
+
+    await vm.refreshIssueFilterCounts()
+
+    #expect(mock.listIssuesState == "all")
+    #expect(vm.issueFilterCount(.open) == 1)
+    #expect(vm.issueFilterCount(.closed) == 1)
+    #expect(vm.issueFilterCount(.all) == 2)
   }
 
   @Test("Issue filter passes correct state to service")

--- a/app/modules/AgentHubGitHub/Tests/AgentHubGitHubTests/MockGitHubCLIService.swift
+++ b/app/modules/AgentHubGitHub/Tests/AgentHubGitHubTests/MockGitHubCLIService.swift
@@ -63,15 +63,27 @@ final class MockGitHubCLIService: GitHubCLIServiceProtocol, @unchecked Sendable 
   // MARK: - Pull Requests
 
   var pullRequestsResult: [GitHubPullRequest] = []
+  var pullRequestsResultsByState: [String: [GitHubPullRequest]] = [:]
   var listPullRequestsCalled = false
+  var listPullRequestsCallCount = 0
   var listPullRequestsState: String?
+  var listPullRequestsStates: [String] = []
   var listPullRequestsLimit: Int?
+  var listPullRequestsAuthoredByMe: Bool?
+  var listPullRequestsLabels: [String]?
 
   func listPullRequests(at repoPath: String, state: String, limit: Int, authoredByMe: Bool, labels: [String]) async throws -> [GitHubPullRequest] {
     listPullRequestsCalled = true
+    listPullRequestsCallCount += 1
     listPullRequestsState = state
+    listPullRequestsStates.append(state)
     listPullRequestsLimit = limit
+    listPullRequestsAuthoredByMe = authoredByMe
+    listPullRequestsLabels = labels
     if let error = errorToThrow { throw error }
+    if let result = pullRequestsResultsByState[state] {
+      return result
+    }
     return pullRequestsResult
   }
 
@@ -221,13 +233,21 @@ final class MockGitHubCLIService: GitHubCLIServiceProtocol, @unchecked Sendable 
   // MARK: - Issues
 
   var issuesResult: [GitHubIssue] = []
+  var issuesResultsByState: [String: [GitHubIssue]] = [:]
   var listIssuesCalled = false
+  var listIssuesCallCount = 0
   var listIssuesState: String?
+  var listIssuesStates: [String] = []
 
   func listIssues(at repoPath: String, state: String, limit: Int) async throws -> [GitHubIssue] {
     listIssuesCalled = true
+    listIssuesCallCount += 1
     listIssuesState = state
+    listIssuesStates.append(state)
     if let error = errorToThrow { throw error }
+    if let result = issuesResultsByState[state] {
+      return result
+    }
     return issuesResult
   }
 
@@ -299,8 +319,12 @@ final class MockGitHubCLIService: GitHubCLIServiceProtocol, @unchecked Sendable 
     lastAuthenticatedRepoPath = nil
     getRepoInfoCalled = false
     listPullRequestsCalled = false
+    listPullRequestsCallCount = 0
     listPullRequestsState = nil
+    listPullRequestsStates = []
     listPullRequestsLimit = nil
+    listPullRequestsAuthoredByMe = nil
+    listPullRequestsLabels = nil
     getPullRequestCalled = false
     getPullRequestCallCount = 0
     getPullRequestNumber = nil
@@ -324,7 +348,9 @@ final class MockGitHubCLIService: GitHubCLIServiceProtocol, @unchecked Sendable 
     checkoutPRCalled = false
     checkoutPRNumber = nil
     listIssuesCalled = false
+    listIssuesCallCount = 0
     listIssuesState = nil
+    listIssuesStates = []
     getIssueCalled = false
     getIssueNumber = nil
     addIssueCommentCalled = false


### PR DESCRIPTION
## Summary

- Load GitHub pull requests, issues, current-branch PR state, and filter counts together when the panel opens.
- Cache per-filter PR and issue counts so badges can populate as async results arrive without requiring tab selection.
- Default PR scope to "Only my pull requests" and render it as an active removable tag.
- Make GitHub filter chips consistently two lines tall so mixed count states do not produce uneven button heights.

## Validation

- `swift test --package-path app/modules/AgentHubGitHub`
- `git diff --check`

## Note

`swift build --package-path app/modules/AgentHubCore --target AgentHubCore` is currently blocked before this code by the existing `CodeEditSymbols` dependency error: `type 'Bundle' has no member 'module'`.