### PR TITLE
Add dynamic model pickers for Claude and Codex

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/Models/AIModelOption.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Models/AIModelOption.swift
@@ -1,0 +1,60 @@
+//
+//  AIModelOption.swift
+//  AgentHub
+//
+//  A single selectable model surfaced in the AI configuration picker.
+//
+
+import Foundation
+
+/// A reasoning/effort level a model supports, as reported by the provider.
+public struct AIReasoningEffort: Identifiable, Hashable, Sendable {
+  /// The `--effort` value (e.g. "low", "medium", "high", "xhigh").
+  public let effort: String
+  /// Provider-supplied one-line explanation of the level, if any.
+  public let description: String?
+
+  public var id: String { effort }
+
+  public init(effort: String, description: String? = nil) {
+    self.effort = effort
+    self.description = description
+  }
+}
+
+/// A model the user can pick for a provider.
+///
+/// `identifier` is the exact value passed to the CLI `--model` flag — a Codex
+/// slug like `gpt-5.5`, a Claude alias like `opus`, or a fully versioned id
+/// like `claude-opus-4-8`. An empty identifier represents "use the CLI default"
+/// (AgentHub omits `--model` entirely), so it is never stored as an option here;
+/// the UI offers the default as a separate, empty selection.
+public struct AIModelOption: Identifiable, Hashable, Sendable {
+  /// Value passed to `--model`.
+  public let identifier: String
+  /// Human-facing name (e.g. "GPT-5.5", "Opus", or the raw id when none is known).
+  public let displayName: String
+  /// Optional one-line context shown beside the selection (model description,
+  /// "Latest Opus (alias)", "Used in your sessions", …).
+  public let detail: String?
+  /// Reasoning levels this model supports (Codex reports these; empty when unknown).
+  public let reasoningEfforts: [AIReasoningEffort]
+  /// The model's default reasoning level, if the provider reports one.
+  public let defaultReasoningEffort: String?
+
+  public var id: String { identifier }
+
+  public init(
+    identifier: String,
+    displayName: String,
+    detail: String? = nil,
+    reasoningEfforts: [AIReasoningEffort] = [],
+    defaultReasoningEffort: String? = nil
+  ) {
+    self.identifier = identifier
+    self.displayName = displayName
+    self.detail = detail
+    self.reasoningEfforts = reasoningEfforts
+    self.defaultReasoningEffort = defaultReasoningEffort
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/ClaudeModelCatalog.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/ClaudeModelCatalog.swift
@@ -1,0 +1,142 @@
+//
+//  ClaudeModelCatalog.swift
+//  AgentHub
+//
+//  Resolves the list of selectable Claude models without hardcoding versioned
+//  ids. Claude has no offline "list models" command, so:
+//
+//  - Stable aliases (opus/sonnet/haiku) are always offered. These are
+//    server-resolved — `--model opus` always maps to the latest Opus — so they
+//    never go stale the way a pinned version would.
+//  - Concrete versioned ids (e.g. claude-opus-4-8 vs claude-opus-4-7) are
+//    discovered from the user's own local session JSONL history, which records
+//    the resolved model for every turn. Nothing leaves the machine.
+//
+
+import Foundation
+
+/// Provides the set of selectable Claude models.
+public protocol ClaudeModelCatalogProviding: Sendable {
+  func availableModels() async -> [AIModelOption]
+}
+
+public struct ClaudeModelCatalog: ClaudeModelCatalogProviding {
+  /// Stable, server-resolved aliases. `--model opus` always maps to the latest
+  /// Opus, so these never go stale the way a versioned id would.
+  static let aliasOptions: [AIModelOption] = [
+    AIModelOption(identifier: "opus", displayName: "Opus", detail: "Latest Opus (alias)"),
+    AIModelOption(identifier: "sonnet", displayName: "Sonnet", detail: "Latest Sonnet (alias)"),
+    AIModelOption(identifier: "haiku", displayName: "Haiku", detail: "Latest Haiku (alias)"),
+  ]
+
+  private let projectsDirectory: URL
+  private let fileScanLimit: Int
+
+  public init() {
+    self.init(
+      projectsDirectory: URL(fileURLWithPath: NSHomeDirectory())
+        .appendingPathComponent(".claude/projects")
+    )
+  }
+
+  init(projectsDirectory: URL, fileScanLimit: Int = 80) {
+    self.projectsDirectory = projectsDirectory
+    self.fileScanLimit = fileScanLimit
+  }
+
+  public func availableModels() async -> [AIModelOption] {
+    let directory = projectsDirectory
+    let limit = fileScanLimit
+    let discovered = await Task.detached(priority: .utility) {
+      Self.discoverModelIdentifiers(inProjectsDirectory: directory, fileScanLimit: limit)
+    }.value
+
+    let aliasIdentifiers = Set(Self.aliasOptions.map(\.identifier))
+    let discoveredOptions = discovered
+      .filter { !aliasIdentifiers.contains($0) }
+      .map { AIModelOption(identifier: $0, displayName: $0, detail: "Used in your sessions") }
+
+    return Self.aliasOptions + discoveredOptions
+  }
+
+  // MARK: - Discovery (pure, testable)
+
+  /// Scans the most recently modified session JSONL files for resolved model
+  /// ids, returning distinct valid Claude identifiers ordered most-recent-first.
+  static func discoverModelIdentifiers(
+    inProjectsDirectory directory: URL,
+    fileScanLimit: Int = 80
+  ) -> [String] {
+    let fileManager = FileManager.default
+    guard let enumerator = fileManager.enumerator(
+      at: directory,
+      includingPropertiesForKeys: [.contentModificationDateKey, .isRegularFileKey],
+      options: [.skipsHiddenFiles]
+    ) else {
+      return []
+    }
+
+    var files: [(url: URL, modified: Date)] = []
+    for case let url as URL in enumerator where url.pathExtension == "jsonl" {
+      let values = try? url.resourceValues(forKeys: [.contentModificationDateKey])
+      files.append((url, values?.contentModificationDate ?? .distantPast))
+    }
+
+    let recentFiles = files
+      .sorted { $0.modified > $1.modified }
+      .prefix(fileScanLimit)
+      .map(\.url)
+
+    var ordered: [String] = []
+    var seen = Set<String>()
+    for url in recentFiles {
+      guard let contents = try? String(contentsOf: url, encoding: .utf8) else { continue }
+      for identifier in modelIdentifiers(inJSONL: contents) where seen.insert(identifier).inserted {
+        ordered.append(identifier)
+      }
+    }
+    return ordered
+  }
+
+  /// Distinct valid Claude model ids appearing in one JSONL document, in order.
+  static func modelIdentifiers(inJSONL contents: String) -> [String] {
+    var result: [String] = []
+    var seen = Set<String>()
+    for line in contents.split(whereSeparator: \.isNewline) where line.contains("\"model\"") {
+      for value in modelValues(inLine: String(line))
+      where isValidModelIdentifier(value) && seen.insert(value).inserted {
+        result.append(value)
+      }
+    }
+    return result
+  }
+
+  /// Extracts every `"model":"…"` value from a single line.
+  static func modelValues(inLine line: String) -> [String] {
+    var values: [String] = []
+    var search = line[...]
+    while let keyRange = search.range(of: "\"model\"") {
+      let afterKey = search[keyRange.upperBound...]
+      guard let colon = afterKey.firstIndex(of: ":") else { break }
+      let afterColon = afterKey[afterKey.index(after: colon)...]
+      guard let openQuote = afterColon.firstIndex(of: "\"") else {
+        search = afterColon
+        continue
+      }
+      let valueStart = afterColon.index(after: openQuote)
+      guard let closeQuote = afterColon[valueStart...].firstIndex(of: "\"") else { break }
+      values.append(String(afterColon[valueStart..<closeQuote]))
+      search = afterColon[afterColon.index(after: closeQuote)...]
+    }
+    return values
+  }
+
+  /// A value usable as a `--model` argument: lowercase, `claude-` prefixed, and
+  /// free of spaces/brackets. Excludes display names ("Claude Opus 4.8"),
+  /// beta-context suffixes ("…[1m]"), and non-Claude ids ("gpt-5.5").
+  static func isValidModelIdentifier(_ value: String) -> Bool {
+    guard value.hasPrefix("claude-") else { return false }
+    let allowed = Set("abcdefghijklmnopqrstuvwxyz0123456789-.")
+    return value.allSatisfy { allowed.contains($0) }
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/CodexModelCatalog.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/CodexModelCatalog.swift
@@ -1,0 +1,273 @@
+//
+//  CodexModelCatalog.swift
+//  AgentHub
+//
+//  Dynamically resolves the list of available Codex models by invoking
+//  `codex debug models`, falling back to the on-disk model cache. This avoids
+//  hardcoding model slugs, which change with every Codex release.
+//
+
+import Foundation
+
+// MARK: - Protocols
+
+/// Runs `codex debug models` and returns the raw JSON payload.
+public protocol CodexDebugModelsCommandRunning: Sendable {
+  func debugModelsJSON(homeDirectory: String) async throws -> Data
+}
+
+/// Provides the set of selectable Codex models and the configured default.
+public protocol CodexModelCatalogProviding: Sendable {
+  /// Live `codex debug models` output, falling back to the on-disk cache.
+  func availableModels() async -> [AIModelOption]
+  /// The model id Codex would use by default (`config.toml` → first cached → fallback).
+  func defaultModelIdentifier() async -> String
+}
+
+// MARK: - Catalog
+
+public struct CodexModelCatalog: CodexModelCatalogProviding {
+  /// Used only when neither the live command, the cache, nor config.toml yields anything.
+  static let fallbackModelIdentifier = "gpt-5-codex"
+
+  private let commandRunner: any CodexDebugModelsCommandRunning
+  private let homeDirectory: String
+
+  public init() {
+    self.init(commandRunner: CodexDebugModelsCommandRunner())
+  }
+
+  init(
+    commandRunner: any CodexDebugModelsCommandRunning,
+    homeDirectory: String = NSHomeDirectory()
+  ) {
+    self.commandRunner = commandRunner
+    self.homeDirectory = homeDirectory
+  }
+
+  public func availableModels() async -> [AIModelOption] {
+    if let data = try? await commandRunner.debugModelsJSON(homeDirectory: homeDirectory),
+       let models = try? Self.modelOptions(fromDebugModelsJSON: data),
+       !models.isEmpty {
+      return models
+    }
+    return cachedModels()
+  }
+
+  public func defaultModelIdentifier() async -> String {
+    if let configured = configuredModelIdentifier() {
+      return configured
+    }
+    if let firstCached = cachedModels().first?.identifier {
+      return firstCached
+    }
+    return Self.fallbackModelIdentifier
+  }
+
+  // MARK: - Cache + config (disk)
+
+  func cachedModels() -> [AIModelOption] {
+    let cacheURL = URL(fileURLWithPath: homeDirectory)
+      .appendingPathComponent(".codex/models_cache.json")
+    guard let data = try? Data(contentsOf: cacheURL) else { return [] }
+    return (try? Self.modelOptions(fromDebugModelsJSON: data)) ?? []
+  }
+
+  func configuredModelIdentifier() -> String? {
+    let configURL = URL(fileURLWithPath: homeDirectory)
+      .appendingPathComponent(".codex/config.toml")
+    guard let contents = try? String(contentsOf: configURL, encoding: .utf8) else { return nil }
+    return Self.configuredModelIdentifier(inConfigTOML: contents)
+  }
+
+  // MARK: - Parsing (pure, testable)
+
+  /// Decodes a `codex debug models` / `models_cache.json` payload into options,
+  /// keeping only listable models and ordering them by Codex's own priority.
+  static func modelOptions(fromDebugModelsJSON data: Data) throws -> [AIModelOption] {
+    let payload = try JSONDecoder().decode(ModelCachePayload.self, from: data)
+    return payload.models
+      .filter { ($0.visibility ?? "list") == "list" }
+      .sorted { lhs, rhs in
+        let lhsPriority = lhs.priority ?? Int.max
+        let rhsPriority = rhs.priority ?? Int.max
+        if lhsPriority != rhsPriority {
+          return lhsPriority < rhsPriority
+        }
+        return (lhs.displayName ?? lhs.slug)
+          .localizedStandardCompare(rhs.displayName ?? rhs.slug) == .orderedAscending
+      }
+      .map { model in
+        let trimmedName = model.displayName?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let displayName = (trimmedName?.isEmpty == false) ? trimmedName! : model.slug
+        let trimmedDetail = model.description?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let efforts = (model.supportedReasoningLevels ?? []).map { level -> AIReasoningEffort in
+          let levelDetail = level.description?.trimmingCharacters(in: .whitespacesAndNewlines)
+          return AIReasoningEffort(
+            effort: level.effort,
+            description: (levelDetail?.isEmpty == false) ? levelDetail : nil
+          )
+        }
+        return AIModelOption(
+          identifier: model.slug,
+          displayName: displayName,
+          detail: (trimmedDetail?.isEmpty == false) ? trimmedDetail : nil,
+          reasoningEfforts: efforts,
+          defaultReasoningEffort: model.defaultReasoningLevel
+        )
+      }
+  }
+
+  /// Extracts the top-level `model = "…"` value from a Codex `config.toml`.
+  /// Stops at the first table header so only the root `model` key is honored.
+  static func configuredModelIdentifier(inConfigTOML contents: String) -> String? {
+    for rawLine in contents.split(whereSeparator: \.isNewline) {
+      let line = lineWithoutComment(String(rawLine))
+        .trimmingCharacters(in: .whitespacesAndNewlines)
+
+      if line.hasPrefix("[") {
+        return nil
+      }
+
+      guard let (key, value) = keyValuePair(from: line), key == "model" else {
+        continue
+      }
+
+      return value.isEmpty ? nil : value
+    }
+    return nil
+  }
+
+  private static func keyValuePair(from line: String) -> (key: String, value: String)? {
+    let parts = line.split(separator: "=", maxSplits: 1, omittingEmptySubsequences: false)
+    guard parts.count == 2 else { return nil }
+
+    let key = parts[0].trimmingCharacters(in: .whitespacesAndNewlines)
+    let value = parts[1]
+      .trimmingCharacters(in: .whitespacesAndNewlines)
+      .trimmingCharacters(in: CharacterSet(charactersIn: "\"'"))
+
+    return (key, value)
+  }
+
+  private static func lineWithoutComment(_ line: String) -> String {
+    guard let commentStart = line.firstIndex(of: "#") else { return line }
+    return String(line[..<commentStart])
+  }
+
+  private struct ModelCachePayload: Decodable {
+    let models: [CachedModel]
+  }
+
+  private struct CachedModel: Decodable {
+    let slug: String
+    let displayName: String?
+    let description: String?
+    let visibility: String?
+    let priority: Int?
+    let supportedReasoningLevels: [ReasoningLevel]?
+    let defaultReasoningLevel: String?
+
+    private enum CodingKeys: String, CodingKey {
+      case slug
+      case displayName = "display_name"
+      case description
+      case visibility
+      case priority
+      case supportedReasoningLevels = "supported_reasoning_levels"
+      case defaultReasoningLevel = "default_reasoning_level"
+    }
+  }
+
+  private struct ReasoningLevel: Decodable {
+    let effort: String
+    let description: String?
+  }
+}
+
+// MARK: - Command runner
+
+/// Runs `codex debug models`, preferring a local Codex install and reusing the
+/// app's executable resolution and PATH building.
+public struct CodexDebugModelsCommandRunner: CodexDebugModelsCommandRunning {
+  public init() {}
+
+  public func debugModelsJSON(homeDirectory: String) async throws -> Data {
+    try await Task.detached(priority: .userInitiated) {
+      try Self.run(homeDirectory: homeDirectory)
+    }.value
+  }
+
+  private static func run(homeDirectory: String) throws -> Data {
+    let invocation = codexInvocation(homeDirectory: homeDirectory)
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: invocation.executablePath)
+    process.arguments = invocation.arguments
+    process.environment = environment(homeDirectory: homeDirectory)
+
+    let outputPipe = Pipe()
+    let errorPipe = Pipe()
+    process.standardOutput = outputPipe
+    process.standardError = errorPipe
+
+    try process.run()
+
+    // Drain stdout before waiting: `codex debug models` emits ~170 KB, which
+    // exceeds the pipe buffer and would deadlock a wait-then-read ordering.
+    let output = outputPipe.fileHandleForReading.readDataToEndOfFile()
+    let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
+    process.waitUntilExit()
+
+    guard process.terminationStatus == 0 else {
+      let message = String(data: errorData, encoding: .utf8) ?? "codex debug models failed"
+      throw CodexDebugModelsCommandError.nonZeroExit(message)
+    }
+
+    return output
+  }
+
+  private static func codexInvocation(
+    homeDirectory: String
+  ) -> (executablePath: String, arguments: [String]) {
+    let arguments = ["debug", "models"]
+
+    let localCodexPath = "\(homeDirectory)/.codex/local/codex"
+    if FileManager.default.isExecutableFile(atPath: localCodexPath) {
+      return (localCodexPath, arguments)
+    }
+
+    if let detected = TerminalLauncher.findCodexExecutable(additionalPaths: nil) {
+      return (detected, arguments)
+    }
+
+    return ("/usr/bin/env", ["codex"] + arguments)
+  }
+
+  private static func environment(homeDirectory: String) -> [String: String] {
+    var environment = ProcessInfo.processInfo.environment
+    environment["HOME"] = homeDirectory
+    environment["CODEX_HOME"] = URL(fileURLWithPath: homeDirectory)
+      .appendingPathComponent(".codex")
+      .path
+
+    let resolverPaths = CLIPathResolver.codexPaths(additionalPaths: [], homeDirectory: homeDirectory)
+    if let currentPath = environment["PATH"], !currentPath.isEmpty {
+      environment["PATH"] = (resolverPaths + [currentPath]).joined(separator: ":")
+    } else {
+      environment["PATH"] = resolverPaths.joined(separator: ":")
+    }
+
+    return environment
+  }
+}
+
+enum CodexDebugModelsCommandError: LocalizedError {
+  case nonZeroExit(String)
+
+  var errorDescription: String? {
+    switch self {
+    case .nonZeroExit(let message):
+      return message
+    }
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/AIConfigSettingsView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/AIConfigSettingsView.swift
@@ -21,15 +21,31 @@ public final class AIConfigSettingsViewModel {
   var codexApprovalPolicy: String = ""
   var codexReasoningEffort: String = ""
 
+  /// Dynamically resolved model options surfaced by the pickers.
+  var claudeModels: [AIModelOption] = []
+  var codexModels: [AIModelOption] = []
+
   var codexApprovalPolicyDescription: String {
     Self.codexApprovalPolicyDescription(for: codexApprovalPolicy)
   }
 
   @ObservationIgnored private var aiConfigService: (any AIConfigServiceProtocol)?
+  @ObservationIgnored private let claudeModelCatalog: any ClaudeModelCatalogProviding
+  @ObservationIgnored private let codexModelCatalog: any CodexModelCatalogProviding
   @ObservationIgnored
   private var isLoaded = false
 
-  public init() {}
+  public convenience init() {
+    self.init(claudeModelCatalog: ClaudeModelCatalog(), codexModelCatalog: CodexModelCatalog())
+  }
+
+  init(
+    claudeModelCatalog: any ClaudeModelCatalogProviding,
+    codexModelCatalog: any CodexModelCatalogProviding
+  ) {
+    self.claudeModelCatalog = claudeModelCatalog
+    self.codexModelCatalog = codexModelCatalog
+  }
 
   func load(service: (any AIConfigServiceProtocol)?) async {
     guard !isLoaded, let service else { return }
@@ -72,6 +88,56 @@ public final class AIConfigSettingsViewModel {
     Task { try? await service.saveConfig(record) }
   }
 
+  /// Refreshes the Claude model options (aliases + ids seen in local history).
+  func refreshClaudeModels() async {
+    claudeModels = await claudeModelCatalog.availableModels()
+  }
+
+  /// Refreshes the Codex model options via `codex debug models` / cache.
+  func refreshCodexModels() async {
+    codexModels = await codexModelCatalog.availableModels()
+  }
+
+  // MARK: Codex effort options (model-aware)
+
+  /// Standard fallback when the selected model reports no reasoning levels.
+  static let defaultCodexEfforts: [AIReasoningEffort] = [
+    AIReasoningEffort(effort: "low"),
+    AIReasoningEffort(effort: "medium"),
+    AIReasoningEffort(effort: "high"),
+    AIReasoningEffort(effort: "xhigh"),
+  ]
+
+  private var selectedCodexModel: AIModelOption? {
+    codexModels.first { $0.identifier == codexModel }
+  }
+
+  /// Effort levels offered for the currently selected Codex model. Falls back to
+  /// the standard set when the model is unknown, and always includes any
+  /// already-saved value so the picker can render it.
+  var codexEffortOptions: [AIReasoningEffort] {
+    let modelEfforts = selectedCodexModel?.reasoningEfforts ?? []
+    var efforts = modelEfforts.isEmpty ? Self.defaultCodexEfforts : modelEfforts
+    if !codexReasoningEffort.isEmpty, !efforts.contains(where: { $0.effort == codexReasoningEffort }) {
+      efforts.append(AIReasoningEffort(effort: codexReasoningEffort))
+    }
+    return efforts
+  }
+
+  /// The selected model's default effort, surfaced in the "Default" option.
+  var codexDefaultEffortHint: String? {
+    selectedCodexModel?.defaultReasoningEffort
+  }
+
+  /// Description of the currently selected effort, when the provider supplied one.
+  var codexSelectedEffortDescription: String? {
+    codexEffortOptions.first { $0.effort == codexReasoningEffort }?.description
+  }
+
+  static func codexEffortLabel(_ effort: String) -> String {
+    effort == "xhigh" ? "XHigh" : effort.capitalized
+  }
+
   private static func sanitizedCodexApprovalPolicy(_ value: String) -> String {
     switch value {
     case "untrusted", "on-request", "never", "full-auto":
@@ -104,11 +170,12 @@ struct ClaudeAIConfigView: View {
 
   var body: some View {
     VStack(alignment: .leading, spacing: 16) {
-      settingsTextField(
-        title: "Model",
-        placeholder: "CLI default (e.g. opus, sonnet)",
-        text: $viewModel.claudeModel,
-        onSave: viewModel.saveClaude
+      AIModelPickerRow(
+        selection: $viewModel.claudeModel,
+        options: viewModel.claudeModels,
+        customPlaceholder: "CLI default (e.g. opus, sonnet)",
+        onCommit: viewModel.saveClaude,
+        onRefresh: { Task { await viewModel.refreshClaudeModels() } }
       )
 
       settingsField("Effort") {
@@ -139,6 +206,11 @@ struct ClaudeAIConfigView: View {
     }
     .padding(.vertical, 4)
     .frame(maxWidth: .infinity, alignment: .leading)
+    .task {
+      if viewModel.claudeModels.isEmpty {
+        await viewModel.refreshClaudeModels()
+      }
+    }
   }
 
   private func settingsMultilineEditor(
@@ -164,11 +236,12 @@ struct CodexAIConfigView: View {
 
   var body: some View {
     VStack(alignment: .leading, spacing: 16) {
-      settingsTextField(
-        title: "Model",
-        placeholder: "CLI default (e.g. gpt-5-codex)",
-        text: $viewModel.codexModel,
-        onSave: viewModel.saveCodex
+      AIModelPickerRow(
+        selection: $viewModel.codexModel,
+        options: viewModel.codexModels,
+        customPlaceholder: "CLI default (e.g. gpt-5-codex)",
+        onCommit: viewModel.saveCodex,
+        onRefresh: { Task { await viewModel.refreshCodexModels() } }
       )
 
       settingsField("Approval") {
@@ -192,33 +265,140 @@ struct CodexAIConfigView: View {
 
       settingsField("Effort") {
         Picker("", selection: $viewModel.codexReasoningEffort) {
-          Text("Default").tag("")
-          Text("Low").tag("low")
-          Text("Medium").tag("medium")
-          Text("High").tag("high")
-          Text("XHigh").tag("xhigh")
+          Text(viewModel.codexDefaultEffortHint.map { "Default (\($0))" } ?? "Default").tag("")
+          ForEach(viewModel.codexEffortOptions) { effort in
+            Text(AIConfigSettingsViewModel.codexEffortLabel(effort.effort)).tag(effort.effort)
+          }
         }
         .labelsHidden()
         .onChange(of: viewModel.codexReasoningEffort) { viewModel.saveCodex() }
-        .frame(maxWidth: 180, alignment: .leading)
+        .frame(maxWidth: 220, alignment: .leading)
+
+        if let description = viewModel.codexSelectedEffortDescription {
+          Text(description)
+            .font(.caption2)
+            .foregroundStyle(.secondary)
+            .fixedSize(horizontal: false, vertical: true)
+            .frame(maxWidth: 420, alignment: .leading)
+        }
       }
     }
     .padding(.vertical, 4)
     .frame(maxWidth: .infinity, alignment: .leading)
+    .task {
+      if viewModel.codexModels.isEmpty {
+        await viewModel.refreshCodexModels()
+      }
+    }
   }
 }
 
-private func settingsTextField(
-  title: String,
-  placeholder: String,
-  text: Binding<String>,
-  onSave: @escaping () -> Void
-) -> some View {
-  settingsField(title) {
-    TextField(placeholder, text: text)
-      .textFieldStyle(.roundedBorder)
-      .onSubmit { onSave() }
-      .onChange(of: text.wrappedValue) { onSave() }
+// MARK: - Model Picker Row
+
+/// A dropdown of dynamically discovered models with a free-text escape hatch so
+/// any exact identifier can still be pinned. An empty selection means "CLI
+/// default" (AgentHub omits `--model`).
+private struct AIModelPickerRow: View {
+  @Binding var selection: String
+  let options: [AIModelOption]
+  let customPlaceholder: String
+  let onCommit: () -> Void
+  let onRefresh: () -> Void
+
+  var body: some View {
+    settingsField("Model") {
+      HStack(spacing: 8) {
+        Menu {
+          Button { select("") } label: {
+            menuLabel(name: "Default", isSelected: selection.isEmpty)
+          }
+          if !options.isEmpty {
+            Divider()
+            ForEach(options) { option in
+              Button { select(option.identifier) } label: {
+                menuLabel(name: option.displayName, isSelected: option.identifier == selection)
+              }
+            }
+          }
+        } label: {
+          menuButtonLabel
+        }
+        .menuStyle(.borderlessButton)
+        .menuIndicator(.hidden)
+        .frame(maxWidth: 280, alignment: .leading)
+
+        Button(action: onRefresh) {
+          Image(systemName: "arrow.clockwise")
+            .frame(width: 14, height: 14)
+        }
+        .buttonStyle(.bordered)
+        .help("Refresh available models")
+      }
+
+      // `.labelsHidden()` keeps the grouped Form from promoting the placeholder
+      // into a wrapping leading label (which pushed the field off to the right).
+      TextField(customPlaceholder, text: $selection)
+        .textFieldStyle(.roundedBorder)
+        .labelsHidden()
+        .onSubmit { onCommit() }
+        .onChange(of: selection) { onCommit() }
+        .frame(maxWidth: 320, alignment: .leading)
+
+      Text(footnote)
+        .font(.caption2)
+        .foregroundColor(.secondary)
+        .fixedSize(horizontal: false, vertical: true)
+        .frame(maxWidth: 420, alignment: .leading)
+    }
+  }
+
+  private func select(_ identifier: String) {
+    guard identifier != selection else { return }
+    selection = identifier
+  }
+
+  private var selectedOption: AIModelOption? {
+    options.first { $0.identifier == selection }
+  }
+
+  private var footnote: String {
+    if let detail = selectedOption?.detail, !detail.isEmpty {
+      return detail
+    }
+    return "Pick a detected model, or type any exact identifier."
+  }
+
+  private var menuButtonLabel: some View {
+    HStack(spacing: 6) {
+      Text(selection.isEmpty ? "Default" : (selectedOption?.displayName ?? selection))
+        .lineLimit(1)
+        .truncationMode(.middle)
+      Spacer(minLength: 4)
+      Image(systemName: "chevron.up.chevron.down")
+        .font(.caption2)
+        .foregroundStyle(.secondary)
+    }
+    .padding(.horizontal, 10)
+    .padding(.vertical, 6)
+    .frame(maxWidth: .infinity, alignment: .leading)
+    .background(
+      RoundedRectangle(cornerRadius: 6)
+        .fill(Color(NSColor.controlBackgroundColor))
+    )
+    .overlay(
+      RoundedRectangle(cornerRadius: 6)
+        .stroke(Color(NSColor.separatorColor), lineWidth: 1)
+    )
+    .contentShape(Rectangle())
+  }
+
+  @ViewBuilder
+  private func menuLabel(name: String, isSelected: Bool) -> some View {
+    if isSelected {
+      Label(name, systemImage: "checkmark")
+    } else {
+      Text(name)
+    }
   }
 }
 

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/AIConfigSettingsTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/AIConfigSettingsTests.swift
@@ -542,6 +542,77 @@ struct AIConfigSettingsViewModelTests {
     viewModel.codexApprovalPolicy = "suggest"
     #expect(viewModel.codexApprovalPolicyDescription.contains("CLI defaults"))
   }
+
+  @Test("Refreshing models populates the picker options from the catalogs")
+  @MainActor
+  func refreshModelsPopulatesOptions() async {
+    let viewModel = AIConfigSettingsViewModel(
+      claudeModelCatalog: StubClaudeCatalog(options: [
+        AIModelOption(identifier: "opus", displayName: "Opus"),
+        AIModelOption(identifier: "claude-opus-4-8", displayName: "claude-opus-4-8"),
+      ]),
+      codexModelCatalog: StubCodexCatalog(options: [
+        AIModelOption(identifier: "gpt-5.5", displayName: "GPT-5.5"),
+      ])
+    )
+
+    await viewModel.refreshClaudeModels()
+    await viewModel.refreshCodexModels()
+
+    #expect(viewModel.claudeModels.map(\.identifier) == ["opus", "claude-opus-4-8"])
+    #expect(viewModel.codexModels.map(\.identifier) == ["gpt-5.5"])
+  }
+
+  @Test("Codex effort options follow the selected model's reasoning levels")
+  @MainActor
+  func codexEffortOptionsFollowSelectedModel() async {
+    let viewModel = AIConfigSettingsViewModel(
+      claudeModelCatalog: StubClaudeCatalog(options: []),
+      codexModelCatalog: StubCodexCatalog(options: [
+        AIModelOption(
+          identifier: "gpt-5.3-codex-spark",
+          displayName: "GPT-5.3-Codex-Spark",
+          reasoningEfforts: [
+            AIReasoningEffort(effort: "low", description: "Fast"),
+            AIReasoningEffort(effort: "high", description: "Deep"),
+          ],
+          defaultReasoningEffort: "high"
+        )
+      ])
+    )
+
+    await viewModel.refreshCodexModels()
+    viewModel.codexModel = "gpt-5.3-codex-spark"
+
+    #expect(viewModel.codexEffortOptions.map(\.effort) == ["low", "high"])
+    #expect(viewModel.codexDefaultEffortHint == "high")
+
+    viewModel.codexReasoningEffort = "high"
+    #expect(viewModel.codexSelectedEffortDescription == "Deep")
+  }
+
+  @Test("Codex effort options fall back to the standard set for unknown models")
+  @MainActor
+  func codexEffortOptionsFallBack() {
+    let viewModel = AIConfigSettingsViewModel(
+      claudeModelCatalog: StubClaudeCatalog(options: []),
+      codexModelCatalog: StubCodexCatalog(options: [])
+    )
+
+    #expect(viewModel.codexEffortOptions.map(\.effort) == ["low", "medium", "high", "xhigh"])
+    #expect(viewModel.codexDefaultEffortHint == nil)
+  }
+}
+
+private struct StubClaudeCatalog: ClaudeModelCatalogProviding {
+  let options: [AIModelOption]
+  func availableModels() async -> [AIModelOption] { options }
+}
+
+private struct StubCodexCatalog: CodexModelCatalogProviding {
+  let options: [AIModelOption]
+  func availableModels() async -> [AIModelOption] { options }
+  func defaultModelIdentifier() async -> String { options.first?.identifier ?? "" }
 }
 
 private actor MockAIConfigService: AIConfigServiceProtocol {

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/ClaudeModelCatalogTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/ClaudeModelCatalogTests.swift
@@ -1,0 +1,126 @@
+//
+//  ClaudeModelCatalogTests.swift
+//  AgentHub
+//
+//  Tests local discovery of versioned Claude model ids from session JSONL plus
+//  the stable aliases, with no hardcoded version list.
+//
+
+import Foundation
+import Testing
+@testable import AgentHubCore
+
+@Suite("ClaudeModelCatalog")
+struct ClaudeModelCatalogTests {
+
+  // MARK: - Identifier validation
+
+  @Test("Accepts versioned Claude ids and rejects noise")
+  func validatesModelIdentifiers() {
+    #expect(ClaudeModelCatalog.isValidModelIdentifier("claude-opus-4-8"))
+    #expect(ClaudeModelCatalog.isValidModelIdentifier("claude-haiku-4-5-20251001"))
+
+    // Display name (spaces + uppercase), beta-context suffix, and non-Claude ids.
+    #expect(!ClaudeModelCatalog.isValidModelIdentifier("Claude Opus 4.8"))
+    #expect(!ClaudeModelCatalog.isValidModelIdentifier("claude-opus-4-8[1m]"))
+    #expect(!ClaudeModelCatalog.isValidModelIdentifier("gpt-5.5"))
+    #expect(!ClaudeModelCatalog.isValidModelIdentifier("opus"))
+  }
+
+  // MARK: - Line + document extraction
+
+  @Test("Extracts every model value from a line")
+  func extractsModelValuesFromLine() {
+    let line = #"{"type":"assistant","message":{"model":"claude-opus-4-8","other":"x"},"model":"claude-haiku-4-5"}"#
+
+    #expect(ClaudeModelCatalog.modelValues(inLine: line) == ["claude-opus-4-8", "claude-haiku-4-5"])
+  }
+
+  @Test("Collects distinct valid ids from a JSONL document, dropping noise")
+  func collectsValidIdentifiersFromDocument() {
+    let jsonl = """
+    {"type":"user","message":{"role":"user"}}
+    {"type":"assistant","message":{"model":"claude-opus-4-8"}}
+    {"type":"assistant","message":{"model":"claude-opus-4-8"}}
+    {"type":"assistant","message":{"model":"claude-opus-4-7"}}
+    {"summary":"Claude Opus 4.8 did things"}
+    {"type":"assistant","message":{"model":"gpt-5.5"}}
+    """
+
+    let ids = ClaudeModelCatalog.modelIdentifiers(inJSONL: jsonl)
+
+    #expect(ids == ["claude-opus-4-8", "claude-opus-4-7"])
+  }
+
+  // MARK: - Directory discovery
+
+  @Test("Discovers ids across files ordered most-recent-first")
+  func discoversIdentifiersByRecency() throws {
+    let directory = try makeTempProjects()
+    defer { try? FileManager.default.removeItem(at: directory) }
+
+    // Older file uses 4-7; newer file uses 4-8. Newest should come first.
+    try writeSession(
+      named: "old.jsonl",
+      model: "claude-opus-4-7",
+      modified: Date(timeIntervalSince1970: 1_000),
+      in: directory
+    )
+    try writeSession(
+      named: "new.jsonl",
+      model: "claude-opus-4-8",
+      modified: Date(timeIntervalSince1970: 2_000),
+      in: directory
+    )
+
+    let ids = ClaudeModelCatalog.discoverModelIdentifiers(inProjectsDirectory: directory)
+
+    #expect(ids == ["claude-opus-4-8", "claude-opus-4-7"])
+  }
+
+  @Test("Returns empty when the projects directory does not exist")
+  func emptyWhenDirectoryMissing() {
+    let missing = FileManager.default.temporaryDirectory
+      .appendingPathComponent("does_not_exist_\(UUID().uuidString)")
+
+    #expect(ClaudeModelCatalog.discoverModelIdentifiers(inProjectsDirectory: missing).isEmpty)
+  }
+
+  // MARK: - availableModels
+
+  @Test("availableModels lists aliases first, then discovered versioned ids")
+  func availableModelsMergesAliasesAndDiscovery() async throws {
+    let directory = try makeTempProjects()
+    defer { try? FileManager.default.removeItem(at: directory) }
+    try writeSession(
+      named: "session.jsonl",
+      model: "claude-opus-4-8",
+      modified: Date(timeIntervalSince1970: 2_000),
+      in: directory
+    )
+
+    let catalog = ClaudeModelCatalog(projectsDirectory: directory)
+    let options = await catalog.availableModels()
+
+    #expect(options.prefix(3).map(\.identifier) == ["opus", "sonnet", "haiku"])
+    #expect(options.map(\.identifier).contains("claude-opus-4-8"))
+    let discovered = options.first { $0.identifier == "claude-opus-4-8" }
+    #expect(discovered?.detail == "Used in your sessions")
+  }
+
+  // MARK: - Helpers
+
+  private func makeTempProjects() throws -> URL {
+    let directory = FileManager.default.temporaryDirectory
+      .appendingPathComponent("claude_catalog_\(UUID().uuidString)")
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    return directory
+  }
+
+  private func writeSession(named name: String, model: String, modified: Date, in directory: URL) throws {
+    let url = directory.appendingPathComponent(name)
+    let line = #"{"type":"assistant","message":{"model":"\#(model)"}}"# + "\n"
+    try line.write(to: url, atomically: true, encoding: .utf8)
+    try FileManager.default.setAttributes([.modificationDate: modified], ofItemAtPath: url.path)
+  }
+}

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/CodexModelCatalogTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/CodexModelCatalogTests.swift
@@ -1,0 +1,204 @@
+//
+//  CodexModelCatalogTests.swift
+//  AgentHub
+//
+//  Tests dynamic Codex model resolution: parsing `codex debug models` output,
+//  cache fallback, and reading the configured default from config.toml.
+//
+
+import Foundation
+import Testing
+@testable import AgentHubCore
+
+@Suite("CodexModelCatalog")
+struct CodexModelCatalogTests {
+
+  // MARK: - Parsing
+
+  @Test("Keeps only listable models and orders them by priority")
+  func parsesAndSortsListableModels() throws {
+    let json = Data("""
+    {"models":[
+      {"slug":"gpt-5.4","display_name":"GPT-5.4","description":"Balanced","visibility":"list","priority":16},
+      {"slug":"codex-auto-review","display_name":"Codex Auto Review","visibility":"hide","priority":43},
+      {"slug":"gpt-5.5","display_name":"GPT-5.5","description":"Frontier model","visibility":"list","priority":9}
+    ]}
+    """.utf8)
+
+    let options = try CodexModelCatalog.modelOptions(fromDebugModelsJSON: json)
+
+    #expect(options.map(\.identifier) == ["gpt-5.5", "gpt-5.4"])
+    #expect(options.first?.displayName == "GPT-5.5")
+    #expect(options.first?.detail == "Frontier model")
+  }
+
+  @Test("Falls back to the slug when display name is missing or blank")
+  func displayNameFallsBackToSlug() throws {
+    let json = Data("""
+    {"models":[{"slug":"gpt-5.3-codex-spark","display_name":"   ","visibility":"list","priority":1}]}
+    """.utf8)
+
+    let options = try CodexModelCatalog.modelOptions(fromDebugModelsJSON: json)
+
+    #expect(options.count == 1)
+    #expect(options[0].displayName == "gpt-5.3-codex-spark")
+    #expect(options[0].detail == nil)
+  }
+
+  @Test("Models without explicit visibility are treated as listable")
+  func missingVisibilityIsListed() throws {
+    let json = Data(#"{"models":[{"slug":"gpt-5.5","display_name":"GPT-5.5","priority":9}]}"#.utf8)
+
+    let options = try CodexModelCatalog.modelOptions(fromDebugModelsJSON: json)
+
+    #expect(options.map(\.identifier) == ["gpt-5.5"])
+  }
+
+  @Test("Parses per-model reasoning levels and the default")
+  func parsesReasoningLevels() throws {
+    let json = Data("""
+    {"models":[{
+      "slug":"gpt-5.3-codex-spark","display_name":"GPT-5.3-Codex-Spark","visibility":"list","priority":1,
+      "default_reasoning_level":"high",
+      "supported_reasoning_levels":[
+        {"effort":"low","description":"Fast responses with lighter reasoning"},
+        {"effort":"high","description":"Greater reasoning depth for complex problems"}
+      ]
+    }]}
+    """.utf8)
+
+    let options = try CodexModelCatalog.modelOptions(fromDebugModelsJSON: json)
+
+    #expect(options.count == 1)
+    #expect(options[0].defaultReasoningEffort == "high")
+    #expect(options[0].reasoningEfforts.map(\.effort) == ["low", "high"])
+    #expect(options[0].reasoningEfforts.first?.description == "Fast responses with lighter reasoning")
+  }
+
+  @Test("Reasoning levels are empty when the payload omits them")
+  func reasoningLevelsDefaultEmpty() throws {
+    let json = Data(#"{"models":[{"slug":"gpt-5.5","display_name":"GPT-5.5","visibility":"list","priority":9}]}"#.utf8)
+
+    let options = try CodexModelCatalog.modelOptions(fromDebugModelsJSON: json)
+
+    #expect(options[0].reasoningEfforts.isEmpty)
+    #expect(options[0].defaultReasoningEffort == nil)
+  }
+
+  // MARK: - config.toml
+
+  @Test("Reads the root model key, stripping quotes and comments")
+  func readsConfiguredModelFromTOML() {
+    let toml = """
+    # Codex configuration
+    model = "gpt-5.4-mini"  # preferred model
+    approval_policy = "on-request"
+    """
+
+    #expect(CodexModelCatalog.configuredModelIdentifier(inConfigTOML: toml) == "gpt-5.4-mini")
+  }
+
+  @Test("Ignores model keys nested under a table header")
+  func ignoresModelKeyInsideTable() {
+    let toml = """
+    approval_policy = "never"
+
+    [profiles.work]
+    model = "gpt-5.5"
+    """
+
+    #expect(CodexModelCatalog.configuredModelIdentifier(inConfigTOML: toml) == nil)
+  }
+
+  @Test("Returns nil when no model key is present")
+  func returnsNilWhenModelMissing() {
+    #expect(CodexModelCatalog.configuredModelIdentifier(inConfigTOML: "approval_policy = \"never\"") == nil)
+  }
+
+  // MARK: - Catalog behavior
+
+  @Test("availableModels uses live command output when it succeeds")
+  func availableModelsUsesLiveOutput() async {
+    let json = Data(#"{"models":[{"slug":"gpt-5.5","display_name":"GPT-5.5","visibility":"list","priority":9}]}"#.utf8)
+    let catalog = CodexModelCatalog(
+      commandRunner: StubCommandRunner(result: .success(json)),
+      homeDirectory: NSHomeDirectory()
+    )
+
+    let options = await catalog.availableModels()
+
+    #expect(options.map(\.identifier) == ["gpt-5.5"])
+  }
+
+  @Test("availableModels falls back to the on-disk cache when the command fails")
+  func availableModelsFallsBackToCache() async throws {
+    let home = try makeTempHome()
+    defer { try? FileManager.default.removeItem(atPath: home) }
+    let cache = Data(#"{"models":[{"slug":"gpt-5.4","display_name":"GPT-5.4","visibility":"list","priority":16}]}"#.utf8)
+    try writeCodexFile(cache, named: "models_cache.json", inHome: home)
+
+    let catalog = CodexModelCatalog(
+      commandRunner: StubCommandRunner(result: .failure(SampleError.boom)),
+      homeDirectory: home
+    )
+
+    let options = await catalog.availableModels()
+
+    #expect(options.map(\.identifier) == ["gpt-5.4"])
+  }
+
+  @Test("defaultModelIdentifier prefers config.toml, then cache, then fallback")
+  func defaultModelResolution() async throws {
+    let home = try makeTempHome()
+    defer { try? FileManager.default.removeItem(atPath: home) }
+
+    let catalog = CodexModelCatalog(
+      commandRunner: StubCommandRunner(result: .failure(SampleError.boom)),
+      homeDirectory: home
+    )
+
+    // No config, no cache → fallback.
+    let fallback = await catalog.defaultModelIdentifier()
+    #expect(fallback == CodexModelCatalog.fallbackModelIdentifier)
+
+    // Cache present, still no config → first cached model.
+    let cache = Data(#"{"models":[{"slug":"gpt-5.5","display_name":"GPT-5.5","visibility":"list","priority":9}]}"#.utf8)
+    try writeCodexFile(cache, named: "models_cache.json", inHome: home)
+    let cached = await catalog.defaultModelIdentifier()
+    #expect(cached == "gpt-5.5")
+
+    // config.toml wins over the cache.
+    try writeCodexFile(Data("model = \"gpt-5.4\"\n".utf8), named: "config.toml", inHome: home)
+    let configured = await catalog.defaultModelIdentifier()
+    #expect(configured == "gpt-5.4")
+  }
+
+  // MARK: - Helpers
+
+  private func makeTempHome() throws -> String {
+    let home = FileManager.default.temporaryDirectory
+      .appendingPathComponent("codex_catalog_\(UUID().uuidString)")
+    try FileManager.default.createDirectory(
+      at: home.appendingPathComponent(".codex"),
+      withIntermediateDirectories: true
+    )
+    return home.path
+  }
+
+  private func writeCodexFile(_ data: Data, named name: String, inHome home: String) throws {
+    let url = URL(fileURLWithPath: home).appendingPathComponent(".codex").appendingPathComponent(name)
+    try data.write(to: url)
+  }
+}
+
+private struct StubCommandRunner: CodexDebugModelsCommandRunning {
+  let result: Result<Data, Error>
+
+  func debugModelsJSON(homeDirectory: String) async throws -> Data {
+    try result.get()
+  }
+}
+
+private enum SampleError: Error {
+  case boom
+}


### PR DESCRIPTION
## What

Replaces the free-text **Model** fields in **Settings → Configuration** with dropdown pickers sourced from live provider data — so the lists never go stale — while keeping a free-text escape hatch to pin any exact identifier. Also makes the Codex **Effort** picker model-aware.

## Why

Model slugs were effectively hardcoded. Codex versions its slugs (`gpt-5.5`, `gpt-5.4`, …) so any static list rots every release; Claude versions its ids too (`claude-opus-4-7` vs `claude-opus-4-8`), which the `opus` alias can't distinguish.

## How

**Codex** — runs `codex debug models`, decodes the JSON (keeps `visibility == "list"`, sorts by `priority`), and falls back to `~/.codex/models_cache.json`. The default is read from `~/.codex/config.toml`. The same payload carries `supported_reasoning_levels` / `default_reasoning_level`, so the Effort picker now lists exactly what the selected model supports, shows its default in the "Default" option (e.g. *Default (high)*), and shows each level's description.

**Claude** — there is no offline "list models" command, and hitting `/v1/models` would need credentials + a network call (against the app's local-only guarantee). So it offers the stable, server-resolved aliases (`opus`/`sonnet`/`haiku`) **plus** versioned ids discovered from the user's own `~/.claude/projects/*.jsonl` history (which records the resolved model per turn). Fully local; surfaces the exact `4-7` vs `4-8` distinction automatically.

**Mechanics**
- New `AIModelOption` / `AIReasoningEffort` value types.
- `CodexModelCatalog` + `ClaudeModelCatalog` behind protocols (mockable); the Codex command runner reuses `TerminalLauncher.findCodexExecutable` and drains stdout before waiting (the output is ~170 KB).
- The pickers are dropdown + refresh + free-text escape hatch, with a description line for the selected model/effort.
- **No persistence change** — still writes `AIConfigRecord.defaultModel` / `effortLevel`, so edits apply to **new sessions immediately, no restart** (each launch reads the config fresh via `getAIConfigSync`). Running sessions are unaffected.

## Tests

`CodexModelCatalogTests`, `ClaudeModelCatalogTests`, and additions to `AIConfigSettingsTests` cover JSON parsing/filter/sort, `config.toml` + default resolution, cache fallback, JSONL discovery + recency ordering, identifier validation, reasoning-level parsing, and the model-aware effort wiring.

`xcodebuild … build` and `build-for-testing` both succeed. Note: the suite runs via Xcode **Cmd+U** (the scheme has no headless test action).

🤖 Generated with [Claude Code](https://claude.com/claude-code)