### PR TITLE
[codex] Add remote base option for worktree creation

### DIFF
--- a/app/modules/AgentHubCLI/Sources/AgentHubCLIKit/WorktreeManagementService.swift
+++ b/app/modules/AgentHubCLI/Sources/AgentHubCLIKit/WorktreeManagementService.swift
@@ -7,6 +7,7 @@ public protocol WorktreeManagementServiceProtocol: Sendable {
   func listWorktrees(at repoPath: String) async throws -> [WorktreeInfo]
   func getRemoteBranches(at repoPath: String) async throws -> [BranchInfo]
   func fetchAndGetRemoteBranches(at repoPath: String) async throws -> [BranchInfo]
+  func fetchAndGetDefaultRemoteBaseBranch(at repoPath: String) async throws -> BranchInfo?
   func getLocalBranches(at repoPath: String) async throws -> [BranchInfo]
   func getLocalBranchesWithCurrent(at repoPath: String) async throws -> LocalBranchesResult
   func createWorktree(at repoPath: String, branch: String, directoryName: String) async throws -> String
@@ -138,6 +139,24 @@ public actor WorktreeManagementService: WorktreeManagementServiceProtocol {
     }
 
     return try await getRemoteBranches(at: repoPath)
+  }
+
+  public func fetchAndGetDefaultRemoteBaseBranch(at repoPath: String) async throws -> BranchInfo? {
+    let gitRoot: String
+    do {
+      gitRoot = try await findGitRoot(at: repoPath)
+    } catch {
+      throw WorktreeManagementError.notAGitRepository(repoPath)
+    }
+
+    do {
+      try await runGitCommand(["fetch", "--all"], at: gitRoot)
+    } catch {
+      // Keep the picker useful offline: fall back to the latest cached remote refs.
+    }
+
+    let output = try await runGitCommand(["branch", "-r"], at: gitRoot)
+    return defaultRemoteBaseBranch(from: output)
   }
 
   public func getLocalBranches(at repoPath: String) async throws -> [BranchInfo] {
@@ -733,6 +752,48 @@ private extension WorktreeManagementService {
         return BranchInfo(name: line, remote: String(parts[0]))
       }
       .sorted { $0.displayName < $1.displayName }
+  }
+
+  func defaultRemoteBaseBranch(from output: String) -> BranchInfo? {
+    let branches = parseRemoteBranches(output)
+    guard !branches.isEmpty else { return nil }
+
+    if let headName = remoteHeadTarget(from: output),
+       let headBranch = branches.first(where: {
+         $0.name == headName && Self.isSupportedDefaultBaseName($0.displayName)
+       }) {
+      return headBranch
+    }
+
+    if let originMain = branches.first(where: { $0.name == "origin/main" }) {
+      return originMain
+    }
+
+    if let originMaster = branches.first(where: { $0.name == "origin/master" }) {
+      return originMaster
+    }
+
+    if let remoteMain = branches.first(where: { $0.displayName == "main" }) {
+      return remoteMain
+    }
+
+    return branches.first(where: { $0.displayName == "master" })
+  }
+
+  func remoteHeadTarget(from output: String) -> String? {
+    output.components(separatedBy: .newlines)
+      .map { $0.trimmingCharacters(in: .whitespaces) }
+      .compactMap { line -> String? in
+        guard line.contains("HEAD ->") else { return nil }
+        let parts = line.components(separatedBy: "->")
+        guard parts.count == 2 else { return nil }
+        return parts[1].trimmingCharacters(in: .whitespaces)
+      }
+      .first
+  }
+
+  static func isSupportedDefaultBaseName(_ branchName: String) -> Bool {
+    branchName == "main" || branchName == "master"
   }
 
   func parseLocalBranches(_ output: String) -> [BranchInfo] {

--- a/app/modules/AgentHubCLI/Tests/AgentHubCLIKitTests/WorktreeManagementServiceTests.swift
+++ b/app/modules/AgentHubCLI/Tests/AgentHubCLIKitTests/WorktreeManagementServiceTests.swift
@@ -7,7 +7,7 @@ struct GitRepoFixture {
   let repoPath: String
   let parentDir: String
 
-  static func create() throws -> GitRepoFixture {
+  static func create(initialBranch: String = "main") throws -> GitRepoFixture {
     var resolved = [CChar](repeating: 0, count: Int(PATH_MAX))
     guard realpath(NSTemporaryDirectory(), &resolved) != nil else {
       throw GitFixtureError.commandFailed(command: "realpath", output: "", error: "Failed to resolve temp directory")
@@ -18,7 +18,7 @@ struct GitRepoFixture {
     try FileManager.default.createDirectory(atPath: repoPath, withIntermediateDirectories: true)
 
     let fixture = GitRepoFixture(repoPath: repoPath, parentDir: parentDir)
-    try fixture.runGit("init", "-b", "main")
+    try fixture.runGit("init", "-b", initialBranch)
     try fixture.runGit("config", "user.email", "test@test.com")
     try fixture.runGit("config", "user.name", "Test")
     try "initial".write(toFile: repoPath + "/README.md", atomically: true, encoding: .utf8)
@@ -78,6 +78,11 @@ struct GitRepoFixture {
   func localBranchExists(_ branch: String) throws -> Bool {
     let output = try runGit("branch", "--list", branch)
     return !output.isEmpty
+  }
+
+  func configureUser(at path: String? = nil) throws {
+    try runGit("config", "user.email", "test@test.com", at: path)
+    try runGit("config", "user.name", "Test", at: path)
   }
 
   func cleanup() {
@@ -177,6 +182,64 @@ struct WorktreeConventionTests {
     )
 
     #expect(FileManager.default.fileExists(atPath: path + "/BASE.md"))
+  }
+
+  @Test("Detects fetched origin main as the remote base branch")
+  func detectsFetchedOriginMainAsRemoteBaseBranch() async throws {
+    let seed = try GitRepoFixture.create()
+    defer { seed.cleanup() }
+
+    let remotePath = seed.parentDir + "/origin.git"
+    try seed.runGit("init", "--bare", "-b", "main", remotePath)
+    try seed.runGit("remote", "add", "origin", remotePath)
+    try seed.runGit("push", "-u", "origin", "main")
+
+    let localClonePath = seed.parentDir + "/local-clone"
+    try seed.runGit("clone", remotePath, localClonePath)
+    try seed.configureUser(at: localClonePath)
+
+    let writerClonePath = seed.parentDir + "/writer-clone"
+    try seed.runGit("clone", remotePath, writerClonePath)
+    try seed.configureUser(at: writerClonePath)
+    try "remote".write(toFile: writerClonePath + "/REMOTE.md", atomically: true, encoding: .utf8)
+    try seed.runGit("add", ".", at: writerClonePath)
+    try seed.runGit("commit", "-m", "remote update", at: writerClonePath)
+    try seed.runGit("push", "origin", "main", at: writerClonePath)
+
+    let service = WorktreeManagementService()
+    let remoteBase = try #require(await service.fetchAndGetDefaultRemoteBaseBranch(at: localClonePath))
+    #expect(remoteBase.name == "origin/main")
+    #expect(remoteBase.displayName == "main")
+
+    let path = try await service.createWorktreeWithNewBranch(
+      at: localClonePath,
+      newBranchName: "feature/from-remote-main",
+      directoryName: "feature-from-remote-main",
+      startPoint: remoteBase.name
+    )
+
+    #expect(FileManager.default.fileExists(atPath: path + "/REMOTE.md"))
+    #expect(!FileManager.default.fileExists(atPath: localClonePath + "/REMOTE.md"))
+  }
+
+  @Test("Falls back to origin master when remote main is absent")
+  func fallsBackToOriginMasterWhenRemoteMainIsAbsent() async throws {
+    let seed = try GitRepoFixture.create(initialBranch: "master")
+    defer { seed.cleanup() }
+
+    let remotePath = seed.parentDir + "/origin.git"
+    try seed.runGit("init", "--bare", "-b", "master", remotePath)
+    try seed.runGit("remote", "add", "origin", remotePath)
+    try seed.runGit("push", "-u", "origin", "master")
+
+    let localClonePath = seed.parentDir + "/master-clone"
+    try seed.runGit("clone", remotePath, localClonePath)
+
+    let service = WorktreeManagementService()
+    let remoteBase = try #require(await service.fetchAndGetDefaultRemoteBaseBranch(at: localClonePath))
+
+    #expect(remoteBase.name == "origin/master")
+    #expect(remoteBase.displayName == "master")
   }
 
   @Test("Progress-enabled creation leaves completed as the final update")

--- a/app/modules/AgentHubCore/Sources/AgentHub/Models/RemoteBranch.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Models/RemoteBranch.swift
@@ -7,14 +7,14 @@
 
 import Foundation
 
-/// Represents a remote git branch
+/// Represents a git branch that can be used as a worktree start point.
 public struct RemoteBranch: Identifiable, Hashable, Sendable {
-  public var id: String { name }
+  public var id: String { "\(remote):\(name)" }
 
-  /// Full branch name (e.g., "origin/feature-auth")
+  /// Full branch name (e.g., "main" or "origin/main")
   public let name: String
 
-  /// Remote name (e.g., "origin")
+  /// Source name (e.g., "local" or "origin")
   public let remote: String
 
   /// Display name without remote prefix (e.g., "feature-auth")
@@ -22,8 +22,33 @@ public struct RemoteBranch: Identifiable, Hashable, Sendable {
     name.hasPrefix("\(remote)/") ? String(name.dropFirst(remote.count + 1)) : name
   }
 
+  public var isRemote: Bool {
+    remote != "local"
+  }
+
+  public var gitStartPoint: String {
+    name
+  }
+
+  public var pickerDisplayName: String {
+    isRemote ? "\(name) (latest remote)" : displayName
+  }
+
+  public var startPointDescription: String {
+    isRemote ? "latest fetched \(name)" : "local branch '\(displayName)'"
+  }
+
   public init(name: String, remote: String) {
     self.name = name
     self.remote = remote
+  }
+
+  public static func worktreeBaseOptions(
+    localBranches: [RemoteBranch],
+    remoteDefaultBranch: RemoteBranch?
+  ) -> [RemoteBranch] {
+    guard let remoteDefaultBranch else { return localBranches }
+    guard !localBranches.contains(remoteDefaultBranch) else { return localBranches }
+    return [remoteDefaultBranch] + localBranches
   }
 }

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/GitWorktreeService.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/GitWorktreeService.swift
@@ -69,6 +69,10 @@ public actor GitWorktreeService: GitWorktreeInventoryServiceProtocol, GitWorktre
     try await service.fetchAndGetRemoteBranches(at: repoPath).map(Self.remoteBranch)
   }
 
+  public func fetchAndGetDefaultRemoteBaseBranch(at repoPath: String) async throws -> RemoteBranch? {
+    try await service.fetchAndGetDefaultRemoteBaseBranch(at: repoPath).map(Self.remoteBranch)
+  }
+
   public func getLocalBranches(at repoPath: String) async throws -> [RemoteBranch] {
     try await service.getLocalBranches(at: repoPath).map(Self.remoteBranch)
   }

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/CreateWorktreeSheet.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/CreateWorktreeSheet.swift
@@ -158,7 +158,7 @@ public struct CreateWorktreeSheet: View {
       Picker("Based On", selection: $baseBranch) {
         Text("Current HEAD").tag(nil as RemoteBranch?)
         ForEach(availableBranches) { branch in
-          Text(branch.displayName).tag(branch as RemoteBranch?)
+          Text(branch.pickerDisplayName).tag(branch as RemoteBranch?)
         }
       }
       .pickerStyle(.menu)
@@ -171,7 +171,7 @@ public struct CreateWorktreeSheet: View {
 
   private var baseBranchDescription: String {
     if let branch = baseBranch {
-      return "New branch will start from '\(branch.displayName)'"
+      return "New branch will start from \(branch.startPointDescription)"
     } else {
       return "New branch will start from current commit (HEAD)"
     }
@@ -272,11 +272,20 @@ public struct CreateWorktreeSheet: View {
     isLoading = true
 
     do {
-      // Load local branches for the "Based On" picker
-      availableBranches = try await worktreeService.getLocalBranches(at: repositoryPath)
+      // Load local branches and the fetched remote default branch for the "Based On" picker.
+      async let localBranches = worktreeService.getLocalBranches(at: repositoryPath)
+      async let remoteDefaultBranch = worktreeService.fetchAndGetDefaultRemoteBaseBranch(at: repositoryPath)
+      let branches = try await localBranches
+      let defaultRemoteBranch = try await remoteDefaultBranch
 
-      // Auto-select the first branch (usually main) as default base
-      if let firstBranch = availableBranches.first {
+      availableBranches = RemoteBranch.worktreeBaseOptions(
+        localBranches: branches,
+        remoteDefaultBranch: defaultRemoteBranch
+      )
+
+      if let defaultRemoteBranch {
+        baseBranch = defaultRemoteBranch
+      } else if let firstBranch = availableBranches.first {
         baseBranch = firstBranch
       }
     } catch {
@@ -291,7 +300,7 @@ public struct CreateWorktreeSheet: View {
   /// and surfaces progress in the top bar) and dismisses the sheet immediately.
   private func startCreation() {
     guard isValid else { return }
-    onCreate(branchName, directoryName, baseBranch?.displayName)
+    onCreate(branchName, directoryName, baseBranch?.gitStartPoint)
     onDismiss()
   }
 }

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiSessionLaunchView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiSessionLaunchView.swift
@@ -611,7 +611,7 @@ public struct MultiSessionLaunchView: View {
         Picker("Base", selection: $viewModel.baseBranch) {
           Text("Current HEAD").tag(nil as RemoteBranch?)
           ForEach(viewModel.availableBranches) { branch in
-            Text(branch.displayName).tag(branch as RemoteBranch?)
+            Text(branch.pickerDisplayName).tag(branch as RemoteBranch?)
           }
         }
         .pickerStyle(.menu)
@@ -1380,7 +1380,7 @@ public struct MultiSessionLaunchView: View {
           Picker("", selection: $viewModel.baseBranch) {
             Text("Current HEAD").tag(nil as RemoteBranch?)
             ForEach(viewModel.availableBranches) { branch in
-              Text(branch.displayName).tag(branch as RemoteBranch?)
+              Text(branch.pickerDisplayName).tag(branch as RemoteBranch?)
             }
           }
           .pickerStyle(.menu)

--- a/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/MultiSessionLaunchViewModel.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/MultiSessionLaunchViewModel.swift
@@ -401,10 +401,19 @@ public final class MultiSessionLaunchViewModel {
     isLoadingCurrentBranch = true
 
     do {
-      let result = try await worktreeService.getLocalBranchesWithCurrent(at: repo.path)
-      availableBranches = result.branches
+      async let localBranches = worktreeService.getLocalBranchesWithCurrent(at: repo.path)
+      async let remoteDefaultBranch = worktreeService.fetchAndGetDefaultRemoteBaseBranch(at: repo.path)
+      let result = try await localBranches
+      let defaultRemoteBranch = try await remoteDefaultBranch
+
+      availableBranches = RemoteBranch.worktreeBaseOptions(
+        localBranches: result.branches,
+        remoteDefaultBranch: defaultRemoteBranch
+      )
       currentBranchName = result.currentBranchName
-      if let first = availableBranches.first {
+      if let defaultRemoteBranch {
+        baseBranch = defaultRemoteBranch
+      } else if let first = availableBranches.first {
         baseBranch = first
       }
     } catch {
@@ -773,7 +782,7 @@ public final class MultiSessionLaunchViewModel {
           repoPath: repoPath,
           branchName: session.branchName,
           directoryName: dirName,
-          startPoint: baseBranch?.displayName,
+          startPoint: baseBranch?.gitStartPoint,
           progressKeyPath: \.claudeProgress
         )
 
@@ -853,7 +862,7 @@ public final class MultiSessionLaunchViewModel {
         repoPath: repoPath,
         branchName: branchName,
         directoryName: dirName,
-        startPoint: baseBranch?.displayName,
+        startPoint: baseBranch?.gitStartPoint,
         progressKeyPath: \.claudeProgress
       )
 
@@ -1016,7 +1025,7 @@ public final class MultiSessionLaunchViewModel {
         repoPath: repoPath,
         branchName: claudeBranchName,
         directoryName: dirName,
-        startPoint: baseBranch?.displayName,
+        startPoint: baseBranch?.gitStartPoint,
         progressKeyPath: \.claudeProgress
       )
     } catch is CancellationError {
@@ -1037,7 +1046,7 @@ public final class MultiSessionLaunchViewModel {
         repoPath: repoPath,
         branchName: codexBranchName,
         directoryName: dirName,
-        startPoint: baseBranch?.displayName,
+        startPoint: baseBranch?.gitStartPoint,
         progressKeyPath: \.codexProgress
       )
     } catch is CancellationError {
@@ -1116,7 +1125,7 @@ public final class MultiSessionLaunchViewModel {
         repoPath: repoPath,
         branchName: branchName,
         directoryName: dirName,
-        startPoint: baseBranch?.displayName,
+        startPoint: baseBranch?.gitStartPoint,
         progressKeyPath: progressKeyPath
       )
     } catch is CancellationError {
@@ -1156,11 +1165,11 @@ public final class MultiSessionLaunchViewModel {
   ) async throws -> WorktreeBranchNamingResult {
     let attachmentNames = attachmentBasenames
     let providerNames = providerKinds.map(\.rawValue).joined(separator: ",")
-    let baseBranchName = baseBranch?.displayName ?? "HEAD"
+    let baseBranchName = baseBranch?.gitStartPoint ?? "HEAD"
     let request = WorktreeBranchNamingRequest(
       repoName: repository.name,
       repoPath: repository.path,
-      baseBranchName: baseBranch?.displayName,
+      baseBranchName: baseBranch?.gitStartPoint,
       launchContext: launchContext,
       promptText: promptText,
       attachmentBasenames: attachmentNames,

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/GitWorktreeServiceTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/GitWorktreeServiceTests.swift
@@ -9,7 +9,7 @@ struct GitRepoFixture {
   let repoPath: String
   let parentDir: String
 
-  static func create() throws -> GitRepoFixture {
+  static func create(initialBranch: String = "main") throws -> GitRepoFixture {
     // Resolve symlinks so paths match git's resolved paths (e.g. /var -> /private/var on macOS)
     var resolved = [CChar](repeating: 0, count: Int(PATH_MAX))
     guard realpath(NSTemporaryDirectory(), &resolved) != nil else {
@@ -21,7 +21,7 @@ struct GitRepoFixture {
     try FileManager.default.createDirectory(atPath: repoPath, withIntermediateDirectories: true)
 
     let fixture = GitRepoFixture(repoPath: repoPath, parentDir: parentDir)
-    try fixture.runGit("init", "-b", "main")
+    try fixture.runGit("init", "-b", initialBranch)
     try fixture.runGit("config", "user.email", "test@test.com")
     try fixture.runGit("config", "user.name", "Test")
     try "initial".write(toFile: repoPath + "/README.md", atomically: true, encoding: .utf8)
@@ -88,6 +88,11 @@ struct GitRepoFixture {
   func localBranchExists(_ branch: String) throws -> Bool {
     let output = try runGit("branch", "--list", branch)
     return !output.isEmpty
+  }
+
+  func configureUser(at path: String? = nil) throws {
+    try runGit("config", "user.email", "test@test.com", at: path)
+    try runGit("config", "user.name", "Test", at: path)
   }
 
   func cleanup() {
@@ -171,6 +176,70 @@ struct ListWorktreesTests {
     #expect(secondary.path == worktreePath)
     #expect(secondary.branchName == "inventory-branch")
     #expect(secondary.mainRepoPath == fixture.repoPath)
+  }
+}
+
+@Suite("GitWorktreeService remote base branch")
+struct GitWorktreeServiceRemoteBaseBranchTests {
+  @Test("Returns fetched origin main as a remote worktree start point")
+  func returnsFetchedOriginMainAsRemoteStartPoint() async throws {
+    let seed = try GitRepoFixture.create()
+    defer { seed.cleanup() }
+
+    let remotePath = seed.parentDir + "/origin.git"
+    try seed.runGit("init", "--bare", "-b", "main", remotePath)
+    try seed.runGit("remote", "add", "origin", remotePath)
+    try seed.runGit("push", "-u", "origin", "main")
+
+    let localClonePath = seed.parentDir + "/local-clone"
+    try seed.runGit("clone", remotePath, localClonePath)
+    try seed.configureUser(at: localClonePath)
+
+    let writerClonePath = seed.parentDir + "/writer-clone"
+    try seed.runGit("clone", remotePath, writerClonePath)
+    try seed.configureUser(at: writerClonePath)
+    try "remote".write(toFile: writerClonePath + "/REMOTE.md", atomically: true, encoding: .utf8)
+    try seed.runGit("add", ".", at: writerClonePath)
+    try seed.runGit("commit", "-m", "remote update", at: writerClonePath)
+    try seed.runGit("push", "origin", "main", at: writerClonePath)
+
+    let service = GitWorktreeService()
+    let remoteBase = try #require(await service.fetchAndGetDefaultRemoteBaseBranch(at: localClonePath))
+
+    #expect(remoteBase.name == "origin/main")
+    #expect(remoteBase.gitStartPoint == "origin/main")
+    #expect(remoteBase.pickerDisplayName == "origin/main (latest remote)")
+
+    let path = try await service.createWorktreeWithNewBranch(
+      at: localClonePath,
+      newBranchName: "feature/from-remote-main",
+      directoryName: "feature-from-remote-main",
+      startPoint: remoteBase.gitStartPoint
+    )
+
+    #expect(FileManager.default.fileExists(atPath: path + "/REMOTE.md"))
+    #expect(!FileManager.default.fileExists(atPath: localClonePath + "/REMOTE.md"))
+  }
+
+  @Test("Returns origin master when remote main is absent")
+  func returnsOriginMasterWhenRemoteMainIsAbsent() async throws {
+    let seed = try GitRepoFixture.create(initialBranch: "master")
+    defer { seed.cleanup() }
+
+    let remotePath = seed.parentDir + "/origin.git"
+    try seed.runGit("init", "--bare", "-b", "master", remotePath)
+    try seed.runGit("remote", "add", "origin", remotePath)
+    try seed.runGit("push", "-u", "origin", "master")
+
+    let localClonePath = seed.parentDir + "/master-clone"
+    try seed.runGit("clone", remotePath, localClonePath)
+
+    let service = GitWorktreeService()
+    let remoteBase = try #require(await service.fetchAndGetDefaultRemoteBaseBranch(at: localClonePath))
+
+    #expect(remoteBase.name == "origin/master")
+    #expect(remoteBase.gitStartPoint == "origin/master")
+    #expect(remoteBase.pickerDisplayName == "origin/master (latest remote)")
   }
 }
 

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/RemoteBranchTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/RemoteBranchTests.swift
@@ -1,0 +1,30 @@
+import Testing
+
+@testable import AgentHubCore
+
+@Suite("RemoteBranch worktree base options")
+struct RemoteBranchWorktreeBaseOptionsTests {
+  @Test("Remote default branch appears before local branches")
+  func remoteDefaultBranchAppearsBeforeLocalBranches() {
+    let remoteMain = RemoteBranch(name: "origin/main", remote: "origin")
+    let localMain = RemoteBranch(name: "main", remote: "local")
+    let localFeature = RemoteBranch(name: "feature/example", remote: "local")
+
+    let options = RemoteBranch.worktreeBaseOptions(
+      localBranches: [localFeature, localMain],
+      remoteDefaultBranch: remoteMain
+    )
+
+    #expect(options == [remoteMain, localFeature, localMain])
+    #expect(remoteMain.gitStartPoint == "origin/main")
+    #expect(remoteMain.pickerDisplayName == "origin/main (latest remote)")
+  }
+
+  @Test("Local branch start point remains the local branch name")
+  func localBranchStartPointRemainsLocalBranchName() {
+    let localMaster = RemoteBranch(name: "master", remote: "local")
+
+    #expect(localMaster.gitStartPoint == "master")
+    #expect(localMaster.pickerDisplayName == "master")
+  }
+}


### PR DESCRIPTION
## Summary

Adds a worktree base option for the latest fetched remote default branch. The picker now shows `origin/main (latest remote)` or `origin/master (latest remote)` when available, while keeping `Current HEAD` and local branches as separate choices.

## Details

- Fetches remotes before resolving the default remote base branch, with cached remote refs as an offline fallback.
- Honors remote `HEAD` when it points to `main` or `master`, then falls back through `origin/main`, `origin/master`, other remote `main`, and other remote `master`.
- Preserves the full git start point (`origin/main` / `origin/master`) through worktree creation instead of stripping it to `main` / `master`.
- Updates both the side-panel worktree sheet and multi-session launcher picker labels.

## Validation

- `swift test --filter WorktreeConventionTests` in `app/modules/AgentHubCLI`
- `xcodebuild test -scheme AgentHubCore-Tests -destination 'platform=macOS' -test-timeouts-enabled YES -skipPackagePluginValidation -only-testing:AgentHubTests/GitWorktreeServiceRemoteBaseBranchTests -only-testing:AgentHubTests/RemoteBranchWorktreeBaseOptionsTests`
- `git diff --check`