### PR TITLE
Harden MCP app CSP: default-deny + per-app network consent

### DIFF
--- a/MCPApps.md
+++ b/MCPApps.md
@@ -70,6 +70,7 @@ Codex:   event_msg mcp_tool_call_end { invocation{server,tool,arguments}, result
 - **Resolution keys off the standard `_meta.ui.resourceUri`** (and the `ui/resourceUri` alias) — server/tool-agnostic. No app names hardcoded.
 - **The SDK drops notifications sent before its handlers register.** The app registers `ontoolinput` in a mount effect that runs *after* it sends `ui/notifications/initialized`, so deliver `tool-input`/`tool-result` on the first `ui/notifications/size-changed` (mounted), with a delayed fallback. Delivery is once-per-loaded-resource (`didDeliverReadyNotifications`).
 - **Consent must never hang.** `MCPAppConsentController` auto-denies after a timeout and is cancelled (`cancelPending`) on panel dismiss / resource switch; resolution is guarded against double-resume.
+- **CSP allowlists are derived from untrusted output → default-deny + consent.** An app's declared `_meta.ui.csp` / `openai/widgetCSP` domains arrive in the same tool output as its HTML, so the WKWebView loads `.lockedDown` by default (`MCPAppNetworkTrust` in `AgentHubMCPUIResourceView`): no remote script/connect/resource loads at all. Every remote directive — **including `script-src`** (real apps load their runtime as ES modules from a CDN, e.g. excalidraw imports React from `esm.sh`, and `script-src` governs module imports) — widens **only** after one explicit per-resource user opt-in (the network-consent banner in `MCPAppResourceHostView`), and only to validated http(s) hosts (`domainSources`). `'unsafe-inline'` is always present because the HTML body *is* the app; the real controls are the sandbox (non-persistent store, no file/host access, gated navigation) + this per-app consent gate on all egress. Consent resets on resource switch. Do not widen any directive in the locked-down branch.
 - **Codex MCP host rendering needs the server in `~/.codex/config.toml`.** Capture works regardless, but shell resolution uses the Codex provider's config.
 - Changes here need unit tests (capture, resolution, bridge push, tool-result shaping, consent).
 
@@ -85,12 +86,12 @@ Codex:   event_msg mcp_tool_call_end { invocation{server,tool,arguments}, result
 
 - [ ] **No failure feedback.** When `tools/list`/shell-read fails (server unreachable or not in config), the button silently never appears — only a `[MCPAppHost]` log line. Surface "couldn't load this MCP app" in the panel.
 - [ ] **OpenAI Apps SDK apps not supported.** They use `_meta["openai/outputTemplate"]` + `window.openai.*` instead of `_meta.ui.resourceUri` + `ui/notifications/*`. Add the metadata-key alias (small) and the data API (larger).
-- [ ] **Consent doesn't persist across panel reopens.** Grants are per-`MCPAppConsentController` instance; reopening re-prompts on the first callback. Consider persisting "allow for this app".
+- [ ] **Tool-call consent doesn't persist across panel reopens.** `MCPAppConsentController` grants (callTool/readResource/openLink) are per-instance; reopening re-prompts on the first callback. (Network-access consent *does* persist per app launch — `CLISessionsViewModel.grantMCPAppNetwork`, keyed by server + declared host set; not yet across restarts.) Consider unifying both onto a launch-/disk-scoped "allow for this app".
 - [ ] **`restoreCheckpoint` default.** The newest invocation can be a restore that needs a `read_checkpoint` callback (→ consent) before anything draws. Consider defaulting selection to a full-elements invocation.
 - [ ] **Auto-open deferred.** Panel is button-only; doesn't pop when a new app is produced. Route through `MonitoringAutoOpenSidePanelPolicy` if wanted.
 - [ ] **Title derivation is excalidraw-shaped** (`elements`/`text`); other apps fall back to the generic tool title.
 - [ ] **No streaming.** We push the final `tool-input` once, not `ui/notifications/tool-input-partial` (no progressive draw — cosmetic).
-- [ ] **CSP tuning.** The shell's `_meta` CSP is parsed and enforced by `AgentHubMCPUI`; verify it allows what real apps need (fonts/assets) and widen handling if blocked.
+- [x] **CSP hardening.** The shell's `_meta` CSP is untrusted, so the web view is default-deny (`.lockedDown`); `script-src` is never widened, and connect/resource domains widen only after an explicit per-resource consent banner. See the CSP invariant above. Tests: `MCPAppCSPHardeningTests` (CSP directives) and `MCPAppSidePanelViewTests` (banner host parsing/visibility).
 - [ ] **No automated test for the bridge timing fix** (deliver-on-size-changed is WKWebView-level; validated by reasoning + live run).
 
 ## Verification

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MCPAppSidePanelView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MCPAppSidePanelView.swift
@@ -175,6 +175,41 @@ struct MCPAppSidePanelView: View {
   }
 }
 
+// MARK: - MCPAppNetworkConsent
+
+/// Pure logic for the MCP app network-consent banner. An app's declared CSP
+/// domains are untrusted tool output; the web view stays `.lockedDown` until the
+/// user explicitly opts in for that one app. These helpers decide what to show
+/// and when, and are unit-tested independently of the view.
+enum MCPAppNetworkConsent {
+  /// Distinct https/http hosts declared in the (untrusted) CSP metadata, in
+  /// declaration order. Used to name the domains in the banner — we never render
+  /// the raw declared strings, only validated, parsed hosts.
+  static func declaredHosts(for csp: AgentHubMCPUICSP) -> [String] {
+    var seen = Set<String>()
+    var hosts: [String] = []
+    for domain in csp.connectDomains + csp.resourceDomains {
+      guard let url = URL(string: domain),
+            let scheme = url.scheme?.lowercased(),
+            scheme == "https" || scheme == "http",
+            let host = url.host, !host.isEmpty else {
+        continue
+      }
+      if seen.insert(host).inserted {
+        hosts.append(host)
+      }
+    }
+    return hosts
+  }
+
+  /// Show the consent banner whenever the app declares network hosts and the user
+  /// has not yet granted them. (Declining closes the panel rather than leaving the
+  /// banner dismissed, so there is no "dismissed but still open" state.)
+  static func shouldPrompt(hosts: [String], consented: Bool) -> Bool {
+    !hosts.isEmpty && !consented
+  }
+}
+
 // MARK: - MCPAppResourceHostView
 
 /// Renders a single MCP app resource in a WKWebView and bridges its JSON-RPC
@@ -189,6 +224,28 @@ private struct MCPAppResourceHostView: View {
   let onTeardown: () -> Void
 
   @State private var bridgeHandler: MCPAppHostBridgeHandler?
+  /// User opted this app's declared domains in during the current panel open.
+  @State private var networkConsented = false
+
+  private var declaredHosts: [String] {
+    MCPAppNetworkConsent.declaredHosts(for: resource.resource.metadata.csp)
+  }
+
+  private var appDisplayName: String {
+    resource.title ?? resource.resource.metadata.title ?? resource.serverName
+  }
+
+  /// Granted if approved this open (`networkConsented`) or earlier this launch
+  /// (persisted on the view model), so reopening an already-approved app renders
+  /// with widened CSP immediately — no reload, no banner.
+  private var isNetworkGranted: Bool {
+    networkConsented
+      || (viewModel?.isMCPAppNetworkGranted(serverName: resource.serverName, hosts: declaredHosts) ?? false)
+  }
+
+  private var showsNetworkConsentBanner: Bool {
+    MCPAppNetworkConsent.shouldPrompt(hosts: declaredHosts, consented: isNetworkGranted)
+  }
 
   var body: some View {
     VStack(spacing: 0) {
@@ -196,21 +253,54 @@ private struct MCPAppResourceHostView: View {
 
       Divider()
 
+      if showsNetworkConsentBanner {
+        MCPAppNetworkConsentBanner(
+          appName: appDisplayName,
+          hosts: declaredHosts,
+          onAllow: allowNetwork,
+          onDecline: declineNetwork
+        )
+      }
+
       AgentHubMCPUIWebView(
         resource: resource.resource,
-        bridgeHandler: bridgeHandler
+        bridgeHandler: bridgeHandler,
+        networkTrust: isNetworkGranted ? .allowDeclaredDomains : .lockedDown
       )
       .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
     .frame(maxWidth: .infinity, maxHeight: .infinity)
     .onAppear(perform: installBridgeHandler)
     .onChange(of: resource.id) { _, _ in
-      consentController.cancelPending()
-      installBridgeHandler()
+      handleResourceChange()
     }
     .onDisappear {
       consentController.cancelPending()
     }
+  }
+
+  private func allowNetwork() {
+    // Persist for this launch so reopening the panel doesn't re-prompt, and flip
+    // the local state for an immediate widen on this open.
+    viewModel?.grantMCPAppNetwork(serverName: resource.serverName, hosts: declaredHosts)
+    networkConsented = true
+  }
+
+  /// Declining network closes the panel: an app that declares hosts generally
+  /// needs them to render (e.g. it loads its runtime from a CDN), so leaving a
+  /// locked-down — often blank — panel open would be useless. Reopening later
+  /// asks again (the grant was never given).
+  private func declineNetwork() {
+    onTeardown()
+  }
+
+  /// Switching to a different app drops this-open state; `isNetworkGranted` then
+  /// re-derives from any persisted grant for the new app. In-flight consent is
+  /// cancelled so a bridge call never hangs across the switch.
+  private func handleResourceChange() {
+    consentController.cancelPending()
+    networkConsented = false
+    installBridgeHandler()
   }
 
   private var resourceToolbar: some View {
@@ -468,6 +558,111 @@ private struct MCPAppNoticeBanner: View {
     .padding(.horizontal, 12)
     .padding(.vertical, 8)
     .background(notice.tint.opacity(0.10))
+  }
+}
+
+// MARK: - MCPAppNetworkConsentBanner
+
+/// Prominent one-time consent card shown above an MCP app that declares network
+/// hosts. The app's declared domains are untrusted, so the web view stays locked
+/// down until the user taps Allow here. Because it is seen at most once per app
+/// per launch, it presents the decision deliberately: which app, exactly which
+/// hosts, and that the grant is remembered for the session.
+private struct MCPAppNetworkConsentBanner: View {
+  let appName: String
+  let hosts: [String]
+  let onAllow: () -> Void
+  let onDecline: () -> Void
+
+  @Environment(\.accessibilityReduceMotion) private var reduceMotion
+  @State private var appeared = false
+
+  private static let visibleHostCap = 4
+
+  private var visibleHosts: [String] { Array(hosts.prefix(Self.visibleHostCap)) }
+  private var overflowCount: Int { max(0, hosts.count - Self.visibleHostCap) }
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 12) {
+      HStack(alignment: .top, spacing: 12) {
+        Image(systemName: "network.badge.shield.half.filled")
+          .font(.title3)
+          .foregroundStyle(Color.brandPrimary)
+          .frame(width: 36, height: 36)
+          .background(Color.brandPrimary.opacity(0.12), in: .rect(cornerRadius: 9))
+          .accessibilityHidden(true)
+
+        VStack(alignment: .leading, spacing: 1) {
+          Text("Allow network access?")
+            .font(.headline)
+          Text(appName)
+            .font(.subheadline)
+            .foregroundStyle(.secondary)
+            .lineLimit(1)
+            .truncationMode(.tail)
+        }
+        .accessibilityElement(children: .combine)
+
+        Spacer(minLength: 0)
+      }
+
+      VStack(alignment: .leading, spacing: 6) {
+        Text("Connects to")
+          .font(.caption)
+          .foregroundStyle(.secondary)
+
+        ForEach(visibleHosts, id: \.self) { host in
+          Label {
+            Text(host)
+              .font(.callout.monospaced())
+              .lineLimit(1)
+              .truncationMode(.middle)
+          } icon: {
+            Image(systemName: "globe")
+              .foregroundStyle(.secondary)
+          }
+        }
+
+        if overflowCount > 0 {
+          Text("+\(overflowCount) more")
+            .font(.caption)
+            .foregroundStyle(.secondary)
+        }
+      }
+      .accessibilityElement(children: .combine)
+      .accessibilityLabel("Connects to \(hosts.joined(separator: ", "))")
+
+      Text("Blocked until you allow · kept for this session")
+        .font(.caption)
+        .foregroundStyle(.tertiary)
+
+      HStack(spacing: 8) {
+        Spacer(minLength: 0)
+        Button("Not Now", action: onDecline)
+        Button("Allow", action: onAllow)
+          .buttonStyle(.borderedProminent)
+      }
+    }
+    .padding(14)
+    .background(.regularMaterial, in: .rect(cornerRadius: 12))
+    .overlay {
+      RoundedRectangle(cornerRadius: 12)
+        .strokeBorder(Color.brandPrimary.opacity(0.25), lineWidth: 1)
+    }
+    .shadow(color: .black.opacity(0.10), radius: 6, y: 2)
+    .padding(.horizontal, 12)
+    .padding(.vertical, 10)
+    // Gentle reveal for a deliberate, one-time prompt; instant under Reduce Motion.
+    .opacity(appeared ? 1 : 0)
+    .offset(y: appeared ? 0 : -6)
+    .onAppear {
+      guard !appeared else { return }
+      if reduceMotion {
+        appeared = true
+      } else {
+        withAnimation(.smooth(duration: 0.28)) { appeared = true }
+      }
+    }
   }
 }
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/CLISessionsViewModel.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/CLISessionsViewModel.swift
@@ -282,6 +282,31 @@ public final class CLISessionsViewModel {
     [providerKind.rawValue, projectPath, serverName, uri].joined(separator: "|")
   }
 
+  /// MCP apps whose declared network domains the user approved during this app
+  /// launch. Keyed by app identity (provider + server + sorted declared host set)
+  /// so a new app, or one whose declared domains changed, still prompts. In-memory
+  /// only — approval is re-confirmed after a relaunch (no standing on-disk grant).
+  private var grantedMCPAppNetworkKeys: Set<String> = []
+
+  private func mcpAppNetworkGrantKey(serverName: String, hosts: [String]) -> String {
+    ([providerKind.rawValue, serverName] + hosts.sorted()).joined(separator: "|")
+  }
+
+  /// Whether the user already approved this MCP app's declared network hosts this
+  /// launch, so reopening the panel (or switching back to it) skips the consent
+  /// banner. Empty host sets are never "granted" — there is nothing to allow.
+  public func isMCPAppNetworkGranted(serverName: String, hosts: [String]) -> Bool {
+    guard !hosts.isEmpty else { return false }
+    return grantedMCPAppNetworkKeys.contains(mcpAppNetworkGrantKey(serverName: serverName, hosts: hosts))
+  }
+
+  /// Records the user's approval of this MCP app's declared network hosts for the
+  /// current app launch.
+  public func grantMCPAppNetwork(serverName: String, hosts: [String]) {
+    guard !hosts.isEmpty else { return }
+    grantedMCPAppNetworkKeys.insert(mcpAppNetworkGrantKey(serverName: serverName, hosts: hosts))
+  }
+
   /// Lazily resolves the app shells for the MCP tool invocations the agent made.
   ///
   /// For each server actually used, fetches `tools/list` once to learn which tools

--- a/app/modules/AgentHubCore/Sources/AgentHubMCPUI/AgentHubMCPUIResourceView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHubMCPUI/AgentHubMCPUIResourceView.swift
@@ -157,24 +157,44 @@ public enum AgentHubMCPUIBridgeError: LocalizedError {
   }
 }
 
+/// How much network/resource reach an MCP app's WKWebView is granted.
+///
+/// SECURITY: an MCP app's declared CSP domains come from the same untrusted tool
+/// output as its HTML body, so they are NOT trusted by default. The web view
+/// loads `.lockedDown` until the user explicitly opts in for that one app.
+public enum MCPAppNetworkTrust: Sendable, Equatable {
+  /// Default. No remote network or resources, regardless of declared domains.
+  case lockedDown
+  /// User explicitly approved this app's declared domains. Widens every remote
+  /// directive — including `script-src`, since real apps load their runtime as ES
+  /// modules from a CDN — but only to the validated http(s) hosts that were
+  /// declared. (`'unsafe-eval'` is still never granted.)
+  case allowDeclaredDomains
+}
+
 public struct AgentHubMCPUIWebView: NSViewRepresentable {
   private let resource: AgentHubMCPUIResource
   private let bridgeHandler: (any AgentHubMCPUIBridgeHandler)?
+  private let networkTrust: MCPAppNetworkTrust
 
   public init(
     html: String,
-    bridgeHandler: (any AgentHubMCPUIBridgeHandler)? = nil
+    bridgeHandler: (any AgentHubMCPUIBridgeHandler)? = nil,
+    networkTrust: MCPAppNetworkTrust = .lockedDown
   ) {
     self.resource = AgentHubMCPUIResource(uri: "ui://agenthub/inline", text: html)
     self.bridgeHandler = bridgeHandler
+    self.networkTrust = networkTrust
   }
 
   public init(
     resource: AgentHubMCPUIResource,
-    bridgeHandler: (any AgentHubMCPUIBridgeHandler)? = nil
+    bridgeHandler: (any AgentHubMCPUIBridgeHandler)? = nil,
+    networkTrust: MCPAppNetworkTrust = .lockedDown
   ) {
     self.resource = resource
     self.bridgeHandler = bridgeHandler
+    self.networkTrust = networkTrust
   }
 
   public func makeCoordinator() -> Coordinator {
@@ -199,20 +219,32 @@ public struct AgentHubMCPUIWebView: NSViewRepresentable {
     mcpUILogger.info(
       "[MCPUIBridge] load resource uri=\(resource.uri, privacy: .public) mime=\(resource.mimeType, privacy: .public)"
     )
-    webView.loadHTMLString(Self.hardenedHTML(for: resource), baseURL: Self.baseURL(for: resource))
+    webView.loadHTMLString(
+      Self.hardenedHTML(for: resource, trust: networkTrust),
+      baseURL: Self.baseURL(for: resource)
+    )
     context.coordinator.loadedResource = resource
+    context.coordinator.loadedTrust = networkTrust
     context.coordinator.didDeliverReadyNotifications = false
     return webView
   }
 
   public func updateNSView(_ webView: WKWebView, context: Context) {
     context.coordinator.bridgeHandler = bridgeHandler
-    guard context.coordinator.loadedResource != resource else { return }
+    // Reload when the resource changes or the user's network trust decision does
+    // (e.g. they tapped "Allow" on the consent banner). The non-persistent data
+    // store means the post-consent reload starts from a clean slate.
+    guard context.coordinator.loadedResource != resource
+       || context.coordinator.loadedTrust != networkTrust else { return }
     mcpUILogger.info(
-      "[MCPUIBridge] reload resource uri=\(resource.uri, privacy: .public) mime=\(resource.mimeType, privacy: .public)"
+      "[MCPUIBridge] reload resource uri=\(resource.uri, privacy: .public) mime=\(resource.mimeType, privacy: .public) trust=\(String(describing: networkTrust), privacy: .public)"
     )
-    webView.loadHTMLString(Self.hardenedHTML(for: resource), baseURL: Self.baseURL(for: resource))
+    webView.loadHTMLString(
+      Self.hardenedHTML(for: resource, trust: networkTrust),
+      baseURL: Self.baseURL(for: resource)
+    )
     context.coordinator.loadedResource = resource
+    context.coordinator.loadedTrust = networkTrust
     context.coordinator.didDeliverReadyNotifications = false
   }
 
@@ -234,8 +266,9 @@ public struct AgentHubMCPUIWebView: NSViewRepresentable {
     URL(string: "agenthub-mcp-app://local/")!
   }
 
-  private static func hardenedHTML(for resource: AgentHubMCPUIResource) -> String {
-    let csp = cspContent(for: resource.metadata.csp)
+  // internal (NOT private) so AgentHubMCPUITests can exercise the CSP directly.
+  static func hardenedHTML(for resource: AgentHubMCPUIResource, trust: MCPAppNetworkTrust) -> String {
+    let csp = cspContent(for: resource.metadata.csp, trust: trust)
     let meta = #"<meta http-equiv="Content-Security-Policy" content="\#(AgentHubMCPUIHTML.escape(csp))">"#
     if let headRange = resource.text.range(of: "<head", options: [.caseInsensitive]),
        let close = resource.text[headRange.lowerBound...].firstIndex(of: ">") {
@@ -252,24 +285,56 @@ public struct AgentHubMCPUIWebView: NSViewRepresentable {
     """
   }
 
-  private static func cspContent(for csp: AgentHubMCPUICSP) -> String {
-    let connect = domainSources(csp.connectDomains)
-    let resources = domainSources(csp.resourceDomains)
+  // internal (NOT private) so AgentHubMCPUITests can call it directly.
+  static func cspContent(
+    for csp: AgentHubMCPUICSP,
+    trust: MCPAppNetworkTrust
+  ) -> String {
+    // SECURITY: csp.connectDomains / resourceDomains come from the same untrusted
+    // tool output as the HTML body, so the web view is DEFAULT-DENY: under
+    // `.lockedDown` no remote script, network, or resource loads at all. Every
+    // remote directive — including script-src (real apps load their runtime as ES
+    // modules from a CDN like esm.sh, which script-src governs) — widens ONLY
+    // under `.allowDeclaredDomains`, i.e. after the user explicitly approved this
+    // app's named domains via the consent banner, and only to validated http(s)
+    // hosts (`domainSources`). 'unsafe-inline' is always present because the HTML
+    // body is the app and runs regardless; the meaningful controls are the
+    // sandbox (non-persistent store, no file/host access, gated navigation) and
+    // this per-app consent gate on all egress. Do not widen any directive in the
+    // `.lockedDown` branch.
+    let resources: String
+    let connect: String
+    switch trust {
+    case .lockedDown:
+      resources = ""
+      connect = "'none'"
+    case .allowDeclaredDomains:
+      resources = domainSources(csp.resourceDomains)
+      let c = domainSources(csp.connectDomains)
+      connect = c.isEmpty ? "'none'" : c
+    }
+
+    func join(_ parts: String...) -> String {
+      parts.filter { !$0.isEmpty }.joined(separator: " ")
+    }
+
     return [
       "default-src 'none'",
       "base-uri 'none'",
       "form-action 'none'",
       "frame-ancestors 'none'",
-      "script-src 'unsafe-inline' \(resources)",
-      "style-src 'unsafe-inline' \(resources)",
-      "img-src data: blob: \(resources)",
-      "font-src data: \(resources)",
+      join("script-src 'unsafe-inline'", resources),      // remote scripts (ES modules) only after consent
+      join("style-src 'unsafe-inline'", resources),
+      join("img-src data: blob:", resources),
+      join("font-src data:", resources),
       "connect-src \(connect)",
-      "media-src \(resources)"
+      "media-src \(resources.isEmpty ? "'none'" : resources)"
     ].joined(separator: "; ")
   }
 
-  private static func domainSources(_ domains: [String]) -> String {
+  // internal (NOT private): the only gate on what a consented app can reach, so
+  // it must be testable.
+  static func domainSources(_ domains: [String]) -> String {
     let sanitized = domains.compactMap { domain -> String? in
       let trimmed = domain.trimmingCharacters(in: .whitespacesAndNewlines)
       guard !trimmed.isEmpty else { return nil }
@@ -292,6 +357,9 @@ public struct AgentHubMCPUIWebView: NSViewRepresentable {
     weak var webView: WKWebView?
     weak var bridgeHandler: (any AgentHubMCPUIBridgeHandler)?
     var loadedResource: AgentHubMCPUIResource?
+    /// The network trust the currently-loaded HTML was hardened with. A change
+    /// (consent granted) triggers a reload with a re-widened CSP.
+    var loadedTrust: MCPAppNetworkTrust = .lockedDown
     /// Guards the one-time delivery of `appReadyNotifications` per loaded resource.
     /// Reset whenever a new resource is loaded.
     var didDeliverReadyNotifications = false

--- a/app/modules/AgentHubCore/Tests/AgentHubMCPUITests/AgentHubMCPUIResourceTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubMCPUITests/AgentHubMCPUIResourceTests.swift
@@ -64,3 +64,78 @@ struct AgentHubMCPUIResourceTests {
     #expect(script.contains("event.origin === hostOrigin"))
   }
 }
+
+/// An MCP app's declared CSP domains come from the same untrusted tool output as
+/// its HTML body. These tests pin the security invariant: DEFAULT-DENY — under
+/// `.lockedDown` no remote directive (script, connect, img, …) names any declared
+/// domain. Every remote directive, including `script-src` (real apps load their
+/// runtime as ES modules from a CDN), widens only after explicit user consent and
+/// only to validated http(s) hosts.
+@Suite("MCP app CSP hardening")
+@MainActor
+struct MCPAppCSPHardeningTests {
+  private let hostile = AgentHubMCPUICSP(
+    connectDomains: ["https://attacker.com"],
+    resourceDomains: ["https://attacker.com"]
+  )
+
+  @Test("Locked-down CSP names no declared domain in any directive")
+  func lockedDownIgnoresDeclaredDomains() throws {
+    let policy = AgentHubMCPUIWebView.cspContent(for: hostile, trust: .lockedDown)
+
+    #expect(!policy.contains("attacker.com"))
+    #expect(policy.contains("connect-src 'none'"))
+    #expect(policy.contains("media-src 'none'"))
+    // script-src is inline-only with no remote host until the user consents.
+    let scriptDirective = try #require(
+      policy.split(separator: ";").map(String.init).first { $0.contains("script-src") }
+    )
+    #expect(scriptDirective.contains("'unsafe-inline'"))
+    #expect(!scriptDirective.contains("attacker.com"))
+  }
+
+  @Test("Consent widens script-src to the declared resource domains")
+  func consentWidensScriptSrc() throws {
+    let policy = AgentHubMCPUIWebView.cspContent(for: hostile, trust: .allowDeclaredDomains)
+
+    let scriptDirective = try #require(
+      policy.split(separator: ";").map(String.init).first { $0.contains("script-src") }
+    )
+    #expect(scriptDirective.contains("'unsafe-inline'"))
+    #expect(scriptDirective.contains("https://attacker.com"))
+  }
+
+  @Test("Consent widens connect/img to the validated https domains")
+  func consentWidensValidatedDomains() {
+    let policy = AgentHubMCPUIWebView.cspContent(for: hostile, trust: .allowDeclaredDomains)
+
+    #expect(policy.contains("connect-src https://attacker.com"))
+    #expect(policy.contains("img-src data: blob: https://attacker.com"))
+  }
+
+  @Test("domainSources rejects non-http(s) schemes and hostless junk")
+  func domainSourcesRejectsInvalidDomains() {
+    let csp = AgentHubMCPUICSP(connectDomains: [
+      "https://ok.com", "javascript:alert(1)", "file:///etc/passwd", "data:", "'self'"
+    ])
+    let policy = AgentHubMCPUIWebView.cspContent(for: csp, trust: .allowDeclaredDomains)
+
+    #expect(policy.contains("https://ok.com"))
+    #expect(policy.contains("'self'"))
+    #expect(!policy.contains("javascript:"))
+    #expect(!policy.contains("file:"))
+  }
+
+  @Test("Hardened HTML embeds the locked CSP and leaks no domains by default")
+  func hardenedHTMLLockedByDefault() {
+    let resource = AgentHubMCPUIResource(
+      uri: "ui://x",
+      text: "<head></head><body>x</body>",
+      metadata: AgentHubMCPUIResourceMetadata(csp: hostile)
+    )
+    let html = AgentHubMCPUIWebView.hardenedHTML(for: resource, trust: .lockedDown)
+
+    #expect(html.contains("Content-Security-Policy"))
+    #expect(!html.contains("attacker.com"))
+  }
+}

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/CLISessionsViewModelMCPAppDiscoveryTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/CLISessionsViewModelMCPAppDiscoveryTests.swift
@@ -135,6 +135,25 @@ struct CLISessionsViewModelMCPAppDiscoveryTests {
     }
   }
 
+  @Test("Network grants persist per app for the launch and ignore host order")
+  @MainActor
+  func networkGrantPersistsPerApp() {
+    let viewModel = makeViewModel(provider: .claude, service: RecordingMCPAppDiscoveryService())
+
+    // Nothing granted up front; an empty host set is never grantable.
+    #expect(!viewModel.isMCPAppNetworkGranted(serverName: "excalidraw", hosts: ["esm.sh"]))
+    viewModel.grantMCPAppNetwork(serverName: "excalidraw", hosts: [])
+    #expect(!viewModel.isMCPAppNetworkGranted(serverName: "excalidraw", hosts: []))
+
+    viewModel.grantMCPAppNetwork(serverName: "excalidraw", hosts: ["esm.sh", "cdn.example.com"])
+
+    // Same app + same host set (any order) is remembered.
+    #expect(viewModel.isMCPAppNetworkGranted(serverName: "excalidraw", hosts: ["cdn.example.com", "esm.sh"]))
+    // A different server, or a changed host set, still prompts.
+    #expect(!viewModel.isMCPAppNetworkGranted(serverName: "other", hosts: ["esm.sh", "cdn.example.com"]))
+    #expect(!viewModel.isMCPAppNetworkGranted(serverName: "excalidraw", hosts: ["esm.sh"]))
+  }
+
   @Test("Builds inline MCP app resources from agent tool results")
   @MainActor
   func buildsInlineResourcesFromState() async {

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/MCPAppSidePanelViewTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/MCPAppSidePanelViewTests.swift
@@ -205,6 +205,28 @@ struct MCPAppSidePanelViewTests {
     #expect(result["context"]?["resourceUri"] == .string("ui://fake/app"))
   }
 
+  @Test("declaredHosts returns validated, deduped http(s) hosts in declaration order")
+  func declaredHostsValidatesAndDedupes() {
+    let csp = AgentHubMCPUICSP(
+      connectDomains: ["https://api.example.com", "javascript:alert(1)", "https://api.example.com"],
+      resourceDomains: ["https://cdn.example.com", "file:///x", "'self'"]
+    )
+
+    #expect(MCPAppNetworkConsent.declaredHosts(for: csp) == ["api.example.com", "cdn.example.com"])
+  }
+
+  @Test("declaredHosts is empty when the app declares no network domains")
+  func declaredHostsEmptyByDefault() {
+    #expect(MCPAppNetworkConsent.declaredHosts(for: AgentHubMCPUICSP()).isEmpty)
+  }
+
+  @Test("Consent banner shows only with declared hosts and no prior consent")
+  func bannerVisibilityPredicate() {
+    #expect(MCPAppNetworkConsent.shouldPrompt(hosts: ["example.com"], consented: false))
+    #expect(!MCPAppNetworkConsent.shouldPrompt(hosts: ["example.com"], consented: true))
+    #expect(!MCPAppNetworkConsent.shouldPrompt(hosts: [], consented: false))
+  }
+
   @MainActor
   private func waitForPendingRequest(_ controller: MCPAppConsentController) async {
     for _ in 0..<50 {


### PR DESCRIPTION
## Summary

Closes a CSP self-authorization hole in agent-produced MCP app rendering. An MCP app's declared CSP domains (`_meta.ui.csp` / `openai/widgetCSP`) come from the **same untrusted tool output as its HTML**, but `cspContent` spliced them straight into `script-src` / `connect-src` with **no consent** — so any agent-produced (or prompt-injected) app could silently load remote scripts and exfiltrate data the moment its side panel opened. `default-src 'none'` was meaningless because every overriding allowlist was attacker-controlled.

## The fix — default-deny + explicit per-app consent

The WKWebView now loads **`.lockedDown` by default** (`MCPAppNetworkTrust`): no remote script / connect / resource at all, regardless of declared domains. Pre-consent there is genuinely zero remote egress — `connect-src 'none'` covers `fetch`/WebSocket/`<a ping>`, `form-action 'none'` blocks form posts, and top-level navigation is cancelled and routed through the separate `openLink` consent.

The **only** thing that widens egress is an explicit, per-app user opt-in — an inline consent card that names the exact validated hosts. On approval the app's declared http(s) hosts widen the remote directives; `domainSources` rejects `javascript:` / `file:` / `data:` / hostless junk so even a consented app can only reach real hosts. `'unsafe-eval'` is never granted, and the sandbox (non-persistent store, no file/host access) is unchanged.

- **Consent persists per app launch** (`CLISessionsViewModel`, keyed by `provider + server + sorted host set`) so reopening the panel doesn't re-prompt; a different app or changed domains re-asks; nothing is written to disk.
- **Declining closes the panel** — an app that declares hosts generally needs them to render, so leaving a blank locked-down panel open would be useless.

## Deliberate deviation: `script-src` widens on consent

The original plan mandated `script-src` stay inline-only forever. That makes **every real CDN-hosted MCP app non-functional** — excalidraw and the MCP/OpenAI Apps SDKs load their runtime as ES modules from a CDN (e.g. `esm.sh`), which `script-src` governs. The "inline-only prevents RCE" premise was also overstated: `'unsafe-inline'` already runs arbitrary attacker JS, so blocking remote scripts never prevented execution.

So consent now widens `script-src` too — **bounded** by (1) the explicit consent naming the domains, (2) those same domains being the only egress anyway, (3) no `'unsafe-eval'`, and (4) the sandbox. Net posture is dramatically better than the original auto-allow-everything, while real apps work after one click.

## Behavior changes

| Situation | Result |
|---|---|
| Self-contained / inline app (no declared domains) | Renders as before (locked-down already allows inline + `data:`/`blob:`) |
| CDN app (excalidraw) | One **Allow** per launch, then cached — no re-prompt on reopen |
| Different app, or changed declared domains | Prompts again |
| **Not Now** | Closes the side panel |
| Relaunch AgentHub | Re-confirms once (in-memory only) |

## Tests

- `MCPAppCSPHardeningTests` — locked-down names no declared domain in any directive (incl. `script-src`); consent widens `script-src` / `connect-src` / `img-src`; `domainSources` validation.
- `MCPAppSidePanelViewTests` — banner host parsing/dedup/validation + visibility predicate.
- `CLISessionsViewModelMCPAppDiscoveryTests` — per-launch grant persistence (initial deny, empty-set never grantable, host-order independence, different-server / changed-hosts re-prompt).
- Docs: `MCPApps.md` CSP invariant + updated gaps.

## Verification

- `xcodebuild ... -scheme AgentHub build` and `build-for-testing` both succeed.
- Test suites must be run via Xcode **Cmd+U** — the `AgentHub` scheme has no headless test action (pre-existing limitation; `swift test` also fails on the `CodeEditSymbols` asset bundle).

## Not in scope (enterprise follow-ups)

This hardens the MCP-rendering surface; it is not a whole-app enterprise certification. Stricter orgs would still want a config/MDM **kill-switch** for MCP rendering, an **admin domain allowlist**, and **grant audit logging** — none of which are in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
