### PR TITLE
[codex] Bump SwiftTerm to 1.13.0-agenthub.7

### DIFF
--- a/app/AgentHub.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/app/AgentHub.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "9814d7a4cd33a38053ccfab6bc35edd38884781089729a95f81ce6d70340d440",
+  "originHash" : "5a43a0a027ff402ac9f13b384378e85dea913837eebe5a20954105491bb2c8cc",
   "pins" : [
     {
       "identity" : "beautiful-mermaid-swift",
@@ -177,8 +177,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/jamesrochabrun/SwiftTerm",
       "state" : {
-        "revision" : "0b645ef4019486ee7ce554c1e0309ff647e3ecc9",
-        "version" : "1.13.0-agenthub.6"
+        "revision" : "c53c9a0a71ccda3bcd1133f4eb8e2c165c45a8c7",
+        "version" : "1.13.0-agenthub.7"
       }
     },
     {

--- a/app/modules/AgentHubCore/Package.resolved
+++ b/app/modules/AgentHubCore/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "d80b3cbf155d2836e99c138c84231ef95e4172bbaa593d65b15b26e68b0d7dd2",
+  "originHash" : "9ba6f93bfaf3ff545d8c09a707a4bd0be9400a120911bb737ec9b078b996fe53",
   "pins" : [
     {
       "identity" : "beautiful-mermaid-swift",
@@ -159,8 +159,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/jamesrochabrun/SwiftTerm",
       "state" : {
-        "revision" : "0b645ef4019486ee7ce554c1e0309ff647e3ecc9",
-        "version" : "1.13.0-agenthub.6"
+        "revision" : "c53c9a0a71ccda3bcd1133f4eb8e2c165c45a8c7",
+        "version" : "1.13.0-agenthub.7"
       }
     },
     {

--- a/app/modules/AgentHubCore/Package.swift
+++ b/app/modules/AgentHubCore/Package.swift
@@ -39,7 +39,7 @@ let package = Package(
     .package(path: "../Storybook"),
     .package(url: "https://github.com/jamesrochabrun/Canvas", exact: "1.2.1"),
     .package(url: "https://github.com/jamesrochabrun/PierreDiffsSwift", exact: "1.2.2"),
-    .package(url: "https://github.com/jamesrochabrun/SwiftTerm", exact: "1.13.0-agenthub.6"),
+    .package(url: "https://github.com/jamesrochabrun/SwiftTerm", exact: "1.13.0-agenthub.7"),
     .package(url: "https://github.com/gonzalezreal/swift-markdown-ui", from: "2.0.0"),
     .package(url: "https://github.com/groue/GRDB.swift", from: "6.24.0"),
     .package(url: "https://github.com/appstefan/HighlightSwift", from: "1.1.0"),


### PR DESCRIPTION
## Summary

Bump AgentHub's exact SwiftTerm dependency from `1.13.0-agenthub.6` to `1.13.0-agenthub.7`.

The new SwiftTerm release includes the macOS PTY launch fix from `jamesrochabrun/SwiftTerm#6`, replacing SwiftTerm's local terminal `forkpty` path with `openpty` + `posix_spawn` so AgentHub embedded terminals avoid calling `fork` from a multi-threaded GUI app.

## Changes

- Update `app/modules/AgentHubCore/Package.swift` to `1.13.0-agenthub.7`.
- Update the AgentHubCore `Package.resolved` SwiftTerm pin.
- Update the Xcode workspace `Package.resolved` SwiftTerm pin.

## Validation

- `swift package resolve` from `app/modules/AgentHubCore`
- `xcodebuild -resolvePackageDependencies -project app/AgentHub.xcodeproj -scheme AgentHub`
- `xcodebuild build -project app/AgentHub.xcodeproj -scheme AgentHub -destination 'platform=macOS'`

The app build completed with `BUILD SUCCEEDED` and resolved SwiftTerm at `1.13.0-agenthub.7`.