### PR TITLE
[codex] Fix side panel close window resizing

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubViews.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubViews.swift
@@ -59,10 +59,22 @@ public struct AgentHubSessionsView: View {
       worktreeSuccessSoundService: provider.worktreeSuccessSoundService
     )
       .frame(minWidth: 1200, minHeight: 750)
+      .toolbar {
+        ToolbarItem(placement: .navigation) {
+          Button(action: toggleSidebarVisibility) {
+            Label("Toggle Sidebar", systemImage: "sidebar.left")
+          }
+          .help(columnVisibility == .detailOnly ? "Show Sidebar" : "Hide Sidebar")
+        }
+      }
       .modifier(RemoveTitleToolbarModifier())
       .task {
         provider.startWorktreeLaunchRequestMonitoring()
       }
+  }
+
+  private func toggleSidebarVisibility() {
+    columnVisibility = columnVisibility == .detailOnly ? .all : .detailOnly
   }
 
   private var missingProviderView: some View {

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/EmbeddedSidePanelSidebarVisibilityState.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/EmbeddedSidePanelSidebarVisibilityState.swift
@@ -1,0 +1,39 @@
+//
+//  EmbeddedSidePanelSidebarVisibilityState.swift
+//  AgentHub
+//
+
+import SwiftUI
+
+struct EmbeddedSidePanelSidebarVisibilityState {
+  private(set) var isEmbeddedTrailingPanelVisible = false
+  private(set) var sidebarVisibilityBeforeAutoHide: NavigationSplitViewVisibility?
+
+  mutating func resetAutoHideState() {
+    sidebarVisibilityBeforeAutoHide = nil
+  }
+
+  mutating func columnVisibilityChange(
+    forEmbeddedSidePanelVisible isVisible: Bool,
+    currentColumnVisibility: NavigationSplitViewVisibility
+  ) -> NavigationSplitViewVisibility? {
+    guard isEmbeddedTrailingPanelVisible != isVisible else { return nil }
+    isEmbeddedTrailingPanelVisible = isVisible
+
+    if isVisible {
+      guard currentColumnVisibility != .detailOnly else {
+        sidebarVisibilityBeforeAutoHide = nil
+        return nil
+      }
+
+      sidebarVisibilityBeforeAutoHide = currentColumnVisibility
+      return .detailOnly
+    }
+
+    guard let previousVisibility = sidebarVisibilityBeforeAutoHide else { return nil }
+    sidebarVisibilityBeforeAutoHide = nil
+
+    guard currentColumnVisibility == .detailOnly else { return nil }
+    return previousVisibility
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
@@ -166,8 +166,7 @@ public struct MultiProviderSessionsListView: View {
   @AppStorage(AgentHubDefaults.auxiliaryShellVisible) private var isAuxiliaryShellVisible = false
   @AppStorage(AgentHubDefaults.worktreeDisplayMode)
   private var worktreeDisplayModeRawValue: String = WorktreeDisplayMode.parent.rawValue
-  @State private var isEmbeddedTrailingPanelVisible = false
-  @State private var sidebarVisibilityBeforeAutoHide: NavigationSplitViewVisibility?
+  @State private var embeddedSidePanelSidebarVisibility = EmbeddedSidePanelSidebarVisibilityState()
   @FocusState private var isSearchFieldFocused: Bool
   @Environment(\.colorScheme) private var colorScheme
   @Environment(\.runtimeTheme) private var runtimeTheme
@@ -203,50 +202,28 @@ public struct MultiProviderSessionsListView: View {
 
   public var body: some View {
     GeometryReader { proxy in
-      let sidebarMax = max(280, proxy.size.width * 0.20)
-    ZStack {
-      NavigationSplitView(columnVisibility: $columnVisibility) {
-        sidePanelView
-          .agentHubPanel()
-          .navigationSplitViewColumnWidth(min: 280, ideal: 280, max: sidebarMax)
-          .padding(.vertical, 8)
-          .padding(.horizontal, 8)
-      } detail: {
-        VStack(spacing: 0) {
-          // Progress bar lives above the detail pane only (not over the sidebar).
-          WorktreeGenerationProgressBar()
-
-          MultiProviderMonitoringPanelView(
-            claudeViewModel: claudeViewModel,
-            codexViewModel: codexViewModel,
-            primarySessionId: $primarySessionId,
-            selectedModuleLandingPath: $selectedModuleLandingPath,
-            onEmbeddedSidePanelVisibilityChange: handleEmbeddedSidePanelVisibilityChange,
-            onAddFolder: { showAddRepositoryPicker() },
-            onRequestStartSession: { preferredRepositoryPath in
-              triggerNewSessionFlow(preferredRepositoryPath: preferredRepositoryPath)
-            },
-            onRequestForkSession: { session, targetProvider in
-              triggerForkSessionFlow(session: session, targetProvider: targetProvider)
-            }
-          )
-          .padding(12)
-          .agentHubPanel()
-          .frame(minWidth: 300)
-          .padding(.vertical, 8)
-          .padding(.horizontal, 8)
-          .background {
-            NSSplitViewAutosaveDisabler()
-              .frame(width: 0, height: 0)
-              .allowsHitTesting(false)
+      let sidebarWidth: CGFloat = 280
+      ZStack {
+        HStack(spacing: 0) {
+          if isSidebarVisible {
+            sidePanelView
+              .agentHubPanel()
+              .frame(width: sidebarWidth)
+              .padding(.vertical, 8)
+              .padding(.horizontal, 8)
+              .transition(sidebarVisibilityTransition)
           }
-        }
-      }
-      .navigationSplitViewStyle(.balanced)
-      .background(appBackground.ignoresSafeArea())
 
-      // Invisible global keyboard shortcuts.
-      keyboardShortcutButtons
+          detailPane
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+        .frame(width: proxy.size.width, height: proxy.size.height)
+        .background(appBackground.ignoresSafeArea())
+
+        // Invisible global keyboard shortcuts.
+        keyboardShortcutButtons
+      }
+      .animation(sidebarVisibilityAnimation, value: isSidebarVisible)
     }
     .overlay {
       commandPaletteOverlay
@@ -456,10 +433,52 @@ public struct MultiProviderSessionsListView: View {
     }
     .modifier(ArchiveConfirmationAlert(confirmation: $archiveConfirmation))
     .modifier(RemoveConfirmationAlert(confirmation: $removeConfirmation))
-    }
   }
 
   // MARK: - UI Helpers
+
+  private var isSidebarVisible: Bool {
+    columnVisibility != .detailOnly
+  }
+
+  private var sidebarVisibilityAnimation: Animation {
+    accessibilityReduceMotion
+      ? .easeInOut(duration: 0.08)
+      : .timingCurve(0.22, 1, 0.36, 1, duration: 0.22)
+  }
+
+  private var sidebarVisibilityTransition: AnyTransition {
+    accessibilityReduceMotion
+      ? .opacity
+      : .move(edge: .leading).combined(with: .opacity)
+  }
+
+  private var detailPane: some View {
+    VStack(spacing: 0) {
+      // Progress bar lives above the detail pane only (not over the sidebar).
+      WorktreeGenerationProgressBar()
+
+      MultiProviderMonitoringPanelView(
+        claudeViewModel: claudeViewModel,
+        codexViewModel: codexViewModel,
+        primarySessionId: $primarySessionId,
+        selectedModuleLandingPath: $selectedModuleLandingPath,
+        onEmbeddedSidePanelVisibilityChange: handleEmbeddedSidePanelVisibilityChange,
+        onAddFolder: { showAddRepositoryPicker() },
+        onRequestStartSession: { preferredRepositoryPath in
+          triggerNewSessionFlow(preferredRepositoryPath: preferredRepositoryPath)
+        },
+        onRequestForkSession: { session, targetProvider in
+          triggerForkSessionFlow(session: session, targetProvider: targetProvider)
+        }
+      )
+      .padding(12)
+      .agentHubPanel()
+      .frame(minWidth: 300)
+      .padding(.vertical, 8)
+      .padding(.horizontal, 8)
+    }
+  }
 
   private var keyboardShortcutButtons: some View {
     Group {
@@ -1873,8 +1892,7 @@ public struct MultiProviderSessionsListView: View {
       openSettings()
 
     case .toggleSidebar:
-      sidebarVisibilityBeforeAutoHide = nil
-      columnVisibility = columnVisibility == .all ? .detailOnly : .all
+      toggleSidebarVisibility()
 
     case .toggleTerminalEditor:
       NotificationCenter.default.post(name: .toggleMonitoringContentMode, object: nil)
@@ -1882,25 +1900,17 @@ public struct MultiProviderSessionsListView: View {
   }
 
   private func handleEmbeddedSidePanelVisibilityChange(_ isVisible: Bool) {
-    guard isEmbeddedTrailingPanelVisible != isVisible else { return }
-    isEmbeddedTrailingPanelVisible = isVisible
+    guard let nextVisibility = embeddedSidePanelSidebarVisibility.columnVisibilityChange(
+      forEmbeddedSidePanelVisible: isVisible,
+      currentColumnVisibility: columnVisibility
+    ) else { return }
 
-    if isVisible {
-      guard columnVisibility != .detailOnly else {
-        sidebarVisibilityBeforeAutoHide = nil
-        return
-      }
+    columnVisibility = nextVisibility
+  }
 
-      sidebarVisibilityBeforeAutoHide = columnVisibility
-      columnVisibility = .detailOnly
-      return
-    }
-
-    guard let previousVisibility = sidebarVisibilityBeforeAutoHide else { return }
-    sidebarVisibilityBeforeAutoHide = nil
-
-    guard columnVisibility == .detailOnly else { return }
-    columnVisibility = previousVisibility
+  private func toggleSidebarVisibility() {
+    embeddedSidePanelSidebarVisibility.resetAutoHideState()
+    columnVisibility = isSidebarVisible ? .detailOnly : .all
   }
 
   private var focusedSessionLaunchPath: String? {

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/EmbeddedSidePanelSidebarVisibilityStateTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/EmbeddedSidePanelSidebarVisibilityStateTests.swift
@@ -1,0 +1,94 @@
+import SwiftUI
+import Testing
+
+@testable import AgentHubCore
+
+@Suite("EmbeddedSidePanelSidebarVisibilityState")
+struct EmbeddedSidePanelSidebarVisibilityStateTests {
+  @Test("Opening embedded side panel hides visible sidebar and records previous visibility")
+  func openingEmbeddedSidePanelHidesVisibleSidebar() {
+    var state = EmbeddedSidePanelSidebarVisibilityState()
+
+    let change = state.columnVisibilityChange(
+      forEmbeddedSidePanelVisible: true,
+      currentColumnVisibility: .all
+    )
+
+    #expect(change == .detailOnly)
+    #expect(state.isEmbeddedTrailingPanelVisible)
+    #expect(state.sidebarVisibilityBeforeAutoHide == .all)
+  }
+
+  @Test("Closing embedded side panel restores the visibility auto-hidden on open")
+  func closingEmbeddedSidePanelRestoresAutoHiddenSidebar() {
+    var state = EmbeddedSidePanelSidebarVisibilityState()
+    _ = state.columnVisibilityChange(
+      forEmbeddedSidePanelVisible: true,
+      currentColumnVisibility: .all
+    )
+
+    let change = state.columnVisibilityChange(
+      forEmbeddedSidePanelVisible: false,
+      currentColumnVisibility: .detailOnly
+    )
+
+    #expect(change == .all)
+    #expect(!state.isEmbeddedTrailingPanelVisible)
+    #expect(state.sidebarVisibilityBeforeAutoHide == nil)
+  }
+
+  @Test("Opening embedded side panel while sidebar is already hidden does not restore it later")
+  func alreadyHiddenSidebarIsNotRestoredOnClose() {
+    var state = EmbeddedSidePanelSidebarVisibilityState()
+
+    let openChange = state.columnVisibilityChange(
+      forEmbeddedSidePanelVisible: true,
+      currentColumnVisibility: .detailOnly
+    )
+    let closeChange = state.columnVisibilityChange(
+      forEmbeddedSidePanelVisible: false,
+      currentColumnVisibility: .detailOnly
+    )
+
+    #expect(openChange == nil)
+    #expect(closeChange == nil)
+    #expect(!state.isEmbeddedTrailingPanelVisible)
+    #expect(state.sidebarVisibilityBeforeAutoHide == nil)
+  }
+
+  @Test("Duplicate visibility updates are ignored")
+  func duplicateVisibilityUpdatesAreIgnored() {
+    var state = EmbeddedSidePanelSidebarVisibilityState()
+    _ = state.columnVisibilityChange(
+      forEmbeddedSidePanelVisible: true,
+      currentColumnVisibility: .all
+    )
+
+    let duplicateChange = state.columnVisibilityChange(
+      forEmbeddedSidePanelVisible: true,
+      currentColumnVisibility: .detailOnly
+    )
+
+    #expect(duplicateChange == nil)
+    #expect(state.sidebarVisibilityBeforeAutoHide == .all)
+  }
+
+  @Test("Manual sidebar toggle clears pending auto restore")
+  func resetClearsPendingAutoRestore() {
+    var state = EmbeddedSidePanelSidebarVisibilityState()
+    _ = state.columnVisibilityChange(
+      forEmbeddedSidePanelVisible: true,
+      currentColumnVisibility: .all
+    )
+
+    state.resetAutoHideState()
+    let closeChange = state.columnVisibilityChange(
+      forEmbeddedSidePanelVisible: false,
+      currentColumnVisibility: .detailOnly
+    )
+
+    #expect(closeChange == nil)
+    #expect(!state.isEmbeddedTrailingPanelVisible)
+    #expect(state.sidebarVisibilityBeforeAutoHide == nil)
+  }
+}


### PR DESCRIPTION
## Summary

Fixes the main AgentHub window growing when an embedded trailing side panel is closed.

## Root cause

`NavigationSplitView` was restoring the left sessions sidebar after the right embedded panel closed. AppKit tries to preserve the detail column width when a sidebar column returns, so it expanded the host `NSWindow` even though the user had not resized it.

## Changes

- Replace the outer `NavigationSplitView` shell in `MultiProviderSessionsListView` with a SwiftUI-controlled `HStack`.
- Keep the sessions sidebar at the same 280pt width, but make it consume space inside the existing window instead of causing AppKit to resize the window.
- Keep the titlebar sidebar toggle by moving it to `AgentHubSessionsView`.
- Extract sidebar auto-hide/restore state into `EmbeddedSidePanelSidebarVisibilityState` with focused unit coverage.

## Validation

- `xcodebuild build -project app/AgentHub.xcodeproj -scheme AgentHub -destination 'platform=macOS'` reports `BUILD SUCCEEDED`.