### PR TITLE
[codex] Add direct inline review send shortcut

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,8 +132,8 @@ Updates are delivered automatically via [Sparkle](https://sparkle-project.org/) 
 
 | Shortcut | Action |
 |---|---|
-| **Return** | Send inline comment to Claude |
-| **Cmd+Return** | Add comment to review collection |
+| **Return** | Add inline comment to review collection |
+| **Cmd+Return** | Send inline feedback directly to the agent session |
 | **Shift+Return** | Insert newline in editor |
 | **Escape** | Close inline editor or diff view |
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/DiffCommentsPanelView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/DiffCommentsPanelView.swift
@@ -15,10 +15,23 @@ struct DiffCommentsPanelView: View {
 
   @Bindable var commentsState: DiffCommentsState
   let providerKind: SessionProviderKind
+  let isSendShortcutEnabled: Bool
   let onSendToCloud: () -> Void
 
   @State private var isExpanded = false
   @State private var showClearConfirmation = false
+
+  init(
+    commentsState: DiffCommentsState,
+    providerKind: SessionProviderKind,
+    isSendShortcutEnabled: Bool = true,
+    onSendToCloud: @escaping () -> Void
+  ) {
+    self.commentsState = commentsState
+    self.providerKind = providerKind
+    self.isSendShortcutEnabled = isSendShortcutEnabled
+    self.onSendToCloud = onSendToCloud
+  }
 
   // MARK: - Body
 
@@ -114,25 +127,27 @@ struct DiffCommentsPanelView: View {
     .padding(.vertical, 8)
   }
 
+  @ViewBuilder
   private var headerSendButton: some View {
-    Button(action: onSendToCloud) {
-      HStack(spacing: 4) {
-        Image(systemName: "paperplane")
-          .font(.caption)
-        Text("Send \(commentsState.commentCount) to \(providerKind.rawValue)")
-          .font(.caption.bold())
-      }
-      .foregroundColor(.primary)
-      .padding(.horizontal, 10)
-      .padding(.vertical, 4)
-      .background(
-        RoundedRectangle(cornerRadius: 6)
-          .stroke(Color.primary.opacity(0.3), lineWidth: 1)
-      )
-      .contentShape(Rectangle())
+    let button = Button(action: onSendToCloud) {
+      sendButtonLabel
+        .foregroundColor(.primary)
+        .padding(.horizontal, 10)
+        .padding(.vertical, 4)
+        .background(
+          RoundedRectangle(cornerRadius: 6)
+            .stroke(Color.primary.opacity(0.3), lineWidth: 1)
+        )
+        .contentShape(Rectangle())
     }
     .buttonStyle(.plain)
-    .help("Send all comments to \(providerKind.rawValue) (⌘⇧↵)")
+    .help("Send all comments to \(providerKind.rawValue) (⌘ ↵)")
+
+    if isSendShortcutEnabled {
+      button.keyboardShortcut(.return, modifiers: .command)
+    } else {
+      button
+    }
   }
 
   // MARK: - Toolbar
@@ -156,14 +171,16 @@ struct DiffCommentsPanelView: View {
       .buttonStyle(.plain)
       .help("Clear all comments")
 
-      // Send to provider button
-      Button(action: onSendToCloud) {
-        HStack(spacing: 4) {
-          Image(systemName: "paperplane")
-            .font(.caption)
-          Text("Send \(commentsState.commentCount) to \(providerKind.rawValue)")
-            .font(.caption.bold())
-        }
+      sendToolbarButton
+    }
+    .padding(.horizontal, 12)
+    .padding(.bottom, 8)
+  }
+
+  @ViewBuilder
+  private var sendToolbarButton: some View {
+    let button = Button(action: onSendToCloud) {
+      sendButtonLabel
         .foregroundColor(.primary)
         .padding(.horizontal, 12)
         .padding(.vertical, 6)
@@ -171,12 +188,29 @@ struct DiffCommentsPanelView: View {
           RoundedRectangle(cornerRadius: 6)
             .stroke(Color.primary.opacity(0.3), lineWidth: 1)
         )
-      }
-      .buttonStyle(.plain)
-      .help("Send all comments to \(providerKind.rawValue) (⌘⇧↵)")
     }
-    .padding(.horizontal, 12)
-    .padding(.bottom, 8)
+    .buttonStyle(.plain)
+    .help("Send all comments to \(providerKind.rawValue) (⌘ ↵)")
+
+    if isSendShortcutEnabled {
+      button.keyboardShortcut(.return, modifiers: .command)
+    } else {
+      button
+    }
+  }
+
+  private var sendButtonLabel: some View {
+    HStack(spacing: 4) {
+      Image(systemName: "paperplane")
+        .font(.caption)
+
+      Text("Send \(commentsState.commentCount) to \(providerKind.rawValue)")
+        .font(.caption.bold())
+
+      Text("⌘ ↵")
+        .font(.system(size: 11, weight: .semibold, design: .monospaced))
+        .foregroundColor(.secondary)
+    }
   }
 }
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/GitDiffView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/GitDiffView.swift
@@ -123,6 +123,7 @@ public struct GitDiffView: View {
             DiffCommentsPanelView(
               commentsState: commentsState,
               providerKind: providerKind,
+              isSendShortcutEnabled: !inlineEditorState.isShowing,
               onSendToCloud: sendAllCommentsToCloud
             )
           }
@@ -435,7 +436,8 @@ public struct GitDiffView: View {
             commentsState: commentsState,
             cliConfiguration: cliConfiguration,
             providerKind: providerKind,
-            session: session
+            session: session,
+            onInlineRequestSubmit: onInlineRequestSubmit
           )
           .frame(minHeight: 400)
           .id(selectedId)
@@ -877,6 +879,7 @@ private struct GitDiffContentView: View {
   let cliConfiguration: CLICommandConfiguration?
   let providerKind: SessionProviderKind
   let session: CLISession
+  let onInlineRequestSubmit: ((String, CLISession) -> Void)?
 
   @State private var webViewOpacity: Double = 1.0
   @State private var isWebViewReady = false
@@ -1025,6 +1028,7 @@ private struct GitDiffContentView: View {
                   text: message
                 )
               },
+              onSendComment: sendInlineCommentToAgent,
               commentsState: commentsState
             )
           }
@@ -1180,6 +1184,53 @@ private struct GitDiffContentView: View {
       return ""
     }
     return lines[startIndex...endIndex].joined(separator: "\n")
+  }
+
+  private func sendInlineCommentToAgent(message: String, context: DiffLineContext) -> Bool {
+    let prompt = generateInlineCommentPrompt(message: message, context: context)
+
+    if let callback = onInlineRequestSubmit {
+      callback(prompt, session)
+      return true
+    }
+
+    guard let cliConfiguration else { return false }
+
+    if let error = TerminalLauncher.launchTerminalWithSession(
+      session.id,
+      cliConfiguration: cliConfiguration,
+      projectPath: session.projectPath,
+      initialPrompt: prompt
+    ) {
+      inlineEditorState.errorMessage = error.localizedDescription
+      return false
+    }
+
+    return true
+  }
+
+  private func generateInlineCommentPrompt(message: String, context: DiffLineContext) -> String {
+    let sideLabel = context.side == "left" ? "old" : "new"
+    let lineLabel: String
+    if let endLineNumber = context.endLineNumber {
+      lineLabel = "Lines \(context.lineNumber)-\(endLineNumber)"
+    } else {
+      lineLabel = "Line \(context.lineNumber)"
+    }
+
+    return """
+    I have the following review comment on the code changes:
+
+    ## \(context.fileName)
+
+    **\(lineLabel)** (\(sideLabel)):
+    ```
+    \(context.lineContent)
+    ```
+    Comment: \(message)
+
+    Please address this review comment.
+    """
   }
 
 }

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/InlineEditorOverlay.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/InlineEditorOverlay.swift
@@ -10,7 +10,8 @@ import SwiftUI
 /// An overlay that positions the inline editor below clicked diff lines.
 /// Handles tap-outside dismissal and edge positioning.
 ///
-/// Comments are added to the review collection; sending happens from the bottom panel.
+/// Return adds comments to the review collection; Cmd+Return can send a
+/// single comment directly to the agent session.
 struct InlineEditorOverlay: View {
 
   // MARK: - Properties
@@ -21,6 +22,9 @@ struct InlineEditorOverlay: View {
 
   /// Called when user presses Return - adds to comment collection
   let onAddComment: (String, DiffLineContext) -> Void
+
+  /// Called when user presses Cmd+Return - sends feedback directly to the agent session
+  let onSendComment: ((String, DiffLineContext) -> Bool)?
 
   /// Comments state for checking existing comments (optional)
   let commentsState: DiffCommentsState?
@@ -38,12 +42,14 @@ struct InlineEditorOverlay: View {
     containerSize: CGSize,
     providerKind: SessionProviderKind = .claude,
     onAddComment: @escaping (String, DiffLineContext) -> Void,
+    onSendComment: ((String, DiffLineContext) -> Bool)? = nil,
     commentsState: DiffCommentsState? = nil
   ) {
     self.state = state
     self.containerSize = containerSize
     self.providerKind = providerKind
     self.onAddComment = onAddComment
+    self.onSendComment = onSendComment
     self.commentsState = commentsState
   }
 
@@ -105,6 +111,20 @@ struct InlineEditorOverlay: View {
             onAddComment(message, currentContext)
             withAnimation(.easeOut(duration: 0.15)) {
               state.dismiss()
+            }
+          },
+          onSendComment: onSendComment.map { sendComment in
+            { message in
+              let didSend = sendComment(message, currentContext)
+              if didSend {
+                if let comment = existingComment {
+                  commentsState?.removeComment(id: comment.id)
+                }
+                withAnimation(.easeOut(duration: 0.15)) {
+                  state.dismiss()
+                }
+              }
+              return didSend
             }
           },
           onDeleteComment: isEditMode ? {

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/InlineEditorView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/InlineEditorView.swift
@@ -11,8 +11,8 @@ import AppKit
 /// A compact floating text editor for asking questions about specific diff lines.
 /// Appears below clicked lines in the diff view.
 ///
-/// Comments are always added to the review collection. The only way to send
-/// feedback to Claude is via the bottom panel's "Send to Claude" button.
+/// Return adds comments to the review collection. Cmd+Return can send a
+/// single comment directly to the agent session when a direct-send handler is available.
 struct InlineEditorView: View {
 
   // MARK: - Properties
@@ -26,6 +26,9 @@ struct InlineEditorView: View {
 
   /// Called when user presses Return - adds to comment collection
   let onAddComment: (String) -> Void
+
+  /// Called when user presses Cmd+Return - sends feedback directly to the agent session
+  let onSendComment: ((String) -> Bool)?
 
   /// Called when user wants to delete an existing comment (optional, edit mode only)
   let onDeleteComment: (() -> Void)?
@@ -62,6 +65,7 @@ struct InlineEditorView: View {
     errorMessage: String?,
     providerKind: SessionProviderKind = .claude,
     onAddComment: @escaping (String) -> Void,
+    onSendComment: ((String) -> Bool)? = nil,
     onDeleteComment: (() -> Void)? = nil,
     onDismiss: @escaping () -> Void,
     initialText: String = "",
@@ -74,6 +78,7 @@ struct InlineEditorView: View {
     self.errorMessage = errorMessage
     self.providerKind = providerKind
     self.onAddComment = onAddComment
+    self.onSendComment = onSendComment
     self.onDeleteComment = onDeleteComment
     self.onDismiss = onDismiss
     self.initialText = initialText
@@ -153,6 +158,10 @@ struct InlineEditorView: View {
 
       // Add comment button with return key hint
       addCommentButton
+
+      if onSendComment != nil {
+        sendCommentButton
+      }
     }
     .padding(8)
   }
@@ -218,32 +227,73 @@ struct InlineEditorView: View {
   // MARK: - Add Comment Button
 
   private var addCommentButton: some View {
-    HStack(spacing: 4) {
-      Button(action: addComment) {
+    Button(action: addComment) {
+      HStack(spacing: 6) {
         Image(systemName: isEditMode ? "checkmark" : "plus")
           .font(.system(size: 14, weight: .semibold))
           .foregroundColor(isTextEmpty ? .secondary : .primary)
-          .frame(width: 32, height: 32)
-          .contentShape(Rectangle())
-      }
-      .buttonStyle(.plain)
-      .frame(width: 32, height: 32)
-      .background(
-        RoundedRectangle(cornerRadius: 8)
-          .fill(Color(NSColor.controlBackgroundColor))
-      )
-      .overlay(
-        RoundedRectangle(cornerRadius: 8)
-          .stroke(isTextEmpty ? Color(NSColor.separatorColor) : Color.brandPrimary(for: providerKind).opacity(0.5), lineWidth: 1)
-      )
-      .contentShape(Rectangle())
-      .disabled(isTextEmpty)
-      .help(isEditMode ? "Update comment (↵)" : "Add to review (↵)")
 
-      Text("⏎")
-        .font(.system(size: 11, weight: .medium, design: .rounded))
-        .foregroundColor(.secondary)
+        returnShortcutHint
+      }
+      .frame(width: 46, height: 32)
+      .contentShape(Rectangle())
     }
+    .buttonStyle(.plain)
+    .frame(width: 46, height: 32)
+    .background(
+      RoundedRectangle(cornerRadius: 8)
+        .fill(Color(NSColor.controlBackgroundColor))
+    )
+    .overlay(
+      RoundedRectangle(cornerRadius: 8)
+        .stroke(isTextEmpty ? Color(NSColor.separatorColor) : Color.brandPrimary(for: providerKind).opacity(0.5), lineWidth: 1)
+    )
+    .contentShape(Rectangle())
+    .disabled(isTextEmpty)
+    .help(isEditMode ? "Update comment (↵)" : "Add to review (↵)")
+  }
+
+  private var sendCommentButton: some View {
+    Button(action: sendComment) {
+      HStack(spacing: 6) {
+        Image(systemName: "paperplane")
+          .font(.system(size: 14, weight: .semibold))
+          .foregroundColor(isTextEmpty ? .secondary : .primary)
+
+        commandReturnShortcutHint
+      }
+      .frame(width: 66, height: 32)
+      .contentShape(Rectangle())
+    }
+    .buttonStyle(.plain)
+    .frame(width: 66, height: 32)
+    .background(
+      RoundedRectangle(cornerRadius: 8)
+        .fill(Color(NSColor.controlBackgroundColor))
+    )
+    .overlay(
+      RoundedRectangle(cornerRadius: 8)
+        .stroke(isTextEmpty ? Color(NSColor.separatorColor) : Color.brandPrimary(for: providerKind).opacity(0.5), lineWidth: 1)
+    )
+    .contentShape(Rectangle())
+    .disabled(isTextEmpty)
+    .keyboardShortcut(.return, modifiers: .command)
+    .help("Send to \(providerKind.rawValue) (⌘ ↵)")
+  }
+
+  private var returnShortcutHint: some View {
+    Text("↵")
+      .font(.system(size: 11, weight: .medium, design: .rounded))
+      .foregroundColor(.secondary)
+  }
+
+  private var commandReturnShortcutHint: some View {
+    HStack(spacing: 4) {
+      Text("⌘")
+      Text("↵")
+    }
+    .font(.system(size: 11, weight: .semibold, design: .monospaced))
+    .foregroundColor(.secondary)
   }
 
   // MARK: - Delete Button
@@ -290,10 +340,24 @@ struct InlineEditorView: View {
     onAddComment(messageText)
   }
 
+  /// Sends the comment directly to the agent session without adding it to the review collection.
+  private func sendComment() {
+    guard !isTextEmpty else { return }
+    guard let onSendComment else {
+      addComment()
+      return
+    }
+
+    let messageText = text.trimmingCharacters(in: .whitespacesAndNewlines)
+    if onSendComment(messageText) {
+      text = ""
+    }
+  }
+
   /// Handles keyboard shortcuts for the inline editor.
   ///
   /// - **Return**: Adds comment to review collection
-  /// - **Cmd+Return**: Also adds comment (alias)
+  /// - **Cmd+Return**: Sends feedback directly to the agent session
   /// - **Shift+Return**: Inserts a new line (returns `.ignored` to allow default behavior)
   /// - **Escape**: Dismisses the editor without submitting
   private func handleKeyPress(_ key: KeyPress) -> KeyPress.Result {
@@ -303,7 +367,13 @@ struct InlineEditorView: View {
         // Shift+Enter: insert newline
         return .ignored
       }
-      // Return (or Cmd+Return): add to comment collection
+
+      if key.modifiers.contains(.command) {
+        sendComment()
+        return .handled
+      }
+
+      // Return: add to comment collection
       addComment()
       return .handled
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/PlanView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/PlanView.swift
@@ -252,6 +252,7 @@ public struct PlanView: View {
         DiffCommentsPanelView(
           commentsState: commentsState,
           providerKind: providerKind,
+          isSendShortcutEnabled: activeLineIndex == nil,
           onSendToCloud: sendFeedbackToTerminal
         )
       }


### PR DESCRIPTION
## Summary

- Add a Cmd+Return direct-send path from the inline diff editor to the active agent session.
- Keep Return as the add/update-to-review-tray action, with shortcut hints moved inside the inline buttons.
- Disable the tray Cmd+Return shortcut while an inline editor is open to avoid shortcut collisions.
- Update the README shortcut table to describe the new behavior.

## Validation

- `xcodebuild -quiet -project app/AgentHub.xcodeproj -scheme AgentHub -destination 'platform=macOS' build`
- `git diff --check`
