### PR TITLE
[codex] Add compact segmented controls

### DIFF
--- a/SimulatorPreview.md
+++ b/SimulatorPreview.md
@@ -180,13 +180,14 @@ App build: `xcodebuild -workspace app/AgentHub.xcodeproj/project.xcworkspace -sc
 
 ## Hot reload + Previews tab
 
-The panel header has a **Live | Previews** toggle (booted devices only) and a
-**● Hot reload** status pill. Save a Swift file in the project and the running
-app hot-swaps it in place (~sub-second, state preserved) while the Previews
-tab re-renders on the same signal. Changes injection can't represent (new
-file, deleted file, stored-property layout change, compile failure) quietly
-fall back to an incremental rebuild — the pill shows "Rebuilding…", never a
-silent lie.
+The panel header has a **Live | Previews** toggle (booted devices only) when
+SwiftUI simulator previews are enabled in Settings; **Live** remains available
+when previews are disabled. The header also has a **● Hot reload** status pill.
+Save a Swift file in the project and the running app hot-swaps it in place
+(~sub-second, state preserved) while the Previews tab re-renders on the same
+signal. Changes injection can't represent (new file, deleted file,
+stored-property layout change, compile failure) quietly fall back to an
+incremental rebuild — the pill shows "Rebuilding…", never a silent lie.
 
 ### How it works
 
@@ -249,9 +250,10 @@ Pipeline: `HotReloadSourceWatcher` (host-side FSEvents; existence-snapshot
 classifier so atomic-save renames aren't mistaken for structural changes) and
 the console events feed `HotReloadMonitor` (the pill's state machine; its
 `reloadGeneration` re-renders the visible previews, and its
-`changedSourceFiles` selects it). Both features are **always armed** for
-panel launches — there are no per-feature toggles; the pill is a pure status
-light.
+`changedSourceFiles` selects it). Preview candidate observation is controlled
+by the Settings toggle: when disabled, the Previews tab is hidden, preview
+candidate tracking is stopped, and future panel launches omit the preview-host
+dylib. Live simulator streaming remains available.
 
 The Previews tab (`SimulatorPreviewSpotlightView`) is deliberately bounded:
 it shows the open Swift file first, then recent changed files, deduplicated

--- a/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubDefaults.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubDefaults.swift
@@ -170,6 +170,11 @@ public enum AgentHubDefaults {
   /// Type: Bool (default: false)
   public static let webPreviewDesignPanelEnabled = "\(keyPrefix)developer.webPreviewDesignPanelEnabled"
 
+  /// Whether SwiftUI previews are available in the iOS simulator side panel.
+  /// The live simulator view remains available when this is disabled.
+  /// Type: Bool (default: true)
+  public static let simulatorPreviewsEnabled = "\(keyPrefix)features.simulatorPreviewsEnabled"
+
   /// Inspector payload level used by debug web preview inspect flows
   /// Type: String (default: "regular")
   public static let webPreviewInspectorDataLevel = "\(keyPrefix)developer.webPreviewInspectorDataLevel"

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/SimulatorHotReloadController.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/SimulatorHotReloadController.swift
@@ -41,10 +41,10 @@ public final class SimulatorHotReloadController {
   /// hot-reload launch.
   public private(set) var activePlan: HotReloadLaunchPlan?
 
-  /// Source file names edited in this project, most recent first — tracked
-  /// for the panel's lifetime (independent of arming, which can happen
-  /// later) and seeded from `git status` so files the agent edited before
-  /// the panel opened count too. Drives the previews spotlight.
+  /// Source file names edited in this project, most recent first. This is
+  /// populated only while preview observation is enabled and seeded from
+  /// `git status` so files the agent edited before the panel opened count
+  /// too. Drives the previews spotlight.
   public private(set) var changedSourceFiles: [String] = []
 
   /// Runs the fallback incremental rebuild + relaunch. Injected so tests
@@ -60,7 +60,10 @@ public final class SimulatorHotReloadController {
   private var activeContext: (udid: String, projectPath: String)?
   private var preparationTask: Task<Void, Never>?
   private var isRebuilding = false
-  private var isTracking = false
+  private var isPreviewObservationEnabled = false
+  private var isInjectionObservationEnabled = false
+  private var isSourceObservationActive = false
+  private var observedProjectPath: String?
 
   public init(
     artifactStore: any HotReloadArtifactProviding = HotReloadArtifactStore(),
@@ -87,36 +90,35 @@ public final class SimulatorHotReloadController {
 
   // MARK: - Change tracking (panel lifetime)
 
-  /// Starts watching the project's sources and seeds the changed-files list
-  /// from git. Call when the panel opens — tracking is what lets the
-  /// spotlight show a preview the moment the host becomes reachable, even
-  /// for edits made before any launch was armed.
-  public func startTracking(projectPath: String) {
-    guard !isTracking else { return }
-    isTracking = true
-
-    sourceWatcher.start(projectPath: projectPath) { [weak self] changes in
-      guard let self else { return }
-      for change in changes {
-        self.noteChangedSource((change.path as NSString).lastPathComponent)
-      }
-      self.monitor.handle(sourceChanges: changes)
+  /// Enables preview candidate observation. Call when the Previews feature
+  /// is enabled in settings — this lets the spotlight show a preview the
+  /// moment the host becomes reachable, even for edits made before any
+  /// launch was armed.
+  public func setPreviewObservationEnabled(_ enabled: Bool, projectPath: String) {
+    guard isPreviewObservationEnabled != enabled || observedProjectPath != projectPath else {
+      return
     }
-
-    Task { [weak self, seedChangedFiles] in
-      let seeded = await seedChangedFiles(projectPath)
-      guard let self else { return }
-      for fileName in seeded where !self.changedSourceFiles.contains(fileName) {
-        // Seeds are older than anything observed live — append, not insert.
-        self.changedSourceFiles.append(fileName)
-      }
+    isPreviewObservationEnabled = enabled
+    if enabled {
+      updateSourceObservation(projectPath: projectPath)
+      seedPreviewCandidates(projectPath: projectPath)
+    } else {
+      changedSourceFiles = []
+      updateSourceObservation(projectPath: activeContext?.projectPath ?? observedProjectPath)
     }
   }
 
-  /// Stops the watcher. Call when the panel closes.
+  /// Compatibility wrapper for tests and older call sites.
+  public func startTracking(projectPath: String) {
+    setPreviewObservationEnabled(true, projectPath: projectPath)
+  }
+
+  /// Disables preview candidate observation. Call when the panel closes or
+  /// when the Previews setting is turned off.
   public func stopTracking() {
-    sourceWatcher.stop()
-    isTracking = false
+    isPreviewObservationEnabled = false
+    changedSourceFiles = []
+    updateSourceObservation(projectPath: activeContext?.projectPath ?? observedProjectPath)
   }
 
   /// Most-recent-first, deduplicated, bounded.
@@ -218,10 +220,14 @@ public final class SimulatorHotReloadController {
           plan.configuration.artifacts.injectionDylibPath != nil
     else {
       // Previews-only launch: the pill stays off, the tab works.
+      isInjectionObservationEnabled = false
+      updateSourceObservation(projectPath: projectPath)
       monitor.markDisabled()
       return
     }
 
+    isInjectionObservationEnabled = true
+    updateSourceObservation(projectPath: projectPath)
     monitor.arm()
     monitor.onRequestRebuild = { [weak self] reason in
       self?.performRebuild(reason: reason)
@@ -238,6 +244,8 @@ public final class SimulatorHotReloadController {
     monitor.onRequestRebuild = nil
     activePlan = nil
     activeContext = nil
+    isInjectionObservationEnabled = false
+    updateSourceObservation(projectPath: observedProjectPath)
     monitor.markDisabled()
   }
 
@@ -247,13 +255,62 @@ public final class SimulatorHotReloadController {
     { [weak self] line in
       guard let self, let event = self.consoleParser.parse(line: line) else { return }
       if case .recompiling(let fileName) = event {
-        self.noteChangedSource(fileName)
+        if self.isPreviewObservationEnabled {
+          self.noteChangedSource(fileName)
+        }
       }
       self.monitor.handle(engineEvent: event)
     }
   }
 
   // MARK: - Internals
+
+  private func updateSourceObservation(projectPath: String?) {
+    let shouldObserve = isPreviewObservationEnabled || isInjectionObservationEnabled
+    guard shouldObserve, let projectPath else {
+      if isSourceObservationActive {
+        sourceWatcher.stop()
+        isSourceObservationActive = false
+      }
+      if !shouldObserve {
+        observedProjectPath = nil
+      }
+      return
+    }
+
+    if isSourceObservationActive, observedProjectPath == projectPath {
+      return
+    }
+
+    if isSourceObservationActive {
+      sourceWatcher.stop()
+    }
+
+    observedProjectPath = projectPath
+    isSourceObservationActive = true
+    sourceWatcher.start(projectPath: projectPath) { [weak self] changes in
+      guard let self else { return }
+      if self.isPreviewObservationEnabled {
+        for change in changes {
+          self.noteChangedSource((change.path as NSString).lastPathComponent)
+        }
+      }
+      if self.isInjectionObservationEnabled {
+        self.monitor.handle(sourceChanges: changes)
+      }
+    }
+  }
+
+  private func seedPreviewCandidates(projectPath: String) {
+    Task { [weak self, seedChangedFiles] in
+      let seeded = await seedChangedFiles(projectPath)
+      guard let self, self.isPreviewObservationEnabled else { return }
+      for fileName in seeded where !self.changedSourceFiles.contains(fileName) {
+        // Seeds are older than anything observed live — append, not insert.
+        self.changedSourceFiles.append(fileName)
+      }
+    }
+  }
 
   private func performRebuild(reason: String) {
     guard let context = activeContext, let plan = activePlan, !isRebuilding

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/CompactPillSegmentedControl.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/CompactPillSegmentedControl.swift
@@ -1,0 +1,114 @@
+//
+//  CompactPillSegmentedControl.swift
+//  AgentHub
+//
+
+import SwiftUI
+
+public struct CompactPillSegmentedControlItem<Value: Hashable>: Identifiable {
+  public let value: Value
+  public let title: String
+  public let helpText: String?
+
+  public var id: AnyHashable {
+    AnyHashable(value)
+  }
+
+  public init(
+    value: Value,
+    title: String,
+    helpText: String? = nil
+  ) {
+    self.value = value
+    self.title = title
+    self.helpText = helpText
+  }
+}
+
+public struct CompactPillSegmentedControl<Value: Hashable>: View {
+  private static var controlHeight: CGFloat { 26 }
+  private static var selectedPillVerticalInset: CGFloat { 2 }
+
+  @Binding private var selection: Value
+  private let items: [CompactPillSegmentedControlItem<Value>]
+  private let selectedColor: Color
+  private let textColor: Color
+  private let accessibilityLabel: String
+
+  @Environment(\.accessibilityReduceMotion) private var reduceMotion
+  @Environment(\.colorScheme) private var colorScheme
+  @Namespace private var selectionNamespace
+
+  public init(
+    selection: Binding<Value>,
+    items: [CompactPillSegmentedControlItem<Value>],
+    selectedColor: Color = .brandSecondary,
+    textColor: Color = .secondary,
+    accessibilityLabel: String = "Segmented control"
+  ) {
+    self._selection = selection
+    self.items = items
+    self.selectedColor = selectedColor
+    self.textColor = textColor
+    self.accessibilityLabel = accessibilityLabel
+  }
+
+  public var body: some View {
+    HStack(spacing: 2) {
+      ForEach(items) { item in
+        segmentButton(for: item)
+      }
+    }
+    .padding(2)
+    .frame(height: Self.controlHeight)
+    .background(controlFill, in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+    .overlay {
+      RoundedRectangle(cornerRadius: 8, style: .continuous)
+        .strokeBorder(controlBorder, lineWidth: 1)
+    }
+    .fixedSize(horizontal: true, vertical: false)
+    .accessibilityElement(children: .contain)
+    .accessibilityLabel(accessibilityLabel)
+  }
+
+  private func segmentButton(for item: CompactPillSegmentedControlItem<Value>) -> some View {
+    let isSelected = selection == item.value
+
+    return Button {
+      withAnimation(selectionAnimation) {
+        selection = item.value
+      }
+    } label: {
+      Text(item.title)
+        .font(.secondaryCaption)
+        .lineLimit(1)
+        .foregroundStyle(isSelected ? Color.white : textColor)
+        .padding(.horizontal, 14)
+        .frame(height: Self.controlHeight - (Self.selectedPillVerticalInset * 2))
+        .background {
+          if isSelected {
+            RoundedRectangle(cornerRadius: 6, style: .continuous)
+              .fill(selectedColor)
+              .matchedGeometryEffect(id: "selected-pill", in: selectionNamespace)
+              .shadow(color: selectedColor.opacity(0.18), radius: 6, y: 1)
+          }
+        }
+        .contentShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+    }
+    .buttonStyle(.plain)
+    .help(item.helpText ?? item.title)
+    .accessibilityAddTraits(isSelected ? .isSelected : [])
+  }
+
+  private var selectionAnimation: Animation? {
+    reduceMotion ? nil : .spring(response: 0.28, dampingFraction: 0.86)
+  }
+
+  private var controlFill: Color {
+    colorScheme == .dark ? Color.white.opacity(0.07) : Color.black.opacity(0.06)
+  }
+
+  private var controlBorder: Color {
+    colorScheme == .dark ? Color.white.opacity(0.08) : Color.black.opacity(0.12)
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/GitDiffView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/GitDiffView.swift
@@ -222,16 +222,18 @@ public struct GitDiffView: View {
 
       Spacer()
 
-      // Segmented control
-      Picker("", selection: $diffMode) {
-        ForEach(DiffMode.allCases) { mode in
-          Text(mode.rawValue).tag(mode)
-        }
-      }
-      .pickerStyle(.segmented)
-      .controlSize(.small)
-      .frame(width: 250)
-      .tint(Color.primary)
+      CompactPillSegmentedControl(
+        selection: $diffMode,
+        items: DiffMode.allCases.map { mode in
+          CompactPillSegmentedControlItem(
+            value: mode,
+            title: mode.rawValue,
+            helpText: "Show \(mode.rawValue.lowercased()) changes"
+          )
+        },
+        selectedColor: Color.brandSecondary,
+        accessibilityLabel: "Diff mode"
+      )
       .onChange(of: diffMode) { _, newMode in
         if suppressNextDiffModeReload {
           suppressNextDiffModeReload = false

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/HotReloadStatusPillView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/HotReloadStatusPillView.swift
@@ -3,10 +3,9 @@
 //  AgentHub
 //
 //  The "● Hot reload" status pill in the simulator panel header — a pure
-//  status light. Hot reload and the preview host are always armed for
-//  launches started from the panel (no toggles); the pill mirrors
-//  `HotReloadMonitor.phase` truthfully, pulsing while a reload or fallback
-//  rebuild is in flight and never claiming a swap that didn't happen.
+//  status light. The pill mirrors `HotReloadMonitor.phase` truthfully,
+//  pulsing while a reload or fallback rebuild is in flight and never claiming
+//  a swap that didn't happen.
 //
 
 import SimulatorPreview

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringCardView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringCardView.swift
@@ -949,14 +949,14 @@ enum MonitoringCardContentModeItems {
   static func items(
     diffDisplayMode: DiffDisplayMode,
     diffAvailabilityStatus: DiffAvailabilityStatus?
-  ) -> [BracketedSegmentedControlItem<MonitoringCardContentMode>] {
+  ) -> [CompactPillSegmentedControlItem<MonitoringCardContentMode>] {
     MonitoringEditorStateStore.availableContentModes(
       diffDisplayMode: diffDisplayMode,
       diffAvailabilityStatus: diffAvailabilityStatus
     ).map { mode in
-      BracketedSegmentedControlItem(
+      CompactPillSegmentedControlItem(
         value: mode,
-        title: mode.label.lowercased(),
+        title: mode.label,
         helpText: mode.label
       )
     }
@@ -981,11 +981,11 @@ private struct MonitoringCardPathRow: View {
     )
   }
 
-  private var items: [BracketedSegmentedControlItem<MonitoringCardContentMode>] {
+  private var items: [CompactPillSegmentedControlItem<MonitoringCardContentMode>] {
     availableContentModes.map { mode in
-      BracketedSegmentedControlItem(
+      CompactPillSegmentedControlItem(
         value: mode,
-        title: mode.label.lowercased(),
+        title: mode.label,
         helpText: mode.label
       )
     }
@@ -1008,10 +1008,11 @@ private struct MonitoringCardPathRow: View {
 
       Spacer(minLength: 8)
 
-      BracketedSegmentedControl(
+      CompactPillSegmentedControl(
         selection: selection,
         items: items,
-        selectedColor: Color.brandPrimary(for: providerKind)
+        selectedColor: Color.brandSecondary(for: providerKind),
+        accessibilityLabel: "Switch session content"
       )
       .layoutPriority(2)
       .help("Switch session content")

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderMonitoringPanelView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderMonitoringPanelView.swift
@@ -1027,6 +1027,7 @@ public struct MultiProviderMonitoringPanelView: View {
       SimulatorPreviewSidePanelView(
         session: session,
         projectPath: projectPath,
+        providerKind: payload.providerKind,
         onDismiss: closeEmbeddedSidePanel,
         onSendToSession: { prompt, sess in
           if !viewModel.sendPromptToActiveTerminal(forKey: sess.id, prompt: prompt) {

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
@@ -531,12 +531,14 @@ public struct MultiProviderSessionsListView: View {
     Group {
       if runtimeTheme?.hasCustomBackgrounds == true {
         Color.adaptiveBackground(for: colorScheme, theme: runtimeTheme)
+      } else if colorScheme == .dark {
+        Color.black
       } else {
         LinearGradient(
           colors: [
             Color.surfaceCanvas,
-            Color.surfaceCanvas.opacity(colorScheme == .dark ? 0.98 : 0.94),
-            Color.brandTertiary.opacity(colorScheme == .dark ? 0.06 : 0.1)
+            Color.surfaceCanvas.opacity(0.94),
+            Color.brandTertiary.opacity(0.1)
           ],
           startPoint: .topLeading,
           endPoint: .bottomTrailing

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
@@ -531,14 +531,12 @@ public struct MultiProviderSessionsListView: View {
     Group {
       if runtimeTheme?.hasCustomBackgrounds == true {
         Color.adaptiveBackground(for: colorScheme, theme: runtimeTheme)
-      } else if colorScheme == .dark {
-        Color.black
       } else {
         LinearGradient(
           colors: [
             Color.surfaceCanvas,
-            Color.surfaceCanvas.opacity(0.94),
-            Color.brandTertiary.opacity(0.1)
+            Color.surfaceCanvas.opacity(colorScheme == .dark ? 0.98 : 0.94),
+            Color.brandTertiary.opacity(colorScheme == .dark ? 0.06 : 0.1)
           ],
           startPoint: .topLeading,
           endPoint: .bottomTrailing

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/SettingsView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/SettingsView.swift
@@ -60,6 +60,9 @@ public struct SettingsView: View {
   @AppStorage(AgentHubDefaults.globalSessionPanelEnabled)
   private var globalSessionPanelEnabled: Bool = true
 
+  @AppStorage(AgentHubDefaults.simulatorPreviewsEnabled)
+  private var simulatorPreviewsEnabled: Bool = true
+
   @AppStorage(ClaudeHookInstaller.enabledKey)
   private var claudeApprovalHooksEnabled: Bool = true
 
@@ -263,6 +266,14 @@ public struct SettingsView: View {
             }
           }
         }
+      }
+
+      Section("iOS Simulator") {
+        settingsToggle(
+          title: "Enable SwiftUI previews",
+          description: "Show the Previews tab in the simulator side panel and watch Swift source changes while it is enabled.",
+          isOn: $simulatorPreviewsEnabled
+        )
       }
     }
     .formStyle(.grouped)

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/SimulatorAnnotationOverlayView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/SimulatorAnnotationOverlayView.swift
@@ -47,6 +47,11 @@ final class SimulatorAnnotationModel {
     annotations.removeAll { $0.id == id }
   }
 
+  func updateText(id: UUID, text: String) {
+    guard let index = annotations.firstIndex(where: { $0.id == id }) else { return }
+    annotations[index].text = text
+  }
+
   func clearAnnotations() {
     annotations.removeAll()
     clearPending()

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/SimulatorAnnotationTrayView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/SimulatorAnnotationTrayView.swift
@@ -2,157 +2,351 @@
 //  SimulatorAnnotationTrayView.swift
 //  AgentHub
 //
-//  Queued-feedback tray for simulator annotations — same interaction model as
-//  the web preview's queued updates panel: review the pins, then send them to
-//  the agent in one message (with a pin-stamped screenshot attached).
+//  Floating, collapsible review card for simulator annotations. It mirrors the
+//  diff comments panel pattern so queued annotations float above the live
+//  simulator instead of resizing it.
 //
 
-import AppKit
 import SimulatorPreview
 import SwiftUI
 
 struct SimulatorAnnotationTrayView: View {
   let annotations: [SimulatorAnnotation]
+  let providerKind: SessionProviderKind
   let isSending: Bool
+  @Binding var isExpanded: Bool
+
   let onRemove: (UUID) -> Void
+  let onUpdateText: (UUID, String) -> Void
   let onSendAll: () -> Void
   let onClearAll: () -> Void
 
-  var body: some View {
-    VStack(alignment: .leading, spacing: 0) {
-      header
+  @State private var showClearConfirmation = false
+  @State private var isSendHovered = false
 
-      Divider()
+  private let morph = Animation.spring(response: 0.4, dampingFraction: 0.82)
+  private let cardRadius: CGFloat = 16
 
-      annotationList
+  private var accent: Color { Color.brandPrimary(for: providerKind) }
+  private var count: Int { annotations.count }
+  private var countText: String { "\(count)" }
+  private var commentsWord: String { count == 1 ? "Comment" : "Comments" }
+  private var hasEmptyComment: Bool {
+    annotations.contains {
+      $0.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
-    .frame(maxWidth: .infinity)
-    .background(Color(NSColor.controlBackgroundColor))
-    .clipShape(RoundedRectangle(cornerRadius: 12))
-    .shadow(color: .black.opacity(0.2), radius: 10, x: 0, y: -4)
-    .overlay(
-      RoundedRectangle(cornerRadius: 12)
-        .stroke(Color(NSColor.separatorColor), lineWidth: 1)
-    )
   }
 
-  private var header: some View {
+  var body: some View {
+    VStack(spacing: 0) {
+      headerBar
+
+      if isExpanded {
+        hairline
+        annotationList
+        hairline
+        footerBar
+      }
+    }
+    .frame(maxWidth: 460)
+    .background(surfaceFill)
+    .clipShape(RoundedRectangle(cornerRadius: cardRadius, style: .continuous))
+    .overlay(
+      RoundedRectangle(cornerRadius: cardRadius, style: .continuous)
+        .strokeBorder(Color.primary.opacity(0.10), lineWidth: 1)
+    )
+    .shadow(color: Color.black.opacity(0.24), radius: 18, x: 0, y: 8)
+    .animation(morph, value: isExpanded)
+    .padding(.trailing, 16)
+    .padding(.bottom, 14)
+    .confirmationDialog(
+      "Clear All Comments",
+      isPresented: $showClearConfirmation,
+      titleVisibility: .visible
+    ) {
+      Button("Clear All", role: .destructive, action: onClearAll)
+      Button("Cancel", role: .cancel) {}
+    } message: {
+      Text("This will remove all \(count) pending simulator comments.")
+    }
+  }
+
+  private var headerBar: some View {
     HStack(spacing: 10) {
-      Label("Annotations", systemImage: "pin")
-        .font(.system(size: 12, weight: .semibold))
-        .foregroundStyle(.primary)
-
-      Text("\(annotations.count)")
-        .font(.system(.caption, design: .monospaced))
-        .foregroundStyle(.secondary)
-        .padding(.horizontal, 7)
-        .padding(.vertical, 3)
-        .background(
-          Capsule()
-            .fill(Color.secondary.opacity(0.15))
-        )
-
-      Text("Sent to the agent with a pin-stamped screenshot.")
-        .font(.caption)
-        .foregroundStyle(.secondary)
-        .lineLimit(1)
-
-      Spacer()
+      Button {
+        toggleExpanded()
+      } label: {
+        HStack(spacing: 8) {
+          countBadge
+          Text("\(countText) \(commentsWord)")
+            .font(.system(size: 13, weight: .semibold))
+            .foregroundStyle(.primary)
+          Spacer(minLength: 8)
+        }
+        .contentShape(Rectangle())
+      }
+      .buttonStyle(.plain)
+      .help(isExpanded ? "Collapse simulator comments" : "Show simulator comments")
 
       sendButton
 
-      Button("Clear") {
-        onClearAll()
+      Button {
+        toggleExpanded()
+      } label: {
+        Image(systemName: "chevron.down")
+          .font(.system(size: 11, weight: .bold))
+          .foregroundStyle(.secondary)
+          .rotationEffect(.degrees(isExpanded ? 0 : 180))
+          .frame(width: 24, height: 24)
+          .contentShape(Rectangle())
       }
       .buttonStyle(.plain)
-      .foregroundStyle(.secondary)
-      .disabled(isSending)
-      .help("Discard all annotations")
+      .help(isExpanded ? "Collapse" : "Expand")
     }
-    .padding(.horizontal, 12)
-    .padding(.vertical, 10)
+    .padding(.leading, 14)
+    .padding(.trailing, 10)
+    .padding(.vertical, 9)
   }
 
   @ViewBuilder
   private var sendButton: some View {
     Button(action: onSendAll) {
-      HStack(spacing: 5) {
+      HStack(spacing: 6) {
         if isSending {
           ProgressView()
             .controlSize(.mini)
           Text("Sending…")
         } else {
+          Image(systemName: "paperplane.fill")
+            .font(.system(size: 11, weight: .semibold))
+
           Text("Send")
-          Text("⌘ ↩")
-            .font(.system(.caption, design: .monospaced))
+            .font(.system(size: 12, weight: .semibold))
         }
       }
+      .foregroundStyle(.white)
+      .padding(.horizontal, 12)
+      .padding(.vertical, 6)
+      .background(
+        RoundedRectangle(cornerRadius: 9, style: .continuous)
+          .fill(accent)
+          .brightness(isSendHovered ? 0.06 : 0)
+      )
+      .contentShape(RoundedRectangle(cornerRadius: 9, style: .continuous))
     }
-    .buttonStyle(.borderedProminent)
-    .controlSize(.small)
-    .disabled(isSending)
+    .buttonStyle(.plain)
+    .onHover { isSendHovered = $0 }
+    .disabled(isSending || hasEmptyComment)
     .keyboardShortcut(.return, modifiers: .command)
-    .help("Send annotations to the agent (Command-Return)")
+    .help(hasEmptyComment ? "Add text to each comment before sending" : "Send simulator comments (⌘↵)")
   }
 
   private var annotationList: some View {
     ScrollView {
-      VStack(alignment: .leading, spacing: 6) {
+      LazyVStack(alignment: .leading, spacing: 0) {
         ForEach(Array(annotations.enumerated()), id: \.element.id) { index, annotation in
           annotationRow(number: index + 1, annotation: annotation)
             .transition(.opacity)
+
+          if annotation.id != annotations.last?.id {
+            hairline
+              .padding(.leading, 14)
+          }
         }
       }
-      .padding(.horizontal, 12)
-      .padding(.vertical, 6)
     }
-    .frame(maxHeight: min(CGFloat(max(annotations.count, 1)) * 56, 200))
+    .frame(maxHeight: 300)
     .animation(.easeInOut(duration: 0.25), value: annotations.map(\.id))
   }
 
   private func annotationRow(number: Int, annotation: SimulatorAnnotation) -> some View {
-    HStack(alignment: .center, spacing: 8) {
-      SimulatorAnnotationPinBadge(number: number, size: 18)
+    HStack(alignment: .top, spacing: 10) {
+      RoundedRectangle(cornerRadius: 1.5, style: .continuous)
+        .fill(accent.opacity(0.9))
+        .frame(width: 3)
+        .frame(maxHeight: .infinity)
 
-      VStack(alignment: .leading, spacing: 2) {
-        if let target = annotation.target {
-          Text(target.summary)
-            .font(.system(.caption2, design: .monospaced))
-            .foregroundStyle(.secondary)
+      VStack(alignment: .leading, spacing: 6) {
+        HStack(spacing: 8) {
+          SimulatorAnnotationPinBadge(number: number, size: 20)
+
+          Text(annotationTargetLabel(for: annotation))
+            .font(.system(size: 11, weight: .semibold, design: .monospaced))
+            .foregroundStyle(.primary)
             .lineLimit(1)
-            .truncationMode(.middle)
+
+          Spacer(minLength: 0)
+
+          Button {
+            onRemove(annotation.id)
+          } label: {
+            Image(systemName: "xmark")
+              .font(.system(size: 10, weight: .semibold))
+              .foregroundStyle(.secondary)
+              .frame(width: 24, height: 24)
+              .contentShape(Rectangle())
+          }
+          .buttonStyle(.plain)
+          .disabled(isSending)
+          .help("Remove simulator comment")
         }
 
-        Text(annotation.text)
-          .font(.caption)
-          .foregroundStyle(.primary)
-          .lineLimit(2)
-          .truncationMode(.tail)
+        if let target = annotation.target?.summary {
+          Text(target)
+            .font(.system(size: 11, design: .monospaced))
+            .foregroundStyle(.secondary)
+            .lineLimit(2)
+            .truncationMode(.middle)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 5)
+            .background(
+              RoundedRectangle(cornerRadius: 6, style: .continuous)
+                .fill(Color.primary.opacity(0.05))
+            )
+        }
+
+        TextField("Comment", text: textBinding(for: annotation), axis: .vertical)
+          .textFieldStyle(.plain)
+          .font(.system(size: 12))
+          .foregroundStyle(.primary.opacity(0.92))
+          .lineLimit(1...3)
+          .padding(.horizontal, 8)
+          .padding(.vertical, 6)
+          .background(
+            RoundedRectangle(cornerRadius: 6, style: .continuous)
+              .fill(Color.primary.opacity(0.04))
+          )
+          .overlay(
+            RoundedRectangle(cornerRadius: 6, style: .continuous)
+              .strokeBorder(Color.primary.opacity(0.08), lineWidth: 1)
+          )
+          .disabled(isSending)
+          .accessibilityLabel("Comment \(number)")
       }
+    }
+    .padding(.horizontal, 14)
+    .padding(.vertical, 10)
+    .contentShape(Rectangle())
+  }
 
-      Spacer(minLength: 4)
-
+  private var footerBar: some View {
+    HStack(spacing: 10) {
       Button {
-        onRemove(annotation.id)
+        showClearConfirmation = true
       } label: {
-        Image(systemName: "xmark")
-          .font(.system(size: 10, weight: .semibold))
-          .foregroundStyle(.secondary)
-          .frame(width: 24, height: 24)
-          .contentShape(Rectangle())
+        HStack(spacing: 5) {
+          Image(systemName: "trash")
+            .font(.system(size: 11))
+          Text("Clear all")
+            .font(.system(size: 12, weight: .medium))
+        }
+        .foregroundStyle(.secondary)
+        .contentShape(Rectangle())
       }
       .buttonStyle(.plain)
       .disabled(isSending)
-      .help("Remove annotation")
+      .help("Clear all simulator comments")
+
+      Spacer(minLength: 0)
+
+      Text("Click the simulator to add another")
+        .font(.system(size: 11))
+        .foregroundStyle(.tertiary)
+        .lineLimit(1)
+        .truncationMode(.tail)
     }
-    .padding(6)
-    .background(
-      RoundedRectangle(cornerRadius: 8)
-        .fill(Color(NSColor.windowBackgroundColor).opacity(0.65))
-    )
-    .overlay(
-      RoundedRectangle(cornerRadius: 8)
-        .stroke(Color(NSColor.separatorColor), lineWidth: 1)
+    .padding(.horizontal, 14)
+    .padding(.vertical, 10)
+  }
+
+  private var countBadge: some View {
+    Text(countText)
+      .font(.system(size: 11, weight: .bold, design: .rounded))
+      .foregroundStyle(.white)
+      .frame(minWidth: 18)
+      .padding(.horizontal, 5)
+      .padding(.vertical, 2)
+      .background(
+        Capsule(style: .continuous)
+          .fill(accent)
+      )
+  }
+
+  private var hairline: some View {
+    Rectangle()
+      .fill(Color.primary.opacity(0.08))
+      .frame(height: 1)
+  }
+
+  private var surfaceFill: some View {
+    ZStack {
+      Color.surfaceElevated
+      LinearGradient(
+        colors: [Color.white.opacity(0.05), Color.clear],
+        startPoint: .top,
+        endPoint: .bottom
+      )
+    }
+  }
+
+  private func annotationTargetLabel(for annotation: SimulatorAnnotation) -> String {
+    annotation.target?.summary ?? "Screen"
+  }
+
+  private func textBinding(for annotation: SimulatorAnnotation) -> Binding<String> {
+    Binding(
+      get: {
+        annotations.first { $0.id == annotation.id }?.text ?? annotation.text
+      },
+      set: { newValue in
+        onUpdateText(annotation.id, newValue)
+      }
     )
   }
+
+  private func toggleExpanded() {
+    withAnimation(morph) {
+      isExpanded.toggle()
+    }
+  }
+}
+
+#Preview {
+  SimulatorAnnotationTrayView(
+    annotations: [
+      SimulatorAnnotation(
+        normalizedX: 0.4,
+        normalizedY: 0.3,
+        text: "Move this title up a bit.",
+        target: SimulatorAnnotationTarget(
+          role: "Image",
+          label: "unicorn",
+          identifier: nil,
+          frame: CGRect(x: 120, y: 80, width: 140, height: 160)
+        )
+      ),
+      SimulatorAnnotation(
+        normalizedX: 0.5,
+        normalizedY: 0.6,
+        text: "Make this primary action easier to read.",
+        target: SimulatorAnnotationTarget(
+          role: "Button",
+          label: "Play",
+          identifier: nil,
+          frame: CGRect(x: 100, y: 320, width: 190, height: 44)
+        )
+      )
+    ],
+    providerKind: .claude,
+    isSending: false,
+    isExpanded: .constant(false),
+    onRemove: { _ in },
+    onUpdateText: { _, _ in },
+    onSendAll: {},
+    onClearAll: {}
+  )
+  .padding(24)
+  .frame(width: 520, height: 240)
+  .background(Color.black.opacity(0.8))
 }

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/SimulatorPreviewSidePanelView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/SimulatorPreviewSidePanelView.swift
@@ -252,7 +252,7 @@ struct SimulatorPreviewSidePanelView: View {
       closeButton
     }
     .padding(.horizontal, 12)
-    .padding(.vertical, 8)
+    .frame(height: AgentHubLayout.topBarHeight)
   }
 
   private var viewOnlyBadge: some View {
@@ -267,16 +267,23 @@ struct SimulatorPreviewSidePanelView: View {
   /// Live mirror ↔ Previews. The Previews option is only visible when the
   /// simulator previews setting is enabled.
   private var displayModePicker: some View {
-    Picker("View", selection: $displayMode) {
-      Text("Live").tag(SimulatorPanelDisplayMode.live)
-      Text("Previews").tag(SimulatorPanelDisplayMode.previews)
-    }
-    .pickerStyle(.segmented)
-    .labelsHidden()
-    .tint(Color.brandPrimary)
-    .accentColor(Color.brandPrimary)
-    .fixedSize()
-    .accessibilityLabel("Panel display mode")
+    CompactPillSegmentedControl(
+      selection: $displayMode,
+      items: [
+        CompactPillSegmentedControlItem(
+          value: .live,
+          title: "Live",
+          helpText: "Show the live simulator"
+        ),
+        CompactPillSegmentedControlItem(
+          value: .previews,
+          title: "Previews",
+          helpText: "Show SwiftUI previews"
+        )
+      ],
+      selectedColor: Color.brandSecondary,
+      accessibilityLabel: "Panel display mode"
+    )
   }
 
   @ViewBuilder

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/SimulatorPreviewSidePanelView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/SimulatorPreviewSidePanelView.swift
@@ -25,8 +25,7 @@ import SimulatorPreview
 import SwiftUI
 
 /// Which surface the panel shows for a booted device: the live device
-/// mirror, or the app's SwiftUI previews. Both stay hot — they re-render on
-/// the same hot-reload signal.
+/// mirror, or the app's SwiftUI previews when that feature is enabled.
 enum SimulatorPanelDisplayMode: String, Hashable {
   case live
   case previews
@@ -35,6 +34,7 @@ enum SimulatorPanelDisplayMode: String, Hashable {
 struct SimulatorPreviewSidePanelView: View {
   let session: CLISession
   let projectPath: String
+  let providerKind: SessionProviderKind
   let onDismiss: () -> Void
   var onSendToSession: ((String, CLISession) -> Void)? = nil
   /// File open in the session's editor pane — its previews join the
@@ -47,9 +47,13 @@ struct SimulatorPreviewSidePanelView: View {
   @State private var selectedUDID: String?
   @State private var hasLoadedDevices = false
   @State private var annotationModel = SimulatorAnnotationModel()
+  @State private var isAnnotationTrayExpanded = false
   @State private var showingManageSheet = false
   @State private var displayMode: SimulatorPanelDisplayMode = .live
   @State private var hotReload = SimulatorHotReloadController()
+
+  @AppStorage(AgentHubDefaults.simulatorPreviewsEnabled)
+  private var simulatorPreviewsEnabled: Bool = true
 
   private var streamService: any SimulatorStreamServiceProtocol {
     agentHub?.simulatorStreamService ?? SimulatorStreamService.shared
@@ -91,6 +95,22 @@ struct SimulatorPreviewSidePanelView: View {
 
   private var isShowingLiveStream: Bool {
     isActiveDeviceBooted
+  }
+
+  private var effectiveDisplayMode: SimulatorPanelDisplayMode {
+    simulatorPreviewsEnabled ? displayMode : .live
+  }
+
+  /// The collapsed tray is shallow enough to dodge visually without changing
+  /// layout. Expanded comments stay overlay-only, so the simulator never
+  /// resizes as the tray opens.
+  private var liveStreamVerticalOffset: CGFloat {
+    guard effectiveDisplayMode == .live,
+          !annotationModel.annotations.isEmpty,
+          !isAnnotationTrayExpanded else {
+      return 0
+    }
+    return -56
   }
 
   /// True while an injection or fallback rebuild is mid-flight — preview
@@ -135,8 +155,10 @@ struct SimulatorPreviewSidePanelView: View {
     )
     .task {
       await loadDevicesIfNeeded()
-      hotReload.warmUp()
-      hotReload.startTracking(projectPath: projectPath)
+      if simulatorPreviewsEnabled {
+        hotReload.warmUp()
+      }
+      hotReload.setPreviewObservationEnabled(simulatorPreviewsEnabled, projectPath: projectPath)
     }
     .onDisappear {
       hotReload.stopTracking()
@@ -144,17 +166,29 @@ struct SimulatorPreviewSidePanelView: View {
     }
     .onChange(of: activeUDID) { _, _ in
       annotationModel.reset()
+      isAnnotationTrayExpanded = false
       hotReload.sessionDidStop()
-      if displayMode == .previews { autoArmPreviewsIfNeeded() }
+      if effectiveDisplayMode == .previews { autoArmPreviewsIfNeeded() }
     }
     .onChange(of: displayMode) { _, mode in
-      if mode == .previews { autoArmPreviewsIfNeeded() }
+      if simulatorPreviewsEnabled, mode == .previews { autoArmPreviewsIfNeeded() }
+    }
+    .onChange(of: simulatorPreviewsEnabled) { _, isEnabled in
+      hotReload.setPreviewObservationEnabled(isEnabled, projectPath: projectPath)
+      if isEnabled {
+        hotReload.warmUp()
+        if displayMode == .previews {
+          autoArmPreviewsIfNeeded()
+        }
+      } else {
+        displayMode = .live
+      }
     }
     .onChange(of: openEditorFilePath) { _, _ in
-      if displayMode == .previews { autoArmPreviewsIfNeeded() }
+      if effectiveDisplayMode == .previews { autoArmPreviewsIfNeeded() }
     }
     .onChange(of: hotReload.changedSourceFiles) { _, _ in
-      if displayMode == .previews { autoArmPreviewsIfNeeded() }
+      if effectiveDisplayMode == .previews { autoArmPreviewsIfNeeded() }
     }
     .onChange(of: annotationModel.isAnnotating) { _, isOn in
       if isOn {
@@ -162,6 +196,11 @@ struct SimulatorPreviewSidePanelView: View {
       } else {
         annotationModel.clearPending()
         annotationModel.hoveredElement = nil
+      }
+    }
+    .onChange(of: annotationModel.annotations.isEmpty) { _, isEmpty in
+      if isEmpty {
+        isAnnotationTrayExpanded = false
       }
     }
     .sheet(isPresented: $showingManageSheet) {
@@ -190,7 +229,7 @@ struct SimulatorPreviewSidePanelView: View {
 
   private var header: some View {
     HStack(spacing: 12) {
-      if activeUDID != nil {
+      if activeUDID != nil, simulatorPreviewsEnabled {
         displayModePicker
       }
 
@@ -225,8 +264,8 @@ struct SimulatorPreviewSidePanelView: View {
       .help("Live touch injection is unavailable on this machine; showing a screenshot stream.")
   }
 
-  /// Live mirror ↔ Previews. Both surfaces are hot: the mirror updates in
-  /// place on injection, and previews re-render on the same reload signal.
+  /// Live mirror ↔ Previews. The Previews option is only visible when the
+  /// simulator previews setting is enabled.
   private var displayModePicker: some View {
     Picker("View", selection: $displayMode) {
       Text("Live").tag(SimulatorPanelDisplayMode.live)
@@ -350,12 +389,19 @@ struct SimulatorPreviewSidePanelView: View {
   @ViewBuilder
   private var content: some View {
     contentBody
+      .overlay(alignment: .bottomTrailing) {
+        annotationCommentsOverlay
+      }
       .overlay(alignment: .topTrailing) {
         if activeUDID != nil {
           floatingRunControls
             .padding(14)
         }
       }
+      .animation(
+        .spring(response: 0.34, dampingFraction: 0.85),
+        value: annotationModel.annotations.isEmpty
+      )
   }
 
   @ViewBuilder
@@ -365,15 +411,20 @@ struct SimulatorPreviewSidePanelView: View {
       // re-attach the live stream (a visible reconnect).
       ZStack {
         streamContent(udid: activeUDID)
-          .opacity(displayMode == .live ? 1 : 0)
-          .allowsHitTesting(displayMode == .live)
+          .opacity(effectiveDisplayMode == .live ? 1 : 0)
+          .allowsHitTesting(effectiveDisplayMode == .live)
+          .offset(y: liveStreamVerticalOffset)
+          .animation(
+            .spring(response: 0.34, dampingFraction: 0.85),
+            value: liveStreamVerticalOffset
+          )
 
-        if displayMode == .previews {
+        if effectiveDisplayMode == .previews {
           spotlightView
             .background(Color(nsColor: .windowBackgroundColor))
         }
       }
-    } else if displayMode == .previews, activeUDID != nil {
+    } else if effectiveDisplayMode == .previews, activeUDID != nil {
       // Cold start straight into Previews: the spotlight's states guide the
       // bootstrap, and the tab switch auto-runs the app when a file is open.
       spotlightView
@@ -396,7 +447,8 @@ struct SimulatorPreviewSidePanelView: View {
       },
       isReloadInFlight: isReloadInFlight,
       onLaunchPreviews: launchPreviews,
-      isPreviewHostExpected: hotReload.activePlan?.configuration.enablePreviews == true,
+      isPreviewHostExpected: simulatorPreviewsEnabled
+        && hotReload.activePlan?.configuration.enablePreviews == true,
       connectedDeviceName: hotReload.activePlan != nil
         ? activeDevice?.name : nil
     )
@@ -441,17 +493,22 @@ struct SimulatorPreviewSidePanelView: View {
     .id(udid)
     .frame(maxWidth: .infinity, maxHeight: .infinity)
     .task(id: udid) { observeStreamState(of: streamSession) }
-    .safeAreaInset(edge: .bottom) {
-      if !annotationModel.annotations.isEmpty {
-        SimulatorAnnotationTrayView(
-          annotations: annotationModel.annotations,
-          isSending: annotationModel.isSending,
-          onRemove: { annotationModel.remove(id: $0) },
-          onSendAll: sendAnnotations,
-          onClearAll: { annotationModel.clearAnnotations() }
-        )
-        .padding(12)
-      }
+  }
+
+  @ViewBuilder
+  private var annotationCommentsOverlay: some View {
+    if effectiveDisplayMode == .live, !annotationModel.annotations.isEmpty {
+      SimulatorAnnotationTrayView(
+        annotations: annotationModel.annotations,
+        providerKind: providerKind,
+        isSending: annotationModel.isSending,
+        isExpanded: $isAnnotationTrayExpanded,
+        onRemove: { annotationModel.remove(id: $0) },
+        onUpdateText: { annotationModel.updateText(id: $0, text: $1) },
+        onSendAll: sendAnnotations,
+        onClearAll: { annotationModel.clearAnnotations() }
+      )
+      .transition(.move(edge: .bottom).combined(with: .opacity))
     }
   }
 
@@ -536,14 +593,15 @@ struct SimulatorPreviewSidePanelView: View {
       if !simulatorService.isBooted(udid: activeUDID) {
         await simulatorService.bootDevice(udid: activeUDID)
       }
-      // Arms hot reload + the preview host when the support dylibs are
-      // cached (first use builds them in the background and this launch
-      // proceeds plain — the pill reports it honestly).
+      // Arms hot reload, plus the preview host when that setting is enabled,
+      // once the support dylibs are cached. First use builds them in the
+      // background and this launch proceeds plain — the pill reports it
+      // honestly.
       let plan = await hotReload.preparePlan(
         udid: activeUDID,
         projectPath: projectPath,
         enableInjection: true,
-        enablePreviews: true
+        enablePreviews: simulatorPreviewsEnabled
       )
       let success = await simulatorService.buildAndRunOnSimulator(
         udid: activeUDID, projectPath: projectPath, hotReload: plan)
@@ -565,6 +623,7 @@ struct SimulatorPreviewSidePanelView: View {
   /// isn't armed, hit the play flow programmatically — full Build & Run on
   /// a cold device, the ~1s relaunch when the app is already running.
   private func autoArmPreviewsIfNeeded() {
+    guard simulatorPreviewsEnabled else { return }
     guard activeUDID != nil, !isActiveDevicePreparing else { return }
     let hasSomethingToShow =
       openEditorFilePath?.hasSuffix(".swift") == true
@@ -583,6 +642,7 @@ struct SimulatorPreviewSidePanelView: View {
   /// in launches AgentHub armed, so an app started any other way needs this
   /// one-time relaunch.
   private func launchPreviews() {
+    guard simulatorPreviewsEnabled else { return }
     if isActiveDeviceBooted {
       enablePreviews()
     } else {
@@ -591,6 +651,7 @@ struct SimulatorPreviewSidePanelView: View {
   }
 
   private func enablePreviews() {
+    guard simulatorPreviewsEnabled else { return }
     guard let activeUDID, isActiveDeviceBooted else { return }
     Task {
       let plan = await hotReload.preparePlan(
@@ -659,6 +720,9 @@ struct SimulatorPreviewSidePanelView: View {
     guard let onSendToSession,
           let udid = activeUDID,
           !annotationModel.annotations.isEmpty,
+          annotationModel.annotations.allSatisfy({
+            !$0.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+          }),
           !annotationModel.isSending
     else { return }
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/SimulatorPreviewSpotlightView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/SimulatorPreviewSpotlightView.swift
@@ -50,6 +50,9 @@ struct SimulatorPreviewSpotlightView: View {
   /// Expanded (pinned) preview: takes over the tab and stays visible across
   /// file switches and new changes until minimized.
   @State private var expandedSelection: SimulatorPreviewSelection?
+  @Namespace private var previewExpansionNamespace
+
+  private let expansionAnimation = Animation.spring(response: 0.34, dampingFraction: 0.86)
 
   private var manifestLoadID: String {
     "\(reloadGeneration)|\(isPreviewHostExpected)"
@@ -118,22 +121,26 @@ struct SimulatorPreviewSpotlightView: View {
           reloadGeneration: reloadGeneration,
           isReloadInFlight: isReloadInFlight,
           isExpanded: true,
-          onToggleExpand: { self.expandedSelection = nil }
+          onToggleExpand: collapseExpandedPreview
         )
         .id(expandedSelection.id)
+        .matchedGeometryEffect(id: expandedSelection.id, in: previewExpansionNamespace)
         .padding(16)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .transition(.opacity)
       } else if candidates.count == 1, let single = candidates.first {
         SimulatorPreviewCanvasView(
           client: client,
           selection: single,
           reloadGeneration: reloadGeneration,
           isReloadInFlight: isReloadInFlight,
-          onToggleExpand: { expandedSelection = single }
+          onToggleExpand: { expand(single) }
         )
         .id(single.id)
+        .matchedGeometryEffect(id: single.id, in: previewExpansionNamespace)
         .padding(16)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .transition(.opacity)
       } else {
         ScrollView {
           LazyVGrid(
@@ -147,13 +154,15 @@ struct SimulatorPreviewSpotlightView: View {
                 reloadGeneration: reloadGeneration,
                 isReloadInFlight: isReloadInFlight,
                 canvasHeight: 240,
-                onToggleExpand: { expandedSelection = candidate }
+                onToggleExpand: { expand(candidate) }
               )
               .id(candidate.id)
+              .matchedGeometryEffect(id: candidate.id, in: previewExpansionNamespace)
             }
           }
           .padding(12)
         }
+        .transition(.opacity)
       }
 
       if let connectedDeviceName {
@@ -162,6 +171,19 @@ struct SimulatorPreviewSpotlightView: View {
           .foregroundStyle(.tertiary)
           .padding(.bottom, 6)
       }
+    }
+    .animation(expansionAnimation, value: expandedSelection)
+  }
+
+  private func expand(_ selection: SimulatorPreviewSelection) {
+    withAnimation(expansionAnimation) {
+      expandedSelection = selection
+    }
+  }
+
+  private func collapseExpandedPreview() {
+    withAnimation(expansionAnimation) {
+      expandedSelection = nil
     }
   }
 
@@ -299,9 +321,10 @@ struct SimulatorPreviewCanvasView: View {
           RoundedRectangle(cornerRadius: 10, style: .continuous)
             .strokeBorder(Color.secondary.opacity(0.2))
         )
-        .overlay(alignment: .topTrailing) {
+        .overlay(alignment: .topLeading) {
           if isHovering || isExpanded, onToggleExpand != nil {
             expandButton
+              .transition(.scale(scale: 0.92).combined(with: .opacity))
           }
         }
         .onHover { isHovering = $0 }
@@ -322,6 +345,8 @@ struct SimulatorPreviewCanvasView: View {
       guard !isReloadInFlight else { return }
       await render()
     }
+    .animation(.spring(response: 0.22, dampingFraction: 0.85), value: isHovering)
+    .animation(.spring(response: 0.22, dampingFraction: 0.85), value: isExpanded)
     .help(renderError ?? selection.title)
   }
 

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/SimulatorHotReloadControllerTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/SimulatorHotReloadControllerTests.swift
@@ -225,6 +225,50 @@ struct SimulatorHotReloadControllerTests {
     #expect(controller.changedSourceFiles.first == "After.swift")
   }
 
+  @Test("preview observation toggles source tracking and candidate updates")
+  func previewObservationToggle() async {
+    let (controller, watcher, _) = makeController(
+      cached: Self.artifacts, seededFiles: ["Seeded.swift"])
+
+    controller.setPreviewObservationEnabled(false, projectPath: "/p")
+    #expect(watcher.startedProjectPath == nil)
+    #expect(controller.changedSourceFiles.isEmpty)
+
+    controller.setPreviewObservationEnabled(true, projectPath: "/p")
+    #expect(watcher.startedProjectPath == "/p")
+
+    watcher.onChange?([.injectable(path: "/p/Live.swift")])
+    #expect(controller.changedSourceFiles.first == "Live.swift")
+
+    let deadline = Date().addingTimeInterval(2)
+    while controller.changedSourceFiles.count < 2, Date() < deadline {
+      try? await Task.sleep(nanoseconds: 10_000_000)
+    }
+    #expect(controller.changedSourceFiles == ["Live.swift", "Seeded.swift"])
+
+    controller.setPreviewObservationEnabled(false, projectPath: "/p")
+    #expect(watcher.stopCount == 1)
+    #expect(controller.changedSourceFiles.isEmpty)
+  }
+
+  @Test("injection observation does not populate preview candidates when previews are disabled")
+  func injectionObservationWithoutPreviewCandidates() async {
+    let (controller, watcher, tail) = makeController(cached: Self.artifacts)
+    let plan = await controller.preparePlan(
+      udid: "UDID", projectPath: "/p", enableInjection: true, enablePreviews: false)!
+
+    controller.sessionDidLaunch(udid: "UDID", projectPath: "/p", plan: plan)
+    #expect(watcher.startedProjectPath == "/p")
+
+    watcher.onChange?([.injectable(path: "/p/Live.swift")])
+    #expect(controller.changedSourceFiles.isEmpty)
+    #expect(controller.monitor.phase == .reloading(fileName: "Live.swift"))
+
+    tail.onLine?("🔥 🔄 [Console.swift] Recompiling")
+    #expect(controller.changedSourceFiles.isEmpty)
+    #expect(controller.monitor.phase == .reloading(fileName: "Console.swift"))
+  }
+
   @Test("structural change triggers the rebuild executor and settles to idle")
   func structuralRebuild() async {
     let rebuilds = RebuildLog()


### PR DESCRIPTION
## Summary

- Add a reusable compact pill segmented control with animated selection movement and reduced-motion support.
- Replace the monitoring card content selector, simulator Live/Previews selector, and Git diff mode selector with the shared control.
- Align the simulator preview header to the shared top-bar height.

## Validation

- `xcodebuild test -scheme AgentHubCore-Tests -destination 'platform=macOS' -test-timeouts-enabled YES -skipPackagePluginValidation -only-testing:AgentHubTests/GitDiffServiceTests`
- `xcodebuild -workspace app/AgentHub.xcodeproj/project.xcworkspace -scheme AgentHub build`

Note: Xcode still prints the existing CodeEdit SwiftLint plugin footer after successful test/build exits.
