### PR TITLE
[codex] Import external worktree sessions

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/CLISessionMonitorService.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/CLISessionMonitorService.swift
@@ -305,6 +305,60 @@ public actor CLISessionMonitorService {
     return sessions.sorted { $0.lastActivityAt > $1.lastActivityAt }
   }
 
+  public func loadLatestSessions(
+    inWorktreePath worktreePath: String,
+    excludingSessionIds: Set<String>,
+    limit: Int
+  ) async -> WorktreeSessionImportPage {
+    guard limit > 0 else {
+      return WorktreeSessionImportPage(sessions: [], hasMore: false)
+    }
+
+    let claudeDataPath = claudeDataPath
+    let normalizedWorktreePath = WorktreeModuleResolver.normalizedDirectoryPath(worktreePath)
+    let excludedIds = excludingSessionIds
+    let summaries = await Task.detached(priority: .userInitiated) {
+      CLISessionMonitorService.latestHistorySummaries(
+        claudeDataPath: claudeDataPath,
+        worktreePath: normalizedWorktreePath,
+        excludingSessionIds: excludedIds
+      )
+    }.value
+
+    let pageSummaries = Array(summaries.prefix(limit))
+    let summaryBySessionId = Dictionary(uniqueKeysWithValues: pageSummaries)
+    let metadata = await readSessionMetadataBatch(sessionSummaries: summaryBySessionId)
+
+    let sessions = pageSummaries.map { element in
+      let sessionId = element.0
+      let summary = element.1
+      let sessionMetadata = metadata[sessionId]
+      let encodedPath = summary.project.claudeProjectPathEncoded
+      let sessionFilePath = "\(claudeDataPath)/projects/\(encodedPath)/\(sessionId).jsonl"
+      let fileModifiedAt = fileModificationDate(sessionFilePath)
+      let worktree = worktreeInfo(containing: summary.project)
+
+      return CLISession(
+        id: sessionId,
+        projectPath: summary.project,
+        branchName: sessionMetadata?.branch ?? worktree.branchName,
+        isWorktree: worktree.isWorktree,
+        lastActivityAt: [summary.lastActivityDate, fileModifiedAt].compactMap { $0 }.max() ?? summary.lastActivityDate,
+        messageCount: summary.messageCount,
+        isActive: fileModifiedAt.map { Date().timeIntervalSince($0) < 60 } ?? false,
+        firstMessage: summary.firstDisplay,
+        lastMessage: summary.lastDisplay,
+        slug: sessionMetadata?.slug,
+        sessionFilePath: sessionFilePath
+      )
+    }
+
+    return WorktreeSessionImportPage(
+      sessions: sessions,
+      hasMore: summaries.count > limit
+    )
+  }
+
   // MARK: - Session Scanning
 
   /// Refreshes sessions for all selected repositories
@@ -1029,6 +1083,45 @@ public actor CLISessionMonitorService {
     monitoredPaths.contains { path in
       project == path || project.hasPrefix(path + "/")
     }
+  }
+
+  static func latestHistorySummaries(
+    claudeDataPath: String,
+    worktreePath: String,
+    excludingSessionIds: Set<String>
+  ) -> [(String, HistorySessionSummary)] {
+    let historyPath = claudeDataPath + "/history.jsonl"
+    guard let data = FileManager.default.contents(atPath: historyPath),
+          let content = String(data: data, encoding: .utf8) else {
+      return []
+    }
+
+    let normalizedWorktreePath = WorktreeModuleResolver.normalizedDirectoryPath(worktreePath)
+    let decoder = JSONDecoder()
+    var summaries: [String: HistorySessionSummary] = [:]
+
+    for line in content.components(separatedBy: .newlines) where !line.isEmpty {
+      guard let jsonData = line.data(using: .utf8),
+            let entry = try? decoder.decode(HistoryEntry.self, from: jsonData),
+            !excludingSessionIds.contains(entry.sessionId) else {
+        continue
+      }
+
+      let projectPath = WorktreeModuleResolver.normalizedDirectoryPath(entry.project)
+      guard projectPath == normalizedWorktreePath || projectPath.hasPrefix(normalizedWorktreePath + "/") else {
+        continue
+      }
+
+      mergeHistoryEntry(entry, into: &summaries)
+    }
+
+    return summaries
+      .sorted {
+        if $0.value.lastTimestamp == $1.value.lastTimestamp {
+          return $0.key < $1.key
+        }
+        return $0.value.lastTimestamp > $1.value.lastTimestamp
+      }
   }
 
   static func mergeHistoryEntry(_ entry: HistoryEntry, into summaries: inout [String: HistorySessionSummary]) {

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/CodexSessionMonitorService.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/CodexSessionMonitorService.swift
@@ -224,6 +224,62 @@ public actor CodexSessionMonitorService {
     return sessions.sorted { $0.lastActivityAt > $1.lastActivityAt }
   }
 
+  public func loadLatestSessions(
+    inWorktreePath worktreePath: String,
+    excludingSessionIds: Set<String>,
+    limit: Int
+  ) async -> WorktreeSessionImportPage {
+    guard limit > 0 else {
+      return WorktreeSessionImportPage(sessions: [], hasMore: false)
+    }
+
+    let normalizedWorktreePath = WorktreeModuleResolver.normalizedDirectoryPath(worktreePath)
+    let files = CodexSessionFileScanner.listSessionFiles(codexDataPath: codexDataPath)
+    var sessions: [CLISession] = []
+
+    for path in files {
+      guard let meta = CodexSessionFileScanner.readSessionMeta(from: path),
+            !excludingSessionIds.contains(meta.sessionId) else {
+        continue
+      }
+
+      let projectPath = WorktreeModuleResolver.normalizedDirectoryPath(meta.projectPath)
+      guard projectPath == normalizedWorktreePath || projectPath.hasPrefix(normalizedWorktreePath + "/") else {
+        continue
+      }
+
+      let summary = CodexSessionJSONLParser.parseSessionSummaryFile(at: path)
+      let worktree = worktreeInfo(containing: meta.projectPath)
+      let lastActivity = [summary.lastActivityAt, meta.startedAt, fileModificationDate(path)].compactMap { $0 }.max()
+
+      sessions.append(CLISession(
+        id: meta.sessionId,
+        projectPath: meta.projectPath,
+        branchName: meta.branch ?? worktree.branchName,
+        isWorktree: worktree.isWorktree,
+        lastActivityAt: lastActivity ?? Date(),
+        messageCount: summary.messageCount,
+        isActive: isSessionFileActive(path),
+        firstMessage: summary.firstUserMessage,
+        lastMessage: summary.lastUserMessage,
+        slug: nil,
+        sessionFilePath: path
+      ))
+    }
+
+    sessions.sort {
+      if $0.lastActivityAt == $1.lastActivityAt {
+        return $0.id < $1.id
+      }
+      return $0.lastActivityAt > $1.lastActivityAt
+    }
+
+    return WorktreeSessionImportPage(
+      sessions: Array(sessions.prefix(limit)),
+      hasMore: sessions.count > limit
+    )
+  }
+
   // MARK: - Session Scanning
 
   public func refreshSessions(skipWorktreeRedetection: Bool = false) async {

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/SessionProviderProtocols.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/SessionProviderProtocols.swift
@@ -21,6 +21,16 @@ public extension SessionProviderKind {
 
 // MARK: - SessionMonitorServiceProtocol
 
+public struct WorktreeSessionImportPage: Sendable, Equatable {
+  public let sessions: [CLISession]
+  public let hasMore: Bool
+
+  public init(sessions: [CLISession], hasMore: Bool) {
+    self.sessions = sessions
+    self.hasMore = hasMore
+  }
+}
+
 public protocol SessionMonitorServiceProtocol: AnyObject, Sendable {
   var repositoriesPublisher: AnyPublisher<[SelectedRepository], Never> { get }
 
@@ -31,6 +41,11 @@ public protocol SessionMonitorServiceProtocol: AnyObject, Sendable {
   func addRepositories(_ paths: [String]) async
   func restoreRepositoriesSkeleton(_ paths: [String]) async -> [SelectedRepository]
   func loadSessions(ids: Set<String>) async -> [CLISession]
+  func loadLatestSessions(
+    inWorktreePath worktreePath: String,
+    excludingSessionIds: Set<String>,
+    limit: Int
+  ) async -> WorktreeSessionImportPage
   func removeRepository(_ path: String) async
   func setOwnedWorktreePaths(_ paths: Set<String>) async
   func setFocusedSessionIds(_ ids: Set<String>) async
@@ -65,6 +80,32 @@ public extension SessionMonitorServiceProtocol {
       .flatMap { $0.worktrees }
       .flatMap { $0.sessions }
       .filter { ids.contains($0.id) }
+  }
+
+  func loadLatestSessions(
+    inWorktreePath worktreePath: String,
+    excludingSessionIds: Set<String>,
+    limit: Int
+  ) async -> WorktreeSessionImportPage {
+    guard limit > 0 else {
+      return WorktreeSessionImportPage(sessions: [], hasMore: false)
+    }
+
+    let normalizedWorktreePath = WorktreeModuleResolver.normalizedDirectoryPath(worktreePath)
+    let sessions = await getSelectedRepositories()
+      .flatMap(\.worktrees)
+      .flatMap(\.sessions)
+      .filter { session in
+        guard !excludingSessionIds.contains(session.id) else { return false }
+        let projectPath = WorktreeModuleResolver.normalizedDirectoryPath(session.projectPath)
+        return projectPath == normalizedWorktreePath || projectPath.hasPrefix(normalizedWorktreePath + "/")
+      }
+      .sorted { $0.lastActivityAt > $1.lastActivityAt }
+
+    return WorktreeSessionImportPage(
+      sessions: Array(sessions.prefix(limit)),
+      hasMore: sessions.count > limit
+    )
   }
 
   func registerWorktree(_ worktree: WorktreeBranch, parentRepositoryPath: String) async {}

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/WorktreeInventorySection.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/WorktreeInventorySection.swift
@@ -9,6 +9,7 @@ struct WorktreeInventorySection: View {
   @State private var isDeleteConfirmationPresented = false
   @State private var deletionFailure: WorktreeInventoryDeletionError?
   @State private var isFailureAlertPresented = false
+  @State private var importCoordinator = WorktreeSessionImportCoordinator()
 
   init(
     claudeViewModel: CLISessionsViewModel,
@@ -41,6 +42,10 @@ struct WorktreeInventorySection: View {
           ForEach(currentSnapshot.modules) { module in
             WorktreeInventoryModuleView(
               module: module,
+              isImporting: { importCoordinator.isImporting($0) },
+              canShowMore: { importCoordinator.canShowMore($0) },
+              onImport: importWorktree,
+              onShowMore: showMoreSessions,
               isDeleting: { inventoryViewModel.deletingWorktreePath == $0.path },
               onDelete: requestDelete
             )
@@ -91,6 +96,28 @@ struct WorktreeInventorySection: View {
   private func requestDelete(_ worktree: WorktreeSettingsWorktree) {
     pendingDeletion = worktree
     isDeleteConfirmationPresented = true
+  }
+
+  private func importWorktree(_ worktree: WorktreeSettingsWorktree) {
+    Task {
+      await importCoordinator.importInitial(
+        worktree,
+        claudeViewModel: claudeViewModel,
+        codexViewModel: codexViewModel
+      )
+      await reloadInventory()
+    }
+  }
+
+  private func showMoreSessions(_ worktree: WorktreeSettingsWorktree) {
+    Task {
+      await importCoordinator.showMore(
+        worktree,
+        claudeViewModel: claudeViewModel,
+        codexViewModel: codexViewModel
+      )
+      await reloadInventory()
+    }
   }
 
   private func delete(_ worktree: WorktreeSettingsWorktree) {
@@ -220,6 +247,10 @@ private struct WorktreeInventorySummaryView: View {
 
 private struct WorktreeInventoryModuleView: View {
   let module: WorktreeSettingsModule
+  let isImporting: (WorktreeSettingsWorktree) -> Bool
+  let canShowMore: (WorktreeSettingsWorktree) -> Bool
+  let onImport: (WorktreeSettingsWorktree) -> Void
+  let onShowMore: (WorktreeSettingsWorktree) -> Void
   let isDeleting: (WorktreeSettingsWorktree) -> Bool
   let onDelete: (WorktreeSettingsWorktree) -> Void
 
@@ -249,10 +280,14 @@ private struct WorktreeInventoryModuleView: View {
           .foregroundStyle(.secondary)
           .padding(.leading, 24)
       } else {
-        VStack(spacing: 6) {
+        VStack(spacing: 8) {
           ForEach(module.worktrees) { worktree in
             WorktreeInventoryRow(
               worktree: worktree,
+              isImporting: isImporting(worktree),
+              canShowMore: canShowMore(worktree),
+              onImport: { onImport(worktree) },
+              onShowMore: { onShowMore(worktree) },
               isDeleting: isDeleting(worktree),
               onDelete: { onDelete(worktree) }
             )
@@ -265,76 +300,123 @@ private struct WorktreeInventoryModuleView: View {
 
 private struct WorktreeInventoryRow: View {
   let worktree: WorktreeSettingsWorktree
+  let isImporting: Bool
+  let canShowMore: Bool
+  let onImport: () -> Void
+  let onShowMore: () -> Void
   let isDeleting: Bool
   let onDelete: () -> Void
 
   var body: some View {
-    HStack(alignment: .center, spacing: 10) {
-      Image(systemName: "arrow.triangle.branch")
-        .foregroundStyle(.secondary)
-        .frame(width: 18)
+    VStack(alignment: .leading, spacing: 10) {
+      HStack(alignment: .top, spacing: 10) {
+        Image(systemName: "arrow.triangle.branch")
+          .foregroundStyle(.secondary)
+          .frame(width: 18)
+          .padding(.top, 2)
 
-      VStack(alignment: .leading, spacing: 3) {
-        HStack(spacing: 6) {
+        VStack(alignment: .leading, spacing: 4) {
           Text(worktree.branchName)
             .font(.subheadline.weight(.semibold))
             .lineLimit(1)
 
-          WorktreeInventoryBadge(
-            title: worktree.isFocusedInAgentHub ? "Focused in AgentHub" : "External",
-            systemImage: worktree.isFocusedInAgentHub ? "scope" : "externaldrive",
-            isProminent: worktree.isFocusedInAgentHub,
-            helpText: worktree.isFocusedInAgentHub
-              ? "This worktree is focused in AgentHub, so its sessions can appear in the session list and grouping."
-              : "This worktree belongs to a tracked repository, but AgentHub has not focused it for session grouping."
-          )
-
-          if worktree.isFocusedInAgentHub, !worktree.providerLabel.isEmpty {
-            WorktreeInventoryBadge(
-              title: worktree.providerLabel,
-              systemImage: "terminal",
-              isProminent: false,
-              helpText: "Providers with AgentHub session history for this worktree."
-            )
-          }
+          Text(worktree.path)
+            .font(.caption)
+            .foregroundStyle(.secondary)
+            .lineLimit(1)
+            .truncationMode(.middle)
         }
 
-        Text(worktree.path)
-          .font(.caption)
-          .foregroundStyle(.secondary)
-          .lineLimit(1)
-          .truncationMode(.middle)
+        Spacer(minLength: 12)
+
+        deleteControl
       }
 
-      Spacer(minLength: 8)
+      HStack(spacing: 8) {
+        WorktreeInventoryBadge(
+          title: worktree.isFocusedInAgentHub ? "In AgentHub" : "External",
+          systemImage: worktree.isFocusedInAgentHub ? "scope" : "externaldrive",
+          isProminent: worktree.isFocusedInAgentHub,
+          helpText: worktree.isFocusedInAgentHub
+            ? "This worktree is focused in AgentHub, so its sessions can appear in the session list and grouping."
+            : "This worktree belongs to a tracked repository, but AgentHub has not focused it for session grouping."
+        )
 
-      if worktree.monitoredSessionCount > 0 {
-        Label("\(worktree.monitoredSessionCount)", systemImage: worktree.activeMonitoredSessionCount > 0 ? "circle.fill" : "circle")
-          .font(.caption)
-          .foregroundStyle(worktree.activeMonitoredSessionCount > 0 ? .green : .secondary)
-          .help("\(worktree.monitoredSessionCount) monitored \(worktree.monitoredSessionCount == 1 ? "session" : "sessions")")
-      }
+        if worktree.isFocusedInAgentHub, !worktree.providerLabel.isEmpty {
+          WorktreeInventoryBadge(
+            title: worktree.providerLabel,
+            systemImage: "terminal",
+            isProminent: false,
+            helpText: "Providers with AgentHub session history for this worktree."
+          )
+        }
 
-      if isDeleting {
-        ProgressView()
-          .scaleEffect(0.7)
-          .frame(width: 28, height: 28)
-      } else {
-        Button("Delete worktree \(worktree.branchName)", systemImage: "trash", action: onDelete)
-          .labelStyle(.iconOnly)
-          .font(.system(size: 13))
-          .frame(width: 28, height: 28)
-          .contentShape(Rectangle())
-          .buttonStyle(.plain)
-          .foregroundStyle(.secondary)
-          .help("Delete worktree")
+        Spacer(minLength: 12)
+
+        sessionImportControl
       }
     }
-    .padding(8)
+    .padding(12)
     .background(
       RoundedRectangle(cornerRadius: 8, style: .continuous)
         .fill(Color.primary.opacity(0.04))
     )
+  }
+
+  @ViewBuilder
+  private var sessionImportControl: some View {
+    if worktree.isFocusedInAgentHub {
+      HStack(spacing: 10) {
+        Label(displayedSessionLabel, systemImage: worktree.activeMonitoredSessionCount > 0 ? "circle.fill" : "circle")
+          .font(.caption)
+          .foregroundStyle(worktree.activeMonitoredSessionCount > 0 ? .green : .secondary)
+          .help("\(worktree.monitoredSessionCount) displayed \(worktree.monitoredSessionCount == 1 ? "session" : "sessions")")
+
+        if isImporting {
+          ProgressView()
+            .scaleEffect(0.7)
+            .frame(width: 24, height: 24)
+        } else if canShowMore {
+          Button("Load 3 more", systemImage: "plus.circle", action: onShowMore)
+            .font(.caption)
+            .buttonStyle(.bordered)
+            .controlSize(.small)
+            .help("Load the next 3 sessions")
+        }
+      }
+    } else if isImporting {
+      ProgressView()
+        .scaleEffect(0.7)
+        .frame(width: 28, height: 28)
+    } else {
+      Button("Import", systemImage: "tray.and.arrow.down", action: onImport)
+        .font(.caption)
+        .buttonStyle(.bordered)
+        .controlSize(.small)
+        .help("Import worktree")
+    }
+  }
+
+  @ViewBuilder
+  private var deleteControl: some View {
+    if isDeleting {
+      ProgressView()
+        .scaleEffect(0.7)
+        .frame(width: 28, height: 28)
+    } else {
+      Button("Delete worktree \(worktree.branchName)", systemImage: "trash", action: onDelete)
+        .labelStyle(.iconOnly)
+        .font(.system(size: 13))
+        .frame(width: 28, height: 28)
+        .contentShape(Rectangle())
+        .buttonStyle(.plain)
+        .foregroundStyle(.secondary)
+        .help("Delete worktree")
+    }
+  }
+
+  private var displayedSessionLabel: String {
+    "\(worktree.monitoredSessionCount) \(worktree.monitoredSessionCount == 1 ? "session" : "sessions") displayed"
   }
 }
 
@@ -350,6 +432,8 @@ private struct WorktreeInventoryBadge: View {
     Label(title, systemImage: systemImage)
       .font(.caption)
       .labelStyle(.titleAndIcon)
+      .lineLimit(1)
+      .fixedSize(horizontal: true, vertical: false)
       .foregroundStyle(isProminent ? .primary : .secondary)
       .padding(.horizontal, 6)
       .padding(.vertical, 2)

--- a/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/CLISessionsViewModel.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/CLISessionsViewModel.swift
@@ -2166,11 +2166,28 @@ public final class CLISessionsViewModel {
     path: String,
     parentRepositoryPath: String
   ) async -> WorktreeBranch {
+    return await focusExistingWorktree(
+      WorktreeBranch(
+        name: name,
+        path: path,
+        isWorktree: true,
+        sessions: [],
+        isExpanded: true
+      ),
+      parentRepositoryPath: parentRepositoryPath
+    )
+  }
+
+  @discardableResult
+  public func focusExistingWorktree(
+    _ worktree: WorktreeBranch,
+    parentRepositoryPath: String
+  ) async -> WorktreeBranch {
     let worktree = WorktreeBranch(
-      name: name,
-      path: path,
+      name: worktree.name,
+      path: WorktreeModuleResolver.normalizedDirectoryPath(worktree.path),
       isWorktree: true,
-      sessions: [],
+      sessions: worktree.sessions,
       isExpanded: true
     )
 
@@ -2184,6 +2201,57 @@ public final class CLISessionsViewModel {
     persistSelectedRepositories()
     syncClaudeHookInstalls()
     return worktree
+  }
+
+  public func importMonitoredSessions(_ sessions: [CLISession]) async {
+    let newSessions = sessions.filter { !monitoredSessionIds.contains($0.id) }
+    guard !newSessions.isEmpty else { return }
+
+    var importedWorktreePaths = Set<String>()
+    for session in newSessions {
+      monitoredSessionIds.insert(session.id)
+      monitoredSessionBackup[session.id] = session
+
+      if session.isWorktree {
+        let worktreePath = WorktreeModuleResolver.bestMatch(
+          for: session.projectPath,
+          repositories: selectedRepositories
+        )?.worktree.path ?? session.projectPath
+        importedWorktreePaths.insert(WorktreeModuleResolver.normalizedDirectoryPath(worktreePath))
+      }
+    }
+
+    if !importedWorktreePaths.isEmpty {
+      await setOwnedWorktreePaths(ownedWorktreePaths.union(importedWorktreePaths))
+    }
+    await monitorService.setFocusedSessionIds(monitoredSessionIds)
+    persistMonitoredSessions()
+
+    for session in newSessions {
+      startPolling(session: session)
+    }
+  }
+
+  public func loadLatestSessionsForImport(
+    inWorktreePath worktreePath: String,
+    excludingSessionIds: Set<String>,
+    limit: Int
+  ) async -> WorktreeSessionImportPage {
+    await monitorService.loadLatestSessions(
+      inWorktreePath: worktreePath,
+      excludingSessionIds: excludingSessionIds,
+      limit: limit
+    )
+  }
+
+  public func refreshImportedWorktreeSessions() async {
+    await monitorService.refreshSessions(skipWorktreeRedetection: true)
+    let updatedRepositories = await monitorService.getSelectedRepositories()
+    selectedRepositories = mergePreservingExpandedState(
+      current: selectedRepositories,
+      updated: updatedRepositories
+    )
+    persistSelectedRepositories()
   }
 
   /// Finds the parent repository path for a worktree by searching selectedRepositories.

--- a/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/WorktreeSessionImportCoordinator.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/WorktreeSessionImportCoordinator.swift
@@ -1,0 +1,141 @@
+import Foundation
+
+@MainActor
+@Observable
+final class WorktreeSessionImportCoordinator {
+  private let pageSize: Int
+  private(set) var importingWorktreePaths: Set<String> = []
+  private(set) var hasMoreByWorktreePath: [String: Bool] = [:]
+
+  init(pageSize: Int = 3) {
+    self.pageSize = pageSize
+  }
+
+  func isImporting(_ worktree: WorktreeSettingsWorktree) -> Bool {
+    importingWorktreePaths.contains(normalized(worktree.path))
+  }
+
+  func canShowMore(_ worktree: WorktreeSettingsWorktree) -> Bool {
+    hasMoreByWorktreePath[normalized(worktree.path)] ?? true
+  }
+
+  func importInitial(
+    _ worktree: WorktreeSettingsWorktree,
+    claudeViewModel: CLISessionsViewModel,
+    codexViewModel: CLISessionsViewModel
+  ) async {
+    await importNextPage(
+      worktree,
+      shouldFocusWorktree: true,
+      claudeViewModel: claudeViewModel,
+      codexViewModel: codexViewModel
+    )
+  }
+
+  func showMore(
+    _ worktree: WorktreeSettingsWorktree,
+    claudeViewModel: CLISessionsViewModel,
+    codexViewModel: CLISessionsViewModel
+  ) async {
+    await importNextPage(
+      worktree,
+      shouldFocusWorktree: true,
+      claudeViewModel: claudeViewModel,
+      codexViewModel: codexViewModel
+    )
+  }
+
+  private func importNextPage(
+    _ worktree: WorktreeSettingsWorktree,
+    shouldFocusWorktree: Bool,
+    claudeViewModel: CLISessionsViewModel,
+    codexViewModel: CLISessionsViewModel
+  ) async {
+    let key = normalized(worktree.path)
+    guard importingWorktreePaths.insert(key).inserted else { return }
+    defer {
+      importingWorktreePaths.remove(key)
+    }
+
+    if shouldFocusWorktree {
+      await focus(worktree, in: claudeViewModel)
+      await focus(worktree, in: codexViewModel)
+    }
+
+    let requestLimit = pageSize + 1
+    let loadedClaudePage = await claudeViewModel.loadLatestSessionsForImport(
+      inWorktreePath: key,
+      excludingSessionIds: excludedSessionIds(in: key, for: claudeViewModel),
+      limit: requestLimit
+    )
+    let loadedCodexPage = await codexViewModel.loadLatestSessionsForImport(
+      inWorktreePath: key,
+      excludingSessionIds: excludedSessionIds(in: key, for: codexViewModel),
+      limit: requestLimit
+    )
+
+    let providerPages = [
+      ProviderImportPage(providerKind: .claude, page: loadedClaudePage),
+      ProviderImportPage(providerKind: .codex, page: loadedCodexPage),
+    ]
+    let candidates = providerPages
+      .flatMap { providerPage in
+        providerPage.page.sessions.map {
+          ProviderSessionImportCandidate(providerKind: providerPage.providerKind, session: $0)
+        }
+      }
+      .sorted {
+        if $0.session.lastActivityAt == $1.session.lastActivityAt {
+          return $0.session.id < $1.session.id
+        }
+        return $0.session.lastActivityAt > $1.session.lastActivityAt
+      }
+
+    let selectedCandidates = Array(candidates.prefix(pageSize))
+    let claudeSessions = selectedCandidates.sessions(for: .claude)
+    let codexSessions = selectedCandidates.sessions(for: .codex)
+
+    await claudeViewModel.importMonitoredSessions(claudeSessions)
+    await codexViewModel.importMonitoredSessions(codexSessions)
+
+    if !claudeSessions.isEmpty {
+      await claudeViewModel.refreshImportedWorktreeSessions()
+    }
+    if !codexSessions.isEmpty {
+      await codexViewModel.refreshImportedWorktreeSessions()
+    }
+
+    hasMoreByWorktreePath[key] = candidates.count > pageSize || providerPages.contains { $0.page.hasMore }
+  }
+
+  private func focus(_ worktree: WorktreeSettingsWorktree, in viewModel: CLISessionsViewModel) async {
+    await viewModel.focusExistingWorktree(
+      worktree.worktree,
+      parentRepositoryPath: worktree.parentModulePath
+    )
+  }
+
+  private func excludedSessionIds(in worktreePath: String, for viewModel: CLISessionsViewModel) -> Set<String> {
+    Set(viewModel.monitoredSessions(inWorktreePath: worktreePath).map(\.id))
+  }
+
+  private func normalized(_ path: String) -> String {
+    WorktreeModuleResolver.normalizedDirectoryPath(path)
+  }
+}
+
+private struct ProviderImportPage {
+  let providerKind: SessionProviderKind
+  let page: WorktreeSessionImportPage
+}
+
+private struct ProviderSessionImportCandidate {
+  let providerKind: SessionProviderKind
+  let session: CLISession
+}
+
+private extension Array where Element == ProviderSessionImportCandidate {
+  func sessions(for providerKind: SessionProviderKind) -> [CLISession] {
+    filter { $0.providerKind == providerKind }.map(\.session)
+  }
+}

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/CLISessionMonitorServiceHistoryTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/CLISessionMonitorServiceHistoryTests.swift
@@ -79,6 +79,44 @@ struct CLISessionMonitorServiceHistoryTests {
     #expect(CLISessionMonitorService.matchesMonitoredPath("/repo/subdir", monitoredPaths: ["/repo"]))
     #expect(!CLISessionMonitorService.matchesMonitoredPath("/other", monitoredPaths: ["/repo"]))
   }
+
+  @Test("Loads latest Claude sessions for a worktree import page")
+  func loadsLatestClaudeWorktreeImportPage() async throws {
+    let root = try temporaryDirectory(name: "claude_import")
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    let parentPath = root.appending(path: "Project").path
+    let worktreePath = root.appending(path: "Project-feature").path
+    try FileManager.default.createDirectory(atPath: worktreePath, withIntermediateDirectories: true)
+
+    let service = CLISessionMonitorService(claudeDataPath: root.path)
+    await service.registerWorktree(
+      WorktreeBranch(name: "feature/import", path: worktreePath, isWorktree: true),
+      parentRepositoryPath: parentPath
+    )
+
+    try writeClaudeHistory(
+      root: root,
+      entries: [
+        ("session-1", worktreePath, 1_000, "oldest"),
+        ("session-2", worktreePath + "/app", 2_000, "nested"),
+        ("session-3", worktreePath, 3_000, "third"),
+        ("session-4", worktreePath, 4_000, "fourth"),
+        ("session-5", worktreePath, 5_000, "excluded"),
+        ("session-out", root.appending(path: "Other").path, 6_000, "outside"),
+      ]
+    )
+
+    let page = await service.loadLatestSessions(
+      inWorktreePath: worktreePath,
+      excludingSessionIds: ["session-5"],
+      limit: 3
+    )
+
+    #expect(page.sessions.map(\.id) == ["session-4", "session-3", "session-2"])
+    #expect(page.sessions.allSatisfy(\.isWorktree))
+    #expect(page.hasMore)
+  }
 }
 
 private func historyEntry(
@@ -92,4 +130,51 @@ private func historyEntry(
   """
   let data = try #require(json.data(using: .utf8))
   return try JSONDecoder().decode(HistoryEntry.self, from: data)
+}
+
+private func writeClaudeHistory(
+  root: URL,
+  entries: [(sessionId: String, project: String, timestamp: Int64, display: String)]
+) throws {
+  let historyLines = entries.map { entry in
+    """
+    {"display":"\(entry.display)","timestamp":\(entry.timestamp),"project":"\(entry.project)","sessionId":"\(entry.sessionId)"}
+    """
+  }
+  try historyLines.joined(separator: "\n").write(
+    to: root.appending(path: "history.jsonl"),
+    atomically: true,
+    encoding: .utf8
+  )
+
+  for entry in entries {
+    let projectDirectory = root
+      .appending(path: "projects")
+      .appending(path: entry.project.claudeProjectPathEncoded)
+    try FileManager.default.createDirectory(at: projectDirectory, withIntermediateDirectories: true)
+    try claudeSessionLine(
+      sessionId: entry.sessionId,
+      cwd: entry.project,
+      message: entry.display
+    )
+    .write(
+      to: projectDirectory.appending(path: "\(entry.sessionId).jsonl"),
+      atomically: true,
+      encoding: .utf8
+    )
+  }
+}
+
+private func claudeSessionLine(sessionId: String, cwd: String, message: String) -> String {
+  """
+  {"sessionId":"\(sessionId)","cwd":"\(cwd)","gitBranch":"feature/import","slug":"\(sessionId)-slug","type":"user","timestamp":"2026-05-05T12:00:00.000Z","message":{"role":"user","content":"\(message)"}}
+
+  """
+}
+
+private func temporaryDirectory(name: String) throws -> URL {
+  let url = FileManager.default.temporaryDirectory
+    .appending(path: "\(name)_\(UUID().uuidString)", directoryHint: .isDirectory)
+  try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+  return url
 }

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/CodexWorktreeSessionImportTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/CodexWorktreeSessionImportTests.swift
@@ -1,0 +1,115 @@
+import Foundation
+import Testing
+
+@testable import AgentHubCore
+
+@Suite("Codex worktree session import")
+struct CodexWorktreeSessionImportTests {
+  @Test("Loads latest Codex sessions for a worktree import page")
+  func loadsLatestCodexWorktreeImportPage() async throws {
+    let root = try temporaryDirectory(name: "codex_import")
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    let parentPath = root.appending(path: "Project").path
+    let worktreePath = root.appending(path: "Project-feature").path
+    try FileManager.default.createDirectory(atPath: worktreePath, withIntermediateDirectories: true)
+
+    let service = CodexSessionMonitorService(codexDataPath: root.path)
+    await service.registerWorktree(
+      WorktreeBranch(name: "feature/import", path: worktreePath, isWorktree: true),
+      parentRepositoryPath: parentPath
+    )
+
+    try writeCodexSession(root: root, id: "session-1", cwd: worktreePath, timestamp: "2026-05-05T12:01:00.000Z")
+    try writeCodexSession(root: root, id: "session-2", cwd: worktreePath + "/app", timestamp: "2026-05-05T12:02:00.000Z")
+    try writeCodexSession(root: root, id: "session-3", cwd: worktreePath, timestamp: "2026-05-05T12:03:00.000Z")
+    try writeCodexSession(root: root, id: "session-4", cwd: worktreePath, timestamp: "2026-05-05T12:04:00.000Z")
+    try writeCodexSession(root: root, id: "session-5", cwd: worktreePath, timestamp: "2026-05-05T12:05:00.000Z")
+    try writeCodexSession(root: root, id: "session-out", cwd: root.appending(path: "Other").path, timestamp: "2026-05-05T12:06:00.000Z")
+
+    let page = await service.loadLatestSessions(
+      inWorktreePath: worktreePath,
+      excludingSessionIds: ["session-5"],
+      limit: 3
+    )
+
+    #expect(page.sessions.map(\.id) == ["session-4", "session-3", "session-2"])
+    #expect(page.sessions.allSatisfy(\.isWorktree))
+    #expect(page.hasMore)
+  }
+}
+
+private func writeCodexSession(
+  root: URL,
+  id: String,
+  cwd: String,
+  timestamp: String
+) throws {
+  let sessionsDirectory = root
+    .appending(path: "sessions")
+    .appending(path: "2026")
+    .appending(path: "05")
+    .appending(path: "05")
+  try FileManager.default.createDirectory(at: sessionsDirectory, withIntermediateDirectories: true)
+
+  let fileURL = sessionsDirectory.appending(path: "rollout-\(id).jsonl")
+  try codexSessionLines(id: id, cwd: cwd, timestamp: timestamp)
+    .write(to: fileURL, atomically: true, encoding: .utf8)
+
+  if let modificationDate = iso8601Date(timestamp) {
+    try FileManager.default.setAttributes([.modificationDate: modificationDate], ofItemAtPath: fileURL.path)
+  }
+}
+
+private func codexSessionLines(id: String, cwd: String, timestamp: String) -> String {
+  let sessionMeta: [String: Any] = [
+    "timestamp": timestamp,
+    "type": "session_meta",
+    "payload": [
+      "id": id,
+      "timestamp": timestamp,
+      "cwd": cwd,
+      "git": [
+        "branch": "feature/import"
+      ]
+    ]
+  ]
+  let userMessage: [String: Any] = [
+    "timestamp": timestamp,
+    "type": "event_msg",
+    "payload": [
+      "type": "user_message",
+      "message": id
+    ]
+  ]
+
+  return """
+  \(jsonLine(sessionMeta))
+  \(jsonLine(userMessage))
+
+  """
+}
+
+private func jsonLine(_ object: [String: Any]) -> String {
+  let data = try! JSONSerialization.data(withJSONObject: object)
+  return String(decoding: data, as: UTF8.self)
+}
+
+private func iso8601Date(_ string: String) -> Date? {
+  let fractionalFormatter = ISO8601DateFormatter()
+  fractionalFormatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+  if let date = fractionalFormatter.date(from: string) {
+    return date
+  }
+
+  let formatter = ISO8601DateFormatter()
+  formatter.formatOptions = [.withInternetDateTime]
+  return formatter.date(from: string)
+}
+
+private func temporaryDirectory(name: String) throws -> URL {
+  let url = FileManager.default.temporaryDirectory
+    .appending(path: "\(name)_\(UUID().uuidString)", directoryHint: .isDirectory)
+  try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+  return url
+}

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/WorktreeSessionImportCoordinatorTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/WorktreeSessionImportCoordinatorTests.swift
@@ -1,0 +1,224 @@
+import Combine
+import Foundation
+import Testing
+
+@testable import AgentHubCore
+
+@Suite("Worktree session import coordinator")
+@MainActor
+struct WorktreeSessionImportCoordinatorTests {
+  @Test("Imports newest three sessions total across providers")
+  func importsNewestThreeTotalAcrossProviders() async throws {
+    let worktree = settingsWorktree()
+    let claudeMonitor = ImportMonitorService(sessions: [
+      importSession("claude-1", path: worktree.path, timestamp: 100),
+      importSession("claude-2", path: worktree.path, timestamp: 90),
+      importSession("claude-3", path: worktree.path, timestamp: 50),
+    ])
+    let codexMonitor = ImportMonitorService(sessions: [
+      importSession("codex-1", path: worktree.path, timestamp: 95),
+      importSession("codex-2", path: worktree.path, timestamp: 80),
+    ])
+    let claudeViewModel = importViewModel(provider: .claude, monitor: claudeMonitor)
+    let codexViewModel = importViewModel(provider: .codex, monitor: codexMonitor)
+    let coordinator = WorktreeSessionImportCoordinator()
+
+    await coordinator.importInitial(
+      worktree,
+      claudeViewModel: claudeViewModel,
+      codexViewModel: codexViewModel
+    )
+
+    #expect(claudeViewModel.monitoredSessionIds == Set(["claude-1", "claude-2"]))
+    #expect(codexViewModel.monitoredSessionIds == Set(["codex-1"]))
+    #expect(coordinator.canShowMore(worktree))
+  }
+
+  @Test("Show more excludes already imported sessions")
+  func showMoreExcludesAlreadyImportedSessions() async throws {
+    let worktree = settingsWorktree()
+    let claudeMonitor = ImportMonitorService(sessions: [
+      importSession("claude-1", path: worktree.path, timestamp: 100),
+      importSession("claude-2", path: worktree.path, timestamp: 90),
+      importSession("claude-3", path: worktree.path, timestamp: 50),
+    ])
+    let codexMonitor = ImportMonitorService(sessions: [
+      importSession("codex-1", path: worktree.path, timestamp: 95),
+      importSession("codex-2", path: worktree.path, timestamp: 80),
+    ])
+    let claudeViewModel = importViewModel(provider: .claude, monitor: claudeMonitor)
+    let codexViewModel = importViewModel(provider: .codex, monitor: codexMonitor)
+    let coordinator = WorktreeSessionImportCoordinator()
+
+    await coordinator.importInitial(
+      worktree,
+      claudeViewModel: claudeViewModel,
+      codexViewModel: codexViewModel
+    )
+    await coordinator.showMore(
+      worktree,
+      claudeViewModel: claudeViewModel,
+      codexViewModel: codexViewModel
+    )
+
+    #expect(await claudeMonitor.loadExclusionRequests() == [
+      Set<String>(),
+      Set(["claude-1", "claude-2"]),
+    ])
+    #expect(await codexMonitor.loadExclusionRequests() == [
+      Set<String>(),
+      Set(["codex-1"]),
+    ])
+    #expect(claudeViewModel.monitoredSessionIds == Set(["claude-1", "claude-2", "claude-3"]))
+    #expect(codexViewModel.monitoredSessionIds == Set(["codex-1", "codex-2"]))
+    #expect(!coordinator.canShowMore(worktree))
+  }
+}
+
+private final class ImportMonitorService: SessionMonitorServiceProtocol, @unchecked Sendable {
+  private let subject = CurrentValueSubject<[SelectedRepository], Never>([])
+  private let sessions: [CLISession]
+  private var repositories: [SelectedRepository] = []
+  private var loadRequests: [Set<String>] = []
+
+  var repositoriesPublisher: AnyPublisher<[SelectedRepository], Never> {
+    subject.eraseToAnyPublisher()
+  }
+
+  init(sessions: [CLISession]) {
+    self.sessions = sessions
+  }
+
+  func addRepository(_ path: String) async -> SelectedRepository? { nil }
+  func addRepositories(_ paths: [String]) async {}
+  func restoreRepositoriesSkeleton(_ paths: [String]) async -> [SelectedRepository] { [] }
+  func loadSessions(ids: Set<String>) async -> [CLISession] {
+    sessions.filter { ids.contains($0.id) }
+  }
+
+  func loadLatestSessions(
+    inWorktreePath worktreePath: String,
+    excludingSessionIds: Set<String>,
+    limit: Int
+  ) async -> WorktreeSessionImportPage {
+    loadRequests.append(excludingSessionIds)
+    let normalizedWorktreePath = WorktreeModuleResolver.normalizedDirectoryPath(worktreePath)
+    let filtered = sessions
+      .filter { session in
+        guard !excludingSessionIds.contains(session.id) else { return false }
+        let projectPath = WorktreeModuleResolver.normalizedDirectoryPath(session.projectPath)
+        return projectPath == normalizedWorktreePath || projectPath.hasPrefix(normalizedWorktreePath + "/")
+      }
+      .sorted { $0.lastActivityAt > $1.lastActivityAt }
+
+    return WorktreeSessionImportPage(
+      sessions: Array(filtered.prefix(limit)),
+      hasMore: filtered.count > limit
+    )
+  }
+
+  func removeRepository(_ path: String) async {}
+  func setOwnedWorktreePaths(_ paths: Set<String>) async {}
+  func setFocusedSessionIds(_ ids: Set<String>) async {}
+
+  func registerWorktree(_ worktree: WorktreeBranch, parentRepositoryPath: String) async {
+    let normalizedParentPath = WorktreeModuleResolver.normalizedDirectoryPath(parentRepositoryPath)
+    let normalizedWorktree = WorktreeBranch(
+      name: worktree.name,
+      path: WorktreeModuleResolver.normalizedDirectoryPath(worktree.path),
+      isWorktree: true,
+      sessions: worktree.sessions,
+      isExpanded: true
+    )
+
+    if let repositoryIndex = repositories.firstIndex(where: { $0.path == normalizedParentPath }) {
+      if let worktreeIndex = repositories[repositoryIndex].worktrees.firstIndex(where: { $0.path == normalizedWorktree.path }) {
+        repositories[repositoryIndex].worktrees[worktreeIndex] = normalizedWorktree
+      } else {
+        repositories[repositoryIndex].worktrees.append(normalizedWorktree)
+      }
+    } else {
+      repositories.append(SelectedRepository(
+        path: normalizedParentPath,
+        worktrees: [
+          WorktreeBranch(name: "main", path: normalizedParentPath, isWorktree: false),
+          normalizedWorktree,
+        ]
+      ))
+    }
+    subject.send(repositories)
+  }
+
+  func getSelectedRepositories() async -> [SelectedRepository] {
+    repositories
+  }
+
+  func setSelectedRepositories(_ repositories: [SelectedRepository]) async {
+    self.repositories = repositories
+    subject.send(repositories)
+  }
+
+  func refreshSessions(skipWorktreeRedetection: Bool) async {
+    subject.send(repositories)
+  }
+
+  func loadExclusionRequests() async -> [Set<String>] {
+    loadRequests
+  }
+}
+
+private actor ImportFileWatcher: SessionFileWatcherProtocol {
+  nonisolated(unsafe) private let subject = PassthroughSubject<SessionFileWatcher.StateUpdate, Never>()
+
+  nonisolated var statePublisher: AnyPublisher<SessionFileWatcher.StateUpdate, Never> {
+    subject.eraseToAnyPublisher()
+  }
+
+  func startMonitoring(sessionId: String, projectPath: String, sessionFilePath: String?) async {}
+  func stopMonitoring(sessionId: String) async {}
+  func getState(sessionId: String) async -> SessionMonitorState? { nil }
+  func refreshState(sessionId: String) async {}
+  func setApprovalTimeout(_ seconds: Int) async {}
+}
+
+@MainActor
+private func importViewModel(
+  provider: SessionProviderKind,
+  monitor: ImportMonitorService
+) -> CLISessionsViewModel {
+  CLISessionsViewModel(
+    monitorService: monitor,
+    fileWatcher: ImportFileWatcher(),
+    searchService: nil,
+    cliConfiguration: CLICommandConfiguration(command: provider == .claude ? "claude" : "codex", mode: provider == .claude ? .claude : .codex),
+    providerKind: provider,
+    approvalNotificationService: NoOpApprovalNotificationService()
+  )
+}
+
+private func settingsWorktree() -> WorktreeSettingsWorktree {
+  let path = "/tmp/AgentHub-feature"
+  return WorktreeSettingsWorktree(
+    branchName: "feature/import",
+    path: path,
+    worktree: WorktreeBranch(name: "feature/import", path: path, isWorktree: true),
+    parentModulePath: "/tmp/AgentHub",
+    providerKinds: [],
+    isFocusedInAgentHub: false,
+    monitoredSessionCount: 0,
+    activeMonitoredSessionCount: 0,
+    historicalSessionCount: 0
+  )
+}
+
+private func importSession(_ id: String, path: String, timestamp: TimeInterval) -> CLISession {
+  CLISession(
+    id: id,
+    projectPath: path,
+    branchName: "feature/import",
+    isWorktree: true,
+    lastActivityAt: Date(timeIntervalSince1970: timestamp),
+    firstMessage: id,
+    sessionFilePath: "/tmp/\(id).jsonl"
+  )
+}


### PR DESCRIPTION
## Summary
- add bounded worktree session import pages for Claude and Codex
- focus imported external worktrees through existing owned worktree state
- add Settings row Import / Load 3 more UX with displayed-session counts

## Impact
External git worktrees listed in Settings can now be brought into AgentHub without flooding the session list. AgentHub imports the newest three sessions across providers, then loads three more per click.

## Validation
- xcodebuild -project app/AgentHub.xcodeproj -scheme AgentHub -destination 'platform=macOS' -skipPackagePluginValidation build
- git diff --check

## Notes
SwiftPM targeted package tests currently fail before AgentHubCore due the existing CodeEditSymbols Bundle.module package issue, and the AgentHubCore Xcode scheme is not configured for test action.