### PR TITLE
[codex] Bump PierreDiffsSwift to 1.2.2

### DIFF
--- a/app/AgentHub.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/app/AgentHub.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -105,8 +105,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/jamesrochabrun/PierreDiffsSwift",
       "state" : {
-        "revision" : "71dfed9b1fca94b62229dc65f11122473f22ee89",
-        "version" : "1.2.0"
+        "revision" : "7720cc32659559b4a3b830ec9d3ef27258fee2c3",
+        "version" : "1.2.2"
       }
     },
     {

--- a/app/modules/AgentHubCore/Package.resolved
+++ b/app/modules/AgentHubCore/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "e87044af83063d721854b6fe0eade4e2b983b06280a3d60025bd28cf91aefe6c",
+  "originHash" : "d80b3cbf155d2836e99c138c84231ef95e4172bbaa593d65b15b26e68b0d7dd2",
   "pins" : [
     {
       "identity" : "beautiful-mermaid-swift",
@@ -96,8 +96,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/jamesrochabrun/PierreDiffsSwift",
       "state" : {
-        "revision" : "71dfed9b1fca94b62229dc65f11122473f22ee89",
-        "version" : "1.2.0"
+        "revision" : "7720cc32659559b4a3b830ec9d3ef27258fee2c3",
+        "version" : "1.2.2"
       }
     },
     {

--- a/app/modules/AgentHubCore/Package.swift
+++ b/app/modules/AgentHubCore/Package.swift
@@ -38,7 +38,7 @@ let package = Package(
     .package(path: "../AgentHubGitHub"),
     .package(path: "../Storybook"),
     .package(url: "https://github.com/jamesrochabrun/Canvas", exact: "1.2.1"),
-    .package(url: "https://github.com/jamesrochabrun/PierreDiffsSwift", exact: "1.2.0"),
+    .package(url: "https://github.com/jamesrochabrun/PierreDiffsSwift", exact: "1.2.2"),
     .package(url: "https://github.com/jamesrochabrun/SwiftTerm", exact: "1.13.0-agenthub.6"),
     .package(url: "https://github.com/gonzalezreal/swift-markdown-ui", from: "2.0.0"),
     .package(url: "https://github.com/groue/GRDB.swift", from: "6.24.0"),

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/DiffCommentsPanelView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/DiffCommentsPanelView.swift
@@ -36,75 +36,56 @@ struct DiffCommentsPanelView: View {
   // MARK: - Body
 
   var body: some View {
-    headerView
-      .background(Color.surfaceElevated)
-      .overlay(alignment: .top) {
-        expandedTray
-      }
-      .overlay(
-        Rectangle()
-          .frame(height: 1)
-          .foregroundColor(Color(NSColor.separatorColor)),
-        alignment: .top
-      )
-      .animation(.easeInOut(duration: 0.2), value: isExpanded)
-      .confirmationDialog(
-        "Clear All Comments",
-        isPresented: $showClearConfirmation,
-        titleVisibility: .visible
-      ) {
-        Button("Clear All", role: .destructive) {
-          commentsState.clearAll()
-        }
-        Button("Cancel", role: .cancel) {}
-      } message: {
-        Text("This will remove all \(commentsState.commentCount) pending comments. This action cannot be undone.")
-      }
-  }
-
-  @ViewBuilder
-  private var expandedTray: some View {
-    if isExpanded {
-      VStack(spacing: 0) {
-        expandedContent
-        Divider()
-      }
-      .frame(maxWidth: .infinity)
-      .background(Color.surfaceElevated)
-      .overlay(
-        Rectangle()
-          .frame(height: 1)
-          .foregroundColor(Color(NSColor.separatorColor)),
-        alignment: .top
-      )
-      .alignmentGuide(.top) { dimensions in
-        dimensions[VerticalAlignment.bottom]
-      }
-      .transition(.move(edge: .bottom).combined(with: .opacity))
-    }
-  }
-
-  private var expandedContent: some View {
     VStack(spacing: 0) {
-      ScrollView {
-        LazyVStack(spacing: 0) {
-          ForEach(commentsState.orderedComments) { comment in
-            DiffCommentRow(
-              comment: comment,
-              onSave: { newText in
-                commentsState.updateComment(id: comment.id, newText: newText)
-              },
-              onDelete: {
-                commentsState.removeComment(id: comment.id)
-              }
-            )
-            Divider()
+      // Collapsed header — always visible
+      headerView
+
+      // Expanded content — shown on tap
+      if isExpanded {
+        Divider()
+
+        // Comment list
+        ScrollView {
+          LazyVStack(spacing: 0) {
+            ForEach(commentsState.orderedComments) { comment in
+              DiffCommentRow(
+                comment: comment,
+                onSave: { newText in
+                  commentsState.updateComment(id: comment.id, newText: newText)
+                },
+                onDelete: {
+                  commentsState.removeComment(id: comment.id)
+                }
+              )
+              Divider()
+            }
           }
         }
-      }
-      .frame(maxHeight: 150)
+        .frame(maxHeight: 150)
 
-      toolbarView
+        toolbarView
+          .transition(.move(edge: .bottom).combined(with: .opacity))
+      }
+    }
+    .background(Color.surfaceElevated)
+    .overlay(
+      Rectangle()
+        .frame(height: 1)
+        .foregroundColor(Color(NSColor.separatorColor)),
+      alignment: .top
+    )
+    .animation(.easeInOut(duration: 0.2), value: isExpanded)
+    .confirmationDialog(
+      "Clear All Comments",
+      isPresented: $showClearConfirmation,
+      titleVisibility: .visible
+    ) {
+      Button("Clear All", role: .destructive) {
+        commentsState.clearAll()
+      }
+      Button("Cancel", role: .cancel) {}
+    } message: {
+      Text("This will remove all \(commentsState.commentCount) pending comments. This action cannot be undone.")
     }
   }
 
@@ -116,7 +97,7 @@ struct DiffCommentsPanelView: View {
         isExpanded.toggle()
       } label: {
         HStack(spacing: 8) {
-          Image(systemName: isExpanded ? "chevron.down" : "chevron.up")
+          Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
             .font(.caption2.weight(.semibold))
             .foregroundColor(.secondary)
             .frame(width: 10)

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/DiffCommentsPanelView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/DiffCommentsPanelView.swift
@@ -36,56 +36,75 @@ struct DiffCommentsPanelView: View {
   // MARK: - Body
 
   var body: some View {
-    VStack(spacing: 0) {
-      // Collapsed header — always visible
-      headerView
+    headerView
+      .background(Color.surfaceElevated)
+      .overlay(alignment: .top) {
+        expandedTray
+      }
+      .overlay(
+        Rectangle()
+          .frame(height: 1)
+          .foregroundColor(Color(NSColor.separatorColor)),
+        alignment: .top
+      )
+      .animation(.easeInOut(duration: 0.2), value: isExpanded)
+      .confirmationDialog(
+        "Clear All Comments",
+        isPresented: $showClearConfirmation,
+        titleVisibility: .visible
+      ) {
+        Button("Clear All", role: .destructive) {
+          commentsState.clearAll()
+        }
+        Button("Cancel", role: .cancel) {}
+      } message: {
+        Text("This will remove all \(commentsState.commentCount) pending comments. This action cannot be undone.")
+      }
+  }
 
-      // Expanded content — shown on tap
-      if isExpanded {
+  @ViewBuilder
+  private var expandedTray: some View {
+    if isExpanded {
+      VStack(spacing: 0) {
+        expandedContent
         Divider()
+      }
+      .frame(maxWidth: .infinity)
+      .background(Color.surfaceElevated)
+      .overlay(
+        Rectangle()
+          .frame(height: 1)
+          .foregroundColor(Color(NSColor.separatorColor)),
+        alignment: .top
+      )
+      .alignmentGuide(.top) { dimensions in
+        dimensions[VerticalAlignment.bottom]
+      }
+      .transition(.move(edge: .bottom).combined(with: .opacity))
+    }
+  }
 
-        // Comment list
-        ScrollView {
-          LazyVStack(spacing: 0) {
-            ForEach(commentsState.orderedComments) { comment in
-              DiffCommentRow(
-                comment: comment,
-                onSave: { newText in
-                  commentsState.updateComment(id: comment.id, newText: newText)
-                },
-                onDelete: {
-                  commentsState.removeComment(id: comment.id)
-                }
-              )
-              Divider()
-            }
+  private var expandedContent: some View {
+    VStack(spacing: 0) {
+      ScrollView {
+        LazyVStack(spacing: 0) {
+          ForEach(commentsState.orderedComments) { comment in
+            DiffCommentRow(
+              comment: comment,
+              onSave: { newText in
+                commentsState.updateComment(id: comment.id, newText: newText)
+              },
+              onDelete: {
+                commentsState.removeComment(id: comment.id)
+              }
+            )
+            Divider()
           }
         }
-        .frame(maxHeight: 150)
+      }
+      .frame(maxHeight: 150)
 
-        toolbarView
-          .transition(.move(edge: .bottom).combined(with: .opacity))
-      }
-    }
-    .background(Color.surfaceElevated)
-    .overlay(
-      Rectangle()
-        .frame(height: 1)
-        .foregroundColor(Color(NSColor.separatorColor)),
-      alignment: .top
-    )
-    .animation(.easeInOut(duration: 0.2), value: isExpanded)
-    .confirmationDialog(
-      "Clear All Comments",
-      isPresented: $showClearConfirmation,
-      titleVisibility: .visible
-    ) {
-      Button("Clear All", role: .destructive) {
-        commentsState.clearAll()
-      }
-      Button("Cancel", role: .cancel) {}
-    } message: {
-      Text("This will remove all \(commentsState.commentCount) pending comments. This action cannot be undone.")
+      toolbarView
     }
   }
 
@@ -97,7 +116,7 @@ struct DiffCommentsPanelView: View {
         isExpanded.toggle()
       } label: {
         HStack(spacing: 8) {
-          Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
+          Image(systemName: isExpanded ? "chevron.down" : "chevron.up")
             .font(.caption2.weight(.semibold))
             .foregroundColor(.secondary)
             .frame(width: 10)


### PR DESCRIPTION
## Summary
- Bumps PierreDiffsSwift to the 1.2.2 release.
- Updates the SwiftPM lockfiles to resolve the release revision.

## Validation
- swift package resolve
- xcodebuild -resolvePackageDependencies -project app/AgentHub.xcodeproj -scheme AgentHub
- xcodebuild -project app/AgentHub.xcodeproj -scheme AgentHub -configuration Debug -destination 'platform=macOS' -quiet build