### PR TITLE
Rebuild diff review comments tray as a floating, animated card

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/DiffCommentRow.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/DiffCommentRow.swift
@@ -7,14 +7,20 @@
 
 import SwiftUI
 
-/// A row displaying a single diff comment with inline edit/delete actions.
-/// Uses flat styling consistent with CLISessionRow.
+/// A single review comment inside the floating comments card.
+///
+/// Each row shows a colored side accent (additions/deletions), the line
+/// reference, a code-snippet preview, and the comment body. Edit and delete
+/// controls fade in on hover to keep the resting state clean.
 struct DiffCommentRow: View {
 
   // MARK: - Properties
 
   /// The diff comment to display in this row.
   let comment: DiffComment
+
+  /// Provider whose brand color is used for emphasis.
+  let providerKind: SessionProviderKind
 
   /// Called when the user saves an edited comment with new text.
   let onSave: (String) -> Void
@@ -26,78 +32,84 @@ struct DiffCommentRow: View {
   @State private var isEditing = false
   @State private var editText: String = ""
 
-  // MARK: - Body
+  init(
+    comment: DiffComment,
+    providerKind: SessionProviderKind = .claude,
+    onSave: @escaping (String) -> Void,
+    onDelete: @escaping () -> Void
+  ) {
+    self.comment = comment
+    self.providerKind = providerKind
+    self.onSave = onSave
+    self.onDelete = onDelete
+  }
 
-  var body: some View {
-    VStack(alignment: .leading, spacing: 4) {
-      // Location header
-      locationRow
+  // MARK: - Derived
 
-      // Line content (code preview)
-      Text(comment.lineContent)
-        .font(.system(.caption, design: .monospaced))
-        .foregroundColor(.secondary)
-        .lineLimit(comment.endLineNumber != nil ? 3 : 1)
-        .truncationMode(.middle)
-
-      // Comment text or edit field
-      if isEditing {
-        editingView
-          .transition(.opacity.combined(with: .scale(scale: 0.95, anchor: .top)))
-      } else {
-        Text(comment.text)
-          .font(.caption)
-          .foregroundColor(.primary.opacity(0.9))
-          .lineLimit(2)
-          .transition(.opacity)
-      }
-    }
-    .padding(.vertical, 8)
-    .padding(.horizontal, 10)
-    .contentShape(Rectangle())
-    .agentHubFlatRow(isHighlighted: isEditing)
-    .onHover { hovering in
-      isHovered = hovering
+  private var sideColor: Color {
+    switch comment.side {
+    case "left": return .red
+    case "right": return .green
+    default: return Color.brandPrimary(for: providerKind)
     }
   }
 
-  // MARK: - Editing View
+  private var sideLabel: String {
+    switch comment.side {
+    case "left": return "old"
+    case "right": return "new"
+    case "plan": return "plan"
+    default: return comment.side
+    }
+  }
 
-  private var editingView: some View {
-    VStack(alignment: .leading, spacing: 6) {
-      TextEditor(text: $editText)
-        .font(.callout)
-        .scrollContentBackground(.hidden)
-        .background(Color.primary.opacity(0.05))
-        .overlay(
-          RoundedRectangle(cornerRadius: 4)
-            .stroke(Color.primary.opacity(0.2), lineWidth: 1)
-        )
-        .clipShape(RoundedRectangle(cornerRadius: 4))
-        .frame(minHeight: 40, maxHeight: 80)
+  // MARK: - Body
 
-      HStack(spacing: 8) {
-        Spacer()
+  var body: some View {
+    HStack(alignment: .top, spacing: 10) {
+      // Side accent bar (green = additions, red = deletions)
+      RoundedRectangle(cornerRadius: 1.5, style: .continuous)
+        .fill(sideColor.opacity(0.9))
+        .frame(width: 3)
+        .frame(maxHeight: .infinity)
 
-        Button("Cancel") {
-          isEditing = false
-          editText = ""
+      VStack(alignment: .leading, spacing: 6) {
+        locationRow
+
+        // Line content (code preview)
+        Text(comment.lineContent)
+          .font(.system(size: 11, design: .monospaced))
+          .foregroundColor(.secondary)
+          .lineLimit(comment.endLineNumber != nil ? 3 : 1)
+          .truncationMode(.middle)
+          .frame(maxWidth: .infinity, alignment: .leading)
+          .padding(.horizontal, 8)
+          .padding(.vertical, 5)
+          .background(
+            RoundedRectangle(cornerRadius: 6, style: .continuous)
+              .fill(Color.primary.opacity(0.05))
+          )
+
+        // Comment text or edit field
+        if isEditing {
+          editingView
+            .transition(.opacity.combined(with: .scale(scale: 0.97, anchor: .top)))
+        } else {
+          Text(comment.text)
+            .font(.system(size: 12))
+            .foregroundColor(.primary.opacity(0.92))
+            .lineLimit(3)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .transition(.opacity)
         }
-        .buttonStyle(.plain)
-        .font(.caption)
-        .foregroundColor(.secondary)
-
-        Button("Save") {
-          onSave(editText)
-          isEditing = false
-          editText = ""
-        }
-        .buttonStyle(.plain)
-        .font(.caption.bold())
-        .foregroundColor(.brandPrimary)
-        .disabled(editText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
       }
-      .padding(.horizontal, 4)
+    }
+    .padding(.horizontal, 14)
+    .padding(.vertical, 10)
+    .contentShape(Rectangle())
+    .background(isEditing ? Color.primary.opacity(0.04) : Color.clear)
+    .onHover { hovering in
+      isHovered = hovering
     }
   }
 
@@ -105,60 +117,115 @@ struct DiffCommentRow: View {
 
   private var locationRow: some View {
     HStack(spacing: 6) {
-      // Comment indicator
-      Image(systemName: "text.bubble.fill")
-        .font(.caption2)
-        .foregroundColor(.primary)
-
       // Line number or range
       Text(comment.lineLabel)
-        .font(.system(.caption, design: .monospaced, weight: .semibold))
+        .font(.system(size: 11, weight: .semibold, design: .monospaced))
         .foregroundColor(.primary)
 
-      // Side indicator
-      Text("(\(comment.side == "left" ? "old" : "new"))")
-        .font(.caption2)
-        .foregroundColor(.secondary)
+      // Side indicator pill
+      Text(sideLabel)
+        .font(.system(size: 9, weight: .semibold))
+        .foregroundColor(sideColor)
+        .padding(.horizontal, 5)
+        .padding(.vertical, 1)
+        .background(
+          Capsule(style: .continuous)
+            .fill(sideColor.opacity(0.15))
+        )
 
-      Spacer()
+      Spacer(minLength: 0)
 
       // Action buttons (always rendered to prevent layout shift, opacity controlled by hover)
-      HStack(spacing: 6) {
-        Button {
+      HStack(spacing: 4) {
+        actionButton(
+          systemName: "pencil",
+          tint: .primary,
+          help: "Edit comment"
+        ) {
           editText = comment.text
           withAnimation(.easeOut(duration: 0.2)) {
             isEditing = true
           }
-        } label: {
-          Image(systemName: "pencil")
-            .font(.caption2)
-            .foregroundColor(.primary)
-            .frame(width: 24, height: 24)
-            .contentShape(Rectangle())
-            .background(
-              RoundedRectangle(cornerRadius: 6)
-                .stroke(Color.primary.opacity(0.3), lineWidth: 1)
-            )
         }
-        .buttonStyle(.plain)
-        .help("Edit comment")
 
-        Button(action: onDelete) {
-          Image(systemName: "trash")
-            .font(.caption2)
-            .foregroundColor(.red)
-            .frame(width: 24, height: 24)
-            .contentShape(Rectangle())
-            .background(
-              RoundedRectangle(cornerRadius: 6)
-                .stroke(Color.red.opacity(0.3), lineWidth: 1)
-            )
-        }
-        .buttonStyle(.plain)
-        .help("Delete comment")
+        actionButton(
+          systemName: "trash",
+          tint: .red,
+          help: "Delete comment",
+          action: onDelete
+        )
       }
       .opacity(isHovered && !isEditing ? 1 : 0)
       .animation(.easeInOut(duration: 0.15), value: isHovered)
+    }
+  }
+
+  private func actionButton(
+    systemName: String,
+    tint: Color,
+    help: String,
+    action: @escaping () -> Void
+  ) -> some View {
+    Button(action: action) {
+      Image(systemName: systemName)
+        .font(.system(size: 10, weight: .semibold))
+        .foregroundColor(tint)
+        .frame(width: 22, height: 22)
+        .background(
+          RoundedRectangle(cornerRadius: 6, style: .continuous)
+            .fill(tint.opacity(0.08))
+        )
+        .overlay(
+          RoundedRectangle(cornerRadius: 6, style: .continuous)
+            .stroke(tint.opacity(0.18), lineWidth: 1)
+        )
+        .contentShape(Rectangle())
+    }
+    .buttonStyle(.plain)
+    .help(help)
+  }
+
+  // MARK: - Editing View
+
+  private var editingView: some View {
+    VStack(alignment: .leading, spacing: 6) {
+      TextEditor(text: $editText)
+        .font(.system(size: 12))
+        .scrollContentBackground(.hidden)
+        .padding(4)
+        .background(Color.primary.opacity(0.05))
+        .overlay(
+          RoundedRectangle(cornerRadius: 6, style: .continuous)
+            .stroke(Color.primary.opacity(0.2), lineWidth: 1)
+        )
+        .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+        .frame(minHeight: 44, maxHeight: 90)
+
+      HStack(spacing: 10) {
+        Spacer()
+
+        Button("Cancel") {
+          withAnimation(.easeOut(duration: 0.2)) {
+            isEditing = false
+          }
+          editText = ""
+        }
+        .buttonStyle(.plain)
+        .font(.system(size: 11))
+        .foregroundColor(.secondary)
+
+        Button("Save") {
+          onSave(editText)
+          withAnimation(.easeOut(duration: 0.2)) {
+            isEditing = false
+          }
+          editText = ""
+        }
+        .buttonStyle(.plain)
+        .font(.system(size: 11, weight: .semibold))
+        .foregroundColor(Color.brandPrimary(for: providerKind))
+        .disabled(editText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+      }
     }
   }
 }
@@ -193,5 +260,6 @@ struct DiffCommentRow: View {
       onDelete: {}
     )
   }
-  .frame(width: 350)
+  .frame(width: 440)
+  .background(Color.surfaceElevated)
 }

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/DiffCommentsPanelView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/DiffCommentsPanelView.swift
@@ -7,8 +7,16 @@
 
 import SwiftUI
 
-/// A collapsible bottom toolbar showing the pending review comment count.
-/// Starts collapsed as a header; tapping expands to reveal clear and send actions.
+/// A floating, collapsible card that surfaces pending review comments over the diff.
+///
+/// It is a single morphing card: a persistent header bar (count + quick "Send"
+/// + a rotating chevron) that grows downward to reveal the comment list and a
+/// clear-all footer. Expansion animates the card's *height* (content is revealed
+/// by the growing rounded clip) rather than scaling, so text never distorts.
+///
+/// The card *floats* above the diff content (it is never inline), so it neither
+/// pushes the diff down nor collides with the surrounding "Create PR" bar —
+/// callers attach it via `.overlay(alignment: .bottomTrailing)`.
 struct DiffCommentsPanelView: View {
 
   // MARK: - Properties
@@ -20,6 +28,11 @@ struct DiffCommentsPanelView: View {
 
   @State private var isExpanded = false
   @State private var showClearConfirmation = false
+  @State private var isSendHovered = false
+
+  /// Spring used for the expand/collapse height morph and the chevron rotation.
+  private let morph = Animation.spring(response: 0.4, dampingFraction: 0.82)
+  private let cardRadius: CGFloat = 16
 
   init(
     commentsState: DiffCommentsState,
@@ -33,48 +46,38 @@ struct DiffCommentsPanelView: View {
     self.onSendToCloud = onSendToCloud
   }
 
+  // MARK: - Derived
+
+  private var accent: Color { Color.brandPrimary(for: providerKind) }
+  private var count: Int { commentsState.commentCount }
+  private var countText: String { "\(count)" }
+  private var commentsWord: String { count == 1 ? "Comment" : "Comments" }
+
   // MARK: - Body
 
   var body: some View {
     VStack(spacing: 0) {
-      // Collapsed header — always visible
-      headerView
+      headerBar
 
-      // Expanded content — shown on tap
       if isExpanded {
-        Divider()
-
-        // Comment list
-        ScrollView {
-          LazyVStack(spacing: 0) {
-            ForEach(commentsState.orderedComments) { comment in
-              DiffCommentRow(
-                comment: comment,
-                onSave: { newText in
-                  commentsState.updateComment(id: comment.id, newText: newText)
-                },
-                onDelete: {
-                  commentsState.removeComment(id: comment.id)
-                }
-              )
-              Divider()
-            }
-          }
-        }
-        .frame(maxHeight: 150)
-
-        toolbarView
-          .transition(.move(edge: .bottom).combined(with: .opacity))
+        hairline
+        commentList
+        hairline
+        footerBar
       }
     }
-    .background(Color.surfaceElevated)
+    .frame(maxWidth: 460)
+    .background(surfaceFill)
+    // Clip so the revealing list/footer are unmasked by the growing card edge.
+    .clipShape(RoundedRectangle(cornerRadius: cardRadius, style: .continuous))
     .overlay(
-      Rectangle()
-        .frame(height: 1)
-        .foregroundColor(Color(NSColor.separatorColor)),
-      alignment: .top
+      RoundedRectangle(cornerRadius: cardRadius, style: .continuous)
+        .strokeBorder(Color.primary.opacity(0.10), lineWidth: 1)
     )
-    .animation(.easeInOut(duration: 0.2), value: isExpanded)
+    .shadow(color: Color.black.opacity(0.22), radius: 18, x: 0, y: 8)
+    .animation(morph, value: isExpanded)
+    .padding(.trailing, 16)
+    .padding(.bottom, 14)
     .confirmationDialog(
       "Clear All Comments",
       isPresented: $showClearConfirmation,
@@ -85,112 +88,152 @@ struct DiffCommentsPanelView: View {
       }
       Button("Cancel", role: .cancel) {}
     } message: {
-      Text("This will remove all \(commentsState.commentCount) pending comments. This action cannot be undone.")
+      Text("This will remove all \(count) pending comments. This action cannot be undone.")
     }
   }
 
   // MARK: - Header
 
-  private var headerView: some View {
-    HStack(spacing: 8) {
+  private var headerBar: some View {
+    HStack(spacing: 10) {
       Button {
-        isExpanded.toggle()
+        toggleExpanded()
       } label: {
         HStack(spacing: 8) {
-          Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
-            .font(.caption2.weight(.semibold))
-            .foregroundColor(.secondary)
-            .frame(width: 10)
-
-          Image(systemName: "text.bubble.fill")
-            .font(.caption)
-            .foregroundColor(.secondary)
-
-          Text("\(commentsState.commentCount) Comment\(commentsState.commentCount == 1 ? "" : "s")")
-            .font(.caption.bold())
-            .foregroundColor(.primary)
-
-          Spacer(minLength: 0)
+          countBadge
+          Text("\(countText) \(commentsWord)")
+            .font(.system(size: 13, weight: .semibold))
+            .foregroundStyle(.primary)
+          Spacer(minLength: 8)
         }
-        .frame(maxWidth: .infinity, alignment: .leading)
         .contentShape(Rectangle())
       }
       .buttonStyle(.plain)
+      .help(isExpanded ? "Collapse comments" : "Show comments")
 
-      // Only shown while collapsed — when expanded, the bottom toolbar
-      // already exposes the same action.
-      if !isExpanded {
-        headerSendButton
+      sendButton
+
+      Button {
+        toggleExpanded()
+      } label: {
+        Image(systemName: "chevron.down")
+          .font(.system(size: 11, weight: .bold))
+          .foregroundStyle(.secondary)
+          // Points up when collapsed (expand upward), down when expanded.
+          .rotationEffect(.degrees(isExpanded ? 0 : 180))
+          .frame(width: 24, height: 24)
+          .contentShape(Rectangle())
+      }
+      .buttonStyle(.plain)
+      .help(isExpanded ? "Collapse" : "Expand")
+    }
+    .padding(.leading, 14)
+    .padding(.trailing, 10)
+    .padding(.vertical, 9)
+  }
+
+  // MARK: - List
+
+  private var commentList: some View {
+    ScrollView {
+      LazyVStack(spacing: 0) {
+        ForEach(commentsState.orderedComments) { comment in
+          DiffCommentRow(
+            comment: comment,
+            providerKind: providerKind,
+            onSave: { newText in
+              commentsState.updateComment(id: comment.id, newText: newText)
+            },
+            onDelete: {
+              withAnimation(.easeInOut(duration: 0.2)) {
+                commentsState.removeComment(id: comment.id)
+              }
+            }
+          )
+
+          if comment.id != commentsState.orderedComments.last?.id {
+            hairline
+              .padding(.leading, 14)
+          }
+        }
       }
     }
-    .padding(.horizontal, 12)
-    .padding(.vertical, 8)
+    .frame(maxHeight: 300)
   }
 
-  @ViewBuilder
-  private var headerSendButton: some View {
-    let button = Button(action: onSendToCloud) {
-      sendButtonLabel
-        .foregroundColor(.primary)
-        .padding(.horizontal, 10)
-        .padding(.vertical, 4)
-        .background(
-          RoundedRectangle(cornerRadius: 6)
-            .stroke(Color.primary.opacity(0.3), lineWidth: 1)
-        )
-        .contentShape(Rectangle())
-    }
-    .buttonStyle(.plain)
-    .help("Send all comments to \(providerKind.rawValue) (⌘ ↵)")
+  // MARK: - Footer
 
-    if isSendShortcutEnabled {
-      button.keyboardShortcut(.return, modifiers: .command)
-    } else {
-      button
-    }
-  }
-
-  // MARK: - Toolbar
-
-  private var toolbarView: some View {
-    HStack(spacing: 12) {
-      Spacer()
-
-      // Clear all button
+  private var footerBar: some View {
+    HStack(spacing: 10) {
       Button {
         showClearConfirmation = true
       } label: {
-        HStack(spacing: 4) {
+        HStack(spacing: 5) {
           Image(systemName: "trash")
-            .font(.caption)
-          Text("Clear")
-            .font(.caption)
+            .font(.system(size: 11))
+          Text("Clear all")
+            .font(.system(size: 12, weight: .medium))
         }
-        .foregroundColor(.secondary)
+        .foregroundStyle(.secondary)
+        .contentShape(Rectangle())
       }
       .buttonStyle(.plain)
       .help("Clear all comments")
 
-      sendToolbarButton
+      Spacer(minLength: 0)
+
+      Text("Click a line in the diff to add another")
+        .font(.system(size: 11))
+        .foregroundStyle(.tertiary)
+        .lineLimit(1)
+        .truncationMode(.tail)
     }
-    .padding(.horizontal, 12)
-    .padding(.bottom, 8)
+    .padding(.horizontal, 14)
+    .padding(.vertical, 10)
+  }
+
+  // MARK: - Shared Pieces
+
+  private var countBadge: some View {
+    Text(countText)
+      .font(.system(size: 11, weight: .bold, design: .rounded))
+      .foregroundStyle(.white)
+      .frame(minWidth: 18)
+      .padding(.horizontal, 5)
+      .padding(.vertical, 2)
+      .background(
+        Capsule(style: .continuous)
+          .fill(accent)
+      )
   }
 
   @ViewBuilder
-  private var sendToolbarButton: some View {
+  private var sendButton: some View {
     let button = Button(action: onSendToCloud) {
-      sendButtonLabel
-        .foregroundColor(.primary)
-        .padding(.horizontal, 12)
-        .padding(.vertical, 6)
-        .background(
-          RoundedRectangle(cornerRadius: 6)
-            .stroke(Color.primary.opacity(0.3), lineWidth: 1)
-        )
+      HStack(spacing: 6) {
+        Image(systemName: "paperplane.fill")
+          .font(.system(size: 11, weight: .semibold))
+
+        Text("Send \(countText) to \(providerKind.rawValue)")
+          .font(.system(size: 12, weight: .semibold))
+
+        Text("⌘↵")
+          .font(.system(size: 10, weight: .semibold, design: .monospaced))
+          .opacity(0.8)
+      }
+      .foregroundStyle(.white)
+      .padding(.horizontal, 12)
+      .padding(.vertical, 6)
+      .background(
+        RoundedRectangle(cornerRadius: 9, style: .continuous)
+          .fill(accent)
+          .brightness(isSendHovered ? 0.06 : 0)
+      )
+      .contentShape(RoundedRectangle(cornerRadius: 9, style: .continuous))
     }
     .buttonStyle(.plain)
-    .help("Send all comments to \(providerKind.rawValue) (⌘ ↵)")
+    .onHover { isSendHovered = $0 }
+    .help("Send all comments to \(providerKind.rawValue) (⌘↵)")
 
     if isSendShortcutEnabled {
       button.keyboardShortcut(.return, modifiers: .command)
@@ -199,17 +242,28 @@ struct DiffCommentsPanelView: View {
     }
   }
 
-  private var sendButtonLabel: some View {
-    HStack(spacing: 4) {
-      Image(systemName: "paperplane")
-        .font(.caption)
+  private var hairline: some View {
+    Rectangle()
+      .fill(Color.primary.opacity(0.08))
+      .frame(height: 1)
+  }
 
-      Text("Send \(commentsState.commentCount) to \(providerKind.rawValue)")
-        .font(.caption.bold())
+  private var surfaceFill: some View {
+    ZStack {
+      Color.surfaceElevated
+      LinearGradient(
+        colors: [Color.white.opacity(0.05), Color.clear],
+        startPoint: .top,
+        endPoint: .bottom
+      )
+    }
+  }
 
-      Text("⌘ ↵")
-        .font(.system(size: 11, weight: .semibold, design: .monospaced))
-        .foregroundColor(.secondary)
+  // MARK: - Actions
+
+  private func toggleExpanded() {
+    withAnimation(morph) {
+      isExpanded.toggle()
     }
   }
 }
@@ -221,8 +275,12 @@ struct DiffCommentsPanelView: View {
     @State var commentsState = DiffCommentsState()
 
     var body: some View {
-      VStack {
-        Spacer()
+      ZStack(alignment: .bottomTrailing) {
+        LinearGradient(
+          colors: [Color.gray.opacity(0.3), Color.black.opacity(0.5)],
+          startPoint: .topLeading,
+          endPoint: .bottomTrailing
+        )
 
         DiffCommentsPanelView(
           commentsState: commentsState,
@@ -230,7 +288,7 @@ struct DiffCommentsPanelView: View {
           onSendToCloud: {}
         )
       }
-      .frame(width: 800, height: 400)
+      .frame(width: 800, height: 460)
       .onAppear {
         commentsState.addComment(
           filePath: "/path/to/Example.swift",

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/GitDiffView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/GitDiffView.swift
@@ -104,21 +104,21 @@ public struct GitDiffView: View {
       } else if diffState.files.isEmpty {
         emptyState
       } else {
-        VStack(spacing: 0) {
-          HStack(spacing: 0) {
-            if showSidebar {
-              // File list sidebar
-              fileListSidebar
-                .frame(width: computedSidebarWidth)
-              Divider()
-            }
-
-            // Diff viewer
-            diffViewer
+        HStack(spacing: 0) {
+          if showSidebar {
+            // File list sidebar
+            fileListSidebar
+              .frame(width: computedSidebarWidth)
+            Divider()
           }
-          .animation(.easeInOut(duration: 0.25), value: showSidebar)
 
-          // Comments panel (shown when there are comments)
+          // Diff viewer
+          diffViewer
+        }
+        .animation(.easeInOut(duration: 0.25), value: showSidebar)
+        // Comments tray floats above the diff so it never pushes the diff down
+        // or collides with the "Create PR" bar that sits below this view.
+        .overlay(alignment: .bottomTrailing) {
           if commentsState.hasComments {
             DiffCommentsPanelView(
               commentsState: commentsState,
@@ -126,8 +126,10 @@ public struct GitDiffView: View {
               isSendShortcutEnabled: !inlineEditorState.isShowing,
               onSendToCloud: sendAllCommentsToCloud
             )
+            .transition(.move(edge: .bottom).combined(with: .opacity))
           }
         }
+        .animation(.spring(response: 0.34, dampingFraction: 0.85), value: commentsState.hasComments)
       }
     }
     .frame(

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/PlanView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/PlanView.swift
@@ -238,16 +238,16 @@ public struct PlanView: View {
 
   private func reviewContent(_ text: String) -> some View {
     let lines = text.components(separatedBy: "\n")
-    return VStack(spacing: 0) {
-      ScrollView {
-        LazyVStack(alignment: .leading, spacing: 0) {
-          ForEach(Array(lines.enumerated()), id: \.offset) { idx, line in
-            planLineRow(index: idx, line: line, planFilePath: planState.filePath)
-          }
+    return ScrollView {
+      LazyVStack(alignment: .leading, spacing: 0) {
+        ForEach(Array(lines.enumerated()), id: \.offset) { idx, line in
+          planLineRow(index: idx, line: line, planFilePath: planState.filePath)
         }
-        .padding(DesignTokens.Spacing.md)
       }
-
+      .padding(DesignTokens.Spacing.md)
+    }
+    // Comments tray floats above the review so it never pushes content down.
+    .overlay(alignment: .bottomTrailing) {
       if commentsState.hasComments {
         DiffCommentsPanelView(
           commentsState: commentsState,
@@ -255,8 +255,10 @@ public struct PlanView: View {
           isSendShortcutEnabled: activeLineIndex == nil,
           onSendToCloud: sendFeedbackToTerminal
         )
+        .transition(.move(edge: .bottom).combined(with: .opacity))
       }
     }
+    .animation(.spring(response: 0.34, dampingFraction: 0.85), value: commentsState.hasComments)
   }
 
   // MARK: - Plan Line Row


### PR DESCRIPTION
## Summary

Rebuilds the pending **review-comments tray** (the "N Comments / Send to Claude" panel) in the diff viewer from an inline bottom panel into a modern, floating, collapsible card overlaid on the diff content.

## Fixes

- **Overlap with "Create PR":** the expanded tray used to butt flush against the `ResourceLinksPanel` ("Create PR") bar that sits below the diff. The tray now floats with bottom/trailing margins, leaving a clear gap.
- **Content pushed down:** the tray lived in the same vertical stack as the diff, so it squeezed the diff every time comments appeared or the panel expanded. It's now an `.overlay` and no longer participates in layout — the diff keeps its full height.

## UX changes

- **Single morphing card** — a persistent header (count badge, quick **Send N to Claude ⌘↵**, rotating chevron) that grows downward to reveal the comment list and a clear-all footer.
- **Smooth expand/collapse** — animates the card *height* with a spring and a rounded clip-reveal, so content is unmasked by the growing edge instead of scaling/distorting. Chevron rotates with the same spring.
- **Modernized comment rows** — colored side accents (green = new / red = old), code-snippet chips, line-reference pills, and hover-revealed edit/delete controls.
- Quick-send is preserved in both collapsed and expanded states.

Applied at both call sites — `GitDiffView` and `PlanView` — via `.overlay(alignment: .bottomTrailing)`.

## Files
- `DiffCommentsPanelView.swift` — floating morphing card
- `DiffCommentRow.swift` — redesigned rows
- `GitDiffView.swift` — float tray as bottom-trailing overlay
- `PlanView.swift` — same overlay treatment for the review surface

## Testing
- `xcodebuild -workspace app/AgentHub.xcodeproj/project.xcworkspace -scheme AgentHub build` → **BUILD SUCCEEDED**