### PR TITLE
[codex] Restore navigation split sidebar

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
@@ -206,12 +206,9 @@ public struct MultiProviderSessionsListView: View {
       ZStack {
         HStack(spacing: 0) {
           if isSidebarVisible {
-            sidePanelView
-              .agentHubPanel()
+            sidebarColumn
               .frame(width: sidebarWidth)
-              .padding(.vertical, 8)
-              .padding(.horizontal, 8)
-              .background(appBackground.ignoresSafeArea())
+              .frame(maxHeight: .infinity)
               .transition(sidebarVisibilityTransition)
           }
 
@@ -452,6 +449,22 @@ public struct MultiProviderSessionsListView: View {
     accessibilityReduceMotion
       ? .opacity
       : .move(edge: .leading).combined(with: .opacity)
+  }
+
+  private var sidebarColumn: some View {
+    ZStack {
+      sidebarBackground
+        .ignoresSafeArea()
+
+      sidePanelView
+        .agentHubPanel()
+        .padding(.vertical, 8)
+        .padding(.horizontal, 8)
+    }
+  }
+
+  private var sidebarBackground: Color {
+    Color.adaptiveBackground(for: colorScheme)
   }
 
   private var detailPane: some View {

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
@@ -202,26 +202,23 @@ public struct MultiProviderSessionsListView: View {
 
   public var body: some View {
     GeometryReader { proxy in
-      let sidebarWidth: CGFloat = 280
+      let sidebarMax = max(280, proxy.size.width * 0.20)
       ZStack {
-        HStack(spacing: 0) {
-          if isSidebarVisible {
-            sidebarColumn
-              .frame(width: sidebarWidth)
-              .frame(maxHeight: .infinity)
-              .transition(sidebarVisibilityTransition)
-          }
-
+        NavigationSplitView(columnVisibility: $columnVisibility) {
+          sidePanelView
+            .agentHubPanel()
+            .navigationSplitViewColumnWidth(min: 280, ideal: 280, max: sidebarMax)
+            .padding(.vertical, 8)
+            .padding(.horizontal, 8)
+        } detail: {
           detailPane
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
-        .frame(width: proxy.size.width, height: proxy.size.height)
+        .navigationSplitViewStyle(.balanced)
         .background(appBackground.ignoresSafeArea())
 
         // Invisible global keyboard shortcuts.
         keyboardShortcutButtons
       }
-      .animation(sidebarVisibilityAnimation, value: isSidebarVisible)
     }
     .overlay {
       commandPaletteOverlay
@@ -439,34 +436,6 @@ public struct MultiProviderSessionsListView: View {
     columnVisibility != .detailOnly
   }
 
-  private var sidebarVisibilityAnimation: Animation {
-    accessibilityReduceMotion
-      ? .easeInOut(duration: 0.08)
-      : .timingCurve(0.22, 1, 0.36, 1, duration: 0.22)
-  }
-
-  private var sidebarVisibilityTransition: AnyTransition {
-    accessibilityReduceMotion
-      ? .opacity
-      : .move(edge: .leading).combined(with: .opacity)
-  }
-
-  private var sidebarColumn: some View {
-    ZStack {
-      sidebarBackground
-        .ignoresSafeArea()
-
-      sidePanelView
-        .agentHubPanel()
-        .padding(.vertical, 8)
-        .padding(.horizontal, 8)
-    }
-  }
-
-  private var sidebarBackground: Color {
-    Color.adaptiveBackground(for: colorScheme)
-  }
-
   private var detailPane: some View {
     VStack(spacing: 0) {
       // Progress bar lives above the detail pane only (not over the sidebar).
@@ -491,6 +460,11 @@ public struct MultiProviderSessionsListView: View {
       .frame(minWidth: 300)
       .padding(.vertical, 8)
       .padding(.horizontal, 8)
+      .background {
+        NSSplitViewAutosaveDisabler()
+          .frame(width: 0, height: 0)
+          .allowsHitTesting(false)
+      }
     }
   }
 
@@ -542,7 +516,21 @@ public struct MultiProviderSessionsListView: View {
   }
 
   private var appBackground: some View {
-    Color.adaptiveBackground(for: colorScheme, theme: runtimeTheme)
+    Group {
+      if runtimeTheme?.hasCustomBackgrounds == true {
+        Color.adaptiveBackground(for: colorScheme, theme: runtimeTheme)
+      } else {
+        LinearGradient(
+          colors: [
+            Color.surfaceCanvas,
+            Color.surfaceCanvas.opacity(colorScheme == .dark ? 0.98 : 0.94),
+            Color.brandTertiary.opacity(colorScheme == .dark ? 0.06 : 0.1)
+          ],
+          startPoint: .topLeading,
+          endPoint: .bottomTrailing
+        )
+      }
+    }
   }
 
   private var sessionListContent: some View {

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
@@ -211,6 +211,7 @@ public struct MultiProviderSessionsListView: View {
               .frame(width: sidebarWidth)
               .padding(.vertical, 8)
               .padding(.horizontal, 8)
+              .background(appBackground.ignoresSafeArea())
               .transition(sidebarVisibilityTransition)
           }
 
@@ -528,21 +529,7 @@ public struct MultiProviderSessionsListView: View {
   }
 
   private var appBackground: some View {
-    Group {
-      if runtimeTheme?.hasCustomBackgrounds == true {
-        Color.adaptiveBackground(for: colorScheme, theme: runtimeTheme)
-      } else {
-        LinearGradient(
-          colors: [
-            Color.surfaceCanvas,
-            Color.surfaceCanvas.opacity(colorScheme == .dark ? 0.98 : 0.94),
-            Color.brandTertiary.opacity(colorScheme == .dark ? 0.06 : 0.1)
-          ],
-          startPoint: .topLeading,
-          endPoint: .bottomTrailing
-        )
-      }
-    }
+    Color.adaptiveBackground(for: colorScheme, theme: runtimeTheme)
   }
 
   private var sessionListContent: some View {


### PR DESCRIPTION
## Summary

Restores the main Sessions sidebar/detail shell to `NavigationSplitView` instead of the manual `HStack` layout introduced during the resize fix.

## Why

The manual shell changed native sidebar behavior and made the side panel surface color diverge from the expected split-view appearance. The close/window-resize fix is kept by retaining the tested embedded sidebar visibility state and attaching `NSSplitViewAutosaveDisabler` to the detail pane.

## Validation

- `xcodebuild test -scheme AgentHubCore-Tests -destination 'platform=macOS' -test-timeouts-enabled YES -skipPackagePluginValidation -only-testing:AgentHubTests/EmbeddedSidePanelSidebarVisibilityStateTests -only-testing:AgentHubTests/NSSplitViewAutosaveDisablerTests`
- `xcodebuild build -project app/AgentHub.xcodeproj -scheme AgentHub -destination 'platform=macOS' -skipPackagePluginValidation`