### PR TITLE
Correct stray references and make CLI wrapper detection structural

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubProvider.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubProvider.swift
@@ -401,7 +401,7 @@ public final class AgentHubProvider {
     case .codex:
       let userCommand = defaults.string(forKey: AgentHubDefaults.codexCommand) ?? configuration.codexCommand
       let codexArgString = defaults.string(forKey: AgentHubDefaults.codexCommandArgs) ?? ""
-      // Store the user's configured command string as-is (e.g. "airchat codex")
+      // Store the user's configured command string as-is (e.g. "agenthub codex")
       // Executable resolution happens at launch time using executableName
       cliConfiguration = CLICommandConfiguration(
         command: userCommand,

--- a/app/modules/AgentHubCore/Sources/AgentHub/Configuration/CLICommandConfiguration.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Configuration/CLICommandConfiguration.swift
@@ -243,24 +243,16 @@ public struct CLICommandConfiguration: Codable, Sendable {
 
   private func normalizedPrefixArguments() -> [String] {
     var prefix = subcommandArgs
-    guard isAgentHubExecutable else { return prefix }
-
-    let providerSubcommand: String
-    switch mode {
-    case .claude:
-      providerSubcommand = "claude"
-    case .codex:
-      providerSubcommand = "codex"
-    }
+    guard isWrapperExecutable else { return prefix }
 
     if !prefix.contains("claude"), !prefix.contains("codex") {
-      prefix.append(providerSubcommand)
+      prefix.append(nativeProviderExecutableName)
     }
     return prefix
   }
 
   private func assembleArguments(prefix: [String], providerArgs: [String], trailingArgs: [String]) -> [String] {
-    guard isAgentHubExecutable else {
+    guard isWrapperExecutable else {
       return prefix + providerArgs + extraArgs + trailingArgs
     }
 
@@ -272,8 +264,20 @@ public struct CLICommandConfiguration: Codable, Sendable {
     return prefix + extraArgs + ["--"] + directProviderArgs
   }
 
-  private var isAgentHubExecutable: Bool {
-    URL(fileURLWithPath: executableName).lastPathComponent == "agenthub"
+  /// The provider's own CLI executable name (the binary invoked when no wrapper is used).
+  private var nativeProviderExecutableName: String {
+    switch mode {
+    case .claude: return "claude"
+    case .codex: return "codex"
+    }
+  }
+
+  /// True when the configured command is a wrapper around the provider CLI rather than the
+  /// provider CLI itself. Wrappers receive an injected provider subcommand and pass provider
+  /// arguments after a `--` separator. Detected structurally (the executable isn't the native
+  /// provider binary) so any wrapper works without hardcoding a specific tool name.
+  private var isWrapperExecutable: Bool {
+    URL(fileURLWithPath: executableName).lastPathComponent != nativeProviderExecutableName
   }
 
   private func claudeMCPConfig(agentHubCLIPath: String) -> String {

--- a/app/modules/AgentHubCore/Sources/AgentHub/Configuration/CLICommandConfiguration.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Configuration/CLICommandConfiguration.swift
@@ -46,12 +46,12 @@ public struct CLICommandConfiguration: Codable, Sendable {
     extraArgs = try container.decodeIfPresent([String].self, forKey: .extraArgs) ?? []
   }
 
-  /// The executable name (first word of command). e.g. "airchat" from "airchat codex"
+  /// The executable name (first word of command). e.g. "agenthub" from "agenthub codex"
   public var executableName: String {
     commandParts.first ?? command
   }
 
-  /// Subcommand arguments (remaining words after executable). e.g. ["codex"] from "airchat codex"
+  /// Subcommand arguments (remaining words after executable). e.g. ["codex"] from "agenthub codex"
   public var subcommandArgs: [String] {
     Array(commandParts.dropFirst())
   }
@@ -243,7 +243,7 @@ public struct CLICommandConfiguration: Codable, Sendable {
 
   private func normalizedPrefixArguments() -> [String] {
     var prefix = subcommandArgs
-    guard isAirChatExecutable else { return prefix }
+    guard isAgentHubExecutable else { return prefix }
 
     let providerSubcommand: String
     switch mode {
@@ -260,7 +260,7 @@ public struct CLICommandConfiguration: Codable, Sendable {
   }
 
   private func assembleArguments(prefix: [String], providerArgs: [String], trailingArgs: [String]) -> [String] {
-    guard isAirChatExecutable else {
+    guard isAgentHubExecutable else {
       return prefix + providerArgs + extraArgs + trailingArgs
     }
 
@@ -272,8 +272,8 @@ public struct CLICommandConfiguration: Codable, Sendable {
     return prefix + extraArgs + ["--"] + directProviderArgs
   }
 
-  private var isAirChatExecutable: Bool {
-    URL(fileURLWithPath: executableName).lastPathComponent == "airchat"
+  private var isAgentHubExecutable: Bool {
+    URL(fileURLWithPath: executableName).lastPathComponent == "agenthub"
   }
 
   private func claudeMCPConfig(agentHubCLIPath: String) -> String {

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/AIConfigSettingsTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/AIConfigSettingsTests.swift
@@ -98,6 +98,41 @@ struct CLICommandConfigurationArgumentHandlingTests {
     #expect(args.last == "Start work")
   }
 
+  @Test("Any non-native wrapper executable gets the direct-argument separator")
+  func arbitraryWrapperUsesDirectArgumentSeparator() {
+    let config = CLICommandConfiguration(
+      command: "my-cli-wrapper",
+      mode: .claude,
+      extraArgs: ["--api-mode", "enterprise"]
+    )
+
+    let args = config.argumentsForSession(
+      sessionId: nil,
+      prompt: "Start work"
+    )
+
+    // Wrapper detection is structural (executable != native provider CLI), not a hardcoded name.
+    #expect(Array(args.prefix(4)) == ["claude", "--api-mode", "enterprise", "--"])
+    #expect(args.last == "Start work")
+  }
+
+  @Test("Full-path native provider CLI is not treated as a wrapper")
+  func fullPathNativeCLIIsNotWrapper() {
+    let config = CLICommandConfiguration(
+      command: "/usr/local/bin/claude",
+      mode: .claude,
+      extraArgs: ["--debug"]
+    )
+
+    let args = config.argumentsForSession(
+      sessionId: nil,
+      prompt: "Start work"
+    )
+
+    #expect(!args.contains("--"))
+    #expect(Array(args.suffix(2)) == ["--debug", "Start work"])
+  }
+
   @Test("Direct CLI keeps extra args before prompt")
   func directCLIKeepsExtraArgsBeforePrompt() {
     let config = CLICommandConfiguration(

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/AIConfigSettingsTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/AIConfigSettingsTests.swift
@@ -26,10 +26,10 @@ struct CLICommandConfigurationArgumentHandlingTests {
     #expect(args == ["--name", "", "--label", ""])
   }
 
-  @Test("AirChat Claude wrapper passes wrapper args before Claude direct args")
-  func airChatClaudeWrapperUsesDirectArgumentSeparator() {
+  @Test("AgentHub Claude wrapper passes wrapper args before Claude direct args")
+  func agentHubClaudeWrapperUsesDirectArgumentSeparator() {
     let config = CLICommandConfiguration(
-      command: "airchat",
+      command: "agenthub",
       mode: .claude,
       extraArgs: ["--api-mode", "enterprise"]
     )
@@ -44,7 +44,7 @@ struct CLICommandConfigurationArgumentHandlingTests {
 
     guard let separatorIndex = args.firstIndex(of: "--"),
           let mcpConfigIndex = args.firstIndex(of: "--mcp-config") else {
-      Issue.record("Expected AirChat direct-argument separator and Claude MCP flag")
+      Issue.record("Expected AgentHub direct-argument separator and Claude MCP flag")
       return
     }
 
@@ -52,10 +52,10 @@ struct CLICommandConfigurationArgumentHandlingTests {
     #expect(args.last == "Start work")
   }
 
-  @Test("AirChat Claude command does not duplicate explicit provider subcommand")
-  func airChatClaudeWrapperDoesNotDuplicateExplicitSubcommand() {
+  @Test("AgentHub Claude command does not duplicate explicit provider subcommand")
+  func agentHubClaudeWrapperDoesNotDuplicateExplicitSubcommand() {
     let config = CLICommandConfiguration(
-      command: "airchat claude",
+      command: "agenthub claude",
       mode: .claude,
       extraArgs: ["--api-mode", "enterprise"]
     )
@@ -71,10 +71,10 @@ struct CLICommandConfigurationArgumentHandlingTests {
     #expect(args.prefix(4).contains("--api-mode"))
   }
 
-  @Test("AirChat Codex wrapper passes Codex config overrides after separator")
-  func airChatCodexWrapperUsesDirectArgumentSeparator() {
+  @Test("AgentHub Codex wrapper passes Codex config overrides after separator")
+  func agentHubCodexWrapperUsesDirectArgumentSeparator() {
     let config = CLICommandConfiguration(
-      command: "airchat codex",
+      command: "agenthub codex",
       mode: .codex,
       extraArgs: ["--no-banner"]
     )
@@ -90,7 +90,7 @@ struct CLICommandConfigurationArgumentHandlingTests {
 
     guard let separatorIndex = args.firstIndex(of: "--"),
           let configIndex = args.firstIndex(of: "-c") else {
-      Issue.record("Expected AirChat direct-argument separator and Codex config flag")
+      Issue.record("Expected AgentHub direct-argument separator and Codex config flag")
       return
     }
 
@@ -118,7 +118,7 @@ struct CLICommandConfigurationArgumentHandlingTests {
   func decodesLegacyConfigurationWithoutExtraArgs() throws {
     let data = Data("""
     {
-      "command": "airchat claude",
+      "command": "agenthub claude",
       "additionalPaths": [],
       "mode": "claude"
     }


### PR DESCRIPTION
## Summary

Corrects stray, incorrect references across configuration and test files so they reflect the project's actual naming. Also refactors wrapper detection logic to be structural rather than hardcoded to a specific tool name.

## Key Changes

- **Test naming & documentation**: Cleaned up test names, descriptions, and comments in `AIConfigSettingsTests.swift`.
- **Configuration updates**: Corrected hardcoded command strings in test fixtures and legacy configuration decoding.
- **Wrapper detection refactor**: Replaced the previous hardcoded executable-name check with a structural `isWrapperExecutable` that detects wrappers by comparing the executable name against the native provider CLI name (e.g. `claude`, `codex`), making the logic work with any wrapper tool without hardcoding specific names.
- **Provider abstraction**: Extracted a `nativeProviderExecutableName` computed property to centralize provider CLI name logic, improving maintainability.
- **New test coverage**: Added two tests to verify the refactored wrapper detection:
  - `arbitraryWrapperUsesDirectArgumentSeparator()` — validates that any non-native wrapper gets the `--` separator.
  - `fullPathNativeCLIIsNotWrapper()` — confirms that full-path native provider CLIs are not treated as wrappers.

## Implementation Details

The wrapper detection now works structurally: if the configured executable name (extracted from the command path) differs from the native provider CLI name for the current mode, it's treated as a wrapper. This allows AgentHub to work with any wrapper tool (e.g. `my-cli-wrapper`, custom scripts) without requiring code changes, while still correctly handling direct invocations of native CLIs like `/usr/local/bin/claude`.

https://claude.ai/code/session_01Peg6nbeapkS1aHp5ZaHXjN