### PR TITLE
[codex] Fix GitHub PR review session launch

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
@@ -434,15 +434,11 @@ public struct MultiProviderSessionsListView: View {
           claudeViewModel.showTerminalWithPrompt(for: session, prompt: prompt)
         },
         onStartNewSession: { inputText, provider in
-          let projectPath = item.projectPath
-          let vm = provider == .claude ? claudeViewModel : codexViewModel
-          let repo = vm.selectedRepositories.first(where: { $0.path == projectPath })
-            ?? claudeViewModel.selectedRepositories.first(where: { $0.path == projectPath })
-            ?? codexViewModel.selectedRepositories.first(where: { $0.path == projectPath })
-          if let worktree = repo?.worktrees.first {
-            gitHubSheetItem = nil
-            vm.startNewSessionInHub(worktree, initialInputText: inputText)
-          }
+          launchGitHubReviewSession(
+            projectPath: item.projectPath,
+            inputText: inputText,
+            providerKind: provider
+          )
         }
       )
     }
@@ -1949,6 +1945,37 @@ public struct MultiProviderSessionsListView: View {
         startSessionSheetContext = StartSessionSheetContext(launchViewModel: launchViewModel)
         launchViewModel.selectRepository()
       }
+    }
+  }
+
+  private func launchGitHubReviewSession(
+    projectPath: String,
+    inputText: String,
+    providerKind: SessionProviderKind
+  ) {
+    let viewModel = providerKind == .claude ? claudeViewModel : codexViewModel
+    let target = GitHubReviewSessionLaunchTargetResolver.launchTarget(
+      for: projectPath,
+      repositories: Array(orderedTrackedRepos)
+    )
+
+    gitHubSheetItem = nil
+
+    Task { @MainActor in
+      let worktree: WorktreeBranch
+      if target.worktree.isWorktree, let parentRepositoryPath = target.parentRepositoryPath {
+        worktree = await viewModel.registerCreatedWorktree(
+          name: target.worktree.name,
+          path: target.worktree.path,
+          parentRepositoryPath: parentRepositoryPath
+        )
+      } else {
+        viewModel.addRepository(at: target.worktree.path)
+        worktree = target.worktree
+      }
+
+      viewModel.startNewSessionInHub(worktree, initialPrompt: inputText)
+      viewModel.refresh()
     }
   }
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/Utils/GitHubReviewSessionLaunchTargetResolver.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Utils/GitHubReviewSessionLaunchTargetResolver.swift
@@ -1,0 +1,56 @@
+//
+//  GitHubReviewSessionLaunchTargetResolver.swift
+//  AgentHub
+//
+
+import Foundation
+
+struct GitHubReviewSessionLaunchTarget: Equatable {
+  let worktree: WorktreeBranch
+  let parentRepositoryPath: String?
+}
+
+enum GitHubReviewSessionLaunchTargetResolver {
+  static func launchTarget(
+    for projectPath: String,
+    repositories: [SelectedRepository]
+  ) -> GitHubReviewSessionLaunchTarget {
+    let normalizedPath = WorktreeModuleResolver.normalizedDirectoryPath(projectPath)
+
+    guard let match = WorktreeModuleResolver.bestMatch(for: normalizedPath, repositories: repositories) else {
+      return GitHubReviewSessionLaunchTarget(
+        worktree: WorktreeBranch(
+          name: URL(fileURLWithPath: normalizedPath).lastPathComponent,
+          path: normalizedPath,
+          isWorktree: false,
+          isExpanded: true
+        ),
+        parentRepositoryPath: nil
+      )
+    }
+
+    if match.worktree.isWorktree {
+      return GitHubReviewSessionLaunchTarget(
+        worktree: WorktreeBranch(
+          name: match.worktree.name,
+          path: WorktreeModuleResolver.normalizedDirectoryPath(match.worktree.path),
+          isWorktree: true,
+          sessions: match.worktree.sessions,
+          isExpanded: match.worktree.isExpanded
+        ),
+        parentRepositoryPath: WorktreeModuleResolver.normalizedDirectoryPath(match.repository.path)
+      )
+    }
+
+    return GitHubReviewSessionLaunchTarget(
+      worktree: WorktreeBranch(
+        name: match.worktree.name,
+        path: WorktreeModuleResolver.normalizedDirectoryPath(match.repository.path),
+        isWorktree: false,
+        sessions: match.worktree.sessions,
+        isExpanded: match.worktree.isExpanded
+      ),
+      parentRepositoryPath: nil
+    )
+  }
+}

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/FocusedSessionLaunchTargetResolverTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/FocusedSessionLaunchTargetResolverTests.swift
@@ -87,6 +87,60 @@ struct FocusedSessionLaunchTargetResolverTests {
   }
 }
 
+@Suite("GitHubReviewSessionLaunchTargetResolver")
+struct GitHubReviewSessionLaunchTargetResolverTests {
+  @Test("Tracked repository resolves to local main repository target")
+  func trackedRepositoryResolvesToMainRepositoryTarget() {
+    let target = GitHubReviewSessionLaunchTargetResolver.launchTarget(
+      for: "/tmp/Repo/",
+      repositories: [repositoryWithWorktree()]
+    )
+
+    #expect(target.worktree.name == "main")
+    #expect(target.worktree.path == "/tmp/Repo")
+    #expect(target.worktree.isWorktree == false)
+    #expect(target.parentRepositoryPath == nil)
+  }
+
+  @Test("Tracked worktree module resolves to worktree target with parent repository")
+  func trackedWorktreeModuleResolvesToWorktreeTarget() {
+    let target = GitHubReviewSessionLaunchTargetResolver.launchTarget(
+      for: "/tmp/Repo-feature",
+      repositories: [repositoryWithWorktree()]
+    )
+
+    #expect(target.worktree.name == "feature")
+    #expect(target.worktree.path == "/tmp/Repo-feature")
+    #expect(target.worktree.isWorktree)
+    #expect(target.parentRepositoryPath == "/tmp/Repo")
+  }
+
+  @Test("Nested worktree path resolves to worktree root")
+  func nestedWorktreePathResolvesToWorktreeRoot() {
+    let target = GitHubReviewSessionLaunchTargetResolver.launchTarget(
+      for: "/tmp/Repo-feature/App",
+      repositories: [repositoryWithWorktree()]
+    )
+
+    #expect(target.worktree.path == "/tmp/Repo-feature")
+    #expect(target.worktree.isWorktree)
+    #expect(target.parentRepositoryPath == "/tmp/Repo")
+  }
+
+  @Test("Untracked project resolves to local directory target")
+  func untrackedProjectResolvesToLocalDirectoryTarget() {
+    let target = GitHubReviewSessionLaunchTargetResolver.launchTarget(
+      for: "/tmp/Other",
+      repositories: [repositoryWithWorktree()]
+    )
+
+    #expect(target.worktree.name == "Other")
+    #expect(target.worktree.path == "/tmp/Other")
+    #expect(target.worktree.isWorktree == false)
+    #expect(target.parentRepositoryPath == nil)
+  }
+}
+
 @Suite("MultiSessionLaunchViewModel preselection")
 @MainActor
 struct MultiSessionLaunchViewModelPreselectionTests {


### PR DESCRIPTION
## Summary

Fixes the GitHub panel `Code Review` action so selecting Claude or Codex immediately starts a local review session for the current repository or worktree module.

## Root Cause

The GitHub sheet handoff only launched when it could find `repo?.worktrees.first` for the panel path. Repository/module rows without a registered worktree silently did nothing. The action also passed `/review <pr-url>` as `initialInputText`, which prefilled terminal input instead of using the submitted launch prompt path.

## Changes

- Resolve GitHub review launch targets through a dedicated resolver that handles tracked repos, tracked worktree modules, nested paths, and untracked local directories.
- Register/focus known worktree modules with the selected provider before starting the session.
- Start the selected provider with `initialPrompt` so `/review <pr-url>` is submitted at launch.
- Add focused resolver tests for the supported target cases.

## Validation

- `git diff --check`
- `xcodebuild build -project app/AgentHub.xcodeproj -scheme AgentHub -destination 'platform=macOS'`

Note: `swift test --package-path app/modules/AgentHubCore --filter GitHubReviewSessionLaunchTargetResolverTests` is blocked before reaching these tests by the existing local `CodeEditSymbols` SwiftPM checkout issue where `Bundle.module` is unavailable because its asset catalog is not declared as a package resource.