### PR TITLE
[codex] Smooth embedded side panel resizing

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubViews.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubViews.swift
@@ -59,22 +59,10 @@ public struct AgentHubSessionsView: View {
       worktreeSuccessSoundService: provider.worktreeSuccessSoundService
     )
       .frame(minWidth: 1200, minHeight: 750)
-      .toolbar {
-        ToolbarItem(placement: .navigation) {
-          Button(action: toggleSidebarVisibility) {
-            Label("Toggle Sidebar", systemImage: "sidebar.left")
-          }
-          .help(columnVisibility == .detailOnly ? "Show Sidebar" : "Hide Sidebar")
-        }
-      }
       .modifier(RemoveTitleToolbarModifier())
       .task {
         provider.startWorktreeLaunchRequestMonitoring()
       }
-  }
-
-  private func toggleSidebarVisibility() {
-    columnVisibility = columnVisibility == .detailOnly ? .all : .detailOnly
   }
 
   private var missingProviderView: some View {

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/FileExplorerView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/FileExplorerView.swift
@@ -109,7 +109,6 @@ public struct FileExplorerView: View {
             Divider()
             fileContentArea
           }
-          .blursWhileResizing()
         }
         .animation(.easeInOut(duration: 0.25), value: showSidebar)
       }

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MCPAppSidePanelView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MCPAppSidePanelView.swift
@@ -24,6 +24,8 @@ struct MCPAppSidePanelView: View {
   let viewModel: CLISessionsViewModel?
   let monitorState: SessionMonitorState?
   let onDismiss: () -> Void
+  let isExpanded: Bool
+  var onToggleExpanded: (() -> Void)?
 
   @State private var selectedItemID: String?
   @State private var consentController = MCPAppConsentController()
@@ -136,8 +138,29 @@ struct MCPAppSidePanelView: View {
         .accessibilityLabel("Select MCP app")
       }
 
+      if let onToggleExpanded {
+        Button(action: onToggleExpanded) {
+          Image(systemName: isExpanded ? "arrow.down.right.and.arrow.up.left" : "arrow.up.left.and.arrow.down.right")
+            .font(.system(size: 13, weight: .medium))
+            .foregroundStyle(.secondary)
+            .frame(width: 24, height: 24)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(isExpanded ? "Collapse MCP app" : "Expand MCP app to full width")
+        .help(isExpanded ? "Collapse MCP app (⌘⇧O)" : "Expand MCP app to full width (⌘⇧O)")
+      }
+
       Button("Close", action: onDismiss)
         .keyboardShortcut(.cancelAction)
+    }
+    .overlay {
+      if let onToggleExpanded {
+        Button("") { onToggleExpanded() }
+          .keyboardShortcut("o", modifiers: [.command, .shift])
+          .hidden()
+          .frame(width: 0, height: 0)
+      }
     }
     .padding(.horizontal, 12)
     .padding(.vertical, 8)

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderMonitoringPanelView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderMonitoringPanelView.swift
@@ -161,6 +161,8 @@ public struct MultiProviderMonitoringPanelView: View {
   @State private var observedAutoOpenKeysBySessionID: [String: Set<MonitoringAutoOpenSidePanelKey>] = [:]
   @State private var editorStates: [String: MonitoringEditorState] = [:]
   @State private var availableDetailWidth: CGFloat = 0
+  @State private var showsEmbeddedSidePanelResizeOverlay = false
+  @State private var embeddedSidePanelResizeOverlayGeneration = 0
   @Binding var primarySessionId: String?
   @Binding var selectedModuleLandingPath: String?
   @AppStorage(AgentHubDefaults.worktreeDisplayMode)
@@ -705,6 +707,11 @@ public struct MultiProviderMonitoringPanelView: View {
           maxHeight: .infinity,
           alignment: .leading
         )
+        .overlay {
+          if showsEmbeddedSidePanelResizeOverlay {
+            ResizeObscuringOverlay()
+          }
+        }
         .opacity(isSidePanelExpanded ? 0 : 1)
         .allowsHitTesting(!isSidePanelExpanded)
         .accessibilityHidden(isSidePanelExpanded)
@@ -719,7 +726,8 @@ public struct MultiProviderMonitoringPanelView: View {
           maxWidth: allowedEmbeddedSidePanelWidth,
           defaultWidth: min(embeddedSidePanelDefaultWidth, allowedEmbeddedSidePanelWidth),
           userDefaultsKey: AgentHubDefaults.sidePanelWidth,
-          fixedWidth: isExpanded ? expandedEmbeddedSidePanelWidth : nil
+          fixedWidth: isExpanded ? expandedEmbeddedSidePanelWidth : nil,
+          onResizeInteractionChanged: setEmbeddedSidePanelResizeOverlay
         ) {
           ZStack {
             if let mountedPayload = sidePanelPresentation.mountedPayload,
@@ -735,6 +743,29 @@ public struct MultiProviderMonitoringPanelView: View {
         }
         .animation(embeddedSidePanelContentAnimation, value: sidePanelPresentation.mountedPayload)
         .animation(embeddedSidePanelContentAnimation, value: isExpanded)
+      }
+    }
+  }
+
+  private func setEmbeddedSidePanelResizeOverlay(isActive: Bool) {
+    embeddedSidePanelResizeOverlayGeneration += 1
+    let generation = embeddedSidePanelResizeOverlayGeneration
+
+    if isActive {
+      var transaction = Transaction()
+      transaction.disablesAnimations = true
+      withTransaction(transaction) {
+        showsEmbeddedSidePanelResizeOverlay = true
+      }
+      return
+    }
+
+    Task { @MainActor in
+      try? await Task.sleep(for: .milliseconds(180))
+      guard generation == embeddedSidePanelResizeOverlayGeneration else { return }
+
+      withAnimation(.easeOut(duration: 0.12)) {
+        showsEmbeddedSidePanelResizeOverlay = false
       }
     }
   }
@@ -1020,7 +1051,9 @@ public struct MultiProviderMonitoringPanelView: View {
         session: session,
         viewModel: viewModel,
         monitorState: viewModel.monitorStates[sessionId],
-        onDismiss: closeEmbeddedSidePanel
+        onDismiss: closeEmbeddedSidePanel,
+        isExpanded: sidePanelExpansion.isExpanded(for: payload),
+        onToggleExpanded: { toggleEmbeddedSidePanelExpansion(for: payload) }
       )
     case .simulator(let sessionId, let session, let projectPath):
       SimulatorPreviewSidePanelView(

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderMonitoringPanelView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderMonitoringPanelView.swift
@@ -709,7 +709,6 @@ public struct MultiProviderMonitoringPanelView: View {
         .allowsHitTesting(!isSidePanelExpanded)
         .accessibilityHidden(isSidePanelExpanded)
         .clipped()
-        .blursWhileResizing()
 
       if let shellPayload = sidePanelPresentation.shellPayload {
         let isExpanded = sidePanelExpansion.isExpanded(for: shellPayload)

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/ResizableSplitHandle.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/ResizableSplitHandle.swift
@@ -13,6 +13,18 @@ enum ResizablePanelSide: Equatable {
   case trailing
 }
 
+struct ResizeObscuringOverlay: View {
+  var body: some View {
+    Rectangle()
+      .fill(.thinMaterial)
+      .overlay {
+        Color.black.opacity(0.08)
+      }
+      .accessibilityHidden(true)
+      .allowsHitTesting(false)
+  }
+}
+
 // MARK: - Drag State Suppression
 
 /// Tracks active split-handle drags so the terminal does not treat the mouse-up
@@ -73,11 +85,13 @@ struct ResizablePanelContainer<Content: View>: View {
   let defaultWidth: CGFloat
   let userDefaultsKey: String
   let fixedWidth: CGFloat?
+  let onResizeInteractionChanged: (Bool) -> Void
   let content: Content
 
   @State private var width: CGFloat
-  @State private var previewWidth: CGFloat?
   @State private var isSuppressingTerminalSelection = false
+  @State private var showsResizeObscuringOverlay = false
+  @State private var resizeOverlayGeneration = 0
 
   init(
     side: ResizablePanelSide,
@@ -86,6 +100,7 @@ struct ResizablePanelContainer<Content: View>: View {
     defaultWidth: CGFloat,
     userDefaultsKey: String,
     fixedWidth: CGFloat? = nil,
+    onResizeInteractionChanged: @escaping (Bool) -> Void = { _ in },
     @ViewBuilder content: () -> Content
   ) {
     self.side = side
@@ -94,6 +109,7 @@ struct ResizablePanelContainer<Content: View>: View {
     self.defaultWidth = defaultWidth
     self.userDefaultsKey = userDefaultsKey
     self.fixedWidth = fixedWidth
+    self.onResizeInteractionChanged = onResizeInteractionChanged
     self.content = content()
 
     let savedWidth = UserDefaults.standard.double(forKey: userDefaultsKey)
@@ -104,9 +120,6 @@ struct ResizablePanelContainer<Content: View>: View {
   private var resolvedWidth: CGFloat {
     if let fixedWidth {
       return max(0, fixedWidth)
-    }
-    if let previewWidth {
-      return previewWidth
     }
     return committedWidth
   }
@@ -136,6 +149,11 @@ struct ResizablePanelContainer<Content: View>: View {
   private var resizableContent: some View {
     content
       .frame(width: resolvedWidth)
+      .overlay {
+        if showsResizeObscuringOverlay {
+          ResizeObscuringOverlay()
+        }
+      }
   }
 
   private var handleSlot: some View {
@@ -152,21 +170,17 @@ struct ResizablePanelContainer<Content: View>: View {
       lineOpacity: 0.25,
       helpText: "Drag to resize panel. Double-click to reset.",
       accessibilityLabel: "Resize panel",
-      movesRailWithDrag: false,
       clampedTranslation: clampedDragTranslation,
       onCommitResize: commitResize,
-      onDragTranslationChanged: { dragTranslation in
-        updatePreviewWidth(dragTranslation: dragTranslation)
+      onDoubleClick: {
+        commitWidth(Self.clamped(defaultWidth, minWidth: minWidth, maxWidth: maxWidth))
       },
       onDragActivityChanged: { isActive in
-        setTerminalSelectionSuppression(isActive: isActive)
+        setResizeInteractionActive(isActive)
       }
     )
-    .onTapGesture(count: 2) {
-      commitWidth(Self.clamped(defaultWidth, minWidth: minWidth, maxWidth: maxWidth))
-    }
     .onDisappear {
-      setTerminalSelectionSuppression(isActive: false)
+      setResizeInteractionActive(false, immediatelyHideOverlay: true)
     }
   }
 
@@ -187,8 +201,11 @@ struct ResizablePanelContainer<Content: View>: View {
   }
 
   private func commitWidth(_ newWidth: CGFloat) {
-    previewWidth = nil
-    width = newWidth
+    var transaction = Transaction()
+    transaction.disablesAnimations = true
+    withTransaction(transaction) {
+      width = newWidth
+    }
     UserDefaults.standard.set(Double(newWidth), forKey: userDefaultsKey)
   }
 
@@ -210,13 +227,38 @@ struct ResizablePanelContainer<Content: View>: View {
     }
   }
 
-  private func updatePreviewWidth(dragTranslation: CGFloat?) {
-    guard let dragTranslation else {
-      previewWidth = nil
+  private func setResizeInteractionActive(_ isActive: Bool, immediatelyHideOverlay: Bool = false) {
+    setResizeObscuringOverlay(isActive: isActive, immediatelyHide: immediatelyHideOverlay)
+    setTerminalSelectionSuppression(isActive: isActive)
+    onResizeInteractionChanged(isActive)
+  }
+
+  private func setResizeObscuringOverlay(isActive: Bool, immediatelyHide: Bool = false) {
+    resizeOverlayGeneration += 1
+    let generation = resizeOverlayGeneration
+
+    if isActive {
+      var transaction = Transaction()
+      transaction.disablesAnimations = true
+      withTransaction(transaction) {
+        showsResizeObscuringOverlay = true
+      }
       return
     }
 
-    previewWidth = Self.clamped(width(from: dragTranslation), minWidth: minWidth, maxWidth: maxWidth)
+    if immediatelyHide {
+      showsResizeObscuringOverlay = false
+      return
+    }
+
+    Task { @MainActor in
+      try? await Task.sleep(for: .milliseconds(180))
+      guard generation == resizeOverlayGeneration else { return }
+
+      withAnimation(.easeOut(duration: 0.12)) {
+        showsResizeObscuringOverlay = false
+      }
+    }
   }
 
   private func setTerminalSelectionSuppression(isActive: Bool) {

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/ResizableSplitHandle.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/ResizableSplitHandle.swift
@@ -3,10 +3,9 @@
 //  AgentHub
 //
 //  Horizontal drag-resize primitives for split pane layouts.
-//  Shared drag handle for resizable split panels.
 //
 
-import AppKit
+import Foundation
 import SwiftUI
 
 enum ResizablePanelSide: Equatable {
@@ -14,7 +13,7 @@ enum ResizablePanelSide: Equatable {
   case trailing
 }
 
-// MARK: - Drag State Propagation
+// MARK: - Drag State Suppression
 
 /// Tracks active split-handle drags so the terminal does not treat the mouse-up
 /// that ends a resize as a terminal/tab selection click.
@@ -45,74 +44,11 @@ final class ResizeInteractionSuppression {
   }
 }
 
-/// Process-wide observable that publishes whether ANY split handle is being
-/// dragged. Individual panes subscribe via `.blursWhileResizing()` so both the
-/// main content and the resizable content can fade in a blur overlay without
-/// the overlay covering the handle itself.
-@MainActor
-@Observable
-final class ResizeInteractionState {
-  static let shared = ResizeInteractionState()
-
-  /// Number of concurrent active drags. `isResizing` is `true` when > 0.
-  /// Tracked as a counter so nested / overlapping drags all release cleanly.
-  private var activeCount: Int = 0
-
-  var isResizing: Bool { activeCount > 0 }
-
-  fileprivate func beginResize() { activeCount += 1 }
-  fileprivate func endResize() { activeCount = max(0, activeCount - 1) }
-
-  private init() {}
-}
-
-extension View {
-  /// Fades a blurred material overlay in while any descendant (or sibling)
-  /// `ResizablePanelContainer` is being dragged. Apply to each pane that should
-  /// blur. The handle itself is deliberately NOT wrapped so the preview guide +
-  /// width readout stay sharp on top.
-  func blursWhileResizing() -> some View {
-    modifier(BlurWhileResizingModifier())
-  }
-}
-
-private struct BlurWhileResizingModifier: ViewModifier {
-  @State private var state = ResizeInteractionState.shared
-
-  /// Peak opacity of the material overlay during a drag. `.ultraThinMaterial`
-  /// is already the lightest system material — lowering the opacity further
-  /// makes the blur very subtle so the underlying content stays readable.
-  private static let peakOpacity: Double = 0.75
-
-  func body(content: Content) -> some View {
-    let isResizing = state.isResizing
-    content
-      .overlay {
-        Rectangle()
-          .fill(.ultraThinMaterial)
-          .opacity(isResizing ? Self.peakOpacity : 0)
-          .animation(.easeInOut(duration: 0.2), value: isResizing)
-          .allowsHitTesting(false)
-      }
-  }
-}
-
-func resizableDividerColor(isDragging: Bool, isHovering: Bool) -> Color {
-  if isHovering {
-    return Color.primary.opacity(0.28)
-  }
-  return Color.primary.opacity(isDragging ? 0.14 : 0.09)
-}
-
-func resizableDividerThickness(isDragging: Bool, isHovering: Bool) -> CGFloat {
-  return isHovering || isDragging ? 2 : 1
-}
-
 // MARK: - ResizablePanelContainer
 
 /// A self-contained split pane whose width state lives entirely inside this view.
-/// Because width changes never propagate to the parent, the parent never re-renders
-/// during a drag — eliminating flicker in large parent views like MonitoringPanelView.
+/// During a drag, only the divider rail moves. The pane width is committed when
+/// the drag ends, matching the smoother terminal panel resize implementation.
 ///
 /// Use `.trailing` when the resizable pane is on the right (right side panel):
 /// ```
@@ -140,6 +76,8 @@ struct ResizablePanelContainer<Content: View>: View {
   let content: Content
 
   @State private var width: CGFloat
+  @State private var previewWidth: CGFloat?
+  @State private var isSuppressingTerminalSelection = false
 
   init(
     side: ResizablePanelSide,
@@ -167,6 +105,13 @@ struct ResizablePanelContainer<Content: View>: View {
     if let fixedWidth {
       return max(0, fixedWidth)
     }
+    if let previewWidth {
+      return previewWidth
+    }
+    return committedWidth
+  }
+
+  private var committedWidth: CGFloat {
     return Self.clamped(width, minWidth: minWidth, maxWidth: maxWidth)
   }
 
@@ -188,177 +133,100 @@ struct ResizablePanelContainer<Content: View>: View {
     }
   }
 
-  /// The resizable pane itself, blurred while this (or any sibling) handle is
-  /// being dragged. The handle is rendered separately so it stays sharp.
   private var resizableContent: some View {
     content
       .frame(width: resolvedWidth)
-      .blursWhileResizing()
   }
 
   private var handleSlot: some View {
     handle
       .opacity(isFixedWidth ? 0 : 1)
-      .frame(width: isFixedWidth ? 0 : 8)
-      .clipped()
+      .frame(width: isFixedWidth ? 0 : TerminalPanelKit.SplitSizing.dividerDimension)
       .allowsHitTesting(!isFixedWidth)
       .accessibilityHidden(isFixedWidth)
   }
 
   private var handle: some View {
-    ResizableSplitHandle(
-      side: side,
-      width: $width,
-      minWidth: minWidth,
-      maxWidth: maxWidth,
-      defaultWidth: defaultWidth,
-      onDragEnd: { UserDefaults.standard.set(Double($0), forKey: userDefaultsKey) }
+    TerminalPanelSplitDivider(
+      axis: .horizontal,
+      lineOpacity: 0.25,
+      helpText: "Drag to resize panel. Double-click to reset.",
+      accessibilityLabel: "Resize panel",
+      movesRailWithDrag: false,
+      clampedTranslation: clampedDragTranslation,
+      onCommitResize: commitResize,
+      onDragTranslationChanged: { dragTranslation in
+        updatePreviewWidth(dragTranslation: dragTranslation)
+      },
+      onDragActivityChanged: { isActive in
+        setTerminalSelectionSuppression(isActive: isActive)
+      }
     )
+    .onTapGesture(count: 2) {
+      commitWidth(Self.clamped(defaultWidth, minWidth: minWidth, maxWidth: maxWidth))
+    }
+    .onDisappear {
+      setTerminalSelectionSuppression(isActive: false)
+    }
   }
 
   private static func clamped(_ width: CGFloat, minWidth: CGFloat, maxWidth: CGFloat) -> CGFloat {
     max(minWidth, min(maxWidth, width))
   }
-}
 
-// MARK: - ResizableSplitHandle
-
-/// Low-level vertical drag handle. Prefer ``ResizablePanelContainer`` unless you need
-/// direct binding access. Back `width` with `@State` in the immediate parent —
-/// never bind directly to `@AppStorage`, as that invalidates the entire view tree on
-/// every drag point and causes visible flickering.
-struct ResizableSplitHandle: View {
-
-  let side: ResizablePanelSide
-  @Binding var width: CGFloat
-  let minWidth: CGFloat
-  let maxWidth: CGFloat
-  let defaultWidth: CGFloat
-  /// Called once when the drag ends. Use to persist the value.
-  var onDragEnd: ((CGFloat) -> Void)? = nil
-
-  @State private var isDragging = false
-  @State private var isHovering = false
-  @State private var widthAtDragStart: CGFloat = 0
-  @State private var previewWidth: CGFloat?
-
-  private var resolvedWidth: CGFloat {
-    clamped(width)
+  private func clampedDragTranslation(_ dragTranslation: CGFloat) -> CGFloat {
+    let proposedWidth = width(from: dragTranslation)
+    let clampedWidth = Self.clamped(proposedWidth, minWidth: minWidth, maxWidth: maxWidth)
+    return translationDelta(forWidth: clampedWidth)
   }
 
-  private var previewWidthValue: CGFloat {
-    clamped(previewWidth ?? resolvedWidth)
+  private func commitResize(_ dragTranslation: CGFloat) {
+    let proposedWidth = width(from: dragTranslation)
+    let clampedWidth = Self.clamped(proposedWidth, minWidth: minWidth, maxWidth: maxWidth)
+    commitWidth(clampedWidth)
   }
 
-  private var previewOffset: CGFloat {
+  private func commitWidth(_ newWidth: CGFloat) {
+    previewWidth = nil
+    width = newWidth
+    UserDefaults.standard.set(Double(newWidth), forKey: userDefaultsKey)
+  }
+
+  private func width(from translation: CGFloat) -> CGFloat {
     switch side {
     case .leading:
-      previewWidthValue - resolvedWidth
+      return committedWidth + translation
     case .trailing:
-      resolvedWidth - previewWidthValue
+      return committedWidth - translation
     }
   }
 
-  var body: some View {
-    ZStack {
-      Color.clear
-      Rectangle()
-        .fill(resizableDividerColor(isDragging: isDragging, isHovering: isHovering))
-        .frame(width: resizableDividerThickness(isDragging: isDragging, isHovering: isHovering))
+  private func translationDelta(forWidth newWidth: CGFloat) -> CGFloat {
+    switch side {
+    case .leading:
+      return newWidth - committedWidth
+    case .trailing:
+      return committedWidth - newWidth
     }
-    .frame(width: 8)
-    .contentShape(Rectangle())
-    .onHover { updateCursor(isHovering: $0) }
-    .gesture(dragGesture)
-    .overlay(alignment: side == .trailing ? .leading : .trailing) {
-      if isDragging {
-        previewGuide
-          .offset(x: previewOffset)
-          .allowsHitTesting(false)
-      }
-    }
-    .onTapGesture(count: 2) {
-      let resetWidth = clamped(defaultWidth)
+  }
+
+  private func updatePreviewWidth(dragTranslation: CGFloat?) {
+    guard let dragTranslation else {
       previewWidth = nil
-      withAnimation(.easeInOut(duration: 0.18)) { width = resetWidth }
-      onDragEnd?(resetWidth)
+      return
     }
-    .help("Drag to resize. Double-click to reset.")
-    .zIndex(isDragging ? 20 : 10)
-    .onDisappear {
-      if isDragging {
-        ResizeInteractionSuppression.shared.endResize()
-        ResizeInteractionState.shared.endResize()
-      }
-      isDragging = false
-      previewWidth = nil
-      updateCursor(isHovering: false)
+
+    previewWidth = Self.clamped(width(from: dragTranslation), minWidth: minWidth, maxWidth: maxWidth)
+  }
+
+  private func setTerminalSelectionSuppression(isActive: Bool) {
+    guard isActive != isSuppressingTerminalSelection else { return }
+    isSuppressingTerminalSelection = isActive
+
+    if isActive {
+      ResizeInteractionSuppression.shared.beginResize()
+    } else {
+      ResizeInteractionSuppression.shared.endResize()
     }
-    .animation(.easeInOut(duration: 0.18), value: isDragging)
-  }
-
-  private var previewGuide: some View {
-    ZStack(alignment: .top) {
-      Rectangle()
-        .fill(Color.accentColor.opacity(0.95))
-        .frame(width: 3)
-
-      Text("\(Int(previewWidthValue.rounded()))")
-        .font(.system(.caption2, design: .monospaced))
-        .foregroundColor(.accentColor)
-        .padding(.horizontal, 6)
-        .padding(.vertical, 3)
-        .background(
-          Capsule()
-            .fill(Color(nsColor: .windowBackgroundColor).opacity(0.95))
-        )
-        .overlay(
-          Capsule()
-            .stroke(Color.accentColor.opacity(0.35), lineWidth: 1)
-        )
-        .offset(x: side == .trailing ? -12 : 12, y: 10)
-    }
-    .frame(maxHeight: .infinity)
-  }
-
-  private var dragGesture: some Gesture {
-    DragGesture(minimumDistance: 0)
-      .onChanged { value in
-        if !isDragging {
-          isDragging = true
-          widthAtDragStart = resolvedWidth
-          ResizeInteractionSuppression.shared.beginResize()
-          ResizeInteractionState.shared.beginResize()
-        }
-
-        let translatedWidth: CGFloat
-        switch side {
-        case .leading:
-          translatedWidth = widthAtDragStart + value.translation.width
-        case .trailing:
-          translatedWidth = widthAtDragStart - value.translation.width
-        }
-
-        previewWidth = clamped(translatedWidth)
-      }
-      .onEnded { _ in
-        let finalWidth = previewWidthValue
-        width = finalWidth
-        isDragging = false
-        previewWidth = nil
-        ResizeInteractionSuppression.shared.endResize()
-        ResizeInteractionState.shared.endResize()
-        onDragEnd?(finalWidth)
-      }
-  }
-
-  private func updateCursor(isHovering: Bool) {
-    guard isHovering != self.isHovering else { return }
-    self.isHovering = isHovering
-    if isHovering { NSCursor.resizeLeftRight.push() } else { NSCursor.pop() }
-  }
-
-  private func clamped(_ width: CGFloat) -> CGFloat {
-    max(minWidth, min(maxWidth, width))
   }
 }

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/TerminalPanelSplitDivider.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/TerminalPanelSplitDivider.swift
@@ -8,23 +8,13 @@ import SwiftUI
 
 @MainActor
 public struct TerminalPanelSplitDivider: View {
-  private struct DragState: Equatable {
-    var isActive = false
-    var translation: CGFloat = 0
-  }
-
-  @GestureState private var dragState = DragState()
-  @State private var isHovering = false
-  @State private var cursorIsPushed = false
-
   private let axis: TerminalPanelKit.SplitAxis
   private let lineOpacity: Double
   private let helpText: String
   private let accessibilityLabel: String
-  private let movesRailWithDrag: Bool
   private let clampedTranslation: (CGFloat) -> CGFloat
   private let onCommitResize: (CGFloat) -> Void
-  private let onDragTranslationChanged: (CGFloat?) -> Void
+  private let onDoubleClick: (() -> Void)?
   private let onDragActivityChanged: (Bool) -> Void
 
   public init(
@@ -32,155 +22,400 @@ public struct TerminalPanelSplitDivider: View {
     lineOpacity: Double,
     helpText: String = "Drag to resize terminal panes",
     accessibilityLabel: String = "Resize terminal panes",
-    movesRailWithDrag: Bool = true,
     clampedTranslation: @escaping (CGFloat) -> CGFloat,
     onCommitResize: @escaping (CGFloat) -> Void,
-    onDragTranslationChanged: @escaping (CGFloat?) -> Void = { _ in },
+    onDoubleClick: (() -> Void)? = nil,
     onDragActivityChanged: @escaping (Bool) -> Void = { _ in }
   ) {
     self.axis = axis
     self.lineOpacity = lineOpacity
     self.helpText = helpText
     self.accessibilityLabel = accessibilityLabel
-    self.movesRailWithDrag = movesRailWithDrag
     self.clampedTranslation = clampedTranslation
     self.onCommitResize = onCommitResize
-    self.onDragTranslationChanged = onDragTranslationChanged
+    self.onDoubleClick = onDoubleClick
     self.onDragActivityChanged = onDragActivityChanged
   }
 
   public var body: some View {
-    hitTarget
-      .help(helpText)
-      .onChange(of: isDragActive) { _, isDragActive in
-        onDragActivityChanged(isDragActive)
-        if !isDragActive {
-          onDragTranslationChanged(nil)
-        }
-        updateCursor(isActive: isHovering || isDragActive)
-      }
-      .onChange(of: dragTranslation) { _, dragTranslation in
-        guard isDragActive else { return }
-        onDragTranslationChanged(clampedTranslation(dragTranslation))
-      }
-      .onDisappear {
-        onDragTranslationChanged(nil)
-        onDragActivityChanged(false)
-        updateCursor(isActive: false)
-      }
-  }
-
-  private var hitTarget: some View {
-    ZStack {
-      Color.clear
-        .contentShape(Rectangle())
-
-      dividerRule
-
-      if isIntentVisible {
-        hoverRail
-      }
-    }
+    TerminalPanelSplitDividerRepresentable(
+      axis: axis,
+      lineOpacity: lineOpacity,
+      helpText: helpText,
+      accessibilityLabel: accessibilityLabel,
+      clampedTranslation: clampedTranslation,
+      onCommitResize: onCommitResize,
+      onDoubleClick: onDoubleClick,
+      onDragActivityChanged: onDragActivityChanged
+    )
     .frame(
       width: axis == .horizontal ? TerminalPanelKit.SplitSizing.dividerDimension : nil,
       height: axis == .vertical ? TerminalPanelKit.SplitSizing.dividerDimension : nil
     )
-    .gesture(dragGesture)
-    .accessibilityElement()
-    .accessibilityLabel(accessibilityLabel)
-    .onHover { hovering in
-      isHovering = hovering
-      updateCursor(isActive: hovering || isDragActive)
+  }
+}
+
+@MainActor
+private struct TerminalPanelSplitDividerRepresentable: NSViewRepresentable {
+  let axis: TerminalPanelKit.SplitAxis
+  let lineOpacity: Double
+  let helpText: String
+  let accessibilityLabel: String
+  let clampedTranslation: (CGFloat) -> CGFloat
+  let onCommitResize: (CGFloat) -> Void
+  let onDoubleClick: (() -> Void)?
+  let onDragActivityChanged: (Bool) -> Void
+
+  func makeNSView(context: Context) -> TerminalPanelSplitDividerView {
+    let view = TerminalPanelSplitDividerView()
+    updateNSView(view, context: context)
+    return view
+  }
+
+  func updateNSView(_ nsView: TerminalPanelSplitDividerView, context: Context) {
+    nsView.configure(
+      axis: axis,
+      lineOpacity: lineOpacity,
+      helpText: helpText,
+      accessibilityLabel: accessibilityLabel,
+      clampedTranslation: clampedTranslation,
+      onCommitResize: onCommitResize,
+      onDoubleClick: onDoubleClick,
+      onDragActivityChanged: onDragActivityChanged
+    )
+  }
+
+  static func dismantleNSView(_ nsView: TerminalPanelSplitDividerView, coordinator: ()) {
+    nsView.cancelInteraction()
+  }
+}
+
+@MainActor
+private final class TerminalPanelSplitDividerView: NSView {
+  private let dividerRuleLayer = CALayer()
+  private let railLayer = CALayer()
+  private let railStrokeLayer = CAShapeLayer()
+
+  private var axis: TerminalPanelKit.SplitAxis = .horizontal
+  private var lineOpacity: Double = 0.25
+  private var accessibilityLabelText = "Resize terminal panes"
+  private var clampedTranslation: (CGFloat) -> CGFloat = { $0 }
+  private var onCommitResize: (CGFloat) -> Void = { _ in }
+  private var onDoubleClick: (() -> Void)?
+  private var onDragActivityChanged: (Bool) -> Void = { _ in }
+
+  private var trackingArea: NSTrackingArea?
+  private var isHovering = false
+  private var isDragging = false
+  private var dragStartLocation: CGPoint?
+  private var displayedTranslation: CGFloat = 0
+  private var railTargetLocationInWindow: CGPoint?
+
+  override init(frame frameRect: NSRect) {
+    super.init(frame: frameRect)
+    setupLayers()
+  }
+
+  required init?(coder: NSCoder) {
+    super.init(coder: coder)
+    setupLayers()
+  }
+
+  override var acceptsFirstResponder: Bool {
+    true
+  }
+
+  override var isFlipped: Bool {
+    true
+  }
+
+  override func acceptsFirstMouse(for event: NSEvent?) -> Bool {
+    true
+  }
+
+  func configure(
+    axis: TerminalPanelKit.SplitAxis,
+    lineOpacity: Double,
+    helpText: String,
+    accessibilityLabel: String,
+    clampedTranslation: @escaping (CGFloat) -> CGFloat,
+    onCommitResize: @escaping (CGFloat) -> Void,
+    onDoubleClick: (() -> Void)?,
+    onDragActivityChanged: @escaping (Bool) -> Void
+  ) {
+    self.axis = axis
+    self.lineOpacity = lineOpacity
+    self.toolTip = helpText
+    self.accessibilityLabelText = accessibilityLabel
+    self.clampedTranslation = clampedTranslation
+    self.onCommitResize = onCommitResize
+    self.onDoubleClick = onDoubleClick
+    self.onDragActivityChanged = onDragActivityChanged
+    needsLayout = true
+    window?.invalidateCursorRects(for: self)
+    updateLayerAppearance()
+  }
+
+  func cancelInteraction() {
+    guard isDragging else { return }
+    isDragging = false
+    dragStartLocation = nil
+    displayedTranslation = 0
+    railTargetLocationInWindow = nil
+    onDragActivityChanged(false)
+    updateLayerAppearance()
+    needsLayout = true
+  }
+
+  override func updateTrackingAreas() {
+    super.updateTrackingAreas()
+
+    if let trackingArea {
+      removeTrackingArea(trackingArea)
     }
+
+    let options: NSTrackingArea.Options = [
+      .activeInActiveApp,
+      .inVisibleRect,
+      .mouseEnteredAndExited
+    ]
+    let newTrackingArea = NSTrackingArea(rect: bounds, options: options, owner: self, userInfo: nil)
+    addTrackingArea(newTrackingArea)
+    trackingArea = newTrackingArea
   }
 
-  private var dividerRule: some View {
-    Rectangle()
-      .fill(Color.primary.opacity(isIntentVisible ? max(lineOpacity, 0.42) : lineOpacity))
-      .frame(
-        width: axis == .horizontal ? TerminalPanelKit.SplitSizing.dividerRuleDimension : nil,
-        height: axis == .vertical ? TerminalPanelKit.SplitSizing.dividerRuleDimension : nil
-      )
-      .frame(
-        maxWidth: axis == .vertical ? .infinity : nil,
-        maxHeight: axis == .horizontal ? .infinity : nil
-      )
+  override func resetCursorRects() {
+    super.resetCursorRects()
+    addCursorRect(bounds, cursor: cursor)
   }
 
-  private var hoverRail: some View {
-    RoundedRectangle(cornerRadius: TerminalPanelKit.SplitSizing.dividerHoverRailDimension / 2)
-      .fill(Color.primary.opacity(isDragActive ? 0.28 : 0.18))
-      .overlay {
-        RoundedRectangle(cornerRadius: TerminalPanelKit.SplitSizing.dividerHoverRailDimension / 2)
-          .stroke(Color.white.opacity(isDragActive ? 0.16 : 0.1), lineWidth: 1)
-      }
-      .frame(
-        width: axis == .horizontal ? TerminalPanelKit.SplitSizing.dividerHoverRailDimension : nil,
-        height: axis == .vertical ? TerminalPanelKit.SplitSizing.dividerHoverRailDimension : nil
-      )
-      .frame(
-        maxWidth: axis == .vertical ? .infinity : nil,
-        maxHeight: axis == .horizontal ? .infinity : nil
-      )
-      .offset(
-        x: axis == .horizontal ? visualDragTranslation : 0,
-        y: axis == .vertical ? visualDragTranslation : 0
-      )
+  override func mouseEntered(with event: NSEvent) {
+    isHovering = true
+    updateLayerAppearance()
   }
 
-  private var dragGesture: some Gesture {
-    DragGesture(minimumDistance: 1)
-      .updating($dragState) { value, state, _ in
-        state = DragState(isActive: true, translation: rawTranslation(from: value))
-      }
-      .onEnded { value in
-        onCommitResize(clampedTranslation(rawTranslation(from: value)))
-        onDragTranslationChanged(nil)
-      }
+  override func mouseExited(with event: NSEvent) {
+    isHovering = false
+    updateLayerAppearance()
   }
 
-  private var dragTranslation: CGFloat {
-    dragState.translation
-  }
-
-  private var isDragActive: Bool {
-    dragState.isActive
-  }
-
-  private var isIntentVisible: Bool {
-    isHovering || isDragActive
-  }
-
-  private var visualDragTranslation: CGFloat {
-    movesRailWithDrag ? clampedTranslation(dragTranslation) : 0
-  }
-
-  private func rawTranslation(from value: DragGesture.Value) -> CGFloat {
-    switch axis {
-    case .horizontal:
-      return value.translation.width
-    case .vertical:
-      return value.translation.height
+  override func mouseDown(with event: NSEvent) {
+    if event.clickCount == 2, let onDoubleClick {
+      cancelInteraction()
+      onDoubleClick()
+      return
     }
+
+    window?.makeFirstResponder(self)
+    isDragging = true
+    railTargetLocationInWindow = nil
+    dragStartLocation = convert(event.locationInWindow, from: nil)
+    displayedTranslation = 0
+    onDragActivityChanged(true)
+    updateLayerAppearance()
+    needsLayout = true
   }
 
-  private func updateCursor(isActive: Bool) {
-    if isActive {
-      guard !cursorIsPushed else { return }
-      resizeCursor.push()
-      cursorIsPushed = true
-    } else if cursorIsPushed {
-      NSCursor.pop()
-      cursorIsPushed = false
+  override func mouseDragged(with event: NSEvent) {
+    guard let dragStartLocation else { return }
+    let currentLocation = convert(event.locationInWindow, from: nil)
+    displayedTranslation = clampedTranslation(rawTranslation(from: dragStartLocation, to: currentLocation))
+    railTargetLocationInWindow = nil
+    updateLayerFrames()
+  }
+
+  override func mouseUp(with event: NSEvent) {
+    guard let dragStartLocation else {
+      cancelInteraction()
+      return
     }
+
+    let currentLocation = convert(event.locationInWindow, from: nil)
+    let committedTranslation = clampedTranslation(rawTranslation(from: dragStartLocation, to: currentLocation))
+    displayedTranslation = committedTranslation
+    railTargetLocationInWindow = railTargetLocationInWindow(for: committedTranslation)
+    updateLayerFrames()
+
+    var transaction = Transaction()
+    transaction.disablesAnimations = true
+    withTransaction(transaction) {
+      onCommitResize(committedTranslation)
+    }
+
+    isDragging = false
+    self.dragStartLocation = nil
+    onDragActivityChanged(false)
+    updateLayerAppearance()
+    needsLayout = true
   }
 
-  private var resizeCursor: NSCursor {
+  override func layout() {
+    super.layout()
+    updateDisplayedTranslationFromRailTarget()
+    updateLayerFrames()
+  }
+
+  override func viewDidChangeEffectiveAppearance() {
+    super.viewDidChangeEffectiveAppearance()
+    updateLayerAppearance()
+  }
+
+  override func isAccessibilityElement() -> Bool {
+    true
+  }
+
+  override func accessibilityRole() -> NSAccessibility.Role? {
+    .splitter
+  }
+
+  override func accessibilityLabel() -> String? {
+    accessibilityLabelText
+  }
+
+  private func setupLayers() {
+    wantsLayer = true
+    layer?.backgroundColor = NSColor.clear.cgColor
+
+    dividerRuleLayer.actions = disabledLayerActions
+    railLayer.actions = disabledLayerActions
+    railStrokeLayer.actions = disabledLayerActions
+
+    railLayer.masksToBounds = true
+    railLayer.addSublayer(railStrokeLayer)
+
+    layer?.addSublayer(dividerRuleLayer)
+    layer?.addSublayer(railLayer)
+
+    updateLayerAppearance()
+  }
+
+  private var disabledLayerActions: [String: NSNull] {
+    [
+      "bounds": NSNull(),
+      "position": NSNull(),
+      "frame": NSNull(),
+      "backgroundColor": NSNull(),
+      "hidden": NSNull(),
+      "opacity": NSNull(),
+      "path": NSNull()
+    ]
+  }
+
+  private var cursor: NSCursor {
     switch axis {
     case .horizontal:
       return .resizeLeftRight
     case .vertical:
       return .resizeUpDown
+    }
+  }
+
+  private var isIntentVisible: Bool {
+    isHovering || isDragging || railTargetLocationInWindow != nil
+  }
+
+  private var isStationaryRuleHidden: Bool {
+    isDragging || railTargetLocationInWindow != nil
+  }
+
+  private func rawTranslation(from start: CGPoint, to current: CGPoint) -> CGFloat {
+    switch axis {
+    case .horizontal:
+      return current.x - start.x
+    case .vertical:
+      return current.y - start.y
+    }
+  }
+
+  private func updateLayerAppearance() {
+    let ruleOpacity = isIntentVisible ? max(lineOpacity, 0.42) : lineOpacity
+    dividerRuleLayer.isHidden = isStationaryRuleHidden
+    dividerRuleLayer.backgroundColor = NSColor.labelColor
+      .withAlphaComponent(CGFloat(ruleOpacity))
+      .cgColor
+
+    railLayer.isHidden = !isIntentVisible
+    railLayer.backgroundColor = NSColor.labelColor
+      .withAlphaComponent(isDragging ? 0.28 : 0.18)
+      .cgColor
+
+    railStrokeLayer.strokeColor = NSColor.white
+      .withAlphaComponent(isDragging ? 0.16 : 0.1)
+      .cgColor
+    railStrokeLayer.fillColor = NSColor.clear.cgColor
+  }
+
+  private func updateLayerFrames() {
+    let ruleDimension = TerminalPanelKit.SplitSizing.dividerRuleDimension
+    let railDimension = TerminalPanelKit.SplitSizing.dividerHoverRailDimension
+
+    switch axis {
+    case .horizontal:
+      dividerRuleLayer.frame = CGRect(
+        x: bounds.midX - ruleDimension / 2,
+        y: 0,
+        width: ruleDimension,
+        height: bounds.height
+      )
+      railLayer.frame = CGRect(
+        x: bounds.midX - railDimension / 2 + displayedTranslation,
+        y: 0,
+        width: railDimension,
+        height: bounds.height
+      )
+    case .vertical:
+      dividerRuleLayer.frame = CGRect(
+        x: 0,
+        y: bounds.midY - ruleDimension / 2,
+        width: bounds.width,
+        height: ruleDimension
+      )
+      railLayer.frame = CGRect(
+        x: 0,
+        y: bounds.midY - railDimension / 2 + displayedTranslation,
+        width: bounds.width,
+        height: railDimension
+      )
+    }
+
+    railLayer.cornerRadius = railDimension / 2
+    railStrokeLayer.frame = railLayer.bounds
+    railStrokeLayer.path = CGPath(
+      roundedRect: railLayer.bounds,
+      cornerWidth: railDimension / 2,
+      cornerHeight: railDimension / 2,
+      transform: nil
+    )
+  }
+
+  private func railTargetLocationInWindow(for translation: CGFloat) -> CGPoint {
+    let center = convert(CGPoint(x: bounds.midX, y: bounds.midY), to: nil)
+    switch axis {
+    case .horizontal:
+      return CGPoint(x: center.x + translation, y: center.y)
+    case .vertical:
+      return CGPoint(x: center.x, y: center.y + translation)
+    }
+  }
+
+  private func updateDisplayedTranslationFromRailTarget() {
+    guard !isDragging, let railTargetLocationInWindow else { return }
+
+    let center = convert(CGPoint(x: bounds.midX, y: bounds.midY), to: nil)
+    let translation: CGFloat
+    switch axis {
+    case .horizontal:
+      translation = railTargetLocationInWindow.x - center.x
+    case .vertical:
+      translation = railTargetLocationInWindow.y - center.y
+    }
+
+    if abs(translation) <= 0.5 {
+      displayedTranslation = 0
+      self.railTargetLocationInWindow = nil
+      updateLayerAppearance()
+    } else {
+      displayedTranslation = translation
     }
   }
 }

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/TerminalPanelSplitDivider.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/TerminalPanelSplitDivider.swift
@@ -8,34 +8,64 @@ import SwiftUI
 
 @MainActor
 public struct TerminalPanelSplitDivider: View {
-  @GestureState private var dragTranslation: CGFloat = 0
+  private struct DragState: Equatable {
+    var isActive = false
+    var translation: CGFloat = 0
+  }
+
+  @GestureState private var dragState = DragState()
   @State private var isHovering = false
   @State private var cursorIsPushed = false
 
   private let axis: TerminalPanelKit.SplitAxis
   private let lineOpacity: Double
+  private let helpText: String
+  private let accessibilityLabel: String
+  private let movesRailWithDrag: Bool
   private let clampedTranslation: (CGFloat) -> CGFloat
   private let onCommitResize: (CGFloat) -> Void
+  private let onDragTranslationChanged: (CGFloat?) -> Void
+  private let onDragActivityChanged: (Bool) -> Void
 
   public init(
     axis: TerminalPanelKit.SplitAxis,
     lineOpacity: Double,
+    helpText: String = "Drag to resize terminal panes",
+    accessibilityLabel: String = "Resize terminal panes",
+    movesRailWithDrag: Bool = true,
     clampedTranslation: @escaping (CGFloat) -> CGFloat,
-    onCommitResize: @escaping (CGFloat) -> Void
+    onCommitResize: @escaping (CGFloat) -> Void,
+    onDragTranslationChanged: @escaping (CGFloat?) -> Void = { _ in },
+    onDragActivityChanged: @escaping (Bool) -> Void = { _ in }
   ) {
     self.axis = axis
     self.lineOpacity = lineOpacity
+    self.helpText = helpText
+    self.accessibilityLabel = accessibilityLabel
+    self.movesRailWithDrag = movesRailWithDrag
     self.clampedTranslation = clampedTranslation
     self.onCommitResize = onCommitResize
+    self.onDragTranslationChanged = onDragTranslationChanged
+    self.onDragActivityChanged = onDragActivityChanged
   }
 
   public var body: some View {
     hitTarget
-      .help("Drag to resize terminal panes")
+      .help(helpText)
       .onChange(of: isDragActive) { _, isDragActive in
+        onDragActivityChanged(isDragActive)
+        if !isDragActive {
+          onDragTranslationChanged(nil)
+        }
         updateCursor(isActive: isHovering || isDragActive)
       }
+      .onChange(of: dragTranslation) { _, dragTranslation in
+        guard isDragActive else { return }
+        onDragTranslationChanged(clampedTranslation(dragTranslation))
+      }
       .onDisappear {
+        onDragTranslationChanged(nil)
+        onDragActivityChanged(false)
         updateCursor(isActive: false)
       }
   }
@@ -57,7 +87,7 @@ public struct TerminalPanelSplitDivider: View {
     )
     .gesture(dragGesture)
     .accessibilityElement()
-    .accessibilityLabel("Resize terminal panes")
+    .accessibilityLabel(accessibilityLabel)
     .onHover { hovering in
       isHovering = hovering
       updateCursor(isActive: hovering || isDragActive)
@@ -93,27 +123,36 @@ public struct TerminalPanelSplitDivider: View {
         maxHeight: axis == .horizontal ? .infinity : nil
       )
       .offset(
-        x: axis == .horizontal ? clampedTranslation(dragTranslation) : 0,
-        y: axis == .vertical ? clampedTranslation(dragTranslation) : 0
+        x: axis == .horizontal ? visualDragTranslation : 0,
+        y: axis == .vertical ? visualDragTranslation : 0
       )
   }
 
   private var dragGesture: some Gesture {
     DragGesture(minimumDistance: 1)
-      .updating($dragTranslation) { value, state, _ in
-        state = rawTranslation(from: value)
+      .updating($dragState) { value, state, _ in
+        state = DragState(isActive: true, translation: rawTranslation(from: value))
       }
       .onEnded { value in
         onCommitResize(clampedTranslation(rawTranslation(from: value)))
+        onDragTranslationChanged(nil)
       }
   }
 
+  private var dragTranslation: CGFloat {
+    dragState.translation
+  }
+
   private var isDragActive: Bool {
-    dragTranslation != 0
+    dragState.isActive
   }
 
   private var isIntentVisible: Bool {
     isHovering || isDragActive
+  }
+
+  private var visualDragTranslation: CGFloat {
+    movesRailWithDrag ? clampedTranslation(dragTranslation) : 0
   }
 
   private func rawTranslation(from value: DragGesture.Value) -> CGFloat {

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/WebPreviewView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/WebPreviewView.swift
@@ -649,7 +649,6 @@ public struct WebPreviewView: View {
     HStack(spacing: 0) {
       previewContent
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .blursWhileResizing()
 
       if showsInspectorRail {
         ResizablePanelContainer(


### PR DESCRIPTION
Summary
- Replace the embedded right-panel resize handle with the smoother AppKit-backed terminal split divider behavior.
- Commit panel width only on mouse release while keeping the moving rail visually responsive during drag.
- Add resize-obscuring material overlays over both the side panel and monitor card to hide expensive layout catch-up.
- Hide the stationary divider while the draggable rail is active so the rail reads as the divider being moved.
- Remove the redundant custom sidebar toolbar button and add full-width expansion support for MCP app panels.

Validation
- PASS: `xcodebuild test -scheme AgentHubCore-Tests -destination 'platform=macOS' -test-timeouts-enabled YES -skipPackagePluginValidation -only-testing:AgentHubTests/RegularTerminalWorkspaceTests` (18 tests)\n- PASS: `xcodebuild test -scheme AgentHubCore-Tests -destination 'platform=macOS' -test-timeouts-enabled YES -skipPackagePluginValidation -only-testing:AgentHubTests/MCPAppSidePanelViewTests` (13 tests)\n- PASS: `git diff --check`\n- FAIL: `./scripts/test.sh` failed in the full `AgentHubCore` gate on unrelated timing/headless tests: `DiffAvailabilityServiceTests/invalidateSucceedsAfterAdaptiveWindow()` and `WebPreviewResolverLaunchOptionsTests/noStaticFallbackWhenProjectHasNoHTML()`; package tests passed before the core failure.\n- FAIL: `./scripts/test.sh core` reproduced the same core-gate class of failures plus WebPreview resolver timeout behavior; targeted resize/MCP suites remained green.