### PR TITLE
Add compact display mode to the global Sessions panel

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubDefaults.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubDefaults.swift
@@ -151,6 +151,14 @@ public enum AgentHubDefaults {
   /// Type: String (NSStringFromRect, default: unset)
   public static let globalSessionPanelFrame = "\(keyPrefix)globalSessionPanel.frame"
 
+  /// Last compact frame for the global session control panel
+  /// Type: String (NSStringFromRect, default: unset)
+  public static let globalSessionPanelCompactFrame = "\(keyPrefix)globalSessionPanel.compactFrame"
+
+  /// Display mode for the global session control panel
+  /// Type: Int (default: 0 = regular, 1 = compact)
+  public static let globalSessionPanelDisplayMode = "\(keyPrefix)globalSessionPanel.displayMode"
+
   // MARK: - Feature Flags
 
   /// Whether smart mode (AI-powered orchestration planning) is enabled

--- a/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubProvider.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubProvider.swift
@@ -334,7 +334,8 @@ public final class AgentHubProvider {
     // Persist developer-provided commands to UserDefaults
     let defaults = UserDefaults.standard
     defaults.register(defaults: [
-      AgentHubDefaults.globalSessionPanelEnabled: true
+      AgentHubDefaults.globalSessionPanelEnabled: true,
+      AgentHubDefaults.globalSessionPanelDisplayMode: 0
     ])
 
     // Claude command: if developer provided non-default, lock it

--- a/app/modules/AgentHubCore/Sources/AgentHubGlobalSessionPanel/AppKitGlobalSessionControlPanelPresenter.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHubGlobalSessionPanel/AppKitGlobalSessionControlPanelPresenter.swift
@@ -83,10 +83,15 @@ public final class AppKitGlobalSessionControlPanelPresenter: GlobalSessionContro
   private var pendingFramePersistenceTask: Task<Void, Never>?
   private let displayModeToggleRelay = GlobalSessionPanelDisplayModeToggleRelay()
   private var displayMode: GlobalSessionControlPanelDisplayMode = .defaultValue
+  private var compactContentHeight: CGFloat?
   private let defaultRegularPanelSize = CGSize(width: 560, height: 420)
   private let minimumRegularPanelSize = CGSize(width: 420, height: 300)
-  private let defaultCompactPanelSize = CGSize(width: 560, height: 118)
-  private let minimumCompactPanelSize = CGSize(width: 420, height: 108)
+  // The compact panel hugs its content: the SwiftUI view reports its measured
+  // height and the window resizes to fit. `defaultCompactPanelSize.height` is
+  // only a fallback used until the first measurement arrives; the minimum height
+  // is a low safety floor so a measured height is never clamped up.
+  private let defaultCompactPanelSize = CGSize(width: 560, height: 154)
+  private let minimumCompactPanelSize = CGSize(width: 420, height: 80)
   private let framePersistenceDelay: Duration = .milliseconds(200)
   // Must match the corner radius used by GlobalSessionControlPanelView so the
   // AppKit layer mask and the SwiftUI clip line up.
@@ -124,6 +129,9 @@ public final class AppKitGlobalSessionControlPanelPresenter: GlobalSessionContro
       onSelectSession: { [weak self] in self?.activateMainWindow() },
       onDisplayModeChange: { [weak self] mode in
         self?.handleDisplayModeChange(mode)
+      },
+      onCompactContentHeightChange: { [weak self] height in
+        self?.updateCompactContentHeight(height)
       }
     )
     .agentHub(provider)
@@ -284,7 +292,7 @@ public final class AppKitGlobalSessionControlPanelPresenter: GlobalSessionContro
     case .compact:
       return restoredCompactFrame() ?? resizedFrame(
         from: restoredOrDefaultRegularFrame(),
-        height: defaultCompactPanelSize.height,
+        height: compactTargetHeight,
         minimumSize: minimumCompactPanelSize
       )
     }
@@ -308,10 +316,30 @@ public final class AppKitGlobalSessionControlPanelPresenter: GlobalSessionContro
     case .compact:
       return resizedFrame(
         from: currentFrame,
-        height: defaultCompactPanelSize.height,
+        height: compactTargetHeight,
         minimumSize: minimumCompactPanelSize
       )
     }
+  }
+
+  private var compactTargetHeight: CGFloat {
+    compactContentHeight ?? defaultCompactPanelSize.height
+  }
+
+  // The SwiftUI view reports the measured height of the compact layout; resize
+  // the window to hug it (keeping width + top edge) so the panel is never taller
+  // than its content. Content height is independent of window size, so this
+  // can't feed back into a resize loop.
+  private func updateCompactContentHeight(_ height: CGFloat) {
+    guard height > 20 else { return }
+    let rounded = height.rounded()
+    guard compactContentHeight != rounded else { return }
+    compactContentHeight = rounded
+
+    guard displayMode == .compact, let panel else { return }
+    let target = resizedFrame(from: panel.frame, height: rounded, minimumSize: minimumCompactPanelSize)
+    guard abs(panel.frame.height - target.height) > 0.5 else { return }
+    applyPanelFrame(panel, to: target)
   }
 
   private func restoredOrDefaultRegularFrame() -> NSRect {

--- a/app/modules/AgentHubCore/Sources/AgentHubGlobalSessionPanel/AppKitGlobalSessionControlPanelPresenter.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHubGlobalSessionPanel/AppKitGlobalSessionControlPanelPresenter.swift
@@ -8,6 +8,7 @@ import AgentHubCore
 
 #if canImport(AppKit)
 import AppKit
+import QuartzCore
 #endif
 
 #if canImport(AppKit)
@@ -17,6 +18,24 @@ import AppKit
 private final class GlobalSessionPanelWindow: NSPanel {
   override var canBecomeKey: Bool { true }
   override var canBecomeMain: Bool { false }
+
+  var onToggleDisplayMode: (() -> Void)?
+
+  // ⌘⌥/ toggles the panel's display mode. Command-modified keys are delivered
+  // through the key-equivalent path rather than `keyDown`, so handling it here
+  // (instead of SwiftUI `.onKeyPress`) makes it reliable whenever the panel is
+  // the key window. Command suppresses Option's character remap, so the
+  // character reads as "/".
+  override func performKeyEquivalent(with event: NSEvent) -> Bool {
+    if
+      event.modifierFlags.intersection(.deviceIndependentFlagsMask) == [.command, .option],
+      event.charactersIgnoringModifiers == "/"
+    {
+      onToggleDisplayMode?()
+      return true
+    }
+    return super.performKeyEquivalent(with: event)
+  }
 }
 
 // MARK: - GlobalSessionPanelWindowDelegate
@@ -62,8 +81,12 @@ public final class AppKitGlobalSessionControlPanelPresenter: GlobalSessionContro
   private var panel: GlobalSessionPanelWindow?
   private var windowDelegate: GlobalSessionPanelWindowDelegate?
   private var pendingFramePersistenceTask: Task<Void, Never>?
-  private let defaultCollapsedPanelSize = CGSize(width: 560, height: 420)
-  private let minimumCollapsedPanelSize = CGSize(width: 420, height: 300)
+  private let displayModeToggleRelay = GlobalSessionPanelDisplayModeToggleRelay()
+  private var displayMode: GlobalSessionControlPanelDisplayMode = .defaultValue
+  private let defaultRegularPanelSize = CGSize(width: 560, height: 420)
+  private let minimumRegularPanelSize = CGSize(width: 420, height: 300)
+  private let defaultCompactPanelSize = CGSize(width: 560, height: 118)
+  private let minimumCompactPanelSize = CGSize(width: 420, height: 108)
   private let framePersistenceDelay: Duration = .milliseconds(200)
   // Must match the corner radius used by GlobalSessionControlPanelView so the
   // AppKit layer mask and the SwiftUI clip line up.
@@ -89,19 +112,26 @@ public final class AppKitGlobalSessionControlPanelPresenter: GlobalSessionContro
       return
     }
 
+    displayMode = GlobalSessionControlPanelDisplayMode.load(from: defaults)
+
     let content = GlobalSessionControlPanelView(
       claudeViewModel: provider.claudeSessionsViewModel,
       codexViewModel: provider.codexSessionsViewModel,
       selectionRouter: provider.globalSessionSelectionRouter,
+      displayModeToggleRelay: displayModeToggleRelay,
+      defaults: defaults,
       onClose: { [weak self] in self?.hide() },
-      onSelectSession: { [weak self] in self?.activateMainWindow() }
+      onSelectSession: { [weak self] in self?.activateMainWindow() },
+      onDisplayModeChange: { [weak self] mode in
+        self?.handleDisplayModeChange(mode)
+      }
     )
     .agentHub(provider)
     .frame(maxWidth: .infinity, maxHeight: .infinity)
 
     let hostingView = NSHostingView(rootView: content)
     hostingView.sizingOptions = []
-    hostingView.frame = NSRect(origin: .zero, size: defaultCollapsedPanelSize)
+    hostingView.frame = NSRect(origin: .zero, size: defaultSize(for: displayMode))
     hostingView.autoresizingMask = [.width, .height]
     // Clip the content layer to the rounded shape so the borderless window's
     // shadow follows the rounded corners instead of the rectangular bounds.
@@ -111,10 +141,7 @@ public final class AppKitGlobalSessionControlPanelPresenter: GlobalSessionContro
     hostingView.layer?.masksToBounds = true
 
     let newPanel = GlobalSessionPanelWindow(
-      contentRect: restoredOrDefaultFrame(
-        defaultSize: defaultCollapsedPanelSize,
-        minimumSize: minimumCollapsedPanelSize
-      ),
+      contentRect: initialFrame(for: displayMode),
       styleMask: [.borderless, .nonactivatingPanel, .resizable, .fullSizeContentView],
       backing: .buffered,
       defer: false
@@ -127,7 +154,7 @@ public final class AppKitGlobalSessionControlPanelPresenter: GlobalSessionContro
     newPanel.backgroundColor = .clear
     newPanel.isOpaque = false
     newPanel.hasShadow = true
-    newPanel.contentMinSize = minimumCollapsedPanelSize
+    newPanel.contentMinSize = minimumSize(for: displayMode)
     newPanel.contentView = hostingView
 
     let delegate = GlobalSessionPanelWindowDelegate()
@@ -145,6 +172,9 @@ public final class AppKitGlobalSessionControlPanelPresenter: GlobalSessionContro
       self?.windowDelegate = nil
     }
     newPanel.delegate = delegate
+    newPanel.onToggleDisplayMode = { [weak self] in
+      self?.displayModeToggleRelay.requestToggle()
+    }
 
     panel = newPanel
     windowDelegate = delegate
@@ -160,7 +190,7 @@ public final class AppKitGlobalSessionControlPanelPresenter: GlobalSessionContro
     guard let panel else { return }
     pendingFramePersistenceTask?.cancel()
     pendingFramePersistenceTask = nil
-    persist(frame: panel.frame)
+    persist(frame: panel.frame, for: displayMode)
     panel.delegate = nil
     self.panel = nil
     windowDelegate = nil
@@ -183,11 +213,25 @@ public final class AppKitGlobalSessionControlPanelPresenter: GlobalSessionContro
     mainWindow?.makeKeyAndOrderFront(nil)
   }
 
+  private func handleDisplayModeChange(_ newMode: GlobalSessionControlPanelDisplayMode) {
+    guard let panel, displayMode != newMode else { return }
+
+    persist(frame: panel.frame, for: displayMode)
+
+    pendingFramePersistenceTask?.cancel()
+    pendingFramePersistenceTask = nil
+    let targetPanelFrame = targetFrame(for: newMode, from: panel.frame)
+    displayMode = newMode
+    panel.contentMinSize = minimumSize(for: newMode)
+    applyPanelFrame(panel, to: targetPanelFrame)
+  }
+
   private func handleResize(frame: NSRect) {
     scheduleFramePersistence(frame)
   }
 
   private func scheduleFramePersistence(_ frame: NSRect) {
+    let mode = displayMode
     pendingFramePersistenceTask?.cancel()
     pendingFramePersistenceTask = Task { [weak self] in
       guard let self else { return }
@@ -197,29 +241,140 @@ public final class AppKitGlobalSessionControlPanelPresenter: GlobalSessionContro
         return
       }
       guard !Task.isCancelled else { return }
-      persist(frame: frame)
+      persist(frame: frame, for: mode)
       pendingFramePersistenceTask = nil
     }
   }
 
-  private func persist(frame: NSRect) {
-    defaults.set(NSStringFromRect(frame), forKey: AgentHubDefaults.globalSessionPanelFrame)
+  private func persist(frame: NSRect, for mode: GlobalSessionControlPanelDisplayMode) {
+    defaults.set(NSStringFromRect(frame), forKey: frameDefaultsKey(for: mode))
   }
 
-  private func restoredOrDefaultFrame(defaultSize: CGSize, minimumSize: CGSize) -> NSRect {
-    if let stored = defaults.string(forKey: AgentHubDefaults.globalSessionPanelFrame) {
-      let frame = NSRectFromString(stored)
-      if !frame.isEmpty {
-        return clamped(frame: frame, minimumSize: minimumSize)
-      }
+  private func frameDefaultsKey(for mode: GlobalSessionControlPanelDisplayMode) -> String {
+    switch mode {
+    case .regular:
+      return AgentHubDefaults.globalSessionPanelFrame
+    case .compact:
+      return AgentHubDefaults.globalSessionPanelCompactFrame
     }
+  }
 
+  private func defaultSize(for mode: GlobalSessionControlPanelDisplayMode) -> CGSize {
+    switch mode {
+    case .regular:
+      return defaultRegularPanelSize
+    case .compact:
+      return defaultCompactPanelSize
+    }
+  }
+
+  private func minimumSize(for mode: GlobalSessionControlPanelDisplayMode) -> CGSize {
+    switch mode {
+    case .regular:
+      return minimumRegularPanelSize
+    case .compact:
+      return minimumCompactPanelSize
+    }
+  }
+
+  private func initialFrame(for mode: GlobalSessionControlPanelDisplayMode) -> NSRect {
+    switch mode {
+    case .regular:
+      return restoredOrDefaultRegularFrame()
+    case .compact:
+      return restoredCompactFrame() ?? resizedFrame(
+        from: restoredOrDefaultRegularFrame(),
+        height: defaultCompactPanelSize.height,
+        minimumSize: minimumCompactPanelSize
+      )
+    }
+  }
+
+  // A display-mode switch keeps the panel's current width and top-left corner
+  // (so a width the user dragged in one mode carries into the other) and only
+  // swaps the height. Regular remembers its own height; compact uses its fixed
+  // height.
+  private func targetFrame(
+    for mode: GlobalSessionControlPanelDisplayMode,
+    from currentFrame: NSRect
+  ) -> NSRect {
+    switch mode {
+    case .regular:
+      let height = max(
+        restoredRegularFrame()?.height ?? defaultRegularPanelSize.height,
+        minimumRegularPanelSize.height
+      )
+      return resizedFrame(from: currentFrame, height: height, minimumSize: minimumRegularPanelSize)
+    case .compact:
+      return resizedFrame(
+        from: currentFrame,
+        height: defaultCompactPanelSize.height,
+        minimumSize: minimumCompactPanelSize
+      )
+    }
+  }
+
+  private func restoredOrDefaultRegularFrame() -> NSRect {
+    restoredRegularFrame() ?? defaultRegularFrame()
+  }
+
+  private func restoredRegularFrame() -> NSRect? {
+    restoredFrame(
+      forKey: AgentHubDefaults.globalSessionPanelFrame,
+      minimumSize: minimumRegularPanelSize
+    )
+  }
+
+  private func restoredCompactFrame() -> NSRect? {
+    restoredFrame(
+      forKey: AgentHubDefaults.globalSessionPanelCompactFrame,
+      minimumSize: minimumCompactPanelSize
+    )
+  }
+
+  private func restoredFrame(forKey key: String, minimumSize: CGSize) -> NSRect? {
+    guard let stored = defaults.string(forKey: key) else { return nil }
+    let frame = NSRectFromString(stored)
+    guard !frame.isEmpty else { return nil }
+    return clamped(frame: frame, minimumSize: minimumSize)
+  }
+
+  private func defaultRegularFrame() -> NSRect {
     let visible = activeVisibleFrame()
     let origin = CGPoint(
-      x: visible.midX - defaultSize.width / 2,
-      y: visible.maxY - defaultSize.height - 12
+      x: visible.midX - defaultRegularPanelSize.width / 2,
+      y: visible.maxY - defaultRegularPanelSize.height - 12
     )
-    return clamped(frame: NSRect(origin: origin, size: defaultSize), minimumSize: minimumSize)
+    return clamped(
+      frame: NSRect(origin: origin, size: defaultRegularPanelSize),
+      minimumSize: minimumRegularPanelSize
+    )
+  }
+
+  /// Builds a frame that keeps `referenceFrame`'s width and top-left corner but
+  /// uses the given height. This is what unifies the panel width across display
+  /// modes: a switch reuses the current width (including any width the user
+  /// dragged) and only changes the height.
+  private func resizedFrame(from referenceFrame: NSRect, height: CGFloat, minimumSize: CGSize) -> NSRect {
+    let width = max(referenceFrame.width, minimumSize.width)
+    let frame = NSRect(
+      x: referenceFrame.minX,
+      y: referenceFrame.maxY - height,
+      width: width,
+      height: height
+    )
+    return clamped(frame: frame, minimumSize: minimumSize)
+  }
+
+  /// Resizes the panel for a display-mode change. The size change is instant:
+  /// animating an `NSWindow` frame that hosts a SwiftUI list relayouts the whole
+  /// tree every frame and stutters. The SwiftUI content cross-fades instead (see
+  /// `GlobalSessionControlPanelView`), so the swap reads as a clean dissolve
+  /// rather than a flash or a janky resize.
+  private func applyPanelFrame(_ panel: NSPanel, to frame: NSRect) {
+    panel.setFrame(frame, display: true)
+    panel.contentView?.layoutSubtreeIfNeeded()
+    panel.invalidateShadow()
   }
 
   private func clamped(frame: NSRect, minimumSize: CGSize) -> NSRect {

--- a/app/modules/AgentHubCore/Sources/AgentHubGlobalSessionPanel/GlobalSessionControlPanelCompactItemSelector.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHubGlobalSessionPanel/GlobalSessionControlPanelCompactItemSelector.swift
@@ -1,0 +1,53 @@
+//
+//  GlobalSessionControlPanelCompactItemSelector.swift
+//  AgentHubGlobalSessionPanel
+//
+
+import Foundation
+import AgentHubCore
+
+// MARK: - GlobalSessionControlPanelCompactItemSelector
+
+public enum GlobalSessionControlPanelCompactItemSelector {
+  public static func featuredItem(
+    from items: [GlobalSessionControlPanelItem]
+  ) -> GlobalSessionControlPanelItem? {
+    let activeItems = items.filter(isActiveCandidate)
+    return recencySorted(activeItems.isEmpty ? items : activeItems).first
+  }
+
+  private static func isActiveCandidate(_ item: GlobalSessionControlPanelItem) -> Bool {
+    if item.isPending || item.session.isActive {
+      return true
+    }
+
+    guard let status = item.status else {
+      return false
+    }
+
+    switch status {
+    case .thinking, .executingTool, .waitingForUser, .awaitingApproval:
+      return true
+    case .idle:
+      return false
+    }
+  }
+
+  private static func recencySorted(
+    _ items: [GlobalSessionControlPanelItem]
+  ) -> [GlobalSessionControlPanelItem] {
+    items.sorted { lhs, rhs in
+      if lhs.timestamp != rhs.timestamp {
+        return lhs.timestamp > rhs.timestamp
+      }
+      if lhs.providerKind != rhs.providerKind {
+        return lhs.providerKind.rawValue < rhs.providerKind.rawValue
+      }
+      let displayNameComparison = lhs.displayName.localizedCaseInsensitiveCompare(rhs.displayName)
+      if displayNameComparison != .orderedSame {
+        return displayNameComparison == .orderedAscending
+      }
+      return lhs.id < rhs.id
+    }
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHubGlobalSessionPanel/GlobalSessionControlPanelDisplayMode.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHubGlobalSessionPanel/GlobalSessionControlPanelDisplayMode.swift
@@ -1,0 +1,37 @@
+//
+//  GlobalSessionControlPanelDisplayMode.swift
+//  AgentHubGlobalSessionPanel
+//
+
+import Foundation
+import AgentHubCore
+
+// MARK: - GlobalSessionControlPanelDisplayMode
+
+public enum GlobalSessionControlPanelDisplayMode: Int, CaseIterable, Sendable {
+  case regular = 0
+  case compact = 1
+
+  public static let defaultValue: GlobalSessionControlPanelDisplayMode = .regular
+
+  public static func load(from defaults: UserDefaults) -> GlobalSessionControlPanelDisplayMode {
+    let storedValue = defaults.object(forKey: AgentHubDefaults.globalSessionPanelDisplayMode)
+    let rawValue: Int?
+    if let value = storedValue as? Int {
+      rawValue = value
+    } else if let value = storedValue as? NSNumber {
+      rawValue = value.intValue
+    } else {
+      rawValue = nil
+    }
+
+    guard let rawValue else {
+      return defaultValue
+    }
+    return GlobalSessionControlPanelDisplayMode(rawValue: rawValue) ?? defaultValue
+  }
+
+  public func persist(to defaults: UserDefaults) {
+    defaults.set(rawValue, forKey: AgentHubDefaults.globalSessionPanelDisplayMode)
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHubGlobalSessionPanel/GlobalSessionControlPanelView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHubGlobalSessionPanel/GlobalSessionControlPanelView.swift
@@ -176,40 +176,14 @@ public struct GlobalSessionControlPanelView: View {
   }
 
   private var compactPanelContent: some View {
-    VStack(spacing: 0) {
+    // Even 8pt inset on all sides (matching the regular list) with a small,
+    // balanced gap to the control bar — keeps the featured row's vertical
+    // padding symmetric instead of jammed against the top.
+    VStack(spacing: 6) {
       compactFeaturedContent
-
-      ZStack {
-        Button(action: expandPanel) {
-          Label("Expand Sessions", systemImage: "chevron.down")
-            .labelStyle(.iconOnly)
-            .font(.system(size: 12, weight: .bold))
-            .foregroundStyle(.secondary)
-            .frame(width: 30, height: 20)
-            .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
-        .help("Expand")
-
-        HStack {
-          Spacer()
-
-          Button(action: onClose) {
-            Label("Close", systemImage: "xmark")
-              .labelStyle(.iconOnly)
-              .font(.system(size: 10, weight: .bold))
-              .foregroundStyle(.secondary)
-              .frame(width: 22, height: 20)
-              .contentShape(Rectangle())
-          }
-          .buttonStyle(.plain)
-          .help("Close")
-        }
-      }
-      .padding(.horizontal, 10)
-      .padding(.bottom, 6)
+      compactControlBar
     }
-    .padding(.top, 8)
+    .padding(8)
   }
 
   @ViewBuilder
@@ -220,15 +194,44 @@ public struct GlobalSessionControlPanelView: View {
       GlobalSessionControlPanelRow(
         item: compactFeaturedItem,
         isSelected: compactFeaturedItem.id == selectedItemID,
+        isCleanupCandidate: cleanupCandidateIDs.contains(compactFeaturedItem.id),
         onSelect: { activate(compactFeaturedItem) },
         onGitHubStateChange: { state in
           updateGitHubState(state, for: compactFeaturedItem.id)
         }
       )
-      .padding(.horizontal, 8)
-      .padding(.bottom, 4)
     } else {
       compactEmptyState
+    }
+  }
+
+  private var compactControlBar: some View {
+    ZStack {
+      Button(action: expandPanel) {
+        Label("Expand Sessions", systemImage: "chevron.down")
+          .labelStyle(.iconOnly)
+          .font(.system(size: 12, weight: .bold))
+          .foregroundStyle(.secondary)
+          .frame(width: 30, height: 20)
+          .contentShape(Rectangle())
+      }
+      .buttonStyle(.plain)
+      .help("Expand")
+
+      HStack {
+        Spacer()
+
+        Button(action: onClose) {
+          Label("Close", systemImage: "xmark")
+            .labelStyle(.iconOnly)
+            .font(.system(size: 10, weight: .bold))
+            .foregroundStyle(.secondary)
+            .frame(width: 22, height: 20)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .help("Close")
+      }
     }
   }
 
@@ -242,16 +245,18 @@ public struct GlobalSessionControlPanelView: View {
   }
 
   private var sessionList: some View {
-    ScrollViewReader { proxy in
+    let suggestions = cleanupSuggestions
+    let candidateIDs = Set(suggestions.flatMap(\.sessionIDs))
+    return ScrollViewReader { proxy in
       ScrollView(showsIndicators: true) {
         LazyVStack(spacing: 4) {
-          if !cleanupSuggestions.isEmpty {
+          if !suggestions.isEmpty {
             GlobalSessionCleanupBanner(
-              suggestions: cleanupSuggestions,
+              suggestions: suggestions,
               isDeleting: isDeletingSuggestedWorktrees,
               onDelete: {
                 deletionConfirmation = GlobalSessionCleanupDeletionConfirmation(
-                  suggestions: cleanupSuggestions
+                  suggestions: suggestions
                 )
               }
             )
@@ -262,6 +267,7 @@ public struct GlobalSessionControlPanelView: View {
             GlobalSessionControlPanelRow(
               item: item,
               isSelected: item.id == selectedItemID,
+              isCleanupCandidate: candidateIDs.contains(item.id),
               onSelect: { activate(item) },
               onGitHubStateChange: { state in
                 updateGitHubState(state, for: item.id)
@@ -314,6 +320,12 @@ public struct GlobalSessionControlPanelView: View {
 
   private var cleanupSuggestions: [GlobalSessionCleanupSuggestion] {
     GlobalSessionCleanupSuggestionBuilder.makeSuggestions(items: items)
+  }
+
+  // Item IDs whose worktree is a safe-to-delete cleanup candidate (merged PR and
+  // quiet state). Used to flag individual rows, consistent with the banner.
+  private var cleanupCandidateIDs: Set<String> {
+    Set(cleanupSuggestions.flatMap(\.sessionIDs))
   }
 
   private var panelBackground: some View {
@@ -668,6 +680,7 @@ private struct GlobalSessionControlPanelRow: View {
   let item: GlobalSessionControlPanelItem
   let isSelected: Bool
   var showsPathLines = true
+  var isCleanupCandidate = false
   let onSelect: () -> Void
   let onGitHubStateChange: (GlobalSessionControlPanelGitHubState?) -> Void
 
@@ -725,8 +738,8 @@ private struct GlobalSessionControlPanelRow: View {
           .foregroundStyle(.secondary.opacity(isHovered || isSelected ? 0.9 : 0.45))
           .padding(.top, 3)
       }
-      .padding(.horizontal, 9)
-      .padding(.vertical, 8)
+      .padding(.horizontal, 11)
+      .padding(.vertical, 11)
       .frame(maxWidth: .infinity, minHeight: 62, alignment: .leading)
       .background(rowBackground)
       .contentShape(Rectangle())
@@ -771,6 +784,10 @@ private struct GlobalSessionControlPanelRow: View {
         .foregroundStyle(Color.brandPrimary(for: item.providerKind))
         .fixedSize(horizontal: true, vertical: false)
 
+      if isCleanupCandidate {
+        cleanupBadge
+      }
+
       Spacer(minLength: 4)
 
       Text(item.timestamp.timeAgoDisplay())
@@ -779,6 +796,17 @@ private struct GlobalSessionControlPanelRow: View {
         .monospacedDigit()
         .fixedSize(horizontal: true, vertical: false)
     }
+  }
+
+  private var cleanupBadge: some View {
+    Text("Cleanup")
+      .font(.system(size: 9, weight: .bold))
+      .foregroundStyle(.white)
+      .padding(.horizontal, 5)
+      .padding(.vertical, 1)
+      .background(.orange, in: Capsule())
+      .fixedSize()
+      .help("This worktree's PR is merged — safe to clean up")
   }
 
   private var detailLine: some View {
@@ -814,6 +842,12 @@ private struct GlobalSessionControlPanelRow: View {
           .font(.secondaryCaption)
           .foregroundStyle(.secondary)
 
+        if pullRequest.stateKind == .merged {
+          prStateBadge("Merged", color: .purple)
+        } else if pullRequest.stateKind == .closed {
+          prStateBadge("Closed", color: .red)
+        }
+
         Text("·")
           .font(.secondaryCaption)
           .foregroundStyle(.secondary.opacity(0.7))
@@ -826,6 +860,16 @@ private struct GlobalSessionControlPanelRow: View {
       }
       .transition(.opacity)
     }
+  }
+
+  private func prStateBadge(_ title: String, color: Color) -> some View {
+    Text(title)
+      .font(.system(size: 9, weight: .bold))
+      .foregroundStyle(.white)
+      .padding(.horizontal, 5)
+      .padding(.vertical, 1)
+      .background(color, in: Capsule())
+      .fixedSize()
   }
 
   private var pathLines: some View {
@@ -959,7 +1003,9 @@ private struct GlobalSessionControlPanelRow: View {
     case .pending:
       return summary.pending == 1 ? "1 check pending" : "\(summary.pending) checks pending"
     case .none:
-      return "CI unavailable"
+      // `.none` means the commit's check rollup is empty — i.e. no CI checks
+      // exist for it, not that the status failed to load.
+      return summary.total > 0 ? "Checks skipped" : "No checks"
     }
   }
 

--- a/app/modules/AgentHubCore/Sources/AgentHubGlobalSessionPanel/GlobalSessionControlPanelView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHubGlobalSessionPanel/GlobalSessionControlPanelView.swift
@@ -59,6 +59,7 @@ public struct GlobalSessionControlPanelView: View {
   let onClose: () -> Void
   let onSelectSession: () -> Void
   let onDisplayModeChange: (GlobalSessionControlPanelDisplayMode) -> Void
+  let onCompactContentHeightChange: (CGFloat) -> Void
   private let defaults: UserDefaults
   private let displayModeToggleRelay: GlobalSessionPanelDisplayModeToggleRelay?
 
@@ -81,7 +82,8 @@ public struct GlobalSessionControlPanelView: View {
     defaults: UserDefaults = .standard,
     onClose: @escaping () -> Void = {},
     onSelectSession: @escaping () -> Void = {},
-    onDisplayModeChange: @escaping (GlobalSessionControlPanelDisplayMode) -> Void = { _ in }
+    onDisplayModeChange: @escaping (GlobalSessionControlPanelDisplayMode) -> Void = { _ in },
+    onCompactContentHeightChange: @escaping (CGFloat) -> Void = { _ in }
   ) {
     self.claudeViewModel = claudeViewModel
     self.codexViewModel = codexViewModel
@@ -91,6 +93,7 @@ public struct GlobalSessionControlPanelView: View {
     self.onClose = onClose
     self.onSelectSession = onSelectSession
     self.onDisplayModeChange = onDisplayModeChange
+    self.onCompactContentHeightChange = onCompactContentHeightChange
     _displayMode = State(initialValue: GlobalSessionControlPanelDisplayMode.load(from: defaults))
   }
 
@@ -102,6 +105,16 @@ public struct GlobalSessionControlPanelView: View {
           .transition(.opacity)
       case .compact:
         compactPanelContent
+          .background(
+            GeometryReader { proxy in
+              // Report the compact layout's intrinsic height so the AppKit
+              // window can hug it instead of using a fixed (too-tall) size.
+              Color.clear
+                .onChange(of: proxy.size.height, initial: true) { _, height in
+                  onCompactContentHeightChange(height)
+                }
+            }
+          )
           .transition(.opacity)
       }
     }
@@ -202,10 +215,11 @@ public struct GlobalSessionControlPanelView: View {
   @ViewBuilder
   private var compactFeaturedContent: some View {
     if let compactFeaturedItem {
+      // Show the full row content (including the worktree/root path lines) so the
+      // featured session in compact mode matches a regular-mode row exactly.
       GlobalSessionControlPanelRow(
         item: compactFeaturedItem,
         isSelected: compactFeaturedItem.id == selectedItemID,
-        showsPathLines: false,
         onSelect: { activate(compactFeaturedItem) },
         onGitHubStateChange: { state in
           updateGitHubState(state, for: compactFeaturedItem.id)

--- a/app/modules/AgentHubCore/Sources/AgentHubGlobalSessionPanel/GlobalSessionControlPanelView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHubGlobalSessionPanel/GlobalSessionControlPanelView.swift
@@ -3,6 +3,7 @@
 //  AgentHub
 //
 
+import Foundation
 import SwiftUI
 import AgentHubCore
 import AgentHubGitHub
@@ -57,39 +58,54 @@ public struct GlobalSessionControlPanelView: View {
   let selectionRouter: GlobalSessionSelectionRouter
   let onClose: () -> Void
   let onSelectSession: () -> Void
+  let onDisplayModeChange: (GlobalSessionControlPanelDisplayMode) -> Void
+  private let defaults: UserDefaults
+  private let displayModeToggleRelay: GlobalSessionPanelDisplayModeToggleRelay?
 
   @State private var gitHubStates: [String: GlobalSessionControlPanelGitHubState] = [:]
   @State private var selectedItemID: String?
+  @State private var displayMode: GlobalSessionControlPanelDisplayMode
   @State private var deletionConfirmation: GlobalSessionCleanupDeletionConfirmation?
   @State private var deletionResult: GlobalSessionCleanupDeletionResult?
   @State private var isDeletingSuggestedWorktrees = false
   @FocusState private var isPanelFocused: Bool
   @Environment(\.colorScheme) private var colorScheme
   @Environment(\.runtimeTheme) private var runtimeTheme
+  @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
   public init(
     claudeViewModel: CLISessionsViewModel,
     codexViewModel: CLISessionsViewModel,
     selectionRouter: GlobalSessionSelectionRouter,
+    displayModeToggleRelay: GlobalSessionPanelDisplayModeToggleRelay? = nil,
+    defaults: UserDefaults = .standard,
     onClose: @escaping () -> Void = {},
-    onSelectSession: @escaping () -> Void = {}
+    onSelectSession: @escaping () -> Void = {},
+    onDisplayModeChange: @escaping (GlobalSessionControlPanelDisplayMode) -> Void = { _ in }
   ) {
     self.claudeViewModel = claudeViewModel
     self.codexViewModel = codexViewModel
     self.selectionRouter = selectionRouter
+    self.displayModeToggleRelay = displayModeToggleRelay
+    self.defaults = defaults
     self.onClose = onClose
     self.onSelectSession = onSelectSession
+    self.onDisplayModeChange = onDisplayModeChange
+    _displayMode = State(initialValue: GlobalSessionControlPanelDisplayMode.load(from: defaults))
   }
 
   public var body: some View {
-    VStack(spacing: 0) {
-      header
-
-      Divider()
-        .opacity(0.5)
-
-      panelContent
+    ZStack(alignment: .top) {
+      switch displayMode {
+      case .regular:
+        regularPanelContent
+          .transition(.opacity)
+      case .compact:
+        compactPanelContent
+          .transition(.opacity)
+      }
     }
+    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
     .background(panelBackground)
     .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
     .overlay(
@@ -112,14 +128,94 @@ public struct GlobalSessionControlPanelView: View {
       revalidateSelection()
       isPanelFocused = true
     }
-    .onChange(of: items.map(\.id)) { _, _ in
+    .onChange(of: selectionItemIDs) { _, _ in
       revalidateSelection()
+    }
+    .onChange(of: displayMode) { _, _ in
+      revalidateSelection()
+    }
+    .onChange(of: displayModeToggleRelay?.toggleRequestCount) { _, _ in
+      toggleDisplayMode()
+    }
+  }
+
+  // The window snaps to its new size in the AppKit presenter (no per-frame
+  // relayout, no alpha blink); here we only cross-fade the content between
+  // layouts so the swap reads as a clean dissolve rather than a flash.
+  private var displayModeCrossfadeAnimation: Animation {
+    reduceMotion ? .linear(duration: 0.01) : .easeInOut(duration: 0.18)
+  }
+
+  private var regularPanelContent: some View {
+    VStack(spacing: 0) {
+      header
+
+      Divider()
+        .opacity(0.5)
+
+      panelContent
     }
   }
 
   private var panelContent: some View {
     primarySessionsContent
       .frame(maxWidth: .infinity, maxHeight: .infinity)
+  }
+
+  private var compactPanelContent: some View {
+    VStack(spacing: 0) {
+      compactFeaturedContent
+
+      ZStack {
+        Button(action: expandPanel) {
+          Label("Expand Sessions", systemImage: "chevron.down")
+            .labelStyle(.iconOnly)
+            .font(.system(size: 12, weight: .bold))
+            .foregroundStyle(.secondary)
+            .frame(width: 30, height: 20)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .help("Expand")
+
+        HStack {
+          Spacer()
+
+          Button(action: onClose) {
+            Label("Close", systemImage: "xmark")
+              .labelStyle(.iconOnly)
+              .font(.system(size: 10, weight: .bold))
+              .foregroundStyle(.secondary)
+              .frame(width: 22, height: 20)
+              .contentShape(Rectangle())
+          }
+          .buttonStyle(.plain)
+          .help("Close")
+        }
+      }
+      .padding(.horizontal, 10)
+      .padding(.bottom, 6)
+    }
+    .padding(.top, 8)
+  }
+
+  @ViewBuilder
+  private var compactFeaturedContent: some View {
+    if let compactFeaturedItem {
+      GlobalSessionControlPanelRow(
+        item: compactFeaturedItem,
+        isSelected: compactFeaturedItem.id == selectedItemID,
+        showsPathLines: false,
+        onSelect: { activate(compactFeaturedItem) },
+        onGitHubStateChange: { state in
+          updateGitHubState(state, for: compactFeaturedItem.id)
+        }
+      )
+      .padding(.horizontal, 8)
+      .padding(.bottom, 4)
+    } else {
+      compactEmptyState
+    }
   }
 
   @ViewBuilder
@@ -164,6 +260,7 @@ public struct GlobalSessionControlPanelView: View {
         .padding(.vertical, 8)
       }
       .onChange(of: selectedItemID) { _, newValue in
+        guard displayMode == .regular else { return }
         guard let newValue else { return }
         withAnimation(.easeInOut(duration: 0.15)) {
           proxy.scrollTo(newValue)
@@ -182,6 +279,23 @@ public struct GlobalSessionControlPanelView: View {
       codexCustomNames: codexViewModel.sessionCustomNames,
       gitHubStates: gitHubStates
     )
+  }
+
+  private var compactFeaturedItem: GlobalSessionControlPanelItem? {
+    GlobalSessionControlPanelCompactItemSelector.featuredItem(from: items)
+  }
+
+  private var selectionItems: [GlobalSessionControlPanelItem] {
+    switch displayMode {
+    case .regular:
+      return items
+    case .compact:
+      return compactFeaturedItem.map { [$0] } ?? []
+    }
+  }
+
+  private var selectionItemIDs: [String] {
+    selectionItems.map(\.id)
   }
 
   private var cleanupSuggestions: [GlobalSessionCleanupSuggestion] {
@@ -227,11 +341,24 @@ public struct GlobalSessionControlPanelView: View {
         .background(Color.secondary.opacity(0.12))
         .clipShape(RoundedRectangle(cornerRadius: 4, style: .continuous))
 
-      Button(action: onClose) {
-        Image(systemName: "xmark")
+      Button(action: compactPanel) {
+        Label("Compact Sessions", systemImage: "chevron.up")
+          .labelStyle(.iconOnly)
           .font(.system(size: 11, weight: .bold))
           .foregroundStyle(.secondary)
           .frame(width: 22, height: 22)
+          .contentShape(Rectangle())
+      }
+      .buttonStyle(.plain)
+      .help("Compact")
+
+      Button(action: onClose) {
+        Label("Close", systemImage: "xmark")
+          .labelStyle(.iconOnly)
+          .font(.system(size: 11, weight: .bold))
+          .foregroundStyle(.secondary)
+          .frame(width: 22, height: 22)
+          .contentShape(Rectangle())
       }
       .buttonStyle(.plain)
       .help("Close")
@@ -239,6 +366,30 @@ public struct GlobalSessionControlPanelView: View {
     .padding(.horizontal, 12)
     .padding(.vertical, 10)
     .contentShape(Rectangle())
+  }
+
+  private var compactEmptyState: some View {
+    HStack(spacing: 10) {
+      Image(systemName: "terminal")
+        .font(.system(size: 15, weight: .semibold))
+        .foregroundStyle(.secondary)
+        .frame(width: 18, height: 18)
+
+      VStack(alignment: .leading, spacing: 2) {
+        Text("No monitored sessions")
+          .font(.secondaryDefault)
+          .foregroundStyle(.primary)
+
+        Text("Start or select sessions in AgentHub.")
+          .font(.secondaryCaption)
+          .foregroundStyle(.secondary)
+          .lineLimit(1)
+      }
+
+      Spacer(minLength: 8)
+    }
+    .padding(.horizontal, 16)
+    .padding(.vertical, 12)
   }
 
   private var emptyState: some View {
@@ -269,13 +420,36 @@ public struct GlobalSessionControlPanelView: View {
     }
   }
 
+  private func compactPanel() {
+    setDisplayMode(.compact)
+  }
+
+  private func expandPanel() {
+    setDisplayMode(.regular)
+  }
+
+  private func setDisplayMode(_ mode: GlobalSessionControlPanelDisplayMode) {
+    guard displayMode != mode else { return }
+    mode.persist(to: defaults)
+
+    // Snap the window to its new size immediately (the presenter resizes without
+    // animating the frame), then cross-fade the content for a clean dissolve.
+    onDisplayModeChange(mode)
+    withAnimation(displayModeCrossfadeAnimation) {
+      displayMode = mode
+    }
+  }
+
+  private func toggleDisplayMode() {
+    setDisplayMode(displayMode == .regular ? .compact : .regular)
+  }
+
   private func moveSelection(_ direction: GlobalSessionListNavigationDirection) -> KeyPress.Result {
-    let itemIDs = items.map(\.id)
-    guard !itemIDs.isEmpty else { return .ignored }
+    guard !selectionItemIDs.isEmpty else { return .ignored }
     selectedItemID = GlobalSessionPanelNavigator.nextSelection(
       currentID: selectedItemID,
       direction: direction,
-      itemIDs: itemIDs
+      itemIDs: selectionItemIDs
     )
     return .handled
   }
@@ -283,7 +457,7 @@ public struct GlobalSessionControlPanelView: View {
   private func activateSelectedItem() -> KeyPress.Result {
     guard
       let selectedItemID,
-      let item = items.first(where: { $0.id == selectedItemID })
+      let item = selectionItems.first(where: { $0.id == selectedItemID })
     else { return .ignored }
     activate(item)
     return .handled
@@ -303,7 +477,7 @@ public struct GlobalSessionControlPanelView: View {
   private func revalidateSelection() {
     selectedItemID = GlobalSessionPanelNavigator.validatedSelection(
       currentID: selectedItemID,
-      itemIDs: items.map(\.id)
+      itemIDs: selectionItemIDs
     )
   }
 
@@ -479,6 +653,7 @@ private struct GlobalSessionCleanupBanner: View {
 private struct GlobalSessionControlPanelRow: View {
   let item: GlobalSessionControlPanelItem
   let isSelected: Bool
+  var showsPathLines = true
   let onSelect: () -> Void
   let onGitHubStateChange: (GlobalSessionControlPanelGitHubState?) -> Void
 
@@ -524,7 +699,9 @@ private struct GlobalSessionControlPanelRow: View {
           topLine
           detailLine
           gitHubLine
-          pathLines
+          if showsPathLines {
+            pathLines
+          }
         }
 
         Spacer(minLength: 8)

--- a/app/modules/AgentHubCore/Sources/AgentHubGlobalSessionPanel/GlobalSessionPanelDisplayModeToggleRelay.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHubGlobalSessionPanel/GlobalSessionPanelDisplayModeToggleRelay.swift
@@ -1,0 +1,24 @@
+//
+//  GlobalSessionPanelDisplayModeToggleRelay.swift
+//  AgentHubGlobalSessionPanel
+//
+
+import Observation
+
+// MARK: - GlobalSessionPanelDisplayModeToggleRelay
+
+/// Bridges the AppKit panel window's ⌘⌥/ key equivalent to the SwiftUI panel
+/// view. The window can't mutate the view's `@State` directly, so it bumps a
+/// request counter here that the view observes and acts on — mirroring how
+/// `GlobalSessionSelectionRouter` carries selection requests into the view.
+@MainActor
+@Observable
+public final class GlobalSessionPanelDisplayModeToggleRelay {
+  public private(set) var toggleRequestCount = 0
+
+  public init() {}
+
+  public func requestToggle() {
+    toggleRequestCount &+= 1
+  }
+}

--- a/app/modules/AgentHubCore/Tests/AgentHubGlobalSessionPanelTests/GlobalSessionControlPanelTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubGlobalSessionPanelTests/GlobalSessionControlPanelTests.swift
@@ -58,6 +58,29 @@ struct GlobalSessionControlPanelTests {
     #expect(GlobalHotKey.sessionControlPanelDefault.displayString == "⌘⌥B")
   }
 
+  @Test("Display mode defaults to regular and persists compact")
+  func displayModeDefaultsAndPersists() {
+    let defaults = makeDefaults()
+
+    #expect(GlobalSessionControlPanelDisplayMode.load(from: defaults) == .regular)
+
+    GlobalSessionControlPanelDisplayMode.compact.persist(to: defaults)
+
+    #expect(defaults.integer(forKey: AgentHubDefaults.globalSessionPanelDisplayMode) == 1)
+    #expect(GlobalSessionControlPanelDisplayMode.load(from: defaults) == .compact)
+
+    defaults.set(99, forKey: AgentHubDefaults.globalSessionPanelDisplayMode)
+
+    #expect(GlobalSessionControlPanelDisplayMode.load(from: defaults) == .regular)
+
+    let registeredDefaults = makeDefaults()
+    registeredDefaults.register(defaults: [
+      AgentHubDefaults.globalSessionPanelDisplayMode: 1
+    ])
+
+    #expect(GlobalSessionControlPanelDisplayMode.load(from: registeredDefaults) == .compact)
+  }
+
   @Test("Coordinator registers only when enabled and unregisters when disabled")
   func coordinatorHonorsEnabledPreference() {
     let defaults = makeDefaults()
@@ -216,6 +239,32 @@ struct GlobalSessionControlPanelTests {
     ])
   }
 
+  @Test("Compact selector uses most recent active row")
+  func compactSelectorUsesMostRecentActiveRow() {
+    let items = [
+      panelItem(id: "idle-newer", seconds: 90, status: .idle),
+      panelItem(id: "active-older", seconds: 20, status: .idle, isActive: true),
+      panelItem(id: "pending", seconds: 30, status: nil, isPending: true),
+      panelItem(id: "ready-newest-active-state", seconds: 40, status: .waitingForUser),
+    ]
+
+    let featured = GlobalSessionControlPanelCompactItemSelector.featuredItem(from: items)
+
+    #expect(featured?.id == "ready-newest-active-state")
+  }
+
+  @Test("Compact selector falls back to most recent idle row")
+  func compactSelectorFallsBackToMostRecentIdleRow() {
+    let items = [
+      panelItem(id: "idle-old", seconds: 10, status: .idle),
+      panelItem(id: "idle-new", seconds: 60, status: .idle),
+    ]
+
+    let featured = GlobalSessionControlPanelCompactItemSelector.featuredItem(from: items)
+
+    #expect(featured?.id == "idle-new")
+  }
+
   @Test("Keyboard navigation moves selection and clamps at the list edges")
   func keyboardNavigationClampsAtEdges() {
     let ids = ["a", "b", "c"]
@@ -362,6 +411,33 @@ struct GlobalSessionControlPanelTests {
     ciStatus: CIStatus? = nil
   ) -> (id: String, seconds: TimeInterval, status: SessionStatus?, ciStatus: CIStatus?) {
     (id, seconds, status, ciStatus)
+  }
+
+  private func panelItem(
+    id: String,
+    seconds: TimeInterval,
+    status: SessionStatus?,
+    isActive: Bool = false,
+    isPending: Bool = false,
+    providerKind: SessionProviderKind = .claude
+  ) -> GlobalSessionControlPanelItem {
+    let timestamp = Date(timeIntervalSince1970: 1_000 + seconds)
+    return GlobalSessionControlPanelItem(
+      id: id,
+      session: CLISession(
+        id: id,
+        projectPath: "/tmp/repo",
+        branchName: "feature",
+        lastActivityAt: timestamp,
+        isActive: isActive
+      ),
+      providerKind: providerKind,
+      timestamp: timestamp,
+      isPending: isPending,
+      status: status,
+      linkedPullRequestNumber: nil,
+      customName: nil
+    )
   }
 
   private func cleanupItem(


### PR DESCRIPTION
## Summary

Adds a **regular ⇄ compact** toggle to the floating global Sessions panel, so it can collapse to a single featured session and expand back to the full list.

- **Compact mode** surfaces the most relevant active session (falls back to the most recent), with an expand chevron; **regular mode** shows the full list. Selection is shared via `GlobalSessionControlPanelCompactItemSelector`.
- **Persisted** across launches: display mode + a separate compact frame (`AgentHubDefaults.globalSessionPanelDisplayMode` / `globalSessionPanelCompactFrame`), defaulting to regular.
- **⌘⌥/ toggles modes** — handled as a local key equivalent in the `NSPanel` (`performKeyEquivalent`), since Command-modified keys bypass SwiftUI `.onKeyPress`. Bridged to the SwiftUI view through a small `GlobalSessionPanelDisplayModeToggleRelay` (mirrors the existing `GlobalSessionSelectionRouter` pattern). Stays local to the panel — not a global hotkey like ⌘⌥B.
- **Transition:** the `NSPanel` snaps to its new size and the SwiftUI content cross-fades. Animating the window frame while it hosts a live SwiftUI list relayouts every frame and stutters, so the size change is instant and the motion is expressed via the content dissolve (honors Reduce Motion).
- **Shared width:** a mode switch keeps the panel's current width + top-left and only changes height, so a width you drag in one mode carries into the other (via `resizedFrame`).
- Chevron toggle + close buttons get full-frame click targets (`.contentShape`).

## Notes

- Based directly on top of current `main` (one commit on top of the merged #368). The panel base already lives in `main`.

## Test plan

- Builds via Xcode (`xcodebuild -scheme AgentHub build`).
- Adds/keeps unit tests in `GlobalSessionControlPanelTests` (display-mode persistence, compact featured-item selection, navigation, cleanup suggestions). Note: this package's tests run via Xcode (Cmd+U) per a known headless limitation; the changed resize/relay paths aren't unit-tested (AppKit presenter).
- Manual: toggle via the chevron and ⌘⌥/, drag the width in each mode and confirm it carries across the switch, verify persistence across relaunch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)