### PR TITLE
[codex] Improve terminal pane resizing

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/RegularTerminalWorkspaceView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/RegularTerminalWorkspaceView.swift
@@ -107,6 +107,8 @@ struct RegularTerminalWorkspaceView: View {
 
 @MainActor
 private struct RegularTerminalSplitView: View {
+  @State private var childRatios: [CGFloat] = []
+
   let node: RegularTerminalSplitNode
   let panels: [RegularTerminalPanel]
   let activePanelID: RegularTerminalPanelID?
@@ -176,15 +178,23 @@ private struct RegularTerminalSplitView: View {
     children: [RegularTerminalSplitNode],
     size: CGSize
   ) -> some View {
-    let dividerSize: CGFloat = 1
-    let childCount = CGFloat(max(children.count, 1))
-    let totalDividerWidth = dividerSize * CGFloat(max(children.count - 1, 0))
-    let childWidth = max(0, size.width - totalDividerWidth) / childCount
+    let childWidths = TerminalPanelKit.SplitSizing.childDimensions(
+      ratios: childRatios,
+      childCount: children.count,
+      containerLength: size.width,
+      minimumChildDimension: TerminalPanelKit.SplitSizing.minimumChildDimension(for: .horizontal)
+    )
 
     return HStack(spacing: 0) {
       ForEach(Array(children.enumerated()), id: \.offset) { offset, child in
         if offset > 0 {
-          divider(axis: .horizontal)
+          divider(
+            axis: .horizontal,
+            dividerIndex: offset - 1,
+            childCount: children.count,
+            containerLength: size.width
+          )
+          .zIndex(1)
         }
         RegularTerminalSplitView(
           node: child,
@@ -201,8 +211,15 @@ private struct RegularTerminalSplitView: View {
           onSplitPanel: onSplitPanel,
           onToggleMaximizedPanel: onToggleMaximizedPanel
         )
-        .frame(width: childWidth, height: size.height)
+        .frame(width: childDimension(childWidths, at: offset), height: size.height)
+        .zIndex(0)
       }
+    }
+    .onAppear {
+      reconcileRatios(childCount: children.count)
+    }
+    .onChange(of: children.count) { _, childCount in
+      reconcileRatios(childCount: childCount)
     }
   }
 
@@ -210,15 +227,23 @@ private struct RegularTerminalSplitView: View {
     children: [RegularTerminalSplitNode],
     size: CGSize
   ) -> some View {
-    let dividerSize: CGFloat = 1
-    let childCount = CGFloat(max(children.count, 1))
-    let totalDividerHeight = dividerSize * CGFloat(max(children.count - 1, 0))
-    let childHeight = max(0, size.height - totalDividerHeight) / childCount
+    let childHeights = TerminalPanelKit.SplitSizing.childDimensions(
+      ratios: childRatios,
+      childCount: children.count,
+      containerLength: size.height,
+      minimumChildDimension: TerminalPanelKit.SplitSizing.minimumChildDimension(for: .vertical)
+    )
 
     return VStack(spacing: 0) {
       ForEach(Array(children.enumerated()), id: \.offset) { offset, child in
         if offset > 0 {
-          divider(axis: .vertical)
+          divider(
+            axis: .vertical,
+            dividerIndex: offset - 1,
+            childCount: children.count,
+            containerLength: size.height
+          )
+          .zIndex(1)
         }
         RegularTerminalSplitView(
           node: child,
@@ -235,21 +260,97 @@ private struct RegularTerminalSplitView: View {
           onSplitPanel: onSplitPanel,
           onToggleMaximizedPanel: onToggleMaximizedPanel
         )
-        .frame(width: size.width, height: childHeight)
+        .frame(width: size.width, height: childDimension(childHeights, at: offset))
+        .zIndex(0)
       }
+    }
+    .onAppear {
+      reconcileRatios(childCount: children.count)
+    }
+    .onChange(of: children.count) { _, childCount in
+      reconcileRatios(childCount: childCount)
     }
   }
 
-  @ViewBuilder
-  private func divider(axis: RegularTerminalSplitAxis) -> some View {
-    switch axis {
-    case .horizontal:
-      Color.primary.opacity(0.25)
-        .frame(width: 1)
-    case .vertical:
-      Color.primary.opacity(0.25)
-        .frame(height: 1)
-    }
+  private func divider(
+    axis: RegularTerminalSplitAxis,
+    dividerIndex: Int,
+    childCount: Int,
+    containerLength: CGFloat
+  ) -> some View {
+    TerminalPanelSplitDivider(
+      axis: axis,
+      lineOpacity: 0.25,
+      clampedTranslation: { translation in
+        clampedResizeTranslation(
+          axis: axis,
+          dividerIndex: dividerIndex,
+          childCount: childCount,
+          containerLength: containerLength,
+          translation: translation
+        )
+      },
+      onCommitResize: { translation in
+        commitResize(
+          axis: axis,
+          dividerIndex: dividerIndex,
+          childCount: childCount,
+          containerLength: containerLength,
+          translation: translation
+        )
+      }
+    )
+  }
+
+  private func childDimension(_ dimensions: [CGFloat], at index: Int) -> CGFloat {
+    dimensions.indices.contains(index) ? dimensions[index] : 0
+  }
+
+  private func reconcileRatios(childCount: Int) {
+    childRatios = TerminalPanelKit.SplitSizing.normalizedRatios(
+      childRatios,
+      childCount: childCount
+    )
+  }
+
+  private func clampedResizeTranslation(
+    axis: RegularTerminalSplitAxis,
+    dividerIndex: Int,
+    childCount: Int,
+    containerLength: CGFloat,
+    translation: CGFloat
+  ) -> CGFloat {
+    TerminalPanelKit.SplitSizing.clampedResizeTranslation(
+      from: TerminalPanelKit.SplitSizing.normalizedRatios(
+        childRatios,
+        childCount: childCount
+      ),
+      childCount: childCount,
+      dividerIndex: dividerIndex,
+      translation: translation,
+      containerLength: containerLength,
+      minimumChildDimension: TerminalPanelKit.SplitSizing.minimumChildDimension(for: axis)
+    )
+  }
+
+  private func commitResize(
+    axis: RegularTerminalSplitAxis,
+    dividerIndex: Int,
+    childCount: Int,
+    containerLength: CGFloat,
+    translation: CGFloat
+  ) {
+    childRatios = TerminalPanelKit.SplitSizing.resizedRatios(
+      from: TerminalPanelKit.SplitSizing.normalizedRatios(
+        childRatios,
+        childCount: childCount
+      ),
+      childCount: childCount,
+      dividerIndex: dividerIndex,
+      translation: translation,
+      containerLength: containerLength,
+      minimumChildDimension: TerminalPanelKit.SplitSizing.minimumChildDimension(for: axis)
+    )
   }
 }
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/TerminalPanelKit.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/TerminalPanelKit.swift
@@ -196,6 +196,240 @@ public enum TerminalPanelKit {
     }
   }
 
+  public enum SplitSizing {
+    public static let dividerDimension: CGFloat = 16
+    public static let dividerHitTargetDimension: CGFloat = 16
+    public static let dividerRuleDimension: CGFloat = 1
+    public static let dividerHoverRailDimension: CGFloat = 5
+    public static let minimumHorizontalPanelDimension: CGFloat = 280
+    public static let minimumVerticalPanelDimension: CGFloat = 180
+
+    public static func minimumChildDimension(for axis: SplitAxis) -> CGFloat {
+      switch axis {
+      case .horizontal:
+        return minimumHorizontalPanelDimension
+      case .vertical:
+        return minimumVerticalPanelDimension
+      }
+    }
+
+    public static func normalizedRatios(
+      _ ratios: [CGFloat],
+      childCount: Int
+    ) -> [CGFloat] {
+      guard childCount > 0 else { return [] }
+      guard ratios.count == childCount else {
+        return equalRatios(childCount: childCount)
+      }
+
+      let sanitizedRatios = ratios.map { ratio in
+        ratio.isFinite && ratio > 0 ? ratio : 0
+      }
+      let total = sanitizedRatios.reduce(0, +)
+      guard total > 0 else {
+        return equalRatios(childCount: childCount)
+      }
+
+      return sanitizedRatios.map { $0 / total }
+    }
+
+    public static func childDimensions(
+      ratios: [CGFloat],
+      childCount: Int,
+      containerLength: CGFloat,
+      minimumChildDimension: CGFloat,
+      dividerDimension: CGFloat = dividerDimension
+    ) -> [CGFloat] {
+      guard childCount > 0 else { return [] }
+
+      let availableLength = contentLength(
+        containerLength: containerLength,
+        childCount: childCount,
+        dividerDimension: dividerDimension
+      )
+      guard availableLength > 0 else {
+        return Array(repeating: 0, count: childCount)
+      }
+
+      let normalizedRatios = normalizedRatios(ratios, childCount: childCount)
+      let dimensions = normalizedRatios.map { $0 * availableLength }
+      return clampedDimensions(
+        dimensions,
+        ratios: normalizedRatios,
+        availableLength: availableLength,
+        minimumChildDimension: effectiveMinimumChildDimension(
+          minimumChildDimension,
+          childCount: childCount,
+          availableLength: availableLength
+        )
+      )
+    }
+
+    public static func resizedRatios(
+      from ratios: [CGFloat],
+      childCount: Int,
+      dividerIndex: Int,
+      translation: CGFloat,
+      containerLength: CGFloat,
+      minimumChildDimension: CGFloat,
+      dividerDimension: CGFloat = dividerDimension
+    ) -> [CGFloat] {
+      let availableLength = contentLength(
+        containerLength: containerLength,
+        childCount: childCount,
+        dividerDimension: dividerDimension
+      )
+      guard availableLength > 0,
+            dividerIndex >= 0,
+            dividerIndex + 1 < childCount else {
+        return normalizedRatios(ratios, childCount: childCount)
+      }
+
+      var dimensions = childDimensions(
+        ratios: ratios,
+        childCount: childCount,
+        containerLength: containerLength,
+        minimumChildDimension: minimumChildDimension,
+        dividerDimension: dividerDimension
+      )
+
+      guard dimensions.indices.contains(dividerIndex),
+            dimensions.indices.contains(dividerIndex + 1) else {
+        return normalizedRatios(ratios, childCount: childCount)
+      }
+
+      let clampedTranslation = clampedResizeTranslation(
+        from: ratios,
+        childCount: childCount,
+        dividerIndex: dividerIndex,
+        translation: translation,
+        containerLength: containerLength,
+        minimumChildDimension: minimumChildDimension,
+        dividerDimension: dividerDimension
+      )
+
+      dimensions[dividerIndex] += clampedTranslation
+      dimensions[dividerIndex + 1] -= clampedTranslation
+
+      return dimensions.map { $0 / availableLength }
+    }
+
+    public static func clampedResizeTranslation(
+      from ratios: [CGFloat],
+      childCount: Int,
+      dividerIndex: Int,
+      translation: CGFloat,
+      containerLength: CGFloat,
+      minimumChildDimension: CGFloat,
+      dividerDimension: CGFloat = dividerDimension
+    ) -> CGFloat {
+      let availableLength = contentLength(
+        containerLength: containerLength,
+        childCount: childCount,
+        dividerDimension: dividerDimension
+      )
+      guard availableLength > 0,
+            dividerIndex >= 0,
+            dividerIndex + 1 < childCount else {
+        return 0
+      }
+
+      let minimumDimension = effectiveMinimumChildDimension(
+        minimumChildDimension,
+        childCount: childCount,
+        availableLength: availableLength
+      )
+      let dimensions = childDimensions(
+        ratios: ratios,
+        childCount: childCount,
+        containerLength: containerLength,
+        minimumChildDimension: minimumChildDimension,
+        dividerDimension: dividerDimension
+      )
+
+      guard dimensions.indices.contains(dividerIndex),
+            dimensions.indices.contains(dividerIndex + 1) else {
+        return 0
+      }
+
+      let minimumDelta = minimumDimension - dimensions[dividerIndex]
+      let maximumDelta = dimensions[dividerIndex + 1] - minimumDimension
+      return min(max(translation, minimumDelta), maximumDelta)
+    }
+
+    private static func contentLength(
+      containerLength: CGFloat,
+      childCount: Int,
+      dividerDimension: CGFloat
+    ) -> CGFloat {
+      let dividerCount = CGFloat(max(childCount - 1, 0))
+      return max(0, containerLength - dividerDimension * dividerCount)
+    }
+
+    private static func equalRatios(childCount: Int) -> [CGFloat] {
+      guard childCount > 0 else { return [] }
+      return Array(repeating: 1 / CGFloat(childCount), count: childCount)
+    }
+
+    private static func effectiveMinimumChildDimension(
+      _ minimumChildDimension: CGFloat,
+      childCount: Int,
+      availableLength: CGFloat
+    ) -> CGFloat {
+      guard childCount > 0 else { return 0 }
+      return min(max(0, minimumChildDimension), availableLength / CGFloat(childCount))
+    }
+
+    private static func clampedDimensions(
+      _ dimensions: [CGFloat],
+      ratios: [CGFloat],
+      availableLength: CGFloat,
+      minimumChildDimension: CGFloat
+    ) -> [CGFloat] {
+      guard !dimensions.isEmpty else { return [] }
+
+      var result = dimensions
+      var lockedIndexes = Set<Int>()
+
+      while true {
+        let indexesToLock = result.indices.filter { index in
+          !lockedIndexes.contains(index) && result[index] < minimumChildDimension
+        }
+
+        guard !indexesToLock.isEmpty else { break }
+
+        for index in indexesToLock {
+          lockedIndexes.insert(index)
+          result[index] = minimumChildDimension
+        }
+
+        let remainingIndexes = result.indices.filter { !lockedIndexes.contains($0) }
+        let remainingLength = max(
+          0,
+          availableLength - CGFloat(lockedIndexes.count) * minimumChildDimension
+        )
+        let remainingRatioTotal = remainingIndexes.reduce(CGFloat(0)) { total, index in
+          total + ratios[index]
+        }
+
+        guard !remainingIndexes.isEmpty else { break }
+
+        if remainingRatioTotal > 0 {
+          for index in remainingIndexes {
+            result[index] = remainingLength * ratios[index] / remainingRatioTotal
+          }
+        } else {
+          let dimension = remainingLength / CGFloat(remainingIndexes.count)
+          for index in remainingIndexes {
+            result[index] = dimension
+          }
+        }
+      }
+
+      return result
+    }
+  }
+
   public enum PaneActivity: Equatable {
     case starting
     case closingPanel

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/TerminalPanelSplitDivider.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/TerminalPanelSplitDivider.swift
@@ -1,0 +1,147 @@
+//
+//  TerminalPanelSplitDivider.swift
+//  AgentHub
+//
+
+import AppKit
+import SwiftUI
+
+@MainActor
+public struct TerminalPanelSplitDivider: View {
+  @GestureState private var dragTranslation: CGFloat = 0
+  @State private var isHovering = false
+  @State private var cursorIsPushed = false
+
+  private let axis: TerminalPanelKit.SplitAxis
+  private let lineOpacity: Double
+  private let clampedTranslation: (CGFloat) -> CGFloat
+  private let onCommitResize: (CGFloat) -> Void
+
+  public init(
+    axis: TerminalPanelKit.SplitAxis,
+    lineOpacity: Double,
+    clampedTranslation: @escaping (CGFloat) -> CGFloat,
+    onCommitResize: @escaping (CGFloat) -> Void
+  ) {
+    self.axis = axis
+    self.lineOpacity = lineOpacity
+    self.clampedTranslation = clampedTranslation
+    self.onCommitResize = onCommitResize
+  }
+
+  public var body: some View {
+    hitTarget
+      .help("Drag to resize terminal panes")
+      .onChange(of: isDragActive) { _, isDragActive in
+        updateCursor(isActive: isHovering || isDragActive)
+      }
+      .onDisappear {
+        updateCursor(isActive: false)
+      }
+  }
+
+  private var hitTarget: some View {
+    ZStack {
+      Color.clear
+        .contentShape(Rectangle())
+
+      dividerRule
+
+      if isIntentVisible {
+        hoverRail
+      }
+    }
+    .frame(
+      width: axis == .horizontal ? TerminalPanelKit.SplitSizing.dividerDimension : nil,
+      height: axis == .vertical ? TerminalPanelKit.SplitSizing.dividerDimension : nil
+    )
+    .gesture(dragGesture)
+    .accessibilityElement()
+    .accessibilityLabel("Resize terminal panes")
+    .onHover { hovering in
+      isHovering = hovering
+      updateCursor(isActive: hovering || isDragActive)
+    }
+  }
+
+  private var dividerRule: some View {
+    Rectangle()
+      .fill(Color.primary.opacity(isIntentVisible ? max(lineOpacity, 0.42) : lineOpacity))
+      .frame(
+        width: axis == .horizontal ? TerminalPanelKit.SplitSizing.dividerRuleDimension : nil,
+        height: axis == .vertical ? TerminalPanelKit.SplitSizing.dividerRuleDimension : nil
+      )
+      .frame(
+        maxWidth: axis == .vertical ? .infinity : nil,
+        maxHeight: axis == .horizontal ? .infinity : nil
+      )
+  }
+
+  private var hoverRail: some View {
+    RoundedRectangle(cornerRadius: TerminalPanelKit.SplitSizing.dividerHoverRailDimension / 2)
+      .fill(Color.primary.opacity(isDragActive ? 0.28 : 0.18))
+      .overlay {
+        RoundedRectangle(cornerRadius: TerminalPanelKit.SplitSizing.dividerHoverRailDimension / 2)
+          .stroke(Color.white.opacity(isDragActive ? 0.16 : 0.1), lineWidth: 1)
+      }
+      .frame(
+        width: axis == .horizontal ? TerminalPanelKit.SplitSizing.dividerHoverRailDimension : nil,
+        height: axis == .vertical ? TerminalPanelKit.SplitSizing.dividerHoverRailDimension : nil
+      )
+      .frame(
+        maxWidth: axis == .vertical ? .infinity : nil,
+        maxHeight: axis == .horizontal ? .infinity : nil
+      )
+      .offset(
+        x: axis == .horizontal ? clampedTranslation(dragTranslation) : 0,
+        y: axis == .vertical ? clampedTranslation(dragTranslation) : 0
+      )
+  }
+
+  private var dragGesture: some Gesture {
+    DragGesture(minimumDistance: 1)
+      .updating($dragTranslation) { value, state, _ in
+        state = rawTranslation(from: value)
+      }
+      .onEnded { value in
+        onCommitResize(clampedTranslation(rawTranslation(from: value)))
+      }
+  }
+
+  private var isDragActive: Bool {
+    dragTranslation != 0
+  }
+
+  private var isIntentVisible: Bool {
+    isHovering || isDragActive
+  }
+
+  private func rawTranslation(from value: DragGesture.Value) -> CGFloat {
+    switch axis {
+    case .horizontal:
+      return value.translation.width
+    case .vertical:
+      return value.translation.height
+    }
+  }
+
+  private func updateCursor(isActive: Bool) {
+    if isActive {
+      guard !cursorIsPushed else { return }
+      resizeCursor.push()
+      cursorIsPushed = true
+    } else if cursorIsPushed {
+      NSCursor.pop()
+      cursorIsPushed = false
+    }
+  }
+
+  private var resizeCursor: NSCursor {
+    switch axis {
+    case .horizontal:
+      return .resizeLeftRight
+    case .vertical:
+      return .resizeUpDown
+    }
+  }
+}

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/RegularTerminalWorkspaceTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/RegularTerminalWorkspaceTests.swift
@@ -229,6 +229,98 @@ struct RegularTerminalWorkspaceTests {
     )
   }
 
+  @Test("Split sizing starts with equal panel dimensions")
+  func splitSizingStartsWithEqualPanelDimensions() {
+    let dimensions = TerminalPanelKit.SplitSizing.childDimensions(
+      ratios: [],
+      childCount: 2,
+      containerLength: 1016,
+      minimumChildDimension: 280
+    )
+
+    #expect(dimensions.count == 2)
+    #expect(abs(dimensions[0] - 500) < 0.001)
+    #expect(abs(dimensions[1] - 500) < 0.001)
+  }
+
+  @Test("Split sizing resizes adjacent panels only")
+  func splitSizingResizesAdjacentPanelsOnly() {
+    let resizedRatios = TerminalPanelKit.SplitSizing.resizedRatios(
+      from: [1 / 3, 1 / 3, 1 / 3],
+      childCount: 3,
+      dividerIndex: 0,
+      translation: 100,
+      containerLength: 1232,
+      minimumChildDimension: 280
+    )
+    let dimensions = TerminalPanelKit.SplitSizing.childDimensions(
+      ratios: resizedRatios,
+      childCount: 3,
+      containerLength: 1232,
+      minimumChildDimension: 280
+    )
+
+    #expect(abs(dimensions[0] - 500) < 0.001)
+    #expect(abs(dimensions[1] - 300) < 0.001)
+    #expect(abs(dimensions[2] - 400) < 0.001)
+  }
+
+  @Test("Split sizing clamps drag at the sibling minimum dimension")
+  func splitSizingClampsDragAtSiblingMinimumDimension() {
+    let resizedRatios = TerminalPanelKit.SplitSizing.resizedRatios(
+      from: [0.5, 0.5],
+      childCount: 2,
+      dividerIndex: 0,
+      translation: 800,
+      containerLength: 1016,
+      minimumChildDimension: 280
+    )
+    let dimensions = TerminalPanelKit.SplitSizing.childDimensions(
+      ratios: resizedRatios,
+      childCount: 2,
+      containerLength: 1016,
+      minimumChildDimension: 280
+    )
+
+    #expect(abs(dimensions[0] - 720) < 0.001)
+    #expect(abs(dimensions[1] - 280) < 0.001)
+  }
+
+  @Test("Split sizing exposes the same clamped translation used by resizing")
+  func splitSizingExposesClampedTranslation() {
+    let translation = TerminalPanelKit.SplitSizing.clampedResizeTranslation(
+      from: [0.5, 0.5],
+      childCount: 2,
+      dividerIndex: 0,
+      translation: 800,
+      containerLength: 1016,
+      minimumChildDimension: 280
+    )
+
+    #expect(abs(translation - 220) < 0.001)
+  }
+
+  @Test("Split sizing scales the threshold down in compact containers")
+  func splitSizingScalesThresholdDownInCompactContainers() {
+    let resizedRatios = TerminalPanelKit.SplitSizing.resizedRatios(
+      from: [0.5, 0.5],
+      childCount: 2,
+      dividerIndex: 0,
+      translation: 800,
+      containerLength: 416,
+      minimumChildDimension: 280
+    )
+    let dimensions = TerminalPanelKit.SplitSizing.childDimensions(
+      ratios: resizedRatios,
+      childCount: 2,
+      containerLength: 416,
+      minimumChildDimension: 280
+    )
+
+    #expect(abs(dimensions[0] - 200) < 0.001)
+    #expect(abs(dimensions[1] - 200) < 0.001)
+  }
+
   @Test("Split presentation resolver renders a valid maximized panel")
   func splitPresentationResolverRendersValidMaximizedPanel() {
     let primary = RegularTerminalPanelID(UUID(uuidString: "00000000-0000-0000-0000-000000000001")!)

--- a/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalSplitView.swift
+++ b/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalSplitView.swift
@@ -3,11 +3,14 @@
 //  AgentHub
 //
 
+import AgentHubCore
 import GhosttySwift
 import SwiftUI
 
 @MainActor
 struct AgentHubGhosttyTerminalSplitView: View {
+  @State private var childRatios: [CGFloat] = []
+
   let node: TerminalSplitLayout.Node
   let session: TerminalSession
   let maximizedPanelID: TerminalPanelID?
@@ -78,15 +81,23 @@ struct AgentHubGhosttyTerminalSplitView: View {
     children: [TerminalSplitLayout.Node],
     size: CGSize
   ) -> some View {
-    let dividerSize: CGFloat = 1
-    let childCount = CGFloat(max(children.count, 1))
-    let totalDividerWidth = dividerSize * CGFloat(max(children.count - 1, 0))
-    let childWidth = max(0, size.width - totalDividerWidth) / childCount
+    let childWidths = TerminalPanelKit.SplitSizing.childDimensions(
+      ratios: childRatios,
+      childCount: children.count,
+      containerLength: size.width,
+      minimumChildDimension: TerminalPanelKit.SplitSizing.minimumChildDimension(for: .horizontal)
+    )
 
     return HStack(spacing: 0) {
       ForEach(Array(children.enumerated()), id: \.offset) { offset, child in
         if offset > 0 {
-          divider(axis: .horizontal)
+          divider(
+            axis: .horizontal,
+            dividerIndex: offset - 1,
+            childCount: children.count,
+            containerLength: size.width
+          )
+          .zIndex(1)
         }
         AgentHubGhosttyTerminalSplitView(
           node: child,
@@ -103,8 +114,15 @@ struct AgentHubGhosttyTerminalSplitView: View {
           onToggleMaximizedPanel: onToggleMaximizedPanel,
           activityForPanel: activityForPanel
         )
-        .frame(width: childWidth, height: size.height)
+        .frame(width: childDimension(childWidths, at: offset), height: size.height)
+        .zIndex(0)
       }
+    }
+    .onAppear {
+      reconcileRatios(childCount: children.count)
+    }
+    .onChange(of: children.count) { _, childCount in
+      reconcileRatios(childCount: childCount)
     }
   }
 
@@ -112,15 +130,23 @@ struct AgentHubGhosttyTerminalSplitView: View {
     children: [TerminalSplitLayout.Node],
     size: CGSize
   ) -> some View {
-    let dividerSize: CGFloat = 1
-    let childCount = CGFloat(max(children.count, 1))
-    let totalDividerHeight = dividerSize * CGFloat(max(children.count - 1, 0))
-    let childHeight = max(0, size.height - totalDividerHeight) / childCount
+    let childHeights = TerminalPanelKit.SplitSizing.childDimensions(
+      ratios: childRatios,
+      childCount: children.count,
+      containerLength: size.height,
+      minimumChildDimension: TerminalPanelKit.SplitSizing.minimumChildDimension(for: .vertical)
+    )
 
     return VStack(spacing: 0) {
       ForEach(Array(children.enumerated()), id: \.offset) { offset, child in
         if offset > 0 {
-          divider(axis: .vertical)
+          divider(
+            axis: .vertical,
+            dividerIndex: offset - 1,
+            childCount: children.count,
+            containerLength: size.height
+          )
+          .zIndex(1)
         }
         AgentHubGhosttyTerminalSplitView(
           node: child,
@@ -137,20 +163,108 @@ struct AgentHubGhosttyTerminalSplitView: View {
           onToggleMaximizedPanel: onToggleMaximizedPanel,
           activityForPanel: activityForPanel
         )
-        .frame(width: size.width, height: childHeight)
+        .frame(width: size.width, height: childDimension(childHeights, at: offset))
+        .zIndex(0)
       }
+    }
+    .onAppear {
+      reconcileRatios(childCount: children.count)
+    }
+    .onChange(of: children.count) { _, childCount in
+      reconcileRatios(childCount: childCount)
     }
   }
 
-  @ViewBuilder
-  private func divider(axis: TerminalSplitAxis) -> some View {
+  private func divider(
+    axis: TerminalSplitAxis,
+    dividerIndex: Int,
+    childCount: Int,
+    containerLength: CGFloat
+  ) -> some View {
+    let sizingAxis = TerminalPanelKit.SplitAxis(axis)
+    return TerminalPanelSplitDivider(
+      axis: sizingAxis,
+      lineOpacity: 0.35,
+      clampedTranslation: { translation in
+        clampedResizeTranslation(
+          axis: sizingAxis,
+          dividerIndex: dividerIndex,
+          childCount: childCount,
+          containerLength: containerLength,
+          translation: translation
+        )
+      },
+      onCommitResize: { translation in
+        commitResize(
+          axis: sizingAxis,
+          dividerIndex: dividerIndex,
+          childCount: childCount,
+          containerLength: containerLength,
+          translation: translation
+        )
+      }
+    )
+  }
+
+  private func childDimension(_ dimensions: [CGFloat], at index: Int) -> CGFloat {
+    dimensions.indices.contains(index) ? dimensions[index] : 0
+  }
+
+  private func reconcileRatios(childCount: Int) {
+    childRatios = TerminalPanelKit.SplitSizing.normalizedRatios(
+      childRatios,
+      childCount: childCount
+    )
+  }
+
+  private func clampedResizeTranslation(
+    axis: TerminalPanelKit.SplitAxis,
+    dividerIndex: Int,
+    childCount: Int,
+    containerLength: CGFloat,
+    translation: CGFloat
+  ) -> CGFloat {
+    TerminalPanelKit.SplitSizing.clampedResizeTranslation(
+      from: TerminalPanelKit.SplitSizing.normalizedRatios(
+        childRatios,
+        childCount: childCount
+      ),
+      childCount: childCount,
+      dividerIndex: dividerIndex,
+      translation: translation,
+      containerLength: containerLength,
+      minimumChildDimension: TerminalPanelKit.SplitSizing.minimumChildDimension(for: axis)
+    )
+  }
+
+  private func commitResize(
+    axis: TerminalPanelKit.SplitAxis,
+    dividerIndex: Int,
+    childCount: Int,
+    containerLength: CGFloat,
+    translation: CGFloat
+  ) {
+    childRatios = TerminalPanelKit.SplitSizing.resizedRatios(
+      from: TerminalPanelKit.SplitSizing.normalizedRatios(
+        childRatios,
+        childCount: childCount
+      ),
+      childCount: childCount,
+      dividerIndex: dividerIndex,
+      translation: translation,
+      containerLength: containerLength,
+      minimumChildDimension: TerminalPanelKit.SplitSizing.minimumChildDimension(for: axis)
+    )
+  }
+}
+
+private extension TerminalPanelKit.SplitAxis {
+  init(_ axis: TerminalSplitAxis) {
     switch axis {
     case .horizontal:
-      Color.primary.opacity(0.35)
-        .frame(width: 1)
+      self = .horizontal
     case .vertical:
-      Color.primary.opacity(0.35)
-        .frame(height: 1)
+      self = .vertical
     }
   }
 }


### PR DESCRIPTION
## Summary

- Add shared split sizing and clamp logic for terminal pane resizing.
- Add a reusable SwiftUI divider with a larger hit target, hover/drag intent affordance, and commit-on-release resizing.
- Wire the behavior into regular and Ghostty terminal split views, including explicit divider z-ordering so the drag affordance stays above terminal panes.
- Add focused split sizing tests for ratio normalization, minimum pane thresholds, clamped drag previews, and nested workspace behavior.

## Validation

- `xcodebuild test -scheme AgentHubCore-Tests -destination 'platform=macOS' -test-timeouts-enabled YES -skipPackagePluginValidation -only-testing:AgentHubTests/RegularTerminalWorkspaceTests -quiet`
- `xcodebuild build -project app/AgentHub.xcodeproj -scheme AgentHub -destination 'platform=macOS' -skipPackagePluginValidation -quiet`