### PR TITLE
[codex] Add simulator error fix action

### DIFF
--- a/SimulatorPreview.md
+++ b/SimulatorPreview.md
@@ -17,9 +17,10 @@ The user clicks **Simulator** (shown only for Xcode projects). The side panel le
 them pick/boot a device and Build & Run, then mirrors the device's screen and
 forwards mouse/keyboard back to it. The old per-card Simulator button that opened
 the `SimulatorPickerView` sheet is deprecated: the panel is now the single entry
-point, and the full management sheet (Mac runs, build-error forwarding) is
-reachable from the panel header's manage button. (The legacy `MonitoringPanelView`
-path, which doesn't wire the side-panel callback, still falls back to the sheet.)
+point, and the management sheet code remains wired but hidden while it can drift
+out of sync with the panel picker. Build/run failures surface directly in the
+side panel with a send-to-agent action. (The legacy `MonitoringPanelView` path,
+which doesn't wire the side-panel callback, still falls back to the sheet.)
 
 ## Annotation feedback (element-aware pins sent to the agent)
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/Models/SimulatorBuildErrorPromptBuilder.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Models/SimulatorBuildErrorPromptBuilder.swift
@@ -1,0 +1,15 @@
+//
+//  SimulatorBuildErrorPromptBuilder.swift
+//  AgentHub
+//
+//  Builds the prompt sent to the active agent when a simulator build/run
+//  failure needs to be handed back for repair.
+//
+
+import Foundation
+
+enum SimulatorBuildErrorPromptBuilder {
+  static func prompt(for error: String) -> String {
+    "Fix this simulator build/run error:\n\(error)"
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringCardView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringCardView.swift
@@ -360,7 +360,9 @@ public struct MonitoringCardView: View {
         onDismiss: { simulatorSheetSession = nil },
         onSendToSession: { error in
           guard let vm = viewModel else { return }
-          vm.showTerminalWithPrompt(for: session, prompt: "Fix this build error:\n\(error)")
+          vm.showTerminalWithPrompt(
+            for: session,
+            prompt: SimulatorBuildErrorPromptBuilder.prompt(for: error))
           simulatorSheetSession = nil
         }
       )

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderMonitoringPanelView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderMonitoringPanelView.swift
@@ -1030,9 +1030,12 @@ public struct MultiProviderMonitoringPanelView: View {
         providerKind: payload.providerKind,
         onDismiss: closeEmbeddedSidePanel,
         onSendToSession: { prompt, sess in
-          if !viewModel.sendPromptToActiveTerminal(forKey: sess.id, prompt: prompt) {
-            viewModel.showTerminalWithPrompt(for: sess, prompt: prompt)
-          }
+          showTerminalWithPrompt(
+            prompt,
+            for: sess,
+            itemID: payload.itemID,
+            viewModel: viewModel
+          )
         },
         openEditorFilePath: editorStates[payload.itemID]?.selectedFilePath
       )

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/SimulatorPickerView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/SimulatorPickerView.swift
@@ -237,7 +237,7 @@ public struct SimulatorPickerView: View {
     case .failed(let error):
       HStack(spacing: 6) {
         if onSendToSession != nil {
-          Button("Fix with Claude") {
+          Button("Fix", systemImage: "wrench.and.screwdriver.fill") {
             onSendToSession?(error)
           }
           .font(.caption)
@@ -419,7 +419,7 @@ public struct SimulatorPickerView: View {
     case .failed(let error):
       HStack(spacing: 6) {
         if onSendToSession != nil {
-          Button("Fix with Claude") {
+          Button("Fix", systemImage: "wrench.and.screwdriver.fill") {
             onSendToSession?(error)
           }
           .font(.caption)

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/SimulatorPreviewSidePanelView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/SimulatorPreviewSidePanelView.swift
@@ -5,9 +5,9 @@
 //  Embedded side panel that shows a live, interactive iOS Simulator for the
 //  session's project. Device lifecycle (list/boot/build & run) reuses the
 //  existing `SimulatorService`; the live capture + input comes from the
-//  standalone `SimulatorPreview` module. The full management sheet
-//  (`SimulatorPickerView` — Mac runs, build-error forwarding) is reachable
-//  from the header, replacing the deprecated per-card Simulator button.
+//  standalone `SimulatorPreview` module. The legacy management sheet
+//  (`SimulatorPickerView` — Mac runs, build-error forwarding) is kept wired
+//  but hidden while the side panel remains the single entry point.
 //
 //  Annotate mode pauses touch forwarding so clicks drop numbered pins; the
 //  queued pins are sent to the agent as one prompt plus a pin-stamped
@@ -143,6 +143,13 @@ struct SimulatorPreviewSidePanelView: View {
       .displayName
   }
 
+  private var activeFailureMessage: String? {
+    if case .failed(let message) = activeState {
+      return message
+    }
+    return nil
+  }
+
   var body: some View {
     VStack(spacing: 0) {
       header
@@ -209,7 +216,7 @@ struct SimulatorPreviewSidePanelView: View {
         onDismiss: { showingManageSheet = false },
         onSendToSession: onSendToSession.map { send in
           { error in
-            send("Fix this build error:\n\(error)", session)
+            send(SimulatorBuildErrorPromptBuilder.prompt(for: error), session)
             showingManageSheet = false
           }
         }
@@ -399,6 +406,9 @@ struct SimulatorPreviewSidePanelView: View {
       .overlay(alignment: .bottomTrailing) {
         annotationCommentsOverlay
       }
+      .overlay(alignment: .top) {
+        simulatorFailureBannerOverlay
+      }
       .overlay(alignment: .topTrailing) {
         if activeUDID != nil {
           floatingRunControls
@@ -519,6 +529,26 @@ struct SimulatorPreviewSidePanelView: View {
     }
   }
 
+  @ViewBuilder
+  private var simulatorFailureBannerOverlay: some View {
+    if let activeFailureMessage {
+      HStack(alignment: .top, spacing: 0) {
+        SimulatorBuildErrorBanner(
+          message: activeFailureMessage,
+          providerKind: providerKind,
+          canSend: onSendToSession != nil,
+          onSend: { sendBuildError(activeFailureMessage) }
+        )
+        .frame(maxWidth: 520, alignment: .leading)
+
+        Spacer(minLength: 52)
+      }
+      .frame(maxWidth: .infinity, alignment: .leading)
+      .padding(14)
+      .transition(.move(edge: .top).combined(with: .opacity))
+    }
+  }
+
   private var loadingState: some View {
     VStack(spacing: 8) {
       ProgressView()
@@ -557,13 +587,6 @@ struct SimulatorPreviewSidePanelView: View {
           .font(.subheadline)
       }
 
-      if case .failed(let message) = activeState {
-        Text(message)
-          .font(.caption2)
-          .foregroundStyle(.red)
-          .lineLimit(3)
-          .padding(.horizontal)
-      }
     }
     .frame(maxWidth: .infinity, maxHeight: .infinity)
   }
@@ -623,6 +646,11 @@ struct SimulatorPreviewSidePanelView: View {
     guard let activeUDID else { return }
     hotReload.sessionDidStop()
     Task { await simulatorService.shutdownDevice(udid: activeUDID) }
+  }
+
+  private func sendBuildError(_ error: String) {
+    guard let onSendToSession else { return }
+    onSendToSession(SimulatorBuildErrorPromptBuilder.prompt(for: error), session)
   }
 
   /// Bootstraps the Previews tab without a manual play press: when there's
@@ -807,5 +835,63 @@ private struct SimulatorFloatingActionButton: View {
 
   private var buttonBackground: some View {
     Circle().fill(.thinMaterial)
+  }
+}
+
+private struct SimulatorBuildErrorBanner: View {
+  let message: String
+  let providerKind: SessionProviderKind
+  let canSend: Bool
+  let onSend: () -> Void
+
+  @Environment(\.colorScheme) private var colorScheme
+
+  private var borderColor: Color {
+    Color.red.opacity(colorScheme == .dark ? 0.34 : 0.24)
+  }
+
+  var body: some View {
+    HStack(alignment: .top, spacing: 10) {
+      Image(systemName: "exclamationmark.triangle.fill")
+        .font(.caption.weight(.semibold))
+        .foregroundStyle(.red)
+        .padding(.top, 1)
+        .accessibilityHidden(true)
+
+      VStack(alignment: .leading, spacing: 3) {
+        Text("Simulator error")
+          .font(.caption.weight(.semibold))
+
+        Text(message)
+          .font(.caption2)
+          .foregroundStyle(.secondary)
+          .lineLimit(5)
+          .textSelection(.enabled)
+      }
+      .frame(maxWidth: .infinity, alignment: .leading)
+
+      if canSend {
+        Button {
+          onSend()
+        } label: {
+          Label("Fix", systemImage: "wrench.and.screwdriver.fill")
+        }
+        .font(.caption.weight(.medium))
+        .buttonStyle(.borderedProminent)
+        .controlSize(.small)
+        .tint(Color.brandPrimary(for: providerKind))
+        .help("Ask \(providerKind.rawValue) to fix this simulator error")
+        .accessibilityLabel("Fix simulator error with \(providerKind.rawValue)")
+      }
+    }
+    .padding(.horizontal, 10)
+    .padding(.vertical, 8)
+    .background(.thinMaterial, in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+    .overlay(
+      RoundedRectangle(cornerRadius: 8, style: .continuous)
+        .stroke(borderColor, lineWidth: 1)
+    )
+    .shadow(color: Color.black.opacity(colorScheme == .dark ? 0.24 : 0.12), radius: 10, y: 4)
+    .help(message)
   }
 }

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/SimulatorModelsTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/SimulatorModelsTests.swift
@@ -158,3 +158,32 @@ struct XcodePlatformTests {
     #expect(set.contains(.macOS))
   }
 }
+
+// MARK: - SimulatorBuildErrorPromptBuilder
+
+@Suite("SimulatorBuildErrorPromptBuilder")
+struct SimulatorBuildErrorPromptBuilderTests {
+
+  @Test func wrapsCompilerErrorForAgentRepair() {
+    let error = "/tmp/App/ContentView.swift:12:3: error: cannot find 'foo' in scope"
+
+    let prompt = SimulatorBuildErrorPromptBuilder.prompt(for: error)
+
+    #expect(prompt == """
+    Fix this simulator build/run error:
+    /tmp/App/ContentView.swift:12:3: error: cannot find 'foo' in scope
+    """)
+  }
+
+  @Test func preservesMultiLineErrorDetails() {
+    let error = """
+    ContentView.swift:9:7: error: type 'Demo' has no member 'missing'
+    simctl launch failed (exit 4)
+    """
+
+    let prompt = SimulatorBuildErrorPromptBuilder.prompt(for: error)
+
+    #expect(prompt.contains("ContentView.swift:9:7: error: type 'Demo' has no member 'missing'"))
+    #expect(prompt.contains("simctl launch failed (exit 4)"))
+  }
+}


### PR DESCRIPTION
## Summary

Adds an in-panel simulator build/run error banner so users can see compile or launch failures without reopening the legacy simulator selector sheet. The banner includes a **Fix** action that sends the captured simulator error to the active agent session.

## Details

- Surfaces `SimulatorState.failed` in `SimulatorPreviewSidePanelView`, including when the simulator is already booted and the live stream is visible.
- Routes simulator error sends through the existing terminal-return helper so sessions focused on Files or Diffs switch back to Terminal when the fix request is sent.
- Centralizes the simulator build/run error prompt in `SimulatorBuildErrorPromptBuilder`.
- Keeps the legacy selector path wired but updates its action label from Claude-specific copy to provider-neutral `Fix`.
- Updates simulator preview docs to reflect the hidden management sheet and side-panel error forwarding behavior.

## Validation

- `xcodebuild test -quiet -scheme AgentHubCore-Tests -destination 'platform=macOS' -test-timeouts-enabled YES -skipPackagePluginValidation -only-testing:AgentHubTests/SimulatorBuildErrorPromptBuilderTests`

The targeted test passed with exit `0`. Existing Swift 6 import/concurrency warnings and package plugin messages were still present in the build log.