### PR TITLE
CI: gate on fast packages only; run AgentHubCore locally

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,13 +45,18 @@ jobs:
       - name: Run package tests (required)
         run: bash scripts/test.sh packages
 
-      # Advisory: the AgentHubCore suite runs with retry and reports, but a tail
-      # of timing-sensitive tests (debounce/throttle/waitUntil/monitor) is flaky
-      # on slow/contended CI runners and fails non-deterministically even with
-      # retries. It does NOT fail the gate yet — tracked for hardening in
-      # TestQuarantine.md / issue #380. Flip to required once that tail is fixed.
+      # Advisory: the AgentHubCore suite runs and reports, but a tail of
+      # timing-sensitive tests (debounce/throttle/waitUntil/monitor) is flaky on
+      # slow/contended CI runners. It does NOT fail the gate yet — tracked for
+      # hardening in TestQuarantine.md / issue #380. Flip to required once fixed.
+      #
+      # continue-on-error keeps a failed/timed-out step from failing the job, and
+      # the step-level timeout-minutes bounds it so it can never reach the JOB
+      # timeout (a job timeout would cancel the whole run regardless of
+      # continue-on-error). Together: the core step can never block the gate.
       - name: Run AgentHubCore tests (advisory)
         continue-on-error: true
+        timeout-minutes: 40
         env:
           # Emit an .xcresult bundle so failures can be downloaded for inspection.
           AGENTHUB_TEST_RESULT_BUNDLE: ${{ github.workspace }}/build/AgentHubCore.xcresult

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   test:
     runs-on: macos-14
-    timeout-minutes: 60
+    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -23,50 +23,27 @@ jobs:
         with:
           xcode-version: latest-stable
 
-      # The CLibgit2 shim (AgentHubGitDiff) requires libgit2 headers + lib,
-      # resolved via Homebrew (pkgConfig "libgit2"). Not preinstalled on runners.
-      - name: Install libgit2
-        run: brew install libgit2
-
-      # Best-effort cache of resolved/compiled SPM artifacts. Keyed on the
-      # resolved dependency graph; safe to miss (just slower). The first run
-      # compiles all of AgentHubCore and will be slow.
-      - name: Cache build artifacts
+      # Caches resolved SwiftPM dependencies (clones/resolution). The package
+      # builds themselves are fast.
+      - name: Cache SwiftPM
         uses: actions/cache@v4
         with:
-          path: |
-            ~/Library/Developer/Xcode/DerivedData
-            ~/Library/Caches/org.swift.swiftpm
+          path: ~/Library/Caches/org.swift.swiftpm
           key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
           restore-keys: |
             ${{ runner.os }}-spm-
 
-      # Hard gate: the fast `swift test` module packages must pass.
-      - name: Run package tests (required)
-        run: bash scripts/test.sh packages
-
-      # Advisory: the AgentHubCore suite runs and reports, but a tail of
-      # timing-sensitive tests (debounce/throttle/waitUntil/monitor) is flaky on
-      # slow/contended CI runners. It does NOT fail the gate yet — tracked for
-      # hardening in TestQuarantine.md / issue #380. Flip to required once fixed.
+      # Gate on the fast, stable `swift test` module packages only.
       #
-      # continue-on-error keeps a failed/timed-out step from failing the job, and
-      # the step-level timeout-minutes bounds it so it can never reach the JOB
-      # timeout (a job timeout would cancel the whole run regardless of
-      # continue-on-error). Together: the core step can never block the gate.
-      - name: Run AgentHubCore tests (advisory)
-        continue-on-error: true
-        timeout-minutes: 40
-        env:
-          # Emit an .xcresult bundle so failures can be downloaded for inspection.
-          AGENTHUB_TEST_RESULT_BUNDLE: ${{ github.workspace }}/build/AgentHubCore.xcresult
-        run: bash scripts/test.sh core
-
-      - name: Upload AgentHubCore xcresult
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: AgentHubCore-xcresult
-          path: build/AgentHubCore.xcresult
-          if-no-files-found: ignore
-          retention-days: 7
+      # The AgentHubCore suite is intentionally NOT run in CI: it costs ~20 min
+      # just to compile, has a flaky timing tail on slow runners, and the runner's
+      # Xcode (16.2, capped by macOS 14) differs from local dev (newer beta), so
+      # its CI results diverge from what developers see. It runs LOCALLY instead —
+      # agents run the targeted tests for any code they change (see CLAUDE.md /
+      # AGENTS.md), and `./scripts/test.sh` (or `/test`) runs the full suite on
+      # demand where it's fast and matches the dev toolchain.
+      #
+      # To make AgentHubCore CI-worthy and gate on it, harden the timing tests
+      # (injectable clocks / deterministic awaits) — see TestQuarantine.md / #380.
+      - name: Run package tests
+        run: bash scripts/test.sh packages

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,10 +84,11 @@ responsibility.
   `GitDiffServiceTests`) and run only that:
   - Core: `cd app/modules/AgentHubCore && xcodebuild test -scheme AgentHubCore-Tests -destination 'platform=macOS' -test-timeouts-enabled YES -skipPackagePluginValidation -only-testing:AgentHubTests/<SuiteType>` (`<SuiteType>` = the test `struct` name).
   - Sub-module (`AgentHubGitHub`, `Storybook`, `SimulatorPreview`, `AgentHubCLI`): `cd app/modules/<Module> && swift test --filter <TestName>`.
-- **Full gate (before a PR, or `/test`):** `./scripts/test.sh` — the gate CI runs
-  (`.github/workflows/test.yml`); fast packages are a required check, the `AgentHubCore` suite is
-  advisory (timing-flaky on CI — see `TestQuarantine.md`). `swift test` on `AgentHubCore` does
-  **not** work (CodeEditSymbols xcassets); use the script / the `AgentHubCore-Tests` scheme.
+- **Full gate (before a PR, or `/test`):** `./scripts/test.sh`. **CI
+  (`.github/workflows/test.yml`) gates on the fast packages only** — the `AgentHubCore` suite runs
+  locally, not in CI (slow + timing-flaky on CI's older Xcode; see `TestQuarantine.md`), so running
+  it locally on your changes matters. `swift test` on `AgentHubCore` does **not** work
+  (CodeEditSymbols xcassets); use the script / the `AgentHubCore-Tests` scheme.
 - swift-testing runs `@Test`s in parallel **off the main thread** — AppKit-touching suites must be `@MainActor`.
 - Quarantined tests (`.disabled("headless-quarantine: …")`) are known-broken, not passing — see
   `TestQuarantine.md` / issue #380; don't re-enable without fixing the root cause.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,8 +126,9 @@ every edit; target the code you touched. Run the full suite only before opening/
   - A sub-module (`AgentHubGitHub`, `Storybook`, `SimulatorPreview`, `AgentHubCLI`): `cd app/modules/<Module> && swift test --filter <TestName>`.
 - **Full gate (before a PR, or `/test`): `./scripts/test.sh`** — fast `swift test` packages, then the
   whole `AgentHubCore` xcodebuild suite. Subsets: `./scripts/test.sh core` / `packages`. This is the
-  gate CI runs (`.github/workflows/test.yml`), where the fast packages are a required check and
-  the `AgentHubCore` suite runs advisory (timing-flaky on CI — see `TestQuarantine.md`). There is
+  full local gate. **CI (`.github/workflows/test.yml`) gates on the fast packages only** — the
+  `AgentHubCore` suite is run locally, not in CI (slow to compile + timing-flaky on CI's older
+  Xcode; see `TestQuarantine.md`), so running it locally on your changes is essential. There is
   intentionally **no** git pre-commit/pre-push hook — running tests is the agent's responsibility.
 - The `AgentHubCore` tests run via the shared `AgentHubCore-Tests` scheme, driven **from the package
   dir** (`cd app/modules/AgentHubCore`), with per-test timeouts. `swift test` on `AgentHubCore` does

--- a/TestQuarantine.md
+++ b/TestQuarantine.md
@@ -8,20 +8,18 @@ by removing the `.disabled(...)` trait once the underlying issue is fixed.
 
 ## CI gate status
 
-CI (`.github/workflows/test.yml`) runs on macos-14 (Xcode 16.2 — the newest Xcode on
-Sonoma; local dev is on a newer beta). Two tiers:
+CI (`.github/workflows/test.yml`) gates on the **fast `swift test` packages only**
+(`AgentHubCLI`, `AgentHubGitHub`, `SimulatorPreview`, `Storybook`) — stable and ~5 min.
 
-- **Required (hard gate):** the four fast `swift test` packages (`AgentHubCLI`,
-  `AgentHubGitHub`, `SimulatorPreview`, `Storybook`). These are stable.
-- **Advisory (non-blocking):** the `AgentHubCore` xcodebuild suite. A tail of
-  timing-sensitive tests (debounce/throttle/`waitUntil`/monitor) is flaky on the slow
-  runner and fails non-deterministically. Until that tail is hardened (injectable
-  clocks / deterministic awaits), the core step **reports but does not fail the gate**:
-  it's `continue-on-error` with its own `timeout-minutes` so it can never reach (and
-  trip) the job timeout. It runs a **single pass** — no `-retry-tests-on-failure`,
-  because retrying the whole flaky suite up to 3× could blow past the job timeout and
-  cancel the run (this is what failed PR #384). **Flip it to required** (remove
-  `continue-on-error`) once the timing tests are stable.
+The **`AgentHubCore` suite is intentionally not run in CI**: it costs ~20 min just to
+compile, has a flaky timing tail (clusters B/C below), and the runner's Xcode (16.2,
+capped by macOS 14) differs from local dev (newer beta), so CI results diverge from what
+developers see. It runs **locally** instead — agents run the targeted tests for any code
+they change (CLAUDE.md / AGENTS.md), and `./scripts/test.sh` / `/test` runs it in full.
+
+The quarantines below still matter for the **local** core suite (keep it green locally).
+To put AgentHubCore back in CI as a real gate, harden the timing tests (injectable
+clocks / deterministic awaits) so it's stable on slow runners, then add a core job.
 
 How to run only these (to iterate): remove the trait and run
 `cd app/modules/AgentHubCore && xcodebuild test -scheme AgentHubCore-Tests -destination 'platform=macOS' -test-timeouts-enabled YES -only-testing:<Target>/<SuiteType>/<method>`.

--- a/TestQuarantine.md
+++ b/TestQuarantine.md
@@ -13,12 +13,15 @@ Sonoma; local dev is on a newer beta). Two tiers:
 
 - **Required (hard gate):** the four fast `swift test` packages (`AgentHubCLI`,
   `AgentHubGitHub`, `SimulatorPreview`, `Storybook`). These are stable.
-- **Advisory (non-blocking):** the `AgentHubCore` xcodebuild suite. It runs with
-  `-retry-tests-on-failure -test-iterations 3`, but a tail of timing-sensitive tests
-  (debounce/throttle/`waitUntil`/monitor) is flaky on the slow runner and fails
-  non-deterministically even with retries. Until that tail is hardened (injectable
-  clocks / deterministic awaits), the core step reports but does not fail the gate.
-  **Flip it to required** (remove `continue-on-error`) once the timing tests are stable.
+- **Advisory (non-blocking):** the `AgentHubCore` xcodebuild suite. A tail of
+  timing-sensitive tests (debounce/throttle/`waitUntil`/monitor) is flaky on the slow
+  runner and fails non-deterministically. Until that tail is hardened (injectable
+  clocks / deterministic awaits), the core step **reports but does not fail the gate**:
+  it's `continue-on-error` with its own `timeout-minutes` so it can never reach (and
+  trip) the job timeout. It runs a **single pass** — no `-retry-tests-on-failure`,
+  because retrying the whole flaky suite up to 3× could blow past the job timeout and
+  cancel the run (this is what failed PR #384). **Flip it to required** (remove
+  `continue-on-error`) once the timing tests are stable.
 
 How to run only these (to iterate): remove the trait and run
 `cd app/modules/AgentHubCore && xcodebuild test -scheme AgentHubCore-Tests -destination 'platform=macOS' -test-timeouts-enabled YES -only-testing:<Target>/<SuiteType>/<method>`.
@@ -45,9 +48,10 @@ falling back to the CLI. Affects the whole app's git layer — review carefully.
 ## B. Reactive/async delivery timing (test fragility, product-adjacent)
 
 > **CI note:** most cluster-B timing tests are *flaky* (not deterministically broken) on the
-> slow/contended CI runner — they pass locally and on retry. CI runs the core suite with
-> `xcodebuild -retry-tests-on-failure -test-iterations 3`, so a flaky test only fails the gate
-> if it fails all attempts. The `.disabled` ones below failed *consistently* even with retry.
+> slow/contended CI runner — they pass locally and intermittently on CI. Because the
+> `AgentHubCore` CI step is **advisory** (non-blocking), these don't gate merges; they're not
+> all `.disabled` (only the chronic/hanging offenders are). Harden them (injectable clocks /
+> deterministic awaits) and flip the core step to required.
 
 These poll `waitUntil { … }` / `await condition()` for state that arrives via Combine
 `.values` async sequences or real `Date.now`/sleep-based throttles. Values sent between

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -55,11 +55,11 @@ run_core() {
   fi
   # Per-test timeouts keep a single hanging test from blocking the whole gate
   # forever (the suite has a few service tests that can block headlessly).
-  # Retry-on-failure tolerates the timing-sensitive tests (debounce/throttle/
-  # waitUntil/monitor) that are flaky on slow/contended CI runners but pass on a
-  # retry; a test only fails the gate if it fails all attempts. Deterministic
-  # failures still fail. (Genuinely-hanging tests are quarantined, not retried —
-  # retrying a 60s timeout just wastes time.)
+  # NOTE: no -retry-tests-on-failure here. The timing-sensitive tail is flaky on
+  # slow CI runners, and retrying the whole suite up to 3x can blow past the CI
+  # job timeout (cancelling the job). In CI the AgentHubCore step is advisory
+  # (non-blocking, see test.yml), so a single deterministic-duration pass is what
+  # we want; flaky tests are tracked in TestQuarantine.md / #380.
   if ( cd "$MODULES/AgentHubCore" && \
        xcodebuild test \
          -scheme AgentHubCore-Tests \
@@ -67,8 +67,6 @@ run_core() {
          -test-timeouts-enabled YES \
          -default-test-execution-time-allowance 60 \
          -maximum-test-execution-time-allowance 120 \
-         -retry-tests-on-failure \
-         -test-iterations 3 \
          "${result_bundle_args[@]+"${result_bundle_args[@]}"}" \
          -skipPackagePluginValidation ); then
     echo "✓ AgentHubCore"


### PR DESCRIPTION
Per discussion: the advisory AgentHubCore CI run cost ~20 min to compile, was timing-flaky, ran on a different Xcode than local dev, and didn't gate — low value, and its 60-min job-timeout cancellations were failing unrelated PRs (e.g. #384).

**CI now gates on the four fast `swift test` packages only** (`AgentHubCLI`, `AgentHubGitHub`, `SimulatorPreview`, `Storybook`) — ~5 min, stable. None depend on AgentHubCore/libgit2, so the libgit2 install + DerivedData cache are removed too.

**AgentHubCore runs locally**, not in CI: agents run targeted tests on any code change (CLAUDE.md / AGENTS.md), and `./scripts/test.sh` / `/test` run it in full where it's fast and matches the dev toolchain. Revisit gating on core once the timing tests are hardened (TestQuarantine.md / #380).

CI-config + docs only.