### PR TITLE
[codex] Fix worktree session counts and deletion

### DIFF
--- a/app/modules/AgentHubCLI/Sources/AgentHubCLIKit/WorktreeManagementService.swift
+++ b/app/modules/AgentHubCLI/Sources/AgentHubCLIKit/WorktreeManagementService.swift
@@ -482,9 +482,15 @@ public actor WorktreeManagementService: WorktreeManagementServiceProtocol {
     force: Bool = false,
     deleteAssociatedBranch: Bool = false
   ) async throws {
+    let mainRepoPath = try await findMainRepositoryRoot(at: parentRepoPath)
     guard FileManager.default.fileExists(atPath: worktreePath) else {
-      try await runGitCommand(["worktree", "prune"], at: parentRepoPath)
+      try await pruneStaleWorktreeMetadata(for: worktreePath, parentRepoPath: mainRepoPath)
       return
+    }
+
+    let registeredInfo = try await registeredWorktree(at: worktreePath, relativeTo: mainRepoPath)
+    if let registeredInfo, !registeredInfo.isWorktree {
+      throw WorktreeManagementError.gitCommandFailed("Refusing to delete the main worktree: \(worktreePath)")
     }
 
     let branchToDelete: String?
@@ -502,10 +508,31 @@ public actor WorktreeManagementService: WorktreeManagementServiceProtocol {
     // Removing a worktree deletes its files, which can be slow on a large tree —
     // use the longer worktree timeout so a healthy removal isn't cut short, while
     // still bounding a genuine git hang (the old sync path waited forever).
-    try await runGitCommand(args, at: parentRepoPath, timeout: Self.gitWorktreeTimeout)
+    do {
+      try await runGitCommand(args, at: mainRepoPath, timeout: Self.gitWorktreeTimeout)
+    } catch {
+      guard force, registeredInfo?.isWorktree == true else {
+        throw error
+      }
+      try await forceRemoveRegisteredWorktreeDirectory(worktreePath, parentRepoPath: mainRepoPath)
+    }
+
+    if FileManager.default.fileExists(atPath: worktreePath) {
+      guard force, registeredInfo?.isWorktree == true else {
+        throw WorktreeManagementError.gitCommandFailed(
+          "Git reported success but the worktree directory still exists: \(worktreePath)"
+        )
+      }
+      try await forceRemoveRegisteredWorktreeDirectory(worktreePath, parentRepoPath: mainRepoPath)
+    }
+
+    if let stillRegistered = try await registeredWorktree(at: worktreePath, relativeTo: mainRepoPath),
+       stillRegistered.isWorktree {
+      try await pruneStaleWorktreeMetadata(for: worktreePath, parentRepoPath: mainRepoPath)
+    }
 
     if let branchToDelete, !branchToDelete.isEmpty {
-      try await runGitCommand(["branch", force ? "-D" : "-d", branchToDelete], at: parentRepoPath)
+      try await runGitCommand(["branch", force ? "-D" : "-d", branchToDelete], at: mainRepoPath)
     }
   }
 
@@ -618,6 +645,35 @@ private extension WorktreeManagementService {
       .standardizedFileURL
       .resolvingSymlinksInPath()
       .path
+  }
+
+  func registeredWorktree(at worktreePath: String, relativeTo parentRepoPath: String) async throws -> WorktreeInfo? {
+    let normalizedTargetPath = normalizedExistingPath(worktreePath)
+    return try await listWorktrees(at: parentRepoPath).first { worktree in
+      normalizedExistingPath(worktree.path) == normalizedTargetPath
+    }
+  }
+
+  func pruneStaleWorktreeMetadata(for worktreePath: String, parentRepoPath: String) async throws {
+    try await runGitCommand(["worktree", "prune", "--expire", "now"], at: parentRepoPath)
+    if let stillRegistered = try await registeredWorktree(at: worktreePath, relativeTo: parentRepoPath),
+       stillRegistered.isWorktree {
+      throw WorktreeManagementError.gitCommandFailed(
+        "Worktree metadata still exists after prune: \(worktreePath)"
+      )
+    }
+  }
+
+  func forceRemoveRegisteredWorktreeDirectory(_ worktreePath: String, parentRepoPath: String) async throws {
+    if FileManager.default.fileExists(atPath: worktreePath) {
+      try FileManager.default.removeItem(atPath: worktreePath)
+    }
+    try await pruneStaleWorktreeMetadata(for: worktreePath, parentRepoPath: parentRepoPath)
+    if FileManager.default.fileExists(atPath: worktreePath) {
+      throw WorktreeManagementError.gitCommandFailed(
+        "Worktree directory still exists after force delete: \(worktreePath)"
+      )
+    }
   }
 
   func copyUntrackedFiles(

--- a/app/modules/AgentHubCLI/Tests/AgentHubCLIKitTests/WorktreeManagementServiceTests.swift
+++ b/app/modules/AgentHubCLI/Tests/AgentHubCLIKitTests/WorktreeManagementServiceTests.swift
@@ -347,6 +347,26 @@ struct WorktreeRemovalTests {
     #expect(!listAfter.contains("test-branch"))
   }
 
+  @Test("Force removes dirty worktree from disk")
+  func forceRemovesDirtyWorktreeFromDisk() async throws {
+    let fixture = try GitRepoFixture.create()
+    defer { fixture.cleanup() }
+
+    let worktreePath = try fixture.addSiblingWorktree(branch: "dirty-branch")
+    try "untracked".write(
+      toFile: (worktreePath as NSString).appendingPathComponent("untracked.txt"),
+      atomically: true,
+      encoding: .utf8
+    )
+
+    let service = WorktreeManagementService()
+    try await service.removeWorktree(at: worktreePath, relativeTo: fixture.repoPath, force: true)
+
+    #expect(!FileManager.default.fileExists(atPath: worktreePath))
+    let listAfter = try fixture.runGit("worktree", "list")
+    #expect(!listAfter.contains("dirty-branch"))
+  }
+
   @Test("Cancels in-flight worktree creation and cleans generated artifacts")
   func cancelsWorktreeCreationAndCleansUp() async throws {
     let fixture = try GitRepoFixture.create()

--- a/app/modules/AgentHubCore/Sources/AgentHub/Models/WorktreeSettingsInventory.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Models/WorktreeSettingsInventory.swift
@@ -116,12 +116,20 @@ enum WorktreeSettingsInventoryBuilder {
         from: discoveredWorktree,
         fallbackPath: worktreePath
       )
-      let monitoredSessions = providerMatches.flatMap { providerKind, _ in
+      let monitoredSessions = providerMatches.flatMap { providerKind, providerWorktree in
         switch providerKind {
         case .claude:
-          return sessions(in: worktreePath, from: claudeMonitoredSessions)
+          return sessions(
+            in: worktreePath,
+            from: claudeMonitoredSessions,
+            attachedTo: providerWorktree
+          )
         case .codex:
-          return sessions(in: worktreePath, from: codexMonitoredSessions)
+          return sessions(
+            in: worktreePath,
+            from: codexMonitoredSessions,
+            attachedTo: providerWorktree
+          )
         }
       }
       let historicalSessionCount = Set(providerMatches.flatMap { $0.1.sessions.map(\.id) }).count
@@ -144,11 +152,20 @@ enum WorktreeSettingsInventoryBuilder {
     }
   }
 
-  private static func sessions(in worktreePath: String, from sessions: [CLISession]) -> [CLISession] {
-    sessions.filter { session in
+  private static func sessions(
+    in worktreePath: String,
+    from sessions: [CLISession],
+    attachedTo worktree: WorktreeBranch?
+  ) -> [CLISession] {
+    let pathMatchedSessions = sessions.filter { session in
       let projectPath = normalized(session.projectPath)
       return projectPath == worktreePath || projectPath.hasPrefix(worktreePath + "/")
     }
+    guard let worktree else { return [] }
+
+    let attachedSessionIds = Set(worktree.sessions.map(\.id))
+    guard !attachedSessionIds.isEmpty else { return [] }
+    return pathMatchedSessions.filter { attachedSessionIds.contains($0.id) }
   }
 
   private static func appendPath(_ path: String, to paths: inout [String], seen: inout Set<String>) {

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
@@ -1016,18 +1016,6 @@ public struct MultiProviderSessionsListView: View {
     }
   }
 
-  private func focusedSessionCount(inWorktreePath worktreePath: String) -> Int {
-    selectedSessionItems.filter { item in
-      !item.isPending && isProjectPath(item.session.projectPath, containedIn: worktreePath)
-    }.count
-  }
-
-  private func isProjectPath(_ path: String, containedIn root: String) -> Bool {
-    let path = WorktreeModuleResolver.normalizedDirectoryPath(path)
-    let root = WorktreeModuleResolver.normalizedDirectoryPath(root)
-    return path == root || path.hasPrefix(root + "/")
-  }
-
   private func removeWorktreeModuleFocus(_ worktree: WorktreeBranch) {
     let path = WorktreeModuleResolver.normalizedDirectoryPath(worktree.path)
     if selectedModuleLandingPath == path {
@@ -1129,9 +1117,9 @@ public struct MultiProviderSessionsListView: View {
             ForEach(section.groups) { group in
               let isExpanded = !collapsedProjectGroups.contains(group.id)
               let worktreeModule = worktreeModule(for: group.id)
-              let worktreeSessionCount = worktreeModule.map {
-                focusedSessionCount(inWorktreePath: $0.path)
-              } ?? 0
+              let worktreeSessionCount = worktreeModule == nil
+                ? 0
+                : group.items.filter { !$0.isPending }.count
 
               ProjectGroupHeader(
                 name: group.displayName,

--- a/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/CLISessionsViewModel.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/CLISessionsViewModel.swift
@@ -2256,12 +2256,33 @@ public final class CLISessionsViewModel {
 
   /// Finds the parent repository path for a worktree by searching selectedRepositories.
   private func findParentRepoPath(for worktree: WorktreeBranch) -> String? {
+    let normalizedWorktreePath = WorktreeModuleResolver.normalizedDirectoryPath(worktree.path)
     for repo in selectedRepositories {
-      if repo.worktrees.contains(where: { $0.path == worktree.path }) {
+      if repo.worktrees.contains(where: {
+        WorktreeModuleResolver.normalizedDirectoryPath($0.path) == normalizedWorktreePath
+      }) {
         return repo.path
       }
     }
     return nil
+  }
+
+  private func worktreeDeletionTarget(for session: CLISession) -> (worktree: WorktreeBranch, parentRepoPath: String?) {
+    if let match = WorktreeModuleResolver.bestMatch(
+      for: session.projectPath,
+      repositories: selectedRepositories
+    ), match.worktree.isWorktree {
+      return (match.worktree, match.repository.path)
+    }
+
+    return (
+      WorktreeBranch(
+        name: session.branchName ?? URL(fileURLWithPath: session.projectPath).lastPathComponent,
+        path: WorktreeModuleResolver.normalizedDirectoryPath(session.projectPath),
+        isWorktree: true
+      ),
+      nil
+    )
   }
 
   /// Deletes a worktree
@@ -2274,15 +2295,16 @@ public final class CLISessionsViewModel {
     deletingWorktreePath = worktree.path
 
     do {
-      if FileManager.default.fileExists(atPath: worktree.path) {
-        try await worktreeRemovalService.removeWorktree(at: worktree.path, force: force)
-      } else if let parentRepoPath = findParentRepoPath(for: worktree) {
+      if let parentRepoPath = findParentRepoPath(for: worktree) {
         try await worktreeRemovalService.removeWorktree(at: worktree.path, relativeTo: parentRepoPath, force: force)
+      } else if FileManager.default.fileExists(atPath: worktree.path) {
+        try await worktreeRemovalService.removeWorktree(at: worktree.path, force: force)
       } else {
         throw NSError(domain: "AgentHub", code: 1, userInfo: [
           NSLocalizedDescriptionKey: "Cannot find parent repository for worktree at \(worktree.path)"
         ])
       }
+      archiveMonitoredSessions(inWorktreePath: worktree.path)
       removeOwnedWorktreePath(worktree.path)
       deletingWorktreePath = nil
       clearWorktreeDeletionError()
@@ -2320,6 +2342,7 @@ public final class CLISessionsViewModel {
 
     do {
       try await worktreeRemovalService.removeOrphanedWorktree(at: worktree.path, parentRepoPath: parentRepoPath)
+      archiveMonitoredSessions(inWorktreePath: worktree.path)
       removeOwnedWorktreePath(worktree.path)
       deletingWorktreePath = nil
       clearWorktreeDeletionError()
@@ -2361,32 +2384,33 @@ public final class CLISessionsViewModel {
   ///   - force: When true, uses double `--force` to remove worktrees with untracked files
   @discardableResult
   public func deleteWorktreeForSession(_ session: CLISession, force: Bool = false) async -> Bool {
-    deletingWorktreePath = session.projectPath
+    let target = worktreeDeletionTarget(for: session)
+    let worktree = target.worktree
+    deletingWorktreePath = worktree.path
     do {
-      try await worktreeRemovalService.removeWorktree(at: session.projectPath, force: force)
-      removeOwnedWorktreePath(session.projectPath)
+      if let parentRepoPath = target.parentRepoPath {
+        try await worktreeRemovalService.removeWorktree(at: worktree.path, relativeTo: parentRepoPath, force: force)
+      } else {
+        try await worktreeRemovalService.removeWorktree(at: worktree.path, force: force)
+      }
+      archiveMonitoredSessions(inWorktreePath: worktree.path)
+      removeOwnedWorktreePath(worktree.path)
       deletingWorktreePath = nil
-      stopMonitoring(session: session)
       refresh()
       return true
     } catch {
       deletingWorktreePath = nil
-      let syntheticWorktree = WorktreeBranch(
-        name: session.branchName ?? session.projectPath,
-        path: session.projectPath,
-        isWorktree: true
-      )
-      if let orphanInfo = worktreeRemovalService.checkIfOrphaned(at: session.projectPath),
+      if let orphanInfo = worktreeRemovalService.checkIfOrphaned(at: worktree.path),
          orphanInfo.isOrphaned {
         worktreeDeletionError = WorktreeDeletionError(
-          worktree: syntheticWorktree,
+          worktree: worktree,
           message: error.localizedDescription,
           isOrphaned: true,
           parentRepoPath: orphanInfo.parentRepoPath
         )
       } else {
         worktreeDeletionError = WorktreeDeletionError(
-          worktree: syntheticWorktree,
+          worktree: worktree,
           message: error.localizedDescription
         )
       }

--- a/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/WorktreeSessionImportCoordinator.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/WorktreeSessionImportCoordinator.swift
@@ -26,6 +26,7 @@ final class WorktreeSessionImportCoordinator {
   ) async {
     await importNextPage(
       worktree,
+      pageSize: 1,
       shouldFocusWorktree: true,
       claudeViewModel: claudeViewModel,
       codexViewModel: codexViewModel
@@ -39,6 +40,7 @@ final class WorktreeSessionImportCoordinator {
   ) async {
     await importNextPage(
       worktree,
+      pageSize: pageSize,
       shouldFocusWorktree: true,
       claudeViewModel: claudeViewModel,
       codexViewModel: codexViewModel
@@ -47,6 +49,7 @@ final class WorktreeSessionImportCoordinator {
 
   private func importNextPage(
     _ worktree: WorktreeSettingsWorktree,
+    pageSize: Int,
     shouldFocusWorktree: Bool,
     claudeViewModel: CLISessionsViewModel,
     codexViewModel: CLISessionsViewModel

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/WorktreeSessionImportCoordinatorTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/WorktreeSessionImportCoordinatorTests.swift
@@ -7,8 +7,8 @@ import Testing
 @Suite("Worktree session import coordinator")
 @MainActor
 struct WorktreeSessionImportCoordinatorTests {
-  @Test("Imports newest three sessions total across providers")
-  func importsNewestThreeTotalAcrossProviders() async throws {
+  @Test("Initial import brings only the newest session across providers")
+  func initialImportBringsNewestSessionAcrossProviders() async throws {
     let worktree = settingsWorktree()
     let claudeMonitor = ImportMonitorService(sessions: [
       importSession("claude-1", path: worktree.path, timestamp: 100),
@@ -29,8 +29,8 @@ struct WorktreeSessionImportCoordinatorTests {
       codexViewModel: codexViewModel
     )
 
-    #expect(claudeViewModel.monitoredSessionIds == Set(["claude-1", "claude-2"]))
-    #expect(codexViewModel.monitoredSessionIds == Set(["codex-1"]))
+    #expect(claudeViewModel.monitoredSessionIds == Set(["claude-1"]))
+    #expect(codexViewModel.monitoredSessionIds.isEmpty)
     #expect(coordinator.canShowMore(worktree))
   }
 
@@ -60,14 +60,21 @@ struct WorktreeSessionImportCoordinatorTests {
       claudeViewModel: claudeViewModel,
       codexViewModel: codexViewModel
     )
+    await coordinator.showMore(
+      worktree,
+      claudeViewModel: claudeViewModel,
+      codexViewModel: codexViewModel
+    )
 
     #expect(await claudeMonitor.loadExclusionRequests() == [
       Set<String>(),
+      Set(["claude-1"]),
       Set(["claude-1", "claude-2"]),
     ])
     #expect(await codexMonitor.loadExclusionRequests() == [
       Set<String>(),
-      Set(["codex-1"]),
+      Set<String>(),
+      Set(["codex-1", "codex-2"]),
     ])
     #expect(claudeViewModel.monitoredSessionIds == Set(["claude-1", "claude-2", "claude-3"]))
     #expect(codexViewModel.monitoredSessionIds == Set(["codex-1", "codex-2"]))

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/WorktreeSettingsInventoryTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/WorktreeSettingsInventoryTests.swift
@@ -157,6 +157,36 @@ struct WorktreeSettingsInventoryTests {
     #expect(worktree.providerKinds == [.claude])
     #expect(worktree.isFocusedInAgentHub)
   }
+
+  @Test("Snapshot counts only sessions attached to the focused worktree row")
+  func snapshotIgnoresStalePathMatchedBackups() throws {
+    let displayedSession = session("displayed-session", path: "/tmp/AgentHub-feature")
+    let staleSession = session("stale-session", path: "/tmp/AgentHub-feature")
+    let nestedStaleSession = session("nested-stale-session", path: "/tmp/AgentHub-feature/app")
+    let repository = SelectedRepository(
+      path: "/tmp/AgentHub",
+      worktrees: [
+        WorktreeBranch(name: "main", path: "/tmp/AgentHub", isWorktree: false),
+        WorktreeBranch(
+          name: "feature/focused",
+          path: "/tmp/AgentHub-feature",
+          isWorktree: true,
+          sessions: [displayedSession]
+        ),
+      ]
+    )
+
+    let snapshot = WorktreeSettingsInventoryBuilder.snapshot(
+      claudeRepositories: [repository],
+      codexRepositories: [],
+      claudeMonitoredSessions: [displayedSession, staleSession, nestedStaleSession],
+      codexMonitoredSessions: []
+    )
+
+    let worktree = try #require(snapshot.modules.first?.worktrees.first)
+    #expect(worktree.monitoredSessionCount == 1)
+    #expect(worktree.historicalSessionCount == 1)
+  }
 }
 
 @Suite("Worktree settings deletion helpers")
@@ -208,6 +238,42 @@ struct WorktreeSettingsDeletionHelperTests {
     #expect(viewModel.worktreeDeletionError?.worktree.path == worktreePath)
     #expect(viewModel.monitoredSessionIds == Set(["session-1"]))
   }
+
+  @Test("Delete worktree for nested session removes the worktree root")
+  func deleteWorktreeForNestedSessionRemovesWorktreeRoot() async throws {
+    let remover = RecordingWorktreeRemovalService()
+    let repoPath = try temporaryDirectory(name: "delete-nested-repo")
+    let worktreePath = try temporaryDirectory(name: "delete-nested-worktree")
+    let nestedSession = session("nested-session", path: worktreePath + "/app")
+    let rootSession = session("root-session", path: worktreePath)
+    let repository = SelectedRepository(
+      path: repoPath,
+      worktrees: [
+        WorktreeBranch(name: "main", path: repoPath, isWorktree: false),
+        WorktreeBranch(
+          name: "feature",
+          path: worktreePath,
+          isWorktree: true,
+          sessions: [nestedSession, rootSession]
+        ),
+      ]
+    )
+    let monitor = WorktreeDeletionMonitorService(repositories: [repository])
+    let viewModel = makeDeletionViewModel(remover: remover, monitor: monitor)
+    await waitForDeletionViewModel {
+      !viewModel.selectedRepositories.isEmpty
+    }
+    viewModel.startMonitoring(session: nestedSession)
+    viewModel.startMonitoring(session: rootSession)
+
+    let succeeded = await viewModel.deleteWorktreeForSession(nestedSession)
+
+    #expect(succeeded)
+    #expect(viewModel.monitoredSessionIds.isEmpty)
+    #expect(await remover.relativeRemovals() == [
+      WorktreeRelativeRemoval(path: worktreePath, parentRepoPath: repoPath, force: false)
+    ])
+  }
 }
 
 private func session(_ id: String, path: String, isActive: Bool = false) -> CLISession {
@@ -223,10 +289,11 @@ private func session(_ id: String, path: String, isActive: Bool = false) -> CLIS
 
 @MainActor
 private func makeDeletionViewModel(
-  remover: RecordingWorktreeRemovalService = RecordingWorktreeRemovalService()
+  remover: RecordingWorktreeRemovalService = RecordingWorktreeRemovalService(),
+  monitor: WorktreeDeletionMonitorService = WorktreeDeletionMonitorService()
 ) -> CLISessionsViewModel {
   CLISessionsViewModel(
-    monitorService: WorktreeDeletionMonitorService(),
+    monitorService: monitor,
     fileWatcher: WorktreeDeletionFileWatcher(),
     searchService: nil,
     cliConfiguration: CLICommandConfiguration(command: "claude", mode: .claude),
@@ -237,7 +304,13 @@ private func makeDeletionViewModel(
 }
 
 private final class WorktreeDeletionMonitorService: SessionMonitorServiceProtocol, @unchecked Sendable {
-  private let subject = PassthroughSubject<[SelectedRepository], Never>()
+  private let subject: CurrentValueSubject<[SelectedRepository], Never>
+  private var repositories: [SelectedRepository]
+
+  init(repositories: [SelectedRepository] = []) {
+    self.repositories = repositories
+    self.subject = CurrentValueSubject(repositories)
+  }
 
   var repositoriesPublisher: AnyPublisher<[SelectedRepository], Never> {
     subject.eraseToAnyPublisher()
@@ -245,8 +318,13 @@ private final class WorktreeDeletionMonitorService: SessionMonitorServiceProtoco
 
   func addRepository(_ path: String) async -> SelectedRepository? { nil }
   func removeRepository(_ path: String) async {}
-  func getSelectedRepositories() async -> [SelectedRepository] { [] }
-  func setSelectedRepositories(_ repositories: [SelectedRepository]) async {}
+  func getSelectedRepositories() async -> [SelectedRepository] { repositories }
+
+  func setSelectedRepositories(_ repositories: [SelectedRepository]) async {
+    self.repositories = repositories
+    subject.send(repositories)
+  }
+
   func refreshSessions(skipWorktreeRedetection: Bool) async {}
 }
 
@@ -267,6 +345,7 @@ private final class WorktreeDeletionFileWatcher: SessionFileWatcherProtocol, @un
 private actor RecordingWorktreeRemovalService: GitWorktreeRemovalServiceProtocol {
   private let error: Error?
   private var paths: [String] = []
+  private var relativeRemovalRecords: [WorktreeRelativeRemoval] = []
 
   init(error: Error? = nil) {
     self.error = error
@@ -280,6 +359,11 @@ private actor RecordingWorktreeRemovalService: GitWorktreeRemovalServiceProtocol
   func removeWorktree(at worktreePath: String, relativeTo parentRepoPath: String, force: Bool) async throws {
     if let error { throw error }
     paths.append(worktreePath)
+    relativeRemovalRecords.append(WorktreeRelativeRemoval(
+      path: worktreePath,
+      parentRepoPath: parentRepoPath,
+      force: force
+    ))
   }
 
   nonisolated func checkIfOrphaned(at worktreePath: String) -> (isOrphaned: Bool, parentRepoPath: String?)? {
@@ -294,6 +378,16 @@ private actor RecordingWorktreeRemovalService: GitWorktreeRemovalServiceProtocol
   func removedWorktreePaths() -> [String] {
     paths
   }
+
+  func relativeRemovals() -> [WorktreeRelativeRemoval] {
+    relativeRemovalRecords
+  }
+}
+
+private struct WorktreeRelativeRemoval: Equatable, Sendable {
+  let path: String
+  let parentRepoPath: String
+  let force: Bool
 }
 
 private enum TestDeletionError: Error {
@@ -306,4 +400,14 @@ private func temporaryDirectory(name: String) throws -> String {
     .appendingPathComponent("\(name)-\(UUID().uuidString)")
   try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
   return url.path
+}
+
+@MainActor
+private func waitForDeletionViewModel(
+  condition: @escaping @MainActor () -> Bool
+) async {
+  for _ in 0..<20 {
+    if condition() { return }
+    await Task.yield()
+  }
 }


### PR DESCRIPTION
## Summary

Fixes two worktree issues in the Focus on Agents hub:

- Initial import of an external worktree now brings in only the newest matching session instead of preloading three sessions.
- Worktree session counts now use sessions attached to the provider worktree row instead of stale path-matched backup sessions.
- Worktree deletion now resolves nested session paths back to the real worktree root, removes through the parent repository when possible, archives all monitored sessions under the deleted worktree, and force-removes registered dirty worktrees from disk when git removal leaves them behind.

## Root Cause

The initial import path reused the paginated “show more” page size, so a newly brought-in worktree could immediately show three sessions. Separately, some counts were derived from path containment alone, which allowed stale or backup sessions with the same worktree path to inflate the displayed count. Deletion could also target a nested session project directory instead of the registered worktree root, and the force path still depended on `git worktree remove` completing the directory removal.

## Validation

- `git diff --check`
- `swift test --package-path app/modules/AgentHubCLI`
- `xcodebuild build -project app/AgentHub.xcodeproj -scheme AgentHubCore -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO`

Note: the Xcode build exited successfully and printed `** BUILD SUCCEEDED **`; it also prints the existing SwiftLint plugin footer for dependency lint phases.