### PR TITLE
[codex] Add global session control panel

### DIFF
--- a/app/AgentHub/AgentHubApp.swift
+++ b/app/AgentHub/AgentHubApp.swift
@@ -37,6 +37,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
     provider.reconcileClaudeHooksOnLaunch()
     provider.cleanupOrphanedProcesses()
     provider.startWorktreeLaunchRequestMonitoring()
+    provider.globalSessionControlPanelCoordinator.start()
   }
 
   /// Register all bundled fonts (Geist, GeistMono, JetBrains Mono)
@@ -66,6 +67,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
 
   func applicationWillTerminate(_ notification: Notification) {
     provider.stopWorktreeLaunchRequestMonitoring()
+    provider.globalSessionControlPanelCoordinator.stop()
     // Terminate all active terminal processes on app quit
     provider.terminateAllTerminals()
     // Stop all dev servers spawned for web preview

--- a/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubDefaults.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubDefaults.swift
@@ -143,6 +143,14 @@ public enum AgentHubDefaults {
   /// Type: Int (default: 1 = small)
   public static let selectedSessionsPanelSizeMode = "\(keyPrefix)ui.selectedSessionsPanelSizeMode"
 
+  /// Whether the global session control panel hotkey is enabled
+  /// Type: Bool (default: false)
+  public static let globalSessionPanelEnabled = "\(keyPrefix)globalSessionPanel.enabled"
+
+  /// Last frame for the global session control panel
+  /// Type: String (NSStringFromRect, default: unset)
+  public static let globalSessionPanelFrame = "\(keyPrefix)globalSessionPanel.frame"
+
   // MARK: - Feature Flags
 
   /// Whether smart mode (AI-powered orchestration planning) is enabled

--- a/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubProvider.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubProvider.swift
@@ -246,6 +246,18 @@ public final class AgentHubProvider {
     GitHubPRObservationService(service: gitHubService)
   }()
 
+  // MARK: - Global Session Control Panel
+
+  /// Routes global-panel session selections into the main sessions UI.
+  public private(set) lazy var globalSessionSelectionRouter: GlobalSessionSelectionRouter = {
+    GlobalSessionSelectionRouter()
+  }()
+
+  /// Coordinates the opt-in global hotkey and floating sessions panel.
+  public private(set) lazy var globalSessionControlPanelCoordinator: GlobalSessionControlPanelCoordinator = {
+    GlobalSessionControlPanelCoordinator(provider: self)
+  }()
+
   // MARK: - Theme Management
 
   /// Theme manager for YAML and built-in themes

--- a/app/modules/AgentHubCore/Sources/AgentHub/Models/GlobalSessionControlPanelModels.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Models/GlobalSessionControlPanelModels.swift
@@ -1,0 +1,219 @@
+//
+//  GlobalSessionControlPanelModels.swift
+//  AgentHub
+//
+
+import AgentHubGitHub
+import Foundation
+
+// MARK: - GlobalSessionControlPanelGitHubState
+
+public struct GlobalSessionControlPanelGitHubState: Equatable, Sendable {
+  public let hasPullRequest: Bool
+  public let ciStatus: CIStatus
+  public let isRefreshing: Bool
+
+  public init(
+    hasPullRequest: Bool,
+    ciStatus: CIStatus,
+    isRefreshing: Bool = false
+  ) {
+    self.hasPullRequest = hasPullRequest
+    self.ciStatus = ciStatus
+    self.isRefreshing = isRefreshing
+  }
+}
+
+// MARK: - GlobalSessionControlPanelAttention
+
+public enum GlobalSessionControlPanelAttention: Int, Equatable, Sendable {
+  case awaitingApproval = 0
+  case ciFailure = 1
+  case working = 2
+  case pending = 3
+  case ready = 4
+  case idle = 5
+}
+
+// MARK: - GlobalSessionControlPanelItem
+
+public struct GlobalSessionControlPanelItem: Identifiable, Equatable, Sendable {
+  public let id: String
+  public let session: CLISession
+  public let providerKind: SessionProviderKind
+  public let timestamp: Date
+  public let isPending: Bool
+  public let status: SessionStatus?
+  public let linkedPullRequestNumber: Int?
+  public let customName: String?
+  public let gitHubState: GlobalSessionControlPanelGitHubState?
+
+  public init(
+    id: String,
+    session: CLISession,
+    providerKind: SessionProviderKind,
+    timestamp: Date,
+    isPending: Bool,
+    status: SessionStatus?,
+    linkedPullRequestNumber: Int?,
+    customName: String?,
+    gitHubState: GlobalSessionControlPanelGitHubState? = nil
+  ) {
+    self.id = id
+    self.session = session
+    self.providerKind = providerKind
+    self.timestamp = timestamp
+    self.isPending = isPending
+    self.status = status
+    self.linkedPullRequestNumber = linkedPullRequestNumber
+    self.customName = customName
+    self.gitHubState = gitHubState
+  }
+
+  public var displayName: String {
+    customName ?? session.displayName
+  }
+
+  public var attention: GlobalSessionControlPanelAttention {
+    if let status {
+      switch status {
+      case .awaitingApproval:
+        return .awaitingApproval
+      case .thinking, .executingTool:
+        return .working
+      case .waitingForUser:
+        if gitHubState?.ciStatus == .failure { return .ciFailure }
+        if gitHubState?.ciStatus == .pending { return .pending }
+        return .ready
+      case .idle:
+        break
+      }
+    }
+
+    if gitHubState?.ciStatus == .failure { return .ciFailure }
+    if isPending || gitHubState?.ciStatus == .pending { return .pending }
+    return .idle
+  }
+}
+
+// MARK: - GlobalSessionControlPanelSnapshotBuilder
+
+public enum GlobalSessionControlPanelSnapshotBuilder {
+  public static func makeItems(
+    claudePending: [PendingHubSession],
+    codexPending: [PendingHubSession],
+    claudeMonitored: [(session: CLISession, state: SessionMonitorState?)],
+    codexMonitored: [(session: CLISession, state: SessionMonitorState?)],
+    claudeCustomNames: [String: String],
+    codexCustomNames: [String: String],
+    gitHubStates: [String: GlobalSessionControlPanelGitHubState]
+  ) -> [GlobalSessionControlPanelItem] {
+    var items: [GlobalSessionControlPanelItem] = []
+
+    for pending in claudePending {
+      items.append(pendingItem(
+        pending,
+        providerKind: .claude,
+        gitHubStates: gitHubStates
+      ))
+    }
+
+    for pending in codexPending {
+      items.append(pendingItem(
+        pending,
+        providerKind: .codex,
+        gitHubStates: gitHubStates
+      ))
+    }
+
+    for item in claudeMonitored {
+      items.append(monitoredItem(
+        session: item.session,
+        state: item.state,
+        providerKind: .claude,
+        customName: claudeCustomNames[item.session.id],
+        gitHubStates: gitHubStates
+      ))
+    }
+
+    for item in codexMonitored {
+      items.append(monitoredItem(
+        session: item.session,
+        state: item.state,
+        providerKind: .codex,
+        customName: codexCustomNames[item.session.id],
+        gitHubStates: gitHubStates
+      ))
+    }
+
+    return sorted(items)
+  }
+
+  public static func sorted(_ items: [GlobalSessionControlPanelItem]) -> [GlobalSessionControlPanelItem] {
+    items.sorted { lhs, rhs in
+      if lhs.attention != rhs.attention {
+        return lhs.attention.rawValue < rhs.attention.rawValue
+      }
+      if lhs.timestamp != rhs.timestamp {
+        return lhs.timestamp > rhs.timestamp
+      }
+      if lhs.providerKind != rhs.providerKind {
+        return lhs.providerKind.rawValue < rhs.providerKind.rawValue
+      }
+      return lhs.displayName.localizedCaseInsensitiveCompare(rhs.displayName) == .orderedAscending
+    }
+  }
+
+  public static func itemId(providerKind: SessionProviderKind, sessionId: String) -> String {
+    GlobalSessionSelectionRequest.itemId(providerKind: providerKind, sessionId: sessionId)
+  }
+
+  public static func pendingItemId(providerKind: SessionProviderKind, pendingId: UUID) -> String {
+    "pending-\(providerKind.rawValue.lowercased())-\(pendingId.uuidString)"
+  }
+
+  private static func pendingItem(
+    _ pending: PendingHubSession,
+    providerKind: SessionProviderKind,
+    gitHubStates: [String: GlobalSessionControlPanelGitHubState]
+  ) -> GlobalSessionControlPanelItem {
+    let session = pending.placeholderSession
+    let id = pendingItemId(providerKind: providerKind, pendingId: pending.id)
+    return GlobalSessionControlPanelItem(
+      id: id,
+      session: session,
+      providerKind: providerKind,
+      timestamp: pending.startedAt,
+      isPending: true,
+      status: nil,
+      linkedPullRequestNumber: nil,
+      customName: nil,
+      gitHubState: gitHubStates[id]
+    )
+  }
+
+  private static func monitoredItem(
+    session: CLISession,
+    state: SessionMonitorState?,
+    providerKind: SessionProviderKind,
+    customName: String?,
+    gitHubStates: [String: GlobalSessionControlPanelGitHubState]
+  ) -> GlobalSessionControlPanelItem {
+    let id = itemId(providerKind: providerKind, sessionId: session.id)
+    return GlobalSessionControlPanelItem(
+      id: id,
+      session: session,
+      providerKind: providerKind,
+      timestamp: session.lastActivityAt,
+      isPending: false,
+      status: state?.status,
+      linkedPullRequestNumber: latestPullRequestNumber(in: state?.detectedResourceLinks ?? []),
+      customName: customName,
+      gitHubState: gitHubStates[id]
+    )
+  }
+
+  private static func latestPullRequestNumber(in links: [ResourceLink]) -> Int? {
+    GitHubPullRequestURLReference.latestNumber(in: links.map(\.url))
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/Models/GlobalSessionSelectionRouter.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Models/GlobalSessionSelectionRouter.swift
@@ -1,0 +1,63 @@
+//
+//  GlobalSessionSelectionRouter.swift
+//  AgentHub
+//
+
+import Foundation
+
+// MARK: - GlobalSessionSelectionRequest
+
+public struct GlobalSessionSelectionRequest: Identifiable, Equatable, Sendable {
+  public let id: UUID
+  public let providerKind: SessionProviderKind
+  public let sessionId: String
+  public let itemId: String
+  public let projectPath: String
+
+  public init(
+    id: UUID = UUID(),
+    providerKind: SessionProviderKind,
+    sessionId: String,
+    projectPath: String,
+    itemId: String? = nil
+  ) {
+    self.id = id
+    self.providerKind = providerKind
+    self.sessionId = sessionId
+    self.itemId = itemId ?? Self.itemId(providerKind: providerKind, sessionId: sessionId)
+    self.projectPath = projectPath
+  }
+
+  public static func itemId(providerKind: SessionProviderKind, sessionId: String) -> String {
+    "\(providerKind.rawValue.lowercased())-\(sessionId)"
+  }
+}
+
+// MARK: - GlobalSessionSelectionRouter
+
+@MainActor
+@Observable
+public final class GlobalSessionSelectionRouter {
+  public private(set) var selectionRequest: GlobalSessionSelectionRequest?
+
+  public init() {}
+
+  public func select(
+    providerKind: SessionProviderKind,
+    sessionId: String,
+    projectPath: String,
+    itemId: String? = nil
+  ) {
+    selectionRequest = GlobalSessionSelectionRequest(
+      providerKind: providerKind,
+      sessionId: sessionId,
+      projectPath: projectPath,
+      itemId: itemId
+    )
+  }
+
+  public func markConsumed(_ request: GlobalSessionSelectionRequest) {
+    guard selectionRequest?.id == request.id else { return }
+    selectionRequest = nil
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/AppKitGlobalSessionControlPanelPresenter.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/AppKitGlobalSessionControlPanelPresenter.swift
@@ -1,0 +1,195 @@
+//
+//  AppKitGlobalSessionControlPanelPresenter.swift
+//  AgentHub
+//
+
+import SwiftUI
+
+#if canImport(AppKit)
+import AppKit
+#endif
+
+#if canImport(AppKit)
+
+// MARK: - GlobalSessionPanelWindow
+
+private final class GlobalSessionPanelWindow: NSPanel {
+  override var canBecomeKey: Bool { true }
+  override var canBecomeMain: Bool { false }
+}
+
+// MARK: - GlobalSessionPanelWindowDelegate
+
+private final class GlobalSessionPanelWindowDelegate: NSObject, NSWindowDelegate {
+  var onMove: ((NSRect) -> Void)?
+  var onClose: (() -> Void)?
+
+  func windowDidMove(_ notification: Notification) {
+    guard let window = notification.object as? NSWindow else { return }
+    onMove?(window.frame)
+  }
+
+  func windowWillClose(_ notification: Notification) {
+    onClose?()
+  }
+}
+
+#endif
+
+// MARK: - AppKitGlobalSessionControlPanelPresenter
+
+@MainActor
+public final class AppKitGlobalSessionControlPanelPresenter: GlobalSessionControlPanelPresenting {
+  public var isVisible: Bool {
+    #if canImport(AppKit)
+    panel?.isVisible == true
+    #else
+    false
+    #endif
+  }
+
+  private weak var provider: AgentHubProvider?
+  private let defaults: UserDefaults
+
+  #if canImport(AppKit)
+  private var panel: GlobalSessionPanelWindow?
+  private var windowDelegate: GlobalSessionPanelWindowDelegate?
+  private let panelSize = CGSize(width: 560, height: 420)
+  #endif
+
+  public init(
+    provider: AgentHubProvider,
+    defaults: UserDefaults = .standard
+  ) {
+    self.provider = provider
+    self.defaults = defaults
+  }
+
+  public func show() {
+    #if canImport(AppKit)
+    guard let provider else { return }
+
+    if let panel {
+      panel.orderFrontRegardless()
+      return
+    }
+
+    let content = GlobalSessionControlPanelView(
+      claudeViewModel: provider.claudeSessionsViewModel,
+      codexViewModel: provider.codexSessionsViewModel,
+      selectionRouter: provider.globalSessionSelectionRouter,
+      onClose: { [weak self] in self?.hide() },
+      onSelectSession: { [weak self] in self?.activateMainWindow() }
+    )
+    .agentHub(provider)
+    .frame(width: panelSize.width, height: panelSize.height)
+
+    let hostingView = NSHostingView(rootView: content)
+    hostingView.sizingOptions = []
+    hostingView.frame = NSRect(origin: .zero, size: panelSize)
+    hostingView.autoresizingMask = [.width, .height]
+
+    let newPanel = GlobalSessionPanelWindow(
+      contentRect: restoredOrDefaultFrame(size: panelSize),
+      styleMask: [.borderless, .nonactivatingPanel, .fullSizeContentView],
+      backing: .buffered,
+      defer: false
+    )
+    newPanel.isReleasedWhenClosed = false
+    newPanel.hidesOnDeactivate = false
+    newPanel.isMovableByWindowBackground = true
+    newPanel.level = .statusBar
+    newPanel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+    newPanel.backgroundColor = .clear
+    newPanel.isOpaque = false
+    newPanel.hasShadow = true
+    newPanel.contentMinSize = panelSize
+    newPanel.contentMaxSize = panelSize
+    newPanel.contentView = hostingView
+
+    let delegate = GlobalSessionPanelWindowDelegate()
+    delegate.onMove = { [weak self] frame in
+      self?.persist(frame: frame)
+    }
+    delegate.onClose = { [weak self, weak newPanel] in
+      newPanel?.delegate = nil
+      self?.panel = nil
+      self?.windowDelegate = nil
+    }
+    newPanel.delegate = delegate
+
+    panel = newPanel
+    windowDelegate = delegate
+    newPanel.orderFrontRegardless()
+    #endif
+  }
+
+  public func hide() {
+    #if canImport(AppKit)
+    guard let panel else { return }
+    panel.delegate = nil
+    self.panel = nil
+    windowDelegate = nil
+    panel.close()
+    #endif
+  }
+
+  #if canImport(AppKit)
+  private func activateMainWindow() {
+    NSApp.activate(ignoringOtherApps: true)
+
+    let mainWindow = NSApp.windows.first { window in
+      window !== panel
+        && window.isVisible
+        && !(window is NSPanel)
+    } ?? NSApp.windows.first { window in
+      window !== panel
+        && !(window is NSPanel)
+    }
+    mainWindow?.makeKeyAndOrderFront(nil)
+  }
+
+  private func persist(frame: NSRect) {
+    defaults.set(NSStringFromRect(frame), forKey: AgentHubDefaults.globalSessionPanelFrame)
+  }
+
+  private func restoredOrDefaultFrame(size: CGSize) -> NSRect {
+    if let stored = defaults.string(forKey: AgentHubDefaults.globalSessionPanelFrame) {
+      let frame = NSRectFromString(stored)
+      if !frame.isEmpty {
+        return clamped(frame: frame, size: size)
+      }
+    }
+
+    let visible = activeVisibleFrame()
+    let origin = CGPoint(
+      x: visible.midX - size.width / 2,
+      y: visible.maxY - size.height - 12
+    )
+    return clamped(frame: NSRect(origin: origin, size: size), size: size)
+  }
+
+  private func clamped(frame: NSRect, size: CGSize) -> NSRect {
+    let visible = NSScreen.screens
+      .first { $0.visibleFrame.intersects(frame) }?
+      .visibleFrame ?? activeVisibleFrame()
+    let width = min(size.width, visible.width)
+    let height = min(size.height, visible.height)
+    let x = min(max(frame.origin.x, visible.minX), visible.maxX - width)
+    let y = min(max(frame.origin.y, visible.minY), visible.maxY - height)
+    return NSRect(x: x, y: y, width: width, height: height)
+  }
+
+  private func activeVisibleFrame() -> NSRect {
+    let mouseLocation = NSEvent.mouseLocation
+    if let screen = NSScreen.screens.first(where: { screen in
+      NSMouseInRect(mouseLocation, screen.frame, false)
+    }) {
+      return screen.visibleFrame
+    }
+    return NSScreen.main?.visibleFrame
+      ?? NSScreen.screens.first?.visibleFrame
+      ?? NSRect(x: 0, y: 0, width: 1024, height: 768)
+  }
+  #endif
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/GlobalHotKeyRegistrar.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/GlobalHotKeyRegistrar.swift
@@ -1,0 +1,175 @@
+//
+//  GlobalHotKeyRegistrar.swift
+//  AgentHub
+//
+
+import Foundation
+
+#if canImport(Carbon)
+import Carbon
+#endif
+
+// MARK: - GlobalHotKey
+
+public struct GlobalHotKey: Equatable, Sendable {
+  public let keyCode: UInt32
+  public let modifiers: UInt32
+  public let displayString: String
+
+  public init(keyCode: UInt32, modifiers: UInt32, displayString: String) {
+    self.keyCode = keyCode
+    self.modifiers = modifiers
+    self.displayString = displayString
+  }
+
+  public static var sessionControlPanelDefault: GlobalHotKey {
+    #if canImport(Carbon)
+    GlobalHotKey(
+      keyCode: UInt32(kVK_ANSI_P),
+      modifiers: UInt32(cmdKey | optionKey),
+      displayString: "⌘⌥P"
+    )
+    #else
+    GlobalHotKey(keyCode: 0, modifiers: 0, displayString: "⌘⌥P")
+    #endif
+  }
+}
+
+// MARK: - GlobalHotKeyRegistrationError
+
+public enum GlobalHotKeyRegistrationError: Error, Equatable, LocalizedError {
+  case carbonUnavailable
+  case installHandlerFailed(status: Int32)
+  case registerFailed(status: Int32)
+
+  public var errorDescription: String? {
+    switch self {
+    case .carbonUnavailable:
+      return "Global hotkeys are unavailable on this platform."
+    case .installHandlerFailed(let status):
+      return "Could not install the global hotkey handler (status \(status))."
+    case .registerFailed(let status):
+      return "Could not register the global hotkey (status \(status))."
+    }
+  }
+}
+
+// MARK: - GlobalHotKeyRegistrarProtocol
+
+@MainActor
+public protocol GlobalHotKeyRegistrarProtocol: AnyObject {
+  var onHotKeyPressed: (@MainActor @Sendable () -> Void)? { get set }
+  var isRegistered: Bool { get }
+
+  func register(hotKey: GlobalHotKey) throws
+  func unregister()
+}
+
+// MARK: - CarbonGlobalHotKeyRegistrar
+
+@MainActor
+public final class CarbonGlobalHotKeyRegistrar: GlobalHotKeyRegistrarProtocol {
+  public var onHotKeyPressed: (@MainActor @Sendable () -> Void)?
+
+  public var isRegistered: Bool {
+    #if canImport(Carbon)
+    hotKeyRef != nil
+    #else
+    false
+    #endif
+  }
+
+  #if canImport(Carbon)
+  private var hotKeyRef: EventHotKeyRef?
+  private var eventHandlerRef: EventHandlerRef?
+  private let hotKeyID = EventHotKeyID(
+    signature: CarbonGlobalHotKeyRegistrar.fourCharCode("AHGP"),
+    id: 1
+  )
+  #endif
+
+  public init() {}
+
+  deinit {
+    #if canImport(Carbon)
+    if let hotKeyRef {
+      UnregisterEventHotKey(hotKeyRef)
+    }
+    if let eventHandlerRef {
+      RemoveEventHandler(eventHandlerRef)
+    }
+    #endif
+  }
+
+  public func register(hotKey: GlobalHotKey) throws {
+    #if canImport(Carbon)
+    unregister()
+    try installHandlerIfNeeded()
+
+    var ref: EventHotKeyRef?
+    let status = RegisterEventHotKey(
+      hotKey.keyCode,
+      hotKey.modifiers,
+      hotKeyID,
+      GetApplicationEventTarget(),
+      0,
+      &ref
+    )
+    guard status == noErr, let ref else {
+      throw GlobalHotKeyRegistrationError.registerFailed(status: Int32(status))
+    }
+    hotKeyRef = ref
+    #else
+    throw GlobalHotKeyRegistrationError.carbonUnavailable
+    #endif
+  }
+
+  public func unregister() {
+    #if canImport(Carbon)
+    if let hotKeyRef {
+      UnregisterEventHotKey(hotKeyRef)
+      self.hotKeyRef = nil
+    }
+    #endif
+  }
+
+  #if canImport(Carbon)
+  private func installHandlerIfNeeded() throws {
+    guard eventHandlerRef == nil else { return }
+
+    var eventType = EventTypeSpec(
+      eventClass: OSType(kEventClassKeyboard),
+      eventKind: UInt32(kEventHotKeyPressed)
+    )
+    var handlerRef: EventHandlerRef?
+    let status = InstallEventHandler(
+      GetApplicationEventTarget(),
+      { _, _, userData in
+        guard let userData else { return noErr }
+        let registrar = Unmanaged<CarbonGlobalHotKeyRegistrar>
+          .fromOpaque(userData)
+          .takeUnretainedValue()
+        Task { @MainActor in
+          registrar.onHotKeyPressed?()
+        }
+        return noErr
+      },
+      1,
+      &eventType,
+      Unmanaged.passUnretained(self).toOpaque(),
+      &handlerRef
+    )
+
+    guard status == noErr, let handlerRef else {
+      throw GlobalHotKeyRegistrationError.installHandlerFailed(status: Int32(status))
+    }
+    eventHandlerRef = handlerRef
+  }
+
+  private static func fourCharCode(_ value: String) -> OSType {
+    value.utf8.reduce(0) { result, character in
+      (result << 8) + OSType(character)
+    }
+  }
+  #endif
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/GlobalSessionControlPanelCoordinator.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/GlobalSessionControlPanelCoordinator.swift
@@ -1,0 +1,108 @@
+//
+//  GlobalSessionControlPanelCoordinator.swift
+//  AgentHub
+//
+
+import Foundation
+
+// MARK: - GlobalSessionControlPanelPresenting
+
+@MainActor
+public protocol GlobalSessionControlPanelPresenting: AnyObject {
+  var isVisible: Bool { get }
+
+  func show()
+  func hide()
+}
+
+public extension GlobalSessionControlPanelPresenting {
+  func toggle() {
+    isVisible ? hide() : show()
+  }
+}
+
+// MARK: - GlobalSessionControlPanelCoordinator
+
+@MainActor
+@Observable
+public final class GlobalSessionControlPanelCoordinator {
+  public private(set) var registrationErrorMessage: String?
+
+  private let registrar: any GlobalHotKeyRegistrarProtocol
+  private let presenter: any GlobalSessionControlPanelPresenting
+  private let defaults: UserDefaults
+  private let hotKey: GlobalHotKey
+  private var isStarted = false
+
+  public var isPanelVisible: Bool {
+    presenter.isVisible
+  }
+
+  public init(
+    registrar: any GlobalHotKeyRegistrarProtocol,
+    presenter: any GlobalSessionControlPanelPresenting,
+    defaults: UserDefaults = .standard,
+    hotKey: GlobalHotKey = .sessionControlPanelDefault
+  ) {
+    self.registrar = registrar
+    self.presenter = presenter
+    self.defaults = defaults
+    self.hotKey = hotKey
+  }
+
+  public convenience init(
+    provider: AgentHubProvider,
+    defaults: UserDefaults = .standard
+  ) {
+    self.init(
+      registrar: CarbonGlobalHotKeyRegistrar(),
+      presenter: AppKitGlobalSessionControlPanelPresenter(provider: provider, defaults: defaults),
+      defaults: defaults
+    )
+  }
+
+  public func start() {
+    guard !isStarted else {
+      syncHotKeyRegistration()
+      return
+    }
+    isStarted = true
+    registrar.onHotKeyPressed = { [weak self] in
+      self?.togglePanel()
+    }
+    syncHotKeyRegistration()
+  }
+
+  public func stop() {
+    registrar.unregister()
+    registrar.onHotKeyPressed = nil
+    presenter.hide()
+    isStarted = false
+    registrationErrorMessage = nil
+  }
+
+  public func setEnabled(_ enabled: Bool) {
+    defaults.set(enabled, forKey: AgentHubDefaults.globalSessionPanelEnabled)
+    syncHotKeyRegistration()
+  }
+
+  public func syncHotKeyRegistration() {
+    guard defaults.bool(forKey: AgentHubDefaults.globalSessionPanelEnabled) else {
+      registrar.unregister()
+      registrationErrorMessage = nil
+      return
+    }
+
+    do {
+      try registrar.register(hotKey: hotKey)
+      registrationErrorMessage = nil
+    } catch {
+      registrar.unregister()
+      registrationErrorMessage = error.localizedDescription
+    }
+  }
+
+  public func togglePanel() {
+    presenter.toggle()
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/GlobalSessionControlPanelView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/GlobalSessionControlPanelView.swift
@@ -1,0 +1,443 @@
+//
+//  GlobalSessionControlPanelView.swift
+//  AgentHub
+//
+
+import AgentHubGitHub
+import SwiftUI
+
+// MARK: - GlobalSessionControlPanelView
+
+public struct GlobalSessionControlPanelView: View {
+  @Bindable var claudeViewModel: CLISessionsViewModel
+  @Bindable var codexViewModel: CLISessionsViewModel
+
+  let selectionRouter: GlobalSessionSelectionRouter
+  let onClose: () -> Void
+  let onSelectSession: () -> Void
+
+  @State private var gitHubStates: [String: GlobalSessionControlPanelGitHubState] = [:]
+  @Environment(\.colorScheme) private var colorScheme
+  @Environment(\.runtimeTheme) private var runtimeTheme
+
+  public init(
+    claudeViewModel: CLISessionsViewModel,
+    codexViewModel: CLISessionsViewModel,
+    selectionRouter: GlobalSessionSelectionRouter,
+    onClose: @escaping () -> Void = {},
+    onSelectSession: @escaping () -> Void = {}
+  ) {
+    self.claudeViewModel = claudeViewModel
+    self.codexViewModel = codexViewModel
+    self.selectionRouter = selectionRouter
+    self.onClose = onClose
+    self.onSelectSession = onSelectSession
+  }
+
+  public var body: some View {
+    VStack(spacing: 0) {
+      header
+
+      Divider()
+        .opacity(0.5)
+
+      if items.isEmpty {
+        emptyState
+      } else {
+        ScrollView(showsIndicators: true) {
+          LazyVStack(spacing: 4) {
+            ForEach(items) { item in
+              GlobalSessionControlPanelRow(
+                item: item,
+                onSelect: {
+                  selectionRouter.select(
+                    providerKind: item.providerKind,
+                    sessionId: item.session.id,
+                    projectPath: item.session.projectPath,
+                    itemId: item.id
+                  )
+                  onSelectSession()
+                },
+                onGitHubStateChange: { state in
+                  updateGitHubState(state, for: item.id)
+                }
+              )
+            }
+          }
+          .padding(.horizontal, 8)
+          .padding(.vertical, 8)
+        }
+      }
+    }
+    .background(panelBackground)
+    .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+    .overlay(
+      RoundedRectangle(cornerRadius: 14, style: .continuous)
+        .stroke(Color.secondary.opacity(colorScheme == .dark ? 0.22 : 0.16), lineWidth: 1)
+    )
+    .shadow(color: .black.opacity(colorScheme == .dark ? 0.35 : 0.16), radius: 18, y: 10)
+  }
+
+  private var items: [GlobalSessionControlPanelItem] {
+    GlobalSessionControlPanelSnapshotBuilder.makeItems(
+      claudePending: claudeViewModel.pendingHubSessions,
+      codexPending: codexViewModel.pendingHubSessions,
+      claudeMonitored: claudeViewModel.monitoredSessions,
+      codexMonitored: codexViewModel.monitoredSessions,
+      claudeCustomNames: claudeViewModel.sessionCustomNames,
+      codexCustomNames: codexViewModel.sessionCustomNames,
+      gitHubStates: gitHubStates
+    )
+  }
+
+  private var panelBackground: some View {
+    Group {
+      if runtimeTheme?.hasCustomBackgrounds == true {
+        Color.adaptiveBackground(for: colorScheme, theme: runtimeTheme)
+          .opacity(colorScheme == .dark ? 0.96 : 0.98)
+      } else {
+        Color(colorScheme == .dark ? NSColor.windowBackgroundColor : NSColor.controlBackgroundColor)
+          .opacity(0.98)
+      }
+    }
+  }
+
+  private var header: some View {
+    HStack(spacing: 10) {
+      Image(systemName: "rectangle.stack")
+        .font(.system(size: 13, weight: .semibold))
+        .foregroundStyle(Color.brandPrimary(from: runtimeTheme))
+        .frame(width: 18, height: 18)
+
+      VStack(alignment: .leading, spacing: 1) {
+        Text("Sessions")
+          .font(.heading)
+          .foregroundStyle(.primary)
+
+        Text("\(items.count) monitored")
+          .font(.secondaryCaption)
+          .foregroundStyle(.secondary)
+      }
+
+      Spacer()
+
+      Text(GlobalHotKey.sessionControlPanelDefault.displayString)
+        .font(.primaryCaption)
+        .foregroundStyle(.secondary)
+        .padding(.horizontal, 6)
+        .padding(.vertical, 3)
+        .background(Color.secondary.opacity(0.12))
+        .clipShape(RoundedRectangle(cornerRadius: 4, style: .continuous))
+
+      Button(action: onClose) {
+        Image(systemName: "xmark")
+          .font(.system(size: 11, weight: .bold))
+          .foregroundStyle(.secondary)
+          .frame(width: 22, height: 22)
+      }
+      .buttonStyle(.plain)
+      .help("Close")
+    }
+    .padding(.horizontal, 12)
+    .padding(.vertical, 10)
+    .contentShape(Rectangle())
+  }
+
+  private var emptyState: some View {
+    VStack(spacing: 10) {
+      Image(systemName: "terminal")
+        .font(.system(size: 30, weight: .regular))
+        .foregroundStyle(.secondary)
+
+      Text("No monitored sessions")
+        .font(.secondaryLarge)
+        .foregroundStyle(.primary)
+
+      Text("Start or select sessions in AgentHub to show them here.")
+        .font(.secondarySmall)
+        .foregroundStyle(.secondary)
+        .multilineTextAlignment(.center)
+        .frame(maxWidth: 260)
+    }
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+    .padding()
+  }
+
+  private func updateGitHubState(_ state: GlobalSessionControlPanelGitHubState?, for itemID: String) {
+    if let state {
+      gitHubStates[itemID] = state
+    } else {
+      gitHubStates.removeValue(forKey: itemID)
+    }
+  }
+}
+
+// MARK: - GlobalSessionControlPanelRow
+
+private struct GlobalSessionControlPanelRow: View {
+  let item: GlobalSessionControlPanelItem
+  let onSelect: () -> Void
+  let onGitHubStateChange: (GlobalSessionControlPanelGitHubState?) -> Void
+
+  @State private var isHovered = false
+  @State private var gitHubViewModel = SessionGitHubQuickAccessViewModel()
+  @Environment(\.agentHub) private var agentHub
+  @Environment(\.colorScheme) private var colorScheme
+
+  private var gitHubObservationTaskID: String {
+    let repositoryKey = SessionGitHubQuickAccessViewModel.repositoryKey(
+      projectPath: item.session.projectPath,
+      branchName: item.session.branchName,
+      linkedPullRequestNumber: item.linkedPullRequestNumber
+    )
+    return "\(item.id)|\(repositoryKey)|\(item.isPending)|\(agentHub != nil)"
+  }
+
+  private var gitHubSignature: String {
+    let prNumber = gitHubViewModel.currentBranchPR?.number ?? 0
+    let summary = gitHubViewModel.ciSummary
+    return [
+      "\(prNumber)",
+      "\(summary.overallStatus.rawValue)",
+      "\(summary.passed)",
+      "\(summary.failed)",
+      "\(summary.pending)",
+      "\(summary.total)",
+      "\(gitHubViewModel.observationState.isRefreshing)"
+    ].joined(separator: "|")
+  }
+
+  var body: some View {
+    Button(action: onSelect) {
+      HStack(alignment: .top, spacing: 10) {
+        statusIndicator
+          .padding(.top, 5)
+
+        VStack(alignment: .leading, spacing: 5) {
+          topLine
+          detailLine
+          gitHubLine
+        }
+
+        Spacer(minLength: 8)
+
+        Image(systemName: "arrow.up.forward")
+          .font(.system(size: 10, weight: .semibold))
+          .foregroundStyle(.secondary.opacity(isHovered ? 0.9 : 0.45))
+          .padding(.top, 3)
+      }
+      .padding(.horizontal, 9)
+      .padding(.vertical, 8)
+      .frame(maxWidth: .infinity, minHeight: 62, alignment: .leading)
+      .background(rowBackground)
+      .contentShape(Rectangle())
+    }
+    .buttonStyle(.plain)
+    .onHover { hovering in
+      withAnimation(.easeInOut(duration: 0.12)) {
+        isHovered = hovering
+      }
+    }
+    .task(id: gitHubObservationTaskID) {
+      await observeGitHubIfAvailable()
+      publishGitHubState()
+    }
+    .onDisappear {
+      gitHubViewModel.stopPolling()
+      onGitHubStateChange(nil)
+    }
+    .onChange(of: item.timestamp) { _, newValue in
+      Task {
+        await gitHubViewModel.notifySessionActivity(at: newValue)
+      }
+    }
+    .onChange(of: gitHubSignature) { _, _ in
+      publishGitHubState()
+    }
+  }
+
+  private var topLine: some View {
+    HStack(spacing: 6) {
+      Text(item.displayName)
+        .font(.primaryDefault)
+        .foregroundStyle(.primary)
+        .lineLimit(1)
+        .truncationMode(.tail)
+
+      Text(item.providerKind.rawValue)
+        .font(.secondaryCaption)
+        .foregroundStyle(Color.brandPrimary(for: item.providerKind))
+        .fixedSize(horizontal: true, vertical: false)
+
+      Spacer(minLength: 4)
+
+      Text(item.timestamp.timeAgoDisplay())
+        .font(.secondaryCaption)
+        .foregroundStyle(.secondary)
+        .monospacedDigit()
+        .fixedSize(horizontal: true, vertical: false)
+    }
+  }
+
+  private var detailLine: some View {
+    HStack(spacing: 6) {
+      Text(statusText)
+        .font(.secondarySmall)
+        .foregroundStyle(statusColor)
+        .lineLimit(1)
+        .truncationMode(.tail)
+
+      Text("·")
+        .font(.secondaryCaption)
+        .foregroundStyle(.secondary.opacity(0.7))
+
+      Text(projectText)
+        .font(.secondarySmall)
+        .foregroundStyle(.secondary)
+        .lineLimit(1)
+        .truncationMode(.middle)
+    }
+  }
+
+  @ViewBuilder
+  private var gitHubLine: some View {
+    if let pullRequest = gitHubViewModel.currentBranchPR {
+      HStack(spacing: 5) {
+        Image(systemName: gitHubViewModel.ciSummary.overallStatus.icon)
+          .font(.system(size: 10, weight: .semibold))
+          .foregroundStyle(ciColor)
+          .frame(width: 12, height: 12)
+
+        Text("PR #\(pullRequest.number)")
+          .font(.secondaryCaption)
+          .foregroundStyle(.secondary)
+
+        Text("·")
+          .font(.secondaryCaption)
+          .foregroundStyle(.secondary.opacity(0.7))
+
+        Text(ciText)
+          .font(.secondaryCaption)
+          .foregroundStyle(ciColor)
+          .lineLimit(1)
+          .truncationMode(.tail)
+      }
+      .transition(.opacity)
+    }
+  }
+
+  private var statusIndicator: some View {
+    Circle()
+      .fill(statusColor)
+      .frame(width: 8, height: 8)
+      .shadow(color: statusColor.opacity(item.attention == .working ? 0.55 : 0), radius: 4)
+  }
+
+  private var rowBackground: some View {
+    RoundedRectangle(cornerRadius: 8, style: .continuous)
+      .fill(rowBackgroundColor)
+      .overlay(
+        RoundedRectangle(cornerRadius: 8, style: .continuous)
+          .stroke(Color.secondary.opacity(isHovered ? 0.24 : 0.12), lineWidth: 1)
+      )
+  }
+
+  private var rowBackgroundColor: Color {
+    if isHovered {
+      return Color.brandPrimary(for: item.providerKind)
+        .opacity(colorScheme == .dark ? 0.16 : 0.22)
+    }
+    return Color.surfaceOverlay
+      .opacity(colorScheme == .dark ? 0.55 : 0.65)
+  }
+
+  private var projectText: String {
+    if let branchName = item.session.branchName, !branchName.isEmpty {
+      return "\(item.session.projectName) · \(branchName)"
+    }
+    return item.session.projectName
+  }
+
+  private var statusText: String {
+    if item.isPending { return "starting" }
+    guard let status = item.status else { return item.session.isActive ? "active" : "idle" }
+    switch status {
+    case .thinking:
+      return "working"
+    case .executingTool(let name):
+      return name.lowercased()
+    case .waitingForUser:
+      return "ready"
+    case .awaitingApproval(let tool):
+      return "approval: \(tool.lowercased())"
+    case .idle:
+      return "idle"
+    }
+  }
+
+  private var statusColor: Color {
+    switch item.attention {
+    case .awaitingApproval: return .yellow
+    case .ciFailure: return .red
+    case .working: return .blue
+    case .pending: return .orange
+    case .ready: return .green
+    case .idle: return .secondary
+    }
+  }
+
+  private var ciColor: Color {
+    switch gitHubViewModel.ciSummary.overallStatus {
+    case .success: return .green
+    case .failure: return .red
+    case .pending: return .orange
+    case .none: return .secondary
+    }
+  }
+
+  private var ciText: String {
+    let summary = gitHubViewModel.ciSummary
+    switch summary.overallStatus {
+    case .success:
+      return summary.total > 0 ? "CI passing \(summary.passed)/\(summary.total)" : "CI passing"
+    case .failure:
+      return summary.failed == 1 ? "1 check failing" : "\(summary.failed) checks failing"
+    case .pending:
+      return summary.pending == 1 ? "1 check pending" : "\(summary.pending) checks pending"
+    case .none:
+      return "CI unavailable"
+    }
+  }
+
+  private func observeGitHubIfAvailable() async {
+    guard !item.isPending, let observationService = agentHub?.gitHubPRObservationService else {
+      gitHubViewModel.stopPolling()
+      onGitHubStateChange(nil)
+      return
+    }
+
+    await gitHubViewModel.load(
+      projectPath: item.session.projectPath,
+      branchName: item.session.branchName,
+      linkedPullRequestNumber: item.linkedPullRequestNumber,
+      observationService: observationService,
+      refreshOnSubscribe: false,
+      recordInitialActivity: false,
+      forceRefreshLinkedPullRequest: item.linkedPullRequestNumber != nil
+    )
+    await gitHubViewModel.notifySessionActivity(at: item.timestamp)
+  }
+
+  private func publishGitHubState() {
+    guard gitHubViewModel.currentBranchPR != nil else {
+      onGitHubStateChange(nil)
+      return
+    }
+
+    onGitHubStateChange(GlobalSessionControlPanelGitHubState(
+      hasPullRequest: true,
+      ciStatus: gitHubViewModel.ciSummary.overallStatus,
+      isRefreshing: gitHubViewModel.observationState.isRefreshing
+    ))
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
@@ -171,6 +171,7 @@ public struct MultiProviderSessionsListView: View {
   @FocusState private var isSearchFieldFocused: Bool
   @Environment(\.colorScheme) private var colorScheme
   @Environment(\.runtimeTheme) private var runtimeTheme
+  @Environment(\.agentHub) private var agentHub
   @Environment(\.openSettings) private var openSettings
   @Environment(\.accessibilityReduceMotion) private var accessibilityReduceMotion
 
@@ -256,6 +257,10 @@ public struct MultiProviderSessionsListView: View {
       }
       ensurePrimarySelection()
       scheduleInitialGitHubStateRefreshIfNeeded()
+      consumeGlobalSessionSelectionIfNeeded()
+    }
+    .onChange(of: agentHub?.globalSessionSelectionRouter.selectionRequest?.id) { _, _ in
+      consumeGlobalSessionSelectionIfNeeded()
     }
     .onChange(of: claudeViewModel.resolvedPendingSessions) { _, newResolutions in
       handleResolvedSessions(newResolutions, provider: .claude, viewModel: claudeViewModel)
@@ -1744,6 +1749,23 @@ public struct MultiProviderSessionsListView: View {
       return
     }
     primarySessionId = items.first?.id
+  }
+
+  private func consumeGlobalSessionSelectionIfNeeded() {
+    guard let router = agentHub?.globalSessionSelectionRouter,
+          let request = router.selectionRequest else {
+      return
+    }
+
+    guard selectedSessionItems.contains(where: { $0.id == request.itemId }) else {
+      return
+    }
+
+    selectedModuleLandingPath = nil
+    selectedProviderRaw = request.providerKind.rawValue
+    primarySessionId = request.itemId
+    scrollToSessionId = request.itemId
+    router.markConsumed(request)
   }
 
   private func selectEmptyModule(_ path: String) {

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/SettingsView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/SettingsView.swift
@@ -57,6 +57,9 @@ public struct SettingsView: View {
   @AppStorage(AgentHubDefaults.pushNotificationsEnabled)
   private var pushNotificationsEnabled: Bool = true
 
+  @AppStorage(AgentHubDefaults.globalSessionPanelEnabled)
+  private var globalSessionPanelEnabled: Bool = false
+
   @AppStorage(ClaudeHookInstaller.enabledKey)
   private var claudeApprovalHooksEnabled: Bool = true
 
@@ -203,6 +206,35 @@ public struct SettingsView: View {
           description: "Show a notification banner when tools require approval",
           isOn: $pushNotificationsEnabled
         )
+      }
+
+      Section("Global session control panel") {
+        settingsToggle(
+          title: "Enable global shortcut",
+          description: "Open a floating panel of monitored Claude and Codex sessions from anywhere",
+          isOn: $globalSessionPanelEnabled
+        )
+        .onChange(of: globalSessionPanelEnabled) { _, newValue in
+          agentHub?.globalSessionControlPanelCoordinator.setEnabled(newValue)
+        }
+
+        HStack {
+          Text("Shortcut")
+          Spacer()
+          Text(GlobalHotKey.sessionControlPanelDefault.displayString)
+            .font(.primaryCaption)
+            .foregroundColor(.secondary)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 3)
+            .background(Color.secondary.opacity(0.12))
+            .clipShape(RoundedRectangle(cornerRadius: 4, style: .continuous))
+        }
+
+        if let error = agentHub?.globalSessionControlPanelCoordinator.registrationErrorMessage {
+          Label(error, systemImage: "exclamationmark.triangle")
+            .font(.caption)
+            .foregroundColor(.orange)
+        }
       }
 
       Section("Claude Code integration") {

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/GlobalSessionControlPanelTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/GlobalSessionControlPanelTests.swift
@@ -1,0 +1,209 @@
+import AgentHubGitHub
+import Foundation
+import Testing
+
+@testable import AgentHubCore
+
+@MainActor
+private final class MockGlobalHotKeyRegistrar: GlobalHotKeyRegistrarProtocol {
+  var onHotKeyPressed: (@MainActor @Sendable () -> Void)?
+  private(set) var registeredHotKeys: [GlobalHotKey] = []
+  private(set) var unregisterCallCount = 0
+  var registrationError: Error?
+
+  var isRegistered: Bool {
+    !registeredHotKeys.isEmpty
+  }
+
+  func register(hotKey: GlobalHotKey) throws {
+    if let registrationError {
+      throw registrationError
+    }
+    registeredHotKeys.append(hotKey)
+  }
+
+  func unregister() {
+    unregisterCallCount += 1
+    registeredHotKeys.removeAll()
+  }
+
+  func fire() {
+    onHotKeyPressed?()
+  }
+}
+
+@MainActor
+private final class MockGlobalSessionControlPanelPresenter: GlobalSessionControlPanelPresenting {
+  private(set) var showCallCount = 0
+  private(set) var hideCallCount = 0
+  private(set) var isVisible = false
+
+  func show() {
+    showCallCount += 1
+    isVisible = true
+  }
+
+  func hide() {
+    hideCallCount += 1
+    isVisible = false
+  }
+}
+
+@Suite("Global session control panel")
+@MainActor
+struct GlobalSessionControlPanelTests {
+  @Test("Coordinator registers only when enabled and unregisters when disabled")
+  func coordinatorHonorsEnabledPreference() {
+    let defaults = makeDefaults()
+    let registrar = MockGlobalHotKeyRegistrar()
+    let presenter = MockGlobalSessionControlPanelPresenter()
+    let coordinator = GlobalSessionControlPanelCoordinator(
+      registrar: registrar,
+      presenter: presenter,
+      defaults: defaults
+    )
+
+    coordinator.start()
+    #expect(registrar.registeredHotKeys.isEmpty)
+
+    coordinator.setEnabled(true)
+    #expect(registrar.registeredHotKeys == [.sessionControlPanelDefault])
+    #expect(coordinator.registrationErrorMessage == nil)
+
+    coordinator.setEnabled(false)
+    #expect(registrar.registeredHotKeys.isEmpty)
+    #expect(registrar.unregisterCallCount >= 1)
+  }
+
+  @Test("Coordinator hotkey callback toggles the presenter")
+  func hotKeyCallbackTogglesPanel() {
+    let defaults = makeDefaults()
+    defaults.set(true, forKey: AgentHubDefaults.globalSessionPanelEnabled)
+    let registrar = MockGlobalHotKeyRegistrar()
+    let presenter = MockGlobalSessionControlPanelPresenter()
+    let coordinator = GlobalSessionControlPanelCoordinator(
+      registrar: registrar,
+      presenter: presenter,
+      defaults: defaults
+    )
+
+    coordinator.start()
+    registrar.fire()
+    #expect(presenter.showCallCount == 1)
+    #expect(coordinator.isPanelVisible)
+
+    registrar.fire()
+    #expect(presenter.hideCallCount == 1)
+    #expect(!coordinator.isPanelVisible)
+  }
+
+  @Test("Coordinator stores registration failures without presenting")
+  func registrationFailureIsStored() {
+    let defaults = makeDefaults()
+    let registrar = MockGlobalHotKeyRegistrar()
+    registrar.registrationError = GlobalHotKeyRegistrationError.registerFailed(status: -9876)
+    let presenter = MockGlobalSessionControlPanelPresenter()
+    let coordinator = GlobalSessionControlPanelCoordinator(
+      registrar: registrar,
+      presenter: presenter,
+      defaults: defaults
+    )
+
+    coordinator.setEnabled(true)
+
+    #expect(registrar.registeredHotKeys.isEmpty)
+    #expect(coordinator.registrationErrorMessage?.contains("-9876") == true)
+    #expect(!presenter.isVisible)
+  }
+
+  @Test("Selection router maps provider sessions to main-app item ids")
+  func selectionRouterBuildsProviderScopedItemID() {
+    let router = GlobalSessionSelectionRouter()
+
+    router.select(providerKind: .codex, sessionId: "session-123", projectPath: "/tmp/repo")
+
+    let request = router.selectionRequest
+    #expect(request?.itemId == "codex-session-123")
+    #expect(request?.providerKind == .codex)
+    #expect(request?.projectPath == "/tmp/repo")
+
+    if let request {
+      router.markConsumed(request)
+    }
+    #expect(router.selectionRequest == nil)
+  }
+
+  @Test("Selection router preserves explicit pending item ids")
+  func selectionRouterPreservesPendingItemID() {
+    let router = GlobalSessionSelectionRouter()
+    let pendingItemID = "pending-claude-7F6A9A1B-CC2A-4C74-8C7D-1E220B571111"
+
+    router.select(
+      providerKind: .claude,
+      sessionId: "pending-7F6A9A1B-CC2A-4C74-8C7D-1E220B571111",
+      projectPath: "/tmp/repo",
+      itemId: pendingItemID
+    )
+
+    #expect(router.selectionRequest?.itemId == pendingItemID)
+  }
+
+  @Test("Snapshot ordering prioritizes attention before recency")
+  func snapshotOrderingPrioritizesAttention() {
+    let base = Date(timeIntervalSince1970: 1_000)
+    let items = [
+      item(id: "idle-new", seconds: 50, status: .idle),
+      item(id: "approval-old", seconds: 10, status: .awaitingApproval(tool: "Bash")),
+      item(id: "working", seconds: 40, status: .thinking),
+      item(id: "ci-failure", seconds: 20, status: .waitingForUser, ciStatus: .failure),
+      item(id: "pending-ci", seconds: 30, status: .idle, ciStatus: .pending),
+      item(id: "ready", seconds: 60, status: .waitingForUser),
+    ].map { original in
+      GlobalSessionControlPanelItem(
+        id: original.id,
+        session: CLISession(
+          id: original.id,
+          projectPath: "/tmp/repo",
+          branchName: "main",
+          lastActivityAt: base.addingTimeInterval(original.seconds)
+        ),
+        providerKind: .claude,
+        timestamp: base.addingTimeInterval(original.seconds),
+        isPending: false,
+        status: original.status,
+        linkedPullRequestNumber: nil,
+        customName: nil,
+        gitHubState: original.ciStatus.map {
+          GlobalSessionControlPanelGitHubState(hasPullRequest: true, ciStatus: $0)
+        }
+      )
+    }
+
+    let sorted = GlobalSessionControlPanelSnapshotBuilder.sorted(items)
+
+    #expect(sorted.map(\.id) == [
+      "approval-old",
+      "ci-failure",
+      "working",
+      "pending-ci",
+      "ready",
+      "idle-new",
+    ])
+  }
+
+  private func item(
+    id: String,
+    seconds: TimeInterval,
+    status: SessionStatus?,
+    ciStatus: CIStatus? = nil
+  ) -> (id: String, seconds: TimeInterval, status: SessionStatus?, ciStatus: CIStatus?) {
+    (id, seconds, status, ciStatus)
+  }
+
+  private func makeDefaults() -> UserDefaults {
+    let suiteName = "GlobalSessionControlPanelTests-\(UUID().uuidString)"
+    let defaults = UserDefaults(suiteName: suiteName)!
+    defaults.removePersistentDomain(forName: suiteName)
+    return defaults
+  }
+}


### PR DESCRIPTION
## Summary

Adds an opt-in global session control panel for AgentHub. Users can enable a global shortcut in Settings, then open a floating draggable panel that shows active Claude and Codex sessions, pending launches, agent state, and GitHub PR/CI status.

The default shortcut is `Command + Option + P`, chosen to spread the action across both hands.

## Changes

- Add a Carbon-backed global hotkey registrar and coordinator.
- Add a borderless AppKit floating panel that persists its screen position.
- Add the SwiftUI panel list for Claude/Codex sessions, including pending, working, approval, ready, idle, and CI failure states.
- Reuse the shared GitHub PR observation service through `SessionGitHubQuickAccessViewModel` so the panel avoids independent polling loops.
- Route panel row selection into the main AgentHub session view.
- Add focused coordinator, router, and snapshot ordering tests.

## Validation

- `xcodebuild build -project app/AgentHub.xcodeproj -scheme AgentHub -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO`
- `xcodebuild build -project app/AgentHub.xcodeproj -scheme AgentHubCore -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO`
- `swift test --package-path app/modules/AgentHubGitHub --filter SessionGitHubQuickAccessViewModel`
- `git diff --check`

Note: `swift test --package-path app/modules/AgentHubCore --filter GlobalSessionControlPanelTests` is currently blocked before reaching these tests by the existing `CodeEditSymbols` SPM issue where `Bundle.module` is unavailable.