### PR TITLE
Polish sidebar: text-only open-with menu, thinner section dividers

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringCardView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringCardView.swift
@@ -1015,7 +1015,7 @@ private struct MonitoringCardPathRow: View {
           Button {
             target.open(path: session.projectPath)
           } label: {
-            Label(target.label, systemImage: target.systemImage)
+            Text(target.label)
           }
           .disabled(!target.isInstalled)
         }

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
@@ -2069,9 +2069,9 @@ private struct PendingModuleRow: View {
 
 private struct RepositoryModuleSectionDivider: View {
   var body: some View {
-    RoundedRectangle(cornerRadius: 1.5, style: .continuous)
+    RoundedRectangle(cornerRadius: 0.5, style: .continuous)
       .fill(Color.borderSubtle.opacity(0.9))
-      .frame(height: 3)
+      .frame(height: 1)
       .padding(.vertical, 8)
   }
 }

--- a/app/modules/AgentHubCore/Sources/AgentHub/Utils/ProjectPathOpenTarget.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Utils/ProjectPathOpenTarget.swift
@@ -31,18 +31,6 @@ enum ProjectPathOpenTarget: String, CaseIterable, Identifiable {
     }
   }
 
-  var systemImage: String {
-    switch self {
-    case .finder: return "face.smiling"
-    case .cursor: return "cursorarrow"
-    case .visualStudioCode: return "chevron.left.forwardslash.chevron.right"
-    case .sublimeText: return "textformat"
-    case .xcode: return "hammer"
-    case .ghostty: return "terminal.fill"
-    case .terminal: return "terminal"
-    }
-  }
-
   var bundleIdentifier: String {
     bundleIdentifiers[0]
   }


### PR DESCRIPTION
## Summary

Two small sidebar polish tweaks:

- **Text-only "Open with" menu** — Dropped the SF Symbol icons from the project path "Open with" menu so each option shows just the app name (Finder, Cursor, VS Code, Sublime Text, Xcode, Ghostty, Terminal). Removed the now-unused `systemImage` property from `ProjectPathOpenTarget`.
- **Thinner section dividers** — Reduced the repository section divider thickness from 3pt to 1pt (corner radius adjusted to match) for a lighter visual separation between project groups.

## Changes

- `ProjectPathOpenTarget.swift` — removed `systemImage`
- `MonitoringCardView.swift` — `Label(…, systemImage:)` → `Text(target.label)`
- `MultiProviderSessionsListView.swift` — `RepositoryModuleSectionDivider` height 3 → 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)