### PR TITLE
Add simulator recording audit workflow

### DIFF
--- a/app/modules/AgentHubCLI/Sources/AgentHubCLI/AgentHubMCPServer.swift
+++ b/app/modules/AgentHubCLI/Sources/AgentHubCLI/AgentHubMCPServer.swift
@@ -6,6 +6,9 @@ struct AgentHubMCPServer {
   private let queue = WorktreeLaunchRequestQueue()
   private let deletionQueue = WorktreeDeletionRequestQueue()
   private let progressQueue = WorktreeProgressQueue()
+  private let simulatorContextStore = SimulatorSessionContextStore()
+  private let simulatorRunQueue = SimulatorRunRequestQueue()
+  private let simulatorRecordingService = SimulatorRecordingService()
 
   /// Hard ceiling on any single `tools/call`. Worktree creation normally
   /// completes in seconds and each underlying `git` invocation has its own
@@ -15,7 +18,8 @@ struct AgentHubMCPServer {
   /// tool-level error. Override with `AGENTHUB_MCP_TOOL_TIMEOUT_SECONDS`.
   private static let toolCallTimeout: Duration = {
     if let raw = ProcessInfo.processInfo.environment["AGENTHUB_MCP_TOOL_TIMEOUT_SECONDS"],
-       let seconds = Int(raw.trimmingCharacters(in: .whitespaces)), seconds > 0 {
+       let seconds = Int(raw.trimmingCharacters(in: .whitespaces)), seconds > 0
+    {
       return .seconds(seconds)
     }
     return .seconds(300)
@@ -32,7 +36,8 @@ struct AgentHubMCPServer {
     do {
       guard let data = line.data(using: .utf8),
             let object = try JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let method = object["method"] as? String else {
+            let method = object["method"] as? String
+      else {
         return
       }
 
@@ -45,12 +50,12 @@ struct AgentHubMCPServer {
         writeResponse(id: id, result: [
           "protocolVersion": protocolVersion,
           "capabilities": [
-            "tools": [:]
+            "tools": [:],
           ],
           "serverInfo": [
             "name": "agenthub",
-            "version": "1.0.0"
-          ]
+            "version": "1.0.0",
+          ],
         ])
 
       case "tools/list":
@@ -60,8 +65,11 @@ struct AgentHubMCPServer {
             createWorktreeSessionsToolSchema(),
             listWorktreesToolSchema(),
             deleteWorktreeToolSchema(),
-            planningToolSchema()
-          ]
+            planningToolSchema(),
+            simulatorStatusToolSchema(),
+            simulatorRunToolSchema(),
+            simulatorRecordToolSchema(),
+          ],
         ])
 
       case "tools/call":
@@ -122,7 +130,8 @@ struct AgentHubMCPServer {
 
   private func handleToolCall(params: [String: Any]?) async throws -> [String: Any] {
     guard let params,
-          let name = params["name"] as? String else {
+          let name = params["name"] as? String
+    else {
       throw MCPError.invalidRequest("Missing tool name.")
     }
     let arguments = params["arguments"] as? [String: Any] ?? [:]
@@ -154,6 +163,18 @@ struct AgentHubMCPServer {
     case "agent_hub_planning":
       let plan = try await buildDelegationPlan(arguments: arguments)
       return toolResult(text: planSummary(plan), structuredContent: planJSONObject(plan))
+
+    case "agenthub_simulator_status":
+      let status = try simulatorStatus(arguments: arguments)
+      return toolResult(text: status.summary, structuredContent: status.dictionary)
+
+    case "agenthub_simulator_run":
+      let result = try queueSimulatorRun(arguments: arguments)
+      return toolResult(text: result.summary, structuredContent: result.dictionary)
+
+    case "agenthub_simulator_record":
+      let result = try await recordSimulator(arguments: arguments)
+      return toolResult(text: result.summary, structuredContent: result.dictionary, isError: result.isError)
 
     default:
       throw MCPError.invalidRequest("Unknown AgentHub tool: \(name).")
@@ -388,6 +409,111 @@ struct AgentHubMCPServer {
     )
   }
 
+  private func simulatorStatus(arguments: [String: Any]) throws -> MCPSimulatorStatusResult {
+    let context = try simulatorContextStore.resolveContext(
+      provider: requestedSourceProvider(arguments: arguments),
+      sessionId: optionalString("sessionId", in: arguments) ?? sourceSessionId,
+      projectPath: simulatorProjectPath(arguments: arguments)
+    )
+    let contexts = try simulatorContextStore.contexts()
+    return MCPSimulatorStatusResult(activeContext: context, contexts: contexts)
+  }
+
+  private func queueSimulatorRun(arguments: [String: Any]) throws -> MCPSimulatorRunResult {
+    let target = try simulatorTarget(arguments: arguments, requiresProject: true)
+    guard let projectPath = target.projectPath else {
+      throw MCPError.invalidRequest("Missing simulator project path.")
+    }
+    let request = SimulatorRunRequest(
+      projectPath: projectPath,
+      udid: target.udid,
+      sourceProvider: sourceProvider,
+      sourceSessionId: sourceSessionId,
+      reason: optionalString("reason", in: arguments)
+    )
+    let queued = try simulatorRunQueue.enqueue(request)
+    return MCPSimulatorRunResult(
+      requestID: queued.request.id,
+      target: target,
+      context: target.context
+    )
+  }
+
+  private func recordSimulator(arguments: [String: Any]) async throws -> MCPSimulatorRecordResult {
+    let action = (optionalString("action", in: arguments) ?? "start").lowercased()
+    let target = try simulatorTarget(arguments: arguments, requiresProject: false)
+
+    switch action {
+    case "start":
+      let outputDirectory = optionalString("outputDirectory", in: arguments).map {
+        URL(fileURLWithPath: ($0 as NSString).expandingTildeInPath, isDirectory: true)
+      }
+      let started = try await simulatorRecordingService.startRecording(
+        udid: target.udid,
+        outputDirectory: outputDirectory,
+        fileName: optionalString("fileName", in: arguments)
+      )
+      return .started(started, target: target)
+
+    case "stop":
+      let result = try await simulatorRecordingService.stopRecording(udid: target.udid)
+      return .stopped(result, target: target)
+
+    default:
+      throw MCPError.invalidRequest("Invalid simulator recording action '\(action)'. Expected start or stop.")
+    }
+  }
+
+  private func simulatorTarget(arguments: [String: Any], requiresProject: Bool) throws -> MCPSimulatorTarget {
+    let explicitProjectPath = simulatorProjectPath(arguments: arguments)
+    if let explicitUDID = optionalString("udid", in: arguments), !explicitUDID.isEmpty {
+      if requiresProject {
+        guard let projectPath = explicitProjectPath, !projectPath.isEmpty else {
+          throw MCPError.invalidRequest("Pass projectPath/repo when using an explicit simulator udid.")
+        }
+        return MCPSimulatorTarget(udid: explicitUDID, projectPath: projectPath, context: nil)
+      }
+      return MCPSimulatorTarget(udid: explicitUDID, projectPath: explicitProjectPath, context: nil)
+    }
+
+    guard let context = try simulatorContextStore.resolveContext(
+      provider: requestedSourceProvider(arguments: arguments),
+      sessionId: optionalString("sessionId", in: arguments) ?? sourceSessionId,
+      projectPath: explicitProjectPath
+    ) else {
+      throw MCPError.invalidRequest(
+        "No AgentHub simulator panel context was found. Open the Simulator panel for this session, or pass an explicit udid."
+      )
+    }
+
+    return MCPSimulatorTarget(
+      udid: context.udid,
+      projectPath: context.projectPath,
+      context: context
+    )
+  }
+
+  private var sourceProvider: WorktreeLaunchProvider? {
+    ProcessInfo.processInfo.environment["AGENTHUB_PROVIDER"]
+      .flatMap(WorktreeLaunchProvider.init(commandLineValue:))
+  }
+
+  private var sourceSessionId: String? {
+    ProcessInfo.processInfo.environment["AGENTHUB_SESSION_ID"]
+  }
+
+  private func requestedSourceProvider(arguments: [String: Any]) -> WorktreeLaunchProvider? {
+    optionalString("provider", in: arguments)
+      .flatMap(WorktreeLaunchProvider.init(commandLineValue:))
+      ?? sourceProvider
+  }
+
+  private func simulatorProjectPath(arguments: [String: Any]) -> String? {
+    optionalString("projectPath", in: arguments)
+      ?? optionalString("repo", in: arguments)
+      ?? ProcessInfo.processInfo.environment["AGENTHUB_PROJECT_PATH"]
+  }
+
   private func planSummary(_ plan: DelegationPlan) -> String {
     var lines = ["Delegation plan: \(plan.assignments.count) subtask(s)."]
     for assignment in plan.assignments {
@@ -408,7 +534,7 @@ struct AgentHubMCPServer {
       [
         "provider": cli.provider.commandLineValue,
         "harness": cli.provider.harnessName,
-        "executablePath": cli.executablePath
+        "executablePath": cli.executablePath,
       ]
     }
 
@@ -417,7 +543,7 @@ struct AgentHubMCPServer {
         "provider": capability.provider.commandLineValue,
         "harness": capability.provider.harnessName,
         "skills": capability.skills.map { ["name": $0.name, "description": $0.description] },
-        "mcpServers": capability.mcpServers
+        "mcpServers": capability.mcpServers,
       ]
     }
 
@@ -427,11 +553,11 @@ struct AgentHubMCPServer {
           "id": assignment.subtask.id,
           "title": assignment.subtask.title,
           "detail": assignment.subtask.detail,
-          "tags": tags(assignment.subtask.tags)
+          "tags": tags(assignment.subtask.tags),
         ],
         "rationale": assignment.rationale,
         "instructions": assignment.instructions,
-        "branchSuggestion": assignment.branchSuggestion
+        "branchSuggestion": assignment.branchSuggestion,
       ]
       if let provider = assignment.assignedProvider {
         value["assignedProvider"] = provider.commandLineValue
@@ -448,7 +574,7 @@ struct AgentHubMCPServer {
       "detectedCLIs": detectedCLIs,
       "harnessCapabilities": harnessCapabilities,
       "assignments": assignments,
-      "notes": plan.notes
+      "notes": plan.notes,
     ]
     if let repositoryPath = plan.repositoryPath {
       result["repositoryPath"] = repositoryPath
@@ -489,7 +615,8 @@ struct AgentHubMCPServer {
     }
 
     if let provider = ProcessInfo.processInfo.environment["AGENTHUB_PROVIDER"]
-      .flatMap(WorktreeLaunchProvider.init(commandLineValue:)) {
+      .flatMap(WorktreeLaunchProvider.init(commandLineValue:))
+    {
       return provider
     }
 
@@ -555,11 +682,11 @@ struct AgentHubMCPServer {
       "content": [
         [
           "type": "text",
-          "text": text
-        ]
+          "text": text,
+        ],
       ],
       "structuredContent": structuredContent,
-      "isError": isError
+      "isError": isError,
     ]
   }
 
@@ -572,12 +699,12 @@ struct AgentHubMCPServer {
         "properties": [
           "repo": [
             "type": "string",
-            "description": "Repository path applied to every task unless a task overrides it. Defaults to AGENTHUB_PROJECT_PATH."
+            "description": "Repository path applied to every task unless a task overrides it. Defaults to AGENTHUB_PROJECT_PATH.",
           ],
           "provider": [
             "type": "string",
             "enum": ["claude", "codex"],
-            "description": "Provider applied to every task unless a task overrides it."
+            "description": "Provider applied to every task unless a task overrides it.",
           ],
           "tasks": [
             "type": "array",
@@ -590,19 +717,19 @@ struct AgentHubMCPServer {
                 "provider": [
                   "type": "string",
                   "enum": ["claude", "codex"],
-                  "description": "Agent/provider assigned to this task."
+                  "description": "Agent/provider assigned to this task.",
                 ],
                 "from": ["type": "string"],
-                "checkoutExisting": ["type": "boolean"]
+                "checkoutExisting": ["type": "boolean"],
               ],
               "required": ["branch", "prompt", "provider"],
-              "additionalProperties": false
-            ]
-          ]
+              "additionalProperties": false,
+            ],
+          ],
         ],
         "required": ["tasks"],
-        "additionalProperties": false
-      ]
+        "additionalProperties": false,
+      ],
     ]
   }
 
@@ -615,11 +742,11 @@ struct AgentHubMCPServer {
         "properties": [
           "repo": [
             "type": "string",
-            "description": "Optional repository or worktree path. Defaults to AGENTHUB_PROJECT_PATH, then the MCP server current working directory."
-          ]
+            "description": "Optional repository or worktree path. Defaults to AGENTHUB_PROJECT_PATH, then the MCP server current working directory.",
+          ],
         ],
-        "additionalProperties": false
-      ]
+        "additionalProperties": false,
+      ],
     ]
   }
 
@@ -632,24 +759,24 @@ struct AgentHubMCPServer {
         "properties": [
           "target": [
             "type": "string",
-            "description": "Exact worktree path, branch name, or worktree directory name from agenthub_list_worktrees. The main repository entry cannot be deleted."
+            "description": "Exact worktree path, branch name, or worktree directory name from agenthub_list_worktrees. The main repository entry cannot be deleted.",
           ],
           "repo": [
             "type": "string",
-            "description": "Optional repository or worktree path used to resolve the main repository root. Defaults to AGENTHUB_PROJECT_PATH."
+            "description": "Optional repository or worktree path used to resolve the main repository root. Defaults to AGENTHUB_PROJECT_PATH.",
           ],
           "force": [
             "type": "boolean",
-            "description": "When true, force-removes the worktree even if git reports untracked or modified files."
+            "description": "When true, force-removes the worktree even if git reports untracked or modified files.",
           ],
           "deleteAssociatedBranch": [
             "type": "boolean",
-            "description": "When true, also deletes the local branch checked out in the worktree. Defaults to false."
-          ]
+            "description": "When true, also deletes the local branch checked out in the worktree. Defaults to false.",
+          ],
         ],
         "required": ["target"],
-        "additionalProperties": false
-      ]
+        "additionalProperties": false,
+      ],
     ]
   }
 
@@ -662,21 +789,126 @@ struct AgentHubMCPServer {
         "properties": [
           "prompt": [
             "type": "string",
-            "description": "The full bundled, multi-part request to plan and delegate."
+            "description": "The full bundled, multi-part request to plan and delegate.",
           ],
           "subtasks": [
             "type": "array",
             "items": ["type": "string"],
-            "description": "The independent subtasks you inferred from the request, one entry per task. When omitted, AgentHub plans the whole prompt as a single task — it never statically splits prose or lists."
+            "description": "The independent subtasks you inferred from the request, one entry per task. When omitted, AgentHub plans the whole prompt as a single task — it never statically splits prose or lists.",
           ],
           "repo": [
             "type": "string",
-            "description": "Optional repository path for context. Defaults to AGENTHUB_PROJECT_PATH."
-          ]
+            "description": "Optional repository path for context. Defaults to AGENTHUB_PROJECT_PATH.",
+          ],
         ],
         "required": ["prompt"],
-        "additionalProperties": false
-      ]
+        "additionalProperties": false,
+      ],
+    ]
+  }
+
+  private func simulatorStatusToolSchema() -> [String: Any] {
+    [
+      "name": "agenthub_simulator_status",
+      "description": "Returns the iOS Simulator target currently displayed by AgentHub's Simulator panel for this agent session/project. Use this before running simctl yourself so verification targets the same device the user is viewing.",
+      "inputSchema": [
+        "type": "object",
+        "properties": [
+          "sessionId": [
+            "type": "string",
+            "description": "Optional AgentHub session id. Defaults to AGENTHUB_SESSION_ID.",
+          ],
+          "provider": [
+            "type": "string",
+            "enum": ["claude", "codex"],
+            "description": "Optional provider used to disambiguate the session.",
+          ],
+          "projectPath": [
+            "type": "string",
+            "description": "Optional project path. Defaults to AGENTHUB_PROJECT_PATH.",
+          ],
+          "repo": [
+            "type": "string",
+            "description": "Alias for projectPath.",
+          ],
+        ],
+        "additionalProperties": false,
+      ],
+    ]
+  }
+
+  private func simulatorRunToolSchema() -> [String: Any] {
+    [
+      "name": "agenthub_simulator_run",
+      "description": "Queues AgentHub to Build & Run the current project on the same simulator device shown in the AgentHub Simulator panel. Prefer this over launching a random booted simulator from the terminal.",
+      "inputSchema": [
+        "type": "object",
+        "properties": [
+          "udid": [
+            "type": "string",
+            "description": "Optional simulator UDID. Defaults to the AgentHub Simulator panel target.",
+          ],
+          "projectPath": [
+            "type": "string",
+            "description": "Optional Xcode project repository path. Defaults to the panel context or AGENTHUB_PROJECT_PATH.",
+          ],
+          "repo": [
+            "type": "string",
+            "description": "Alias for projectPath.",
+          ],
+          "sessionId": [
+            "type": "string",
+            "description": "Optional AgentHub session id. Defaults to AGENTHUB_SESSION_ID.",
+          ],
+          "reason": [
+            "type": "string",
+            "description": "Short note explaining why the run was requested.",
+          ],
+        ],
+        "additionalProperties": false,
+      ],
+    ]
+  }
+
+  private func simulatorRecordToolSchema() -> [String: Any] {
+    [
+      "name": "agenthub_simulator_record",
+      "description": "Starts or stops a simulator video recording for the same device shown in AgentHub's Simulator panel. After stop, finalized MP4s include ffprobe/ffmpeg hints for animation and motion timing audits.",
+      "inputSchema": [
+        "type": "object",
+        "properties": [
+          "action": [
+            "type": "string",
+            "enum": ["start", "stop"],
+            "description": "Recording action. Defaults to start.",
+          ],
+          "udid": [
+            "type": "string",
+            "description": "Optional simulator UDID. Defaults to the AgentHub Simulator panel target.",
+          ],
+          "sessionId": [
+            "type": "string",
+            "description": "Optional AgentHub session id. Defaults to AGENTHUB_SESSION_ID.",
+          ],
+          "projectPath": [
+            "type": "string",
+            "description": "Optional project path used only to resolve the panel context.",
+          ],
+          "repo": [
+            "type": "string",
+            "description": "Alias for projectPath.",
+          ],
+          "outputDirectory": [
+            "type": "string",
+            "description": "Optional directory for the MP4. Defaults to Application Support/AgentHub/Simulator Recordings.",
+          ],
+          "fileName": [
+            "type": "string",
+            "description": "Optional output filename. .mp4 is appended when omitted.",
+          ],
+        ],
+        "additionalProperties": false,
+      ],
     ]
   }
 
@@ -684,7 +916,7 @@ struct AgentHubMCPServer {
     writeJSON([
       "jsonrpc": "2.0",
       "id": id,
-      "result": result
+      "result": result,
     ])
   }
 
@@ -693,8 +925,8 @@ struct AgentHubMCPServer {
       "jsonrpc": "2.0",
       "error": [
         "code": code,
-        "message": message
-      ]
+        "message": message,
+      ],
     ]
     if let id {
       response["id"] = id
@@ -704,7 +936,8 @@ struct AgentHubMCPServer {
 
   private func writeJSON(_ object: [String: Any]) {
     guard JSONSerialization.isValidJSONObject(object),
-          let data = try? JSONSerialization.data(withJSONObject: object, options: []) else {
+          let data = try? JSONSerialization.data(withJSONObject: object, options: [])
+    else {
       // Never silently drop a JSON-RPC message: a dropped response leaves the
       // caller's tool call loading forever. Surface it on stderr (stdout is
       // reserved for the protocol) so the failure is at least diagnosable.
@@ -719,7 +952,8 @@ struct AgentHubMCPServer {
 
   private func requestId(from line: String) -> Any? {
     guard let data = line.data(using: .utf8),
-          let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+          let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+    else {
       return nil
     }
     return object["id"]
@@ -742,7 +976,7 @@ private struct MCPWorktreeInventory {
   var dictionary: [String: Any] {
     [
       "repositoryPath": repositoryPath,
-      "worktrees": items.map(\.dictionary)
+      "worktrees": items.map(\.dictionary),
     ]
   }
 }
@@ -760,8 +994,8 @@ private struct MCPWorktreeInventoryItem {
       "sessionCounts": [
         "total": sessionCounts.total,
         "claude": sessionCounts.claude,
-        "codex": sessionCounts.codex
-      ]
+        "codex": sessionCounts.codex,
+      ],
     ]
     if let branch {
       value["branch"] = branch
@@ -788,7 +1022,7 @@ private struct MCPWorktreeDeletionResult {
       "deletedWorktree": deletedWorktree.dictionary,
       "force": force,
       "deleteAssociatedBranch": deleteAssociatedBranch,
-      "sidebarCleanupRequestId": sidebarCleanupRequestId
+      "sidebarCleanupRequestId": sidebarCleanupRequestId,
     ]
   }
 }
@@ -812,7 +1046,7 @@ private struct MCPWorktreeTaskFailure {
   var dictionary: [String: Any] {
     [
       "branch": branch,
-      "error": message
+      "error": message,
     ]
   }
 }
@@ -834,9 +1068,206 @@ private struct MCPWorktreeLaunchResult {
       "provider": provider.commandLineValue,
       "repositoryPath": repositoryPath,
       "worktreePath": worktreePath,
-      "launchRequestId": launchRequestId
+      "launchRequestId": launchRequestId,
     ]
   }
+}
+
+private struct MCPSimulatorTarget {
+  let udid: String
+  let projectPath: String?
+  let context: SimulatorSessionContext?
+
+  var displayName: String {
+    context?.deviceName ?? udid
+  }
+
+  var dictionary: [String: Any] {
+    var value: [String: Any] = [
+      "udid": udid,
+    ]
+    if let projectPath {
+      value["projectPath"] = projectPath
+    }
+    if let context {
+      value["context"] = context.dictionary
+    }
+    return value
+  }
+}
+
+private struct MCPSimulatorStatusResult {
+  let activeContext: SimulatorSessionContext?
+  let contexts: [SimulatorSessionContext]
+
+  var summary: String {
+    guard let activeContext else {
+      return "No active AgentHub Simulator panel context found. Open the Simulator panel for this session, or pass an explicit simulator UDID."
+    }
+
+    let device = activeContext.deviceName ?? activeContext.udid
+    let runtime = activeContext.runtimeName.map { " on \($0)" } ?? ""
+    let bootState = activeContext.isBooted ? "booted" : "not booted"
+    return "AgentHub Simulator panel target: \(device)\(runtime) (\(activeContext.udid)), \(bootState), project \(activeContext.projectPath)."
+  }
+
+  var dictionary: [String: Any] {
+    var value: [String: Any] = [
+      "contexts": contexts.map(\.dictionary),
+      "recordingSupported": true,
+      "runRequestSupported": true,
+    ]
+    if let activeContext {
+      value["activeContext"] = activeContext.dictionary
+    }
+    return value
+  }
+}
+
+private struct MCPSimulatorRunResult {
+  let requestID: String
+  let target: MCPSimulatorTarget
+  let context: SimulatorSessionContext?
+
+  var summary: String {
+    let project = target.projectPath ?? context?.projectPath ?? "(unknown project)"
+    return "Queued AgentHub simulator Build & Run request \(requestID) for \(target.displayName) (\(target.udid)) in \(project)."
+  }
+
+  var dictionary: [String: Any] {
+    [
+      "requestId": requestID,
+      "target": target.dictionary,
+    ]
+  }
+}
+
+private enum MCPSimulatorRecordResult {
+  case started(SimulatorRecordingStarted, target: MCPSimulatorTarget)
+  case stopped(SimulatorRecordingResult, target: MCPSimulatorTarget)
+
+  var isError: Bool {
+    switch self {
+    case .started:
+      return false
+    case let .stopped(result, _):
+      return !result.isUsable
+    }
+  }
+
+  var summary: String {
+    switch self {
+    case let .started(started, target):
+      return "Started simulator recording for \(target.displayName) (\(started.udid)). Output: \(started.outputPath)"
+    case let .stopped(result, target):
+      if result.isUsable {
+        return [
+          "Stopped simulator recording for \(target.displayName) (\(result.udid)).",
+          "Saved finalized MP4: \(result.outputPath)",
+          "Duration: \(String(format: "%.1f", result.duration))s",
+          "Use ffprobe or ffmpeg to inspect motion timing, for example: ffprobe -hide_banner \(shellExample(result.outputPath))",
+        ].joined(separator: "\n")
+      }
+
+      return [
+        "Stopped simulator recording for \(target.displayName) (\(result.udid)).",
+        "Recording did not produce a finalized MP4: \(result.validationError ?? "validation failed")",
+        "Output path: \(result.outputPath)",
+      ].joined(separator: "\n")
+    }
+  }
+
+  var dictionary: [String: Any] {
+    switch self {
+    case let .started(started, target):
+      return [
+        "action": "start",
+        "target": target.dictionary,
+        "recording": started.dictionary,
+      ]
+    case let .stopped(result, target):
+      var value: [String: Any] = [
+        "action": "stop",
+        "target": target.dictionary,
+        "recording": result.dictionary,
+      ]
+      if result.isUsable {
+        value["ffmpegHints"] = [
+          "ffprobe -hide_banner \(shellExample(result.outputPath))",
+          "ffmpeg -i \(shellExample(result.outputPath)) -vf fps=6 frames/frame-%04d.png",
+        ]
+      }
+      return value
+    }
+  }
+
+  private func shellExample(_ path: String) -> String {
+    "'\(path.replacingOccurrences(of: "'", with: "'\\''"))'"
+  }
+}
+
+private extension SimulatorSessionContext {
+  var dictionary: [String: Any] {
+    var value: [String: Any] = [
+      "projectPath": projectPath,
+      "udid": udid,
+      "isBooted": isBooted,
+      "panelVisible": panelVisible,
+      "updatedAt": iso8601(updatedAt),
+    ]
+    if let provider {
+      value["provider"] = provider.commandLineValue
+    }
+    if let sessionId {
+      value["sessionId"] = sessionId
+    }
+    if let deviceName {
+      value["deviceName"] = deviceName
+    }
+    if let runtimeName {
+      value["runtimeName"] = runtimeName
+    }
+    if let displayMode {
+      value["displayMode"] = displayMode
+    }
+    return value
+  }
+}
+
+private extension SimulatorRecordingStarted {
+  var dictionary: [String: Any] {
+    [
+      "udid": udid,
+      "outputPath": outputPath,
+      "startedAt": iso8601(startedAt),
+    ]
+  }
+}
+
+private extension SimulatorRecordingResult {
+  var dictionary: [String: Any] {
+    var value: [String: Any] = [
+      "udid": udid,
+      "outputPath": outputPath,
+      "startedAt": iso8601(startedAt),
+      "endedAt": iso8601(endedAt),
+      "duration": duration,
+      "fileExists": fileExists,
+      "isFinalized": isFinalized,
+      "isUsable": isUsable,
+    ]
+    if let fileSizeBytes {
+      value["fileSizeBytes"] = fileSizeBytes
+    }
+    if let validationError {
+      value["validationError"] = validationError
+    }
+    return value
+  }
+}
+
+private func iso8601(_ date: Date) -> String {
+  ISO8601DateFormatter().string(from: date)
 }
 
 private enum MCPError: LocalizedError {
@@ -844,7 +1275,7 @@ private enum MCPError: LocalizedError {
 
   var errorDescription: String? {
     switch self {
-    case .invalidRequest(let message):
+    case let .invalidRequest(message):
       return message
     }
   }

--- a/app/modules/AgentHubCLI/Sources/AgentHubCLIKit/SimulatorRecordingFileValidator.swift
+++ b/app/modules/AgentHubCLI/Sources/AgentHubCLIKit/SimulatorRecordingFileValidator.swift
@@ -1,0 +1,155 @@
+import Foundation
+
+struct SimulatorRecordingFileValidation: Equatable, Sendable {
+  let fileExists: Bool
+  let fileSizeBytes: Int64?
+  let topLevelBoxes: Set<String>
+  let readError: String?
+
+  var isFinalized: Bool {
+    fileExists
+      && (fileSizeBytes ?? 0) > 0
+      && readError == nil
+      && topLevelBoxes.contains("ftyp")
+      && topLevelBoxes.contains("mdat")
+      && topLevelBoxes.contains("moov")
+  }
+
+  var errorDescription: String? {
+    guard !isFinalized else { return nil }
+    guard fileExists else {
+      return "The expected MP4 file was not created."
+    }
+    guard let fileSizeBytes, fileSizeBytes > 0 else {
+      return "The MP4 file is empty."
+    }
+    if let readError {
+      return "The MP4 file could not be inspected: \(readError)"
+    }
+
+    let missingBoxes = ["ftyp", "mdat", "moov"].filter { !topLevelBoxes.contains($0) }
+    if !missingBoxes.isEmpty {
+      return "The MP4 file did not finalize correctly; missing top-level \(missingBoxes.joined(separator: ", ")) atom(s)."
+    }
+    return "The MP4 file did not finalize correctly."
+  }
+}
+
+enum SimulatorRecordingFileValidator {
+  static func validate(
+    url: URL,
+    fileManager: FileManager = .default
+  ) -> SimulatorRecordingFileValidation {
+    guard fileManager.fileExists(atPath: url.path) else {
+      return SimulatorRecordingFileValidation(
+        fileExists: false,
+        fileSizeBytes: nil,
+        topLevelBoxes: [],
+        readError: nil
+      )
+    }
+
+    let attributes = try? fileManager.attributesOfItem(atPath: url.path)
+    let fileSize = (attributes?[.size] as? NSNumber)?.int64Value
+    guard let fileSize, fileSize > 0 else {
+      return SimulatorRecordingFileValidation(
+        fileExists: true,
+        fileSizeBytes: fileSize,
+        topLevelBoxes: [],
+        readError: nil
+      )
+    }
+
+    do {
+      return SimulatorRecordingFileValidation(
+        fileExists: true,
+        fileSizeBytes: fileSize,
+        topLevelBoxes: try topLevelBoxes(in: url, fileSize: UInt64(fileSize)),
+        readError: nil
+      )
+    } catch {
+      return SimulatorRecordingFileValidation(
+        fileExists: true,
+        fileSizeBytes: fileSize,
+        topLevelBoxes: [],
+        readError: error.localizedDescription
+      )
+    }
+  }
+
+  private static func topLevelBoxes(in url: URL, fileSize: UInt64) throws -> Set<String> {
+    let handle = try FileHandle(forReadingFrom: url)
+    defer { try? handle.close() }
+
+    var boxes: Set<String> = []
+    var offset: UInt64 = 0
+
+    while offset + 8 <= fileSize {
+      try handle.seek(toOffset: offset)
+      guard let header = try handle.read(upToCount: 8), header.count == 8 else {
+        break
+      }
+
+      let boxType = String(data: header.subdata(in: 4..<8), encoding: .ascii) ?? "????"
+      var headerSize: UInt64 = 8
+      var boxSize = uint32(header, at: 0)
+
+      if boxSize == 1 {
+        guard let extendedSizeData = try handle.read(upToCount: 8),
+              extendedSizeData.count == 8 else {
+          throw SimulatorRecordingFileValidatorError.truncatedBoxHeader(boxType)
+        }
+        boxSize = uint64(extendedSizeData, at: 0)
+        headerSize = 16
+      } else if boxSize == 0 {
+        boxSize = fileSize - offset
+      }
+
+      guard boxSize >= headerSize else {
+        throw SimulatorRecordingFileValidatorError.invalidBoxSize(boxType)
+      }
+      guard boxSize > 0 else {
+        break
+      }
+
+      boxes.insert(boxType)
+      let nextOffset = offset + boxSize
+      guard nextOffset > offset else {
+        throw SimulatorRecordingFileValidatorError.invalidBoxSize(boxType)
+      }
+      offset = nextOffset
+    }
+
+    return boxes
+  }
+
+  private static func uint32(_ data: Data, at offset: Int) -> UInt64 {
+    var value: UInt64 = 0
+    for byte in data.dropFirst(offset).prefix(4) {
+      value = (value << 8) | UInt64(byte)
+    }
+    return value
+  }
+
+  private static func uint64(_ data: Data, at offset: Int) -> UInt64 {
+    var value: UInt64 = 0
+    for byte in data.dropFirst(offset).prefix(8) {
+      value = (value << 8) | UInt64(byte)
+    }
+    return value
+  }
+}
+
+private enum SimulatorRecordingFileValidatorError: LocalizedError {
+  case truncatedBoxHeader(String)
+  case invalidBoxSize(String)
+
+  var errorDescription: String? {
+    switch self {
+    case .truncatedBoxHeader(let box):
+      return "Truncated extended-size header for \(box) atom."
+    case .invalidBoxSize(let box):
+      return "Invalid size for \(box) atom."
+    }
+  }
+}

--- a/app/modules/AgentHubCLI/Sources/AgentHubCLIKit/SimulatorRecordingService.swift
+++ b/app/modules/AgentHubCLI/Sources/AgentHubCLIKit/SimulatorRecordingService.swift
@@ -1,0 +1,475 @@
+import Darwin
+import Foundation
+
+public struct SimulatorRecordingStarted: Codable, Equatable, Sendable {
+  public let udid: String
+  public let outputPath: String
+  public let startedAt: Date
+
+  public init(udid: String, outputPath: String, startedAt: Date) {
+    self.udid = udid
+    self.outputPath = outputPath
+    self.startedAt = startedAt
+  }
+}
+
+public struct SimulatorRecordingResult: Codable, Equatable, Sendable {
+  public let udid: String
+  public let outputPath: String
+  public let startedAt: Date
+  public let endedAt: Date
+  public let duration: TimeInterval
+  public let fileExists: Bool
+  public let fileSizeBytes: Int64?
+  public let isFinalized: Bool
+  public let validationError: String?
+
+  public var isUsable: Bool {
+    fileExists && (fileSizeBytes ?? 0) > 0 && isFinalized && validationError == nil
+  }
+
+  public init(
+    udid: String,
+    outputPath: String,
+    startedAt: Date,
+    endedAt: Date,
+    duration: TimeInterval,
+    fileExists: Bool,
+    fileSizeBytes: Int64?,
+    isFinalized: Bool,
+    validationError: String?
+  ) {
+    self.udid = udid
+    self.outputPath = outputPath
+    self.startedAt = startedAt
+    self.endedAt = endedAt
+    self.duration = duration
+    self.fileExists = fileExists
+    self.fileSizeBytes = fileSizeBytes
+    self.isFinalized = isFinalized
+    self.validationError = validationError
+  }
+}
+
+public enum SimulatorRecordingError: LocalizedError, Equatable, Sendable {
+  case xcrunNotFound
+  case alreadyRecording(String)
+  case notRecording(String)
+  case invalidFileName(String)
+  case startFailed(String)
+
+  public var errorDescription: String? {
+    switch self {
+    case .xcrunNotFound:
+      return "xcrun not found in PATH."
+    case .alreadyRecording(let udid):
+      return "Simulator \(udid) is already recording."
+    case .notRecording(let udid):
+      return "Simulator \(udid) is not recording."
+    case .invalidFileName(let fileName):
+      return "Invalid recording file name: \(fileName)"
+    case .startFailed(let detail):
+      return "Could not start simulator recording: \(detail)"
+    }
+  }
+}
+
+public protocol SimulatorRecordingProcess: AnyObject, Sendable {
+  var isRunning: Bool { get }
+  var terminationStatus: Int32 { get }
+  var diagnosticOutput: String { get }
+  func interrupt()
+  func terminate()
+  func waitUntilExit()
+}
+
+public protocol SimulatorRecordingProcessRunning: Sendable {
+  func start(arguments: [String]) throws -> any SimulatorRecordingProcess
+}
+
+public final class SimulatorRecordingProcessRef: SimulatorRecordingProcess, @unchecked Sendable {
+  private let process: Process
+  private let diagnosticURL: URL
+
+  public init(process: Process, diagnosticURL: URL) {
+    self.process = process
+    self.diagnosticURL = diagnosticURL
+  }
+
+  deinit {
+    try? FileManager.default.removeItem(at: diagnosticURL)
+  }
+
+  public var isRunning: Bool { process.isRunning }
+  public var terminationStatus: Int32 { process.terminationStatus }
+  public var diagnosticOutput: String {
+    guard let data = try? Data(contentsOf: diagnosticURL),
+          let output = String(data: data, encoding: .utf8) else {
+      return ""
+    }
+    return output.trimmingCharacters(in: .whitespacesAndNewlines)
+  }
+
+  public func interrupt() {
+    signalProcessTree(SIGINT)
+  }
+
+  public func terminate() {
+    signalProcessTree(SIGTERM)
+  }
+
+  public func waitUntilExit() {
+    process.waitUntilExit()
+  }
+
+  private func signalProcessTree(_ signal: Int32) {
+    let pid = process.processIdentifier
+    for childPID in Self.descendantPIDs(of: pid).reversed() {
+      _ = kill(childPID, signal)
+    }
+    _ = kill(pid, signal)
+  }
+
+  private static func descendantPIDs(of rootPID: pid_t) -> [pid_t] {
+    var descendants: [pid_t] = []
+    var stack = childPIDs(of: rootPID)
+
+    while let pid = stack.popLast() {
+      descendants.append(pid)
+      stack.append(contentsOf: childPIDs(of: pid))
+    }
+
+    return descendants
+  }
+
+  private static func childPIDs(of pid: pid_t) -> [pid_t] {
+    let childCount = proc_listchildpids(pid, nil, 0)
+    guard childCount > 0 else { return [] }
+
+    var pids = [pid_t](repeating: 0, count: Int(childCount))
+    let byteCount = Int32(pids.count * MemoryLayout<pid_t>.size)
+    let result = pids.withUnsafeMutableBytes { buffer in
+      proc_listchildpids(pid, buffer.baseAddress, byteCount)
+    }
+
+    guard result > 0 else { return [] }
+    return Array(pids.prefix(Int(result))).filter { $0 > 0 }
+  }
+}
+
+public struct SimulatorRecordingProcessRunner: SimulatorRecordingProcessRunning {
+  public init() {}
+
+  public func start(arguments: [String]) throws -> any SimulatorRecordingProcess {
+    guard let xcrun = Self.findExecutable(named: "xcrun") else {
+      throw SimulatorRecordingError.xcrunNotFound
+    }
+
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: xcrun)
+    process.arguments = arguments
+    process.standardOutput = Pipe()
+    let diagnosticURL = FileManager.default.temporaryDirectory
+      .appendingPathComponent("agenthub-simulator-recording-\(UUID().uuidString).stderr")
+    FileManager.default.createFile(atPath: diagnosticURL.path, contents: nil)
+    let diagnosticHandle = try FileHandle(forWritingTo: diagnosticURL)
+    process.standardError = diagnosticHandle
+    try process.run()
+    try? diagnosticHandle.close()
+    return SimulatorRecordingProcessRef(process: process, diagnosticURL: diagnosticURL)
+  }
+
+  private static func findExecutable(named name: String) -> String? {
+    let paths = (ProcessInfo.processInfo.environment["PATH"] ?? "/usr/bin:/bin:/usr/sbin:/sbin")
+      .split(separator: ":")
+      .map(String.init)
+    for path in paths {
+      let candidate = (path as NSString).appendingPathComponent(name)
+      if FileManager.default.isExecutableFile(atPath: candidate) {
+        return candidate
+      }
+    }
+    return nil
+  }
+}
+
+public actor SimulatorRecordingService {
+  public static let shared = SimulatorRecordingService()
+
+  private struct ActiveRecording {
+    let process: any SimulatorRecordingProcess
+    let started: SimulatorRecordingStarted
+  }
+
+  private struct ProcessStopResult {
+    let wasForced: Bool
+    let exited: Bool
+    let diagnosticOutput: String
+  }
+
+  private let runner: any SimulatorRecordingProcessRunning
+  private let dateProvider: @Sendable () -> Date
+  private let startConfirmationTimeout: Duration
+  private let gracefulStopTimeout: Duration
+  private let forcedStopTimeout: Duration
+  private let finalizationTimeout: Duration
+  private let pollingInterval: Duration
+  private var activeRecordings: [String: ActiveRecording] = [:]
+
+  public init(
+    runner: any SimulatorRecordingProcessRunning = SimulatorRecordingProcessRunner(),
+    dateProvider: @escaping @Sendable () -> Date = { Date() },
+    startConfirmationTimeout: Duration = .seconds(5),
+    gracefulStopTimeout: Duration = .seconds(8),
+    forcedStopTimeout: Duration = .seconds(2),
+    finalizationTimeout: Duration = .seconds(3),
+    pollingInterval: Duration = .milliseconds(100)
+  ) {
+    self.runner = runner
+    self.dateProvider = dateProvider
+    self.startConfirmationTimeout = startConfirmationTimeout
+    self.gracefulStopTimeout = gracefulStopTimeout
+    self.forcedStopTimeout = forcedStopTimeout
+    self.finalizationTimeout = finalizationTimeout
+    self.pollingInterval = pollingInterval
+  }
+
+  public func startRecording(
+    udid: String,
+    outputDirectory: URL? = nil,
+    fileName: String? = nil
+  ) async throws -> SimulatorRecordingStarted {
+    if let active = activeRecordings[udid], active.process.isRunning {
+      throw SimulatorRecordingError.alreadyRecording(udid)
+    }
+    activeRecordings.removeValue(forKey: udid)
+
+    let directory = outputDirectory ?? Self.defaultRecordingsDirectory()
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+
+    let startedAt = dateProvider()
+    let outputURL = directory.appendingPathComponent(
+      try Self.recordingFileName(udid: udid, startedAt: startedAt, requestedFileName: fileName),
+      isDirectory: false
+    )
+    let process = try runner.start(arguments: [
+      "simctl", "io", udid, "recordVideo", "--force", outputURL.path
+    ])
+
+    guard await waitForRecordingStart(process) else {
+      activeRecordings.removeValue(forKey: udid)
+      try? Self.deleteRecordingFile(at: outputURL.path)
+      let detail = Self.shortDiagnostic(process.diagnosticOutput)
+      throw SimulatorRecordingError.startFailed(
+        detail.isEmpty ? "recordVideo exited before recording started" : detail
+      )
+    }
+
+    let started = SimulatorRecordingStarted(
+      udid: udid,
+      outputPath: outputURL.path,
+      startedAt: startedAt
+    )
+    activeRecordings[udid] = ActiveRecording(process: process, started: started)
+    return started
+  }
+
+  public func stopRecording(udid: String) async throws -> SimulatorRecordingResult {
+    guard let active = activeRecordings.removeValue(forKey: udid) else {
+      throw SimulatorRecordingError.notRecording(udid)
+    }
+
+    let stopResult = await stopProcess(active.process)
+    let endedAt = dateProvider()
+    let fileURL = URL(fileURLWithPath: active.started.outputPath)
+    let validation = await waitForFinalizedMovie(at: fileURL)
+
+    return SimulatorRecordingResult(
+      udid: udid,
+      outputPath: active.started.outputPath,
+      startedAt: active.started.startedAt,
+      endedAt: endedAt,
+      duration: max(0, endedAt.timeIntervalSince(active.started.startedAt)),
+      fileExists: validation.fileExists,
+      fileSizeBytes: validation.fileSizeBytes,
+      isFinalized: validation.isFinalized,
+      validationError: validationError(from: validation, stopResult: stopResult)
+    )
+  }
+
+  @discardableResult
+  public func discardRecording(udid: String) async throws -> SimulatorRecordingResult {
+    let result = try await stopRecording(udid: udid)
+    try Self.deleteRecordingFile(at: result.outputPath)
+    return result
+  }
+
+  public func activeRecording(udid: String) -> SimulatorRecordingStarted? {
+    guard let active = activeRecordings[udid], active.process.isRunning else {
+      activeRecordings.removeValue(forKey: udid)
+      return nil
+    }
+    return active.started
+  }
+
+  private func stopProcess(_ process: any SimulatorRecordingProcess) async -> ProcessStopResult {
+    guard process.isRunning else {
+      process.waitUntilExit()
+      return ProcessStopResult(
+        wasForced: false,
+        exited: true,
+        diagnosticOutput: process.diagnosticOutput
+      )
+    }
+
+    process.interrupt()
+    if await waitForProcessExit(process, timeout: gracefulStopTimeout) {
+      process.waitUntilExit()
+      return ProcessStopResult(
+        wasForced: false,
+        exited: true,
+        diagnosticOutput: process.diagnosticOutput
+      )
+    }
+
+    process.terminate()
+    let exited = await waitForProcessExit(process, timeout: forcedStopTimeout)
+    if exited {
+      process.waitUntilExit()
+    }
+    return ProcessStopResult(
+      wasForced: true,
+      exited: exited,
+      diagnosticOutput: process.diagnosticOutput
+    )
+  }
+
+  private func waitForRecordingStart(_ process: any SimulatorRecordingProcess) async -> Bool {
+    let clock = ContinuousClock()
+    let deadline = clock.now.advanced(by: startConfirmationTimeout)
+
+    while clock.now < deadline {
+      if process.diagnosticOutput.contains("Recording started") {
+        return true
+      }
+      if !process.isRunning {
+        process.waitUntilExit()
+        return false
+      }
+      try? await Task.sleep(for: pollingInterval)
+    }
+
+    return process.isRunning
+  }
+
+  private func waitForProcessExit(
+    _ process: any SimulatorRecordingProcess,
+    timeout: Duration
+  ) async -> Bool {
+    let clock = ContinuousClock()
+    let deadline = clock.now.advanced(by: timeout)
+
+    while process.isRunning {
+      guard clock.now < deadline else { return false }
+      try? await Task.sleep(for: pollingInterval)
+    }
+    return true
+  }
+
+  private func waitForFinalizedMovie(at url: URL) async -> SimulatorRecordingFileValidation {
+    let clock = ContinuousClock()
+    let deadline = clock.now.advanced(by: finalizationTimeout)
+    var previousFinalizedSize: Int64?
+
+    while true {
+      let latest = SimulatorRecordingFileValidator.validate(url: url)
+      if latest.isFinalized {
+        if previousFinalizedSize == latest.fileSizeBytes || clock.now >= deadline {
+          return latest
+        }
+        previousFinalizedSize = latest.fileSizeBytes
+      } else if clock.now >= deadline {
+        return latest
+      }
+
+      try? await Task.sleep(for: pollingInterval)
+    }
+  }
+
+  private func validationError(
+    from validation: SimulatorRecordingFileValidation,
+    stopResult: ProcessStopResult
+  ) -> String? {
+    var messages: [String] = []
+    if stopResult.wasForced {
+      messages.append("Recording process did not stop gracefully.")
+    }
+    if !stopResult.exited {
+      messages.append("Recording process did not exit after fallback termination.")
+    }
+    if validation.isFinalized, messages.isEmpty {
+      return nil
+    }
+
+    if let validationError = validation.errorDescription {
+      messages.append(validationError)
+    }
+    let diagnostic = Self.shortDiagnostic(stopResult.diagnosticOutput)
+    if !diagnostic.isEmpty, !diagnostic.contains("Recording started") {
+      messages.append("simctl: \(diagnostic)")
+    }
+    return messages.joined(separator: " ")
+  }
+
+  private static func shortDiagnostic(_ output: String) -> String {
+    output
+      .split(separator: "\n")
+      .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+      .filter { !$0.isEmpty }
+      .joined(separator: " ")
+      .prefix(500)
+      .description
+  }
+
+  public static func defaultRecordingsDirectory(fileManager: FileManager = .default) -> URL {
+    let appSupportURL = fileManager.urls(
+      for: .applicationSupportDirectory,
+      in: .userDomainMask
+    ).first ?? URL(fileURLWithPath: NSHomeDirectory()).appendingPathComponent("Library/Application Support")
+
+    return appSupportURL
+      .appendingPathComponent("AgentHub", isDirectory: true)
+      .appendingPathComponent("Simulator Recordings", isDirectory: true)
+  }
+
+  public static func deleteRecordingFile(at path: String, fileManager: FileManager = .default) throws {
+    let url = URL(fileURLWithPath: path)
+    guard fileManager.fileExists(atPath: url.path) else { return }
+    try fileManager.removeItem(at: url)
+  }
+
+  static func recordingFileName(
+    udid: String,
+    startedAt: Date,
+    requestedFileName: String?
+  ) throws -> String {
+    if let requestedFileName,
+       !requestedFileName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+      let trimmed = requestedFileName.trimmingCharacters(in: .whitespacesAndNewlines)
+      guard trimmed == (trimmed as NSString).lastPathComponent,
+            !trimmed.contains("\0") else {
+        throw SimulatorRecordingError.invalidFileName(requestedFileName)
+      }
+      return trimmed.lowercased().hasSuffix(".mp4") ? trimmed : "\(trimmed).mp4"
+    }
+
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withInternetDateTime]
+    let timestamp = formatter.string(from: startedAt)
+      .replacingOccurrences(of: ":", with: "-")
+    let safeUDID = udid.map { character -> Character in
+      character.isLetter || character.isNumber || character == "-" ? character : "_"
+    }
+    return "agenthub-simulator-\(String(safeUDID))-\(timestamp).mp4"
+  }
+}

--- a/app/modules/AgentHubCLI/Sources/AgentHubCLIKit/SimulatorRunRequestQueue.swift
+++ b/app/modules/AgentHubCLI/Sources/AgentHubCLIKit/SimulatorRunRequestQueue.swift
@@ -1,0 +1,132 @@
+import Foundation
+
+public enum SimulatorRunRequestMode: String, Codable, Equatable, Sendable {
+  case buildAndRun
+}
+
+public struct SimulatorRunRequest: Codable, Equatable, Identifiable, Sendable {
+  public let id: String
+  public let createdAt: Date
+  public let projectPath: String
+  public let udid: String
+  public let mode: SimulatorRunRequestMode
+  public let sourceProvider: WorktreeLaunchProvider?
+  public let sourceSessionId: String?
+  public let reason: String?
+
+  public init(
+    id: String = UUID().uuidString,
+    createdAt: Date = Date(),
+    projectPath: String,
+    udid: String,
+    mode: SimulatorRunRequestMode = .buildAndRun,
+    sourceProvider: WorktreeLaunchProvider? = nil,
+    sourceSessionId: String? = nil,
+    reason: String? = nil
+  ) {
+    self.id = id
+    self.createdAt = createdAt
+    self.projectPath = projectPath
+    self.udid = udid
+    self.mode = mode
+    self.sourceProvider = sourceProvider
+    self.sourceSessionId = sourceSessionId
+    self.reason = reason
+  }
+}
+
+public struct QueuedSimulatorRunRequest: Equatable, Sendable {
+  public let request: SimulatorRunRequest
+  public let fileURL: URL
+
+  public init(request: SimulatorRunRequest, fileURL: URL) {
+    self.request = request
+    self.fileURL = fileURL
+  }
+}
+
+public struct SimulatorRunRequestQueue: Sendable {
+  public let directoryURL: URL
+
+  public init(directoryURL: URL = SimulatorRunRequestQueue.defaultDirectoryURL()) {
+    self.directoryURL = directoryURL
+  }
+
+  public static func defaultDirectoryURL(fileManager: FileManager = .default) -> URL {
+    let appSupportURL = fileManager.urls(
+      for: .applicationSupportDirectory,
+      in: .userDomainMask
+    ).first ?? URL(fileURLWithPath: NSHomeDirectory()).appendingPathComponent("Library/Application Support")
+
+    return appSupportURL
+      .appendingPathComponent("AgentHub", isDirectory: true)
+      .appendingPathComponent("simulator-run-requests", isDirectory: true)
+  }
+
+  @discardableResult
+  public func enqueue(_ request: SimulatorRunRequest) throws -> QueuedSimulatorRunRequest {
+    try FileManager.default.createDirectory(
+      at: directoryURL,
+      withIntermediateDirectories: true
+    )
+
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+    let data = try encoder.encode(request)
+
+    let finalURL = directoryURL.appendingPathComponent("\(request.id).json", isDirectory: false)
+    let temporaryURL = directoryURL.appendingPathComponent(".\(request.id).tmp", isDirectory: false)
+
+    try data.write(to: temporaryURL, options: [.atomic])
+    if FileManager.default.fileExists(atPath: finalURL.path) {
+      try FileManager.default.removeItem(at: finalURL)
+    }
+    try FileManager.default.moveItem(at: temporaryURL, to: finalURL)
+
+    return QueuedSimulatorRunRequest(request: request, fileURL: finalURL)
+  }
+
+  public func pendingRequests() throws -> [QueuedSimulatorRunRequest] {
+    guard FileManager.default.fileExists(atPath: directoryURL.path) else {
+      return []
+    }
+
+    let files = try FileManager.default.contentsOfDirectory(
+      at: directoryURL,
+      includingPropertiesForKeys: nil
+    )
+
+    let decoder = JSONDecoder()
+    return files
+      .filter { $0.pathExtension == "json" && !$0.lastPathComponent.hasPrefix(".") }
+      .compactMap { url in
+        guard let data = try? Data(contentsOf: url),
+              let request = try? decoder.decode(SimulatorRunRequest.self, from: data) else {
+          return nil
+        }
+        return QueuedSimulatorRunRequest(request: request, fileURL: url)
+      }
+      .sorted {
+        if $0.request.createdAt == $1.request.createdAt {
+          return $0.request.id < $1.request.id
+        }
+        return $0.request.createdAt < $1.request.createdAt
+      }
+  }
+
+  public func remove(_ queued: QueuedSimulatorRunRequest) throws {
+    guard FileManager.default.fileExists(atPath: queued.fileURL.path) else { return }
+    try FileManager.default.removeItem(at: queued.fileURL)
+  }
+
+  public func markFailed(_ queued: QueuedSimulatorRunRequest) throws {
+    guard FileManager.default.fileExists(atPath: queued.fileURL.path) else { return }
+    let failedURL = queued.fileURL
+      .deletingPathExtension()
+      .appendingPathExtension("failed")
+    if FileManager.default.fileExists(atPath: failedURL.path) {
+      try FileManager.default.removeItem(at: failedURL)
+    }
+    try FileManager.default.moveItem(at: queued.fileURL, to: failedURL)
+  }
+}

--- a/app/modules/AgentHubCLI/Sources/AgentHubCLIKit/SimulatorSessionContextStore.swift
+++ b/app/modules/AgentHubCLI/Sources/AgentHubCLIKit/SimulatorSessionContextStore.swift
@@ -1,0 +1,206 @@
+import Foundation
+
+public struct SimulatorSessionContext: Codable, Equatable, Identifiable, Sendable {
+  public let provider: WorktreeLaunchProvider?
+  public let sessionId: String?
+  public let projectPath: String
+  public let udid: String
+  public let deviceName: String?
+  public let runtimeName: String?
+  public let isBooted: Bool
+  public let displayMode: String?
+  public let panelVisible: Bool
+  public let updatedAt: Date
+
+  public init(
+    provider: WorktreeLaunchProvider?,
+    sessionId: String?,
+    projectPath: String,
+    udid: String,
+    deviceName: String?,
+    runtimeName: String?,
+    isBooted: Bool,
+    displayMode: String?,
+    panelVisible: Bool = true,
+    updatedAt: Date = Date()
+  ) {
+    self.provider = provider
+    self.sessionId = sessionId
+    self.projectPath = projectPath
+    self.udid = udid
+    self.deviceName = deviceName
+    self.runtimeName = runtimeName
+    self.isBooted = isBooted
+    self.displayMode = displayMode
+    self.panelVisible = panelVisible
+    self.updatedAt = updatedAt
+  }
+
+  public var id: String {
+    [
+      provider?.commandLineValue ?? "unknown",
+      sessionId ?? "",
+      projectPath,
+      udid
+    ].joined(separator: "|")
+  }
+}
+
+public struct SimulatorSessionContextStore: Sendable {
+  public let directoryURL: URL
+
+  public init(directoryURL: URL = SimulatorSessionContextStore.defaultDirectoryURL()) {
+    self.directoryURL = directoryURL
+  }
+
+  public static func defaultDirectoryURL(fileManager: FileManager = .default) -> URL {
+    let appSupportURL = fileManager.urls(
+      for: .applicationSupportDirectory,
+      in: .userDomainMask
+    ).first ?? URL(fileURLWithPath: NSHomeDirectory()).appendingPathComponent("Library/Application Support")
+
+    return appSupportURL
+      .appendingPathComponent("AgentHub", isDirectory: true)
+      .appendingPathComponent("simulator-context", isDirectory: true)
+  }
+
+  public func write(_ context: SimulatorSessionContext) throws {
+    try FileManager.default.createDirectory(
+      at: directoryURL,
+      withIntermediateDirectories: true
+    )
+
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+    encoder.dateEncodingStrategy = .iso8601
+    let data = try encoder.encode(context)
+
+    let finalURL = fileURL(
+      provider: context.provider,
+      sessionId: context.sessionId,
+      projectPath: context.projectPath
+    )
+    let temporaryURL = directoryURL
+      .appendingPathComponent(".\(finalURL.deletingPathExtension().lastPathComponent).tmp", isDirectory: false)
+
+    try data.write(to: temporaryURL, options: [.atomic])
+    if FileManager.default.fileExists(atPath: finalURL.path) {
+      try FileManager.default.removeItem(at: finalURL)
+    }
+    try FileManager.default.moveItem(at: temporaryURL, to: finalURL)
+  }
+
+  public func remove(
+    provider: WorktreeLaunchProvider?,
+    sessionId: String?,
+    projectPath: String
+  ) throws {
+    let url = fileURL(provider: provider, sessionId: sessionId, projectPath: projectPath)
+    guard FileManager.default.fileExists(atPath: url.path) else { return }
+    try FileManager.default.removeItem(at: url)
+  }
+
+  public func context(
+    provider: WorktreeLaunchProvider?,
+    sessionId: String?,
+    projectPath: String
+  ) throws -> SimulatorSessionContext? {
+    let url = fileURL(provider: provider, sessionId: sessionId, projectPath: projectPath)
+    guard FileManager.default.fileExists(atPath: url.path) else { return nil }
+    let data = try Data(contentsOf: url)
+    return try decoder.decode(SimulatorSessionContext.self, from: data)
+  }
+
+  public func contexts() throws -> [SimulatorSessionContext] {
+    guard FileManager.default.fileExists(atPath: directoryURL.path) else {
+      return []
+    }
+
+    let files = try FileManager.default.contentsOfDirectory(
+      at: directoryURL,
+      includingPropertiesForKeys: nil
+    )
+
+    return files
+      .filter { $0.pathExtension == "json" && !$0.lastPathComponent.hasPrefix(".") }
+      .compactMap { url in
+        guard let data = try? Data(contentsOf: url) else { return nil }
+        return try? decoder.decode(SimulatorSessionContext.self, from: data)
+      }
+      .sorted {
+        if $0.updatedAt == $1.updatedAt {
+          return $0.id < $1.id
+        }
+        return $0.updatedAt > $1.updatedAt
+      }
+  }
+
+  public func resolveContext(
+    provider: WorktreeLaunchProvider?,
+    sessionId: String?,
+    projectPath: String?
+  ) throws -> SimulatorSessionContext? {
+    let allContexts = try contexts()
+    if let sessionId, !sessionId.isEmpty {
+      let exact = allContexts.first { context in
+        context.sessionId == sessionId
+          && (provider == nil || context.provider == provider)
+          && (projectPath == nil || normalizedPath(context.projectPath) == normalizedPath(projectPath ?? ""))
+      }
+      if let exact { return exact }
+    }
+
+    if let projectPath, !projectPath.isEmpty {
+      let normalizedProject = normalizedPath(projectPath)
+      return allContexts.first { context in
+        context.panelVisible && normalizedPath(context.projectPath) == normalizedProject
+      }
+    }
+
+    return allContexts.first { $0.panelVisible }
+  }
+
+  public func fileURL(
+    provider: WorktreeLaunchProvider?,
+    sessionId: String?,
+    projectPath: String
+  ) -> URL {
+    directoryURL.appendingPathComponent(
+      "\(fileStem(provider: provider, sessionId: sessionId, projectPath: projectPath)).json",
+      isDirectory: false
+    )
+  }
+
+  private var decoder: JSONDecoder {
+    let decoder = JSONDecoder()
+    decoder.dateDecodingStrategy = .iso8601
+    return decoder
+  }
+
+  private func fileStem(
+    provider: WorktreeLaunchProvider?,
+    sessionId: String?,
+    projectPath: String
+  ) -> String {
+    let key = [
+      provider?.commandLineValue ?? "unknown",
+      sessionId ?? "",
+      normalizedPath(projectPath)
+    ].joined(separator: "|")
+    return Data(key.utf8)
+      .base64EncodedString()
+      .replacingOccurrences(of: "/", with: "_")
+      .replacingOccurrences(of: "+", with: "-")
+      .replacingOccurrences(of: "=", with: "")
+  }
+
+  private func normalizedPath(_ path: String) -> String {
+    var normalized = URL(fileURLWithPath: (path as NSString).expandingTildeInPath)
+      .standardizedFileURL
+      .path
+    while normalized.count > 1 && normalized.hasSuffix("/") {
+      normalized.removeLast()
+    }
+    return normalized
+  }
+}

--- a/app/modules/AgentHubCLI/Tests/AgentHubCLIKitTests/SimulatorRecordingServiceTests.swift
+++ b/app/modules/AgentHubCLI/Tests/AgentHubCLIKitTests/SimulatorRecordingServiceTests.swift
@@ -1,0 +1,351 @@
+import Foundation
+import Testing
+
+@testable import AgentHubCLIKit
+
+@Suite("SimulatorRecordingService")
+struct SimulatorRecordingServiceTests {
+  @Test("Start invokes simctl recordVideo and stop returns file metadata")
+  func startAndStopRecording() async throws {
+    let directory = try temporarySimulatorRecordingDirectory()
+    defer { try? FileManager.default.removeItem(at: directory.deletingLastPathComponent()) }
+
+    let process = MockRecordingProcess()
+    let runner = MockRecordingRunner(process: process)
+    let dates = DateSequence([
+      Date(timeIntervalSince1970: 1_000),
+      Date(timeIntervalSince1970: 1_010)
+    ])
+    let service = SimulatorRecordingService(
+      runner: runner,
+      dateProvider: { dates.next() },
+      finalizationTimeout: .zero,
+      pollingInterval: .zero
+    )
+
+    let started = try await service.startRecording(
+      udid: "UDID-1",
+      outputDirectory: directory,
+      fileName: "motion-check"
+    )
+    let mp4Data = minimalMP4Data()
+    try mp4Data.write(to: URL(fileURLWithPath: started.outputPath))
+    let result = try await service.stopRecording(udid: "UDID-1")
+
+    #expect(runner.recordedArguments() == [
+      ["simctl", "io", "UDID-1", "recordVideo", "--force", directory.appendingPathComponent("motion-check.mp4").path]
+    ])
+    #expect(process.interruptCallCount == 1)
+    #expect(process.terminateCallCount == 0)
+    #expect(process.waitCallCount == 1)
+    #expect(result.outputPath == started.outputPath)
+    #expect(result.duration == 10)
+    #expect(result.fileExists == true)
+    #expect(result.fileSizeBytes == Int64(mp4Data.count))
+    #expect(result.isFinalized == true)
+    #expect(result.validationError == nil)
+    #expect(result.isUsable == true)
+  }
+
+  @Test("Stop falls back to terminate when interrupt does not exit")
+  func stopFallsBackToTerminate() async throws {
+    let directory = try temporarySimulatorRecordingDirectory()
+    defer { try? FileManager.default.removeItem(at: directory.deletingLastPathComponent()) }
+
+    let process = MockRecordingProcess(exitsOnInterrupt: false)
+    let service = SimulatorRecordingService(
+      runner: MockRecordingRunner(process: process),
+      dateProvider: { Date(timeIntervalSince1970: 1_000) },
+      gracefulStopTimeout: .zero,
+      forcedStopTimeout: .zero,
+      finalizationTimeout: .zero,
+      pollingInterval: .zero
+    )
+
+    let started = try await service.startRecording(
+      udid: "UDID-1",
+      outputDirectory: directory,
+      fileName: "forced-stop"
+    )
+    try minimalMP4Data(includeMoov: false).write(to: URL(fileURLWithPath: started.outputPath))
+    let result = try await service.stopRecording(udid: "UDID-1")
+
+    #expect(process.interruptCallCount == 1)
+    #expect(process.terminateCallCount == 1)
+    #expect(result.isUsable == false)
+    #expect(result.validationError?.contains("did not stop gracefully") == true)
+  }
+
+  @Test("Stop reports incomplete MP4 when moov atom is missing")
+  func stopReportsMissingMoovAtom() async throws {
+    let directory = try temporarySimulatorRecordingDirectory()
+    defer { try? FileManager.default.removeItem(at: directory.deletingLastPathComponent()) }
+
+    let service = SimulatorRecordingService(
+      runner: MockRecordingRunner(process: MockRecordingProcess()),
+      dateProvider: { Date(timeIntervalSince1970: 1_000) },
+      finalizationTimeout: .zero,
+      pollingInterval: .zero
+    )
+
+    let started = try await service.startRecording(
+      udid: "UDID-1",
+      outputDirectory: directory,
+      fileName: "incomplete"
+    )
+    try minimalMP4Data(includeMoov: false).write(to: URL(fileURLWithPath: started.outputPath))
+    let result = try await service.stopRecording(udid: "UDID-1")
+
+    #expect(result.fileExists == true)
+    #expect(result.isFinalized == false)
+    #expect(result.isUsable == false)
+    #expect(result.validationError?.contains("moov") == true)
+  }
+
+  @Test("Discard stops active recording and removes file")
+  func discardStopsActiveRecordingAndRemovesFile() async throws {
+    let directory = try temporarySimulatorRecordingDirectory()
+    defer { try? FileManager.default.removeItem(at: directory.deletingLastPathComponent()) }
+
+    let process = MockRecordingProcess()
+    let dates = DateSequence([
+      Date(timeIntervalSince1970: 1_000),
+      Date(timeIntervalSince1970: 1_006)
+    ])
+    let service = SimulatorRecordingService(
+      runner: MockRecordingRunner(process: process),
+      dateProvider: { dates.next() },
+      finalizationTimeout: .zero,
+      pollingInterval: .zero
+    )
+
+    let started = try await service.startRecording(
+      udid: "UDID-1",
+      outputDirectory: directory,
+      fileName: "discard-me"
+    )
+    try minimalMP4Data().write(to: URL(fileURLWithPath: started.outputPath))
+
+    let result = try await service.discardRecording(udid: "UDID-1")
+
+    #expect(process.interruptCallCount == 1)
+    #expect(result.outputPath == started.outputPath)
+    #expect(FileManager.default.fileExists(atPath: started.outputPath) == false)
+  }
+
+  @Test("Start rejects duplicate active recording for same simulator")
+  func duplicateStartRejected() async throws {
+    let directory = try temporarySimulatorRecordingDirectory()
+    defer { try? FileManager.default.removeItem(at: directory.deletingLastPathComponent()) }
+
+    let service = SimulatorRecordingService(
+      runner: MockRecordingRunner(process: MockRecordingProcess()),
+      dateProvider: { Date(timeIntervalSince1970: 1_000) }
+    )
+
+    _ = try await service.startRecording(
+      udid: "UDID-1",
+      outputDirectory: directory,
+      fileName: "first"
+    )
+
+    await #expect(throws: SimulatorRecordingError.alreadyRecording("UDID-1")) {
+      _ = try await service.startRecording(
+        udid: "UDID-1",
+        outputDirectory: directory,
+        fileName: "second"
+      )
+    }
+  }
+
+  @Test("Start surfaces simctl stderr when recording cannot begin")
+  func startSurfacesSimctlDiagnostic() async throws {
+    let directory = try temporarySimulatorRecordingDirectory()
+    defer { try? FileManager.default.removeItem(at: directory.deletingLastPathComponent()) }
+
+    let process = MockRecordingProcess(
+      isRunning: false,
+      diagnosticOutput: "Host recording is already in progress"
+    )
+    let service = SimulatorRecordingService(
+      runner: MockRecordingRunner(process: process),
+      dateProvider: { Date(timeIntervalSince1970: 1_000) },
+      startConfirmationTimeout: .zero,
+      pollingInterval: .zero
+    )
+
+    await #expect(throws: SimulatorRecordingError.startFailed("Host recording is already in progress")) {
+      _ = try await service.startRecording(
+        udid: "UDID-1",
+        outputDirectory: directory,
+        fileName: "busy"
+      )
+    }
+  }
+
+  @Test("Start failure removes partial output file")
+  func startFailureRemovesPartialOutputFile() async throws {
+    let directory = try temporarySimulatorRecordingDirectory()
+    defer { try? FileManager.default.removeItem(at: directory.deletingLastPathComponent()) }
+
+    let process = MockRecordingProcess(
+      isRunning: false,
+      diagnosticOutput: "Host recording is already in progress"
+    )
+    let runner = MockRecordingRunner(process: process) { arguments in
+      guard let outputPath = arguments.last else { return }
+      try Data([0x00]).write(to: URL(fileURLWithPath: outputPath))
+    }
+    let service = SimulatorRecordingService(
+      runner: runner,
+      dateProvider: { Date(timeIntervalSince1970: 1_000) },
+      startConfirmationTimeout: .zero,
+      pollingInterval: .zero
+    )
+    let outputURL = directory.appendingPathComponent("busy.mp4")
+
+    await #expect(throws: SimulatorRecordingError.startFailed("Host recording is already in progress")) {
+      _ = try await service.startRecording(
+        udid: "UDID-1",
+        outputDirectory: directory,
+        fileName: "busy"
+      )
+    }
+
+    #expect(FileManager.default.fileExists(atPath: outputURL.path) == false)
+  }
+
+  @Test("Generated recording filenames are path safe")
+  func generatedFileNameIsPathSafe() throws {
+    let fileName = try SimulatorRecordingService.recordingFileName(
+      udid: "A/B:C",
+      startedAt: Date(timeIntervalSince1970: 1_000),
+      requestedFileName: nil
+    )
+
+    #expect(fileName.hasPrefix("agenthub-simulator-A_B_C-"))
+    #expect(fileName.hasSuffix(".mp4"))
+    #expect(!fileName.contains("/"))
+    #expect(!fileName.contains(":"))
+  }
+
+  @Test("Requested recording filenames cannot escape output directory")
+  func requestedFileNameCannotEscapeDirectory() throws {
+    #expect(throws: SimulatorRecordingError.invalidFileName("../escape")) {
+      _ = try SimulatorRecordingService.recordingFileName(
+        udid: "UDID",
+        startedAt: Date(),
+        requestedFileName: "../escape"
+      )
+    }
+  }
+}
+
+private final class MockRecordingProcess: SimulatorRecordingProcess, @unchecked Sendable {
+  var isRunning: Bool
+  var terminationStatus: Int32 = 0
+  var diagnosticOutput: String
+  var interruptCallCount = 0
+  var terminateCallCount = 0
+  var waitCallCount = 0
+
+  private let exitsOnInterrupt: Bool
+  private let exitsOnTerminate: Bool
+
+  init(
+    isRunning: Bool = true,
+    diagnosticOutput: String = "Recording started",
+    exitsOnInterrupt: Bool = true,
+    exitsOnTerminate: Bool = true
+  ) {
+    self.isRunning = isRunning
+    self.diagnosticOutput = diagnosticOutput
+    self.exitsOnInterrupt = exitsOnInterrupt
+    self.exitsOnTerminate = exitsOnTerminate
+  }
+
+  func interrupt() {
+    interruptCallCount += 1
+    if exitsOnInterrupt {
+      isRunning = false
+    }
+  }
+
+  func terminate() {
+    terminateCallCount += 1
+    if exitsOnTerminate {
+      isRunning = false
+    }
+  }
+
+  func waitUntilExit() {
+    waitCallCount += 1
+  }
+}
+
+private final class MockRecordingRunner: SimulatorRecordingProcessRunning, @unchecked Sendable {
+  private let lock = NSLock()
+  private let process: MockRecordingProcess
+  private let onStart: ([String]) throws -> Void
+  private var arguments: [[String]] = []
+
+  init(process: MockRecordingProcess, onStart: @escaping ([String]) throws -> Void = { _ in }) {
+    self.process = process
+    self.onStart = onStart
+  }
+
+  func start(arguments: [String]) throws -> any SimulatorRecordingProcess {
+    lock.lock()
+    self.arguments.append(arguments)
+    lock.unlock()
+    try onStart(arguments)
+    return process
+  }
+
+  func recordedArguments() -> [[String]] {
+    lock.lock()
+    defer { lock.unlock() }
+    return arguments
+  }
+}
+
+private final class DateSequence: @unchecked Sendable {
+  private let lock = NSLock()
+  private var dates: [Date]
+
+  init(_ dates: [Date]) {
+    self.dates = dates
+  }
+
+  func next() -> Date {
+    lock.lock()
+    defer { lock.unlock() }
+    return dates.isEmpty ? Date() : dates.removeFirst()
+  }
+}
+
+private func temporarySimulatorRecordingDirectory() throws -> URL {
+  let root = FileManager.default.temporaryDirectory
+    .appendingPathComponent("agenthub-simulator-recording-tests-\(UUID().uuidString)", isDirectory: true)
+  try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+  return root.appendingPathComponent("recordings", isDirectory: true)
+}
+
+private func minimalMP4Data(includeMoov: Bool = true) -> Data {
+  var data = Data()
+  data.append(mp4Box(type: "ftyp", payload: Data("isom0000".utf8)))
+  data.append(mp4Box(type: "mdat", payload: Data([0x00])))
+  if includeMoov {
+    data.append(mp4Box(type: "moov"))
+  }
+  return data
+}
+
+private func mp4Box(type: String, payload: Data = Data()) -> Data {
+  var size = UInt32(payload.count + 8).bigEndian
+  var data = Data()
+  withUnsafeBytes(of: &size) { data.append(contentsOf: $0) }
+  data.append(Data(type.utf8.prefix(4)))
+  data.append(payload)
+  return data
+}

--- a/app/modules/AgentHubCLI/Tests/AgentHubCLIKitTests/SimulatorRunRequestQueueTests.swift
+++ b/app/modules/AgentHubCLI/Tests/AgentHubCLIKitTests/SimulatorRunRequestQueueTests.swift
@@ -1,0 +1,74 @@
+import Foundation
+import Testing
+
+@testable import AgentHubCLIKit
+
+@Suite("SimulatorRunRequestQueue")
+struct SimulatorRunRequestQueueTests {
+  @Test("Enqueue writes pending simulator run request")
+  func enqueueWritesPendingRequest() throws {
+    let directory = try temporarySimulatorRunRequestDirectory()
+    defer { try? FileManager.default.removeItem(at: directory.deletingLastPathComponent()) }
+
+    let queue = SimulatorRunRequestQueue(directoryURL: directory)
+    let request = SimulatorRunRequest(
+      id: "request-1",
+      createdAt: Date(timeIntervalSince1970: 1_000),
+      projectPath: "/tmp/App",
+      udid: "UDID-1",
+      sourceProvider: .codex,
+      sourceSessionId: "session-1",
+      reason: "verify latest changes"
+    )
+
+    let queued = try queue.enqueue(request)
+    let pending = try queue.pendingRequests()
+
+    #expect(FileManager.default.fileExists(atPath: queued.fileURL.path))
+    #expect(pending.map(\.request) == [request])
+  }
+
+  @Test("Remove deletes handled simulator run request")
+  func removeDeletesHandledRequest() throws {
+    let directory = try temporarySimulatorRunRequestDirectory()
+    defer { try? FileManager.default.removeItem(at: directory.deletingLastPathComponent()) }
+
+    let queue = SimulatorRunRequestQueue(directoryURL: directory)
+    let queued = try queue.enqueue(SimulatorRunRequest(
+      id: "request-1",
+      projectPath: "/tmp/App",
+      udid: "UDID-1"
+    ))
+
+    try queue.remove(queued)
+
+    #expect(try queue.pendingRequests().isEmpty)
+    #expect(!FileManager.default.fileExists(atPath: queued.fileURL.path))
+  }
+
+  @Test("Mark failed moves simulator request out of pending queue")
+  func markFailedMovesRequestOutOfPendingQueue() throws {
+    let directory = try temporarySimulatorRunRequestDirectory()
+    defer { try? FileManager.default.removeItem(at: directory.deletingLastPathComponent()) }
+
+    let queue = SimulatorRunRequestQueue(directoryURL: directory)
+    let queued = try queue.enqueue(SimulatorRunRequest(
+      id: "request-1",
+      projectPath: "/tmp/App",
+      udid: "UDID-1"
+    ))
+
+    try queue.markFailed(queued)
+
+    let failedURL = queued.fileURL.deletingPathExtension().appendingPathExtension("failed")
+    #expect(try queue.pendingRequests().isEmpty)
+    #expect(FileManager.default.fileExists(atPath: failedURL.path))
+  }
+}
+
+private func temporarySimulatorRunRequestDirectory() throws -> URL {
+  let root = FileManager.default.temporaryDirectory
+    .appendingPathComponent("agenthub-simulator-run-request-tests-\(UUID().uuidString)", isDirectory: true)
+  try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+  return root.appendingPathComponent("requests", isDirectory: true)
+}

--- a/app/modules/AgentHubCLI/Tests/AgentHubCLIKitTests/SimulatorSessionContextStoreTests.swift
+++ b/app/modules/AgentHubCLI/Tests/AgentHubCLIKitTests/SimulatorSessionContextStoreTests.swift
@@ -1,0 +1,96 @@
+import Foundation
+import Testing
+
+@testable import AgentHubCLIKit
+
+@Suite("SimulatorSessionContextStore")
+struct SimulatorSessionContextStoreTests {
+  @Test("Write and resolve preserve the active panel context")
+  func writeAndResolveContext() throws {
+    let directory = try temporarySimulatorContextDirectory()
+    defer { try? FileManager.default.removeItem(at: directory.deletingLastPathComponent()) }
+
+    let store = SimulatorSessionContextStore(directoryURL: directory)
+    let context = SimulatorSessionContext(
+      provider: .codex,
+      sessionId: "session-1",
+      projectPath: "/tmp/App",
+      udid: "UDID-1",
+      deviceName: "iPhone 17 Pro",
+      runtimeName: "iOS 26.0",
+      isBooted: true,
+      displayMode: "live",
+      updatedAt: Date(timeIntervalSince1970: 1_000)
+    )
+
+    try store.write(context)
+
+    #expect(try store.context(provider: .codex, sessionId: "session-1", projectPath: "/tmp/App") == context)
+    #expect(try store.resolveContext(provider: .codex, sessionId: "session-1", projectPath: "/tmp/App") == context)
+  }
+
+  @Test("Resolve falls back to the newest visible context for the project")
+  func resolveProjectFallbackUsesNewestVisibleContext() throws {
+    let directory = try temporarySimulatorContextDirectory()
+    defer { try? FileManager.default.removeItem(at: directory.deletingLastPathComponent()) }
+
+    let store = SimulatorSessionContextStore(directoryURL: directory)
+    let older = SimulatorSessionContext(
+      provider: .claude,
+      sessionId: "older",
+      projectPath: "/tmp/App/",
+      udid: "OLD",
+      deviceName: nil,
+      runtimeName: nil,
+      isBooted: false,
+      displayMode: "live",
+      updatedAt: Date(timeIntervalSince1970: 1_000)
+    )
+    let newer = SimulatorSessionContext(
+      provider: .codex,
+      sessionId: "newer",
+      projectPath: "/tmp/App",
+      udid: "NEW",
+      deviceName: nil,
+      runtimeName: nil,
+      isBooted: true,
+      displayMode: "previews",
+      updatedAt: Date(timeIntervalSince1970: 2_000)
+    )
+
+    try store.write(older)
+    try store.write(newer)
+
+    #expect(try store.resolveContext(provider: nil, sessionId: nil, projectPath: "/tmp/App") == newer)
+  }
+
+  @Test("Remove deletes a stale panel context")
+  func removeDeletesContext() throws {
+    let directory = try temporarySimulatorContextDirectory()
+    defer { try? FileManager.default.removeItem(at: directory.deletingLastPathComponent()) }
+
+    let store = SimulatorSessionContextStore(directoryURL: directory)
+    let context = SimulatorSessionContext(
+      provider: .claude,
+      sessionId: "session-1",
+      projectPath: "/tmp/App",
+      udid: "UDID",
+      deviceName: nil,
+      runtimeName: nil,
+      isBooted: true,
+      displayMode: "live"
+    )
+
+    try store.write(context)
+    try store.remove(provider: .claude, sessionId: "session-1", projectPath: "/tmp/App")
+
+    #expect(try store.context(provider: .claude, sessionId: "session-1", projectPath: "/tmp/App") == nil)
+  }
+}
+
+private func temporarySimulatorContextDirectory() throws -> URL {
+  let root = FileManager.default.temporaryDirectory
+    .appendingPathComponent("agenthub-simulator-context-tests-\(UUID().uuidString)", isDirectory: true)
+  try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+  return root.appendingPathComponent("contexts", isDirectory: true)
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubProvider.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubProvider.swift
@@ -5,16 +5,16 @@
 //  Central service provider for AgentHub
 //
 
-import AgentHubGitHub
-import AgentHubGitDiff
 import AgentHubCLIKit
-import SimulatorPreview
+import AgentHubGitDiff
+import AgentHubGitHub
+import ClaudeCodeClient
 import Foundation
 import os
-import ClaudeCodeClient
+import SimulatorPreview
 
 #if canImport(AppKit)
-import AppKit
+  import AppKit
 #endif
 
 /// Central service provider that manages all AgentHub services
@@ -36,7 +36,6 @@ import AppKit
 /// ```
 @MainActor
 public final class AgentHubProvider {
-
   // MARK: - Configuration
 
   /// The configuration used by this provider
@@ -52,58 +51,41 @@ public final class AgentHubProvider {
   private let metadataStoreOverride: SessionMetadataStore?
   private let worktreeLaunchRequestMonitorOverride: (any WorktreeLaunchRequestMonitorProtocol)?
   private let worktreeDeletionRequestMonitorOverride: (any WorktreeDeletionRequestMonitorProtocol)?
+  private let simulatorRunRequestMonitorOverride: (any SimulatorRunRequestMonitorProtocol)?
 
   // MARK: - Lazy Services
 
   /// Monitor service for tracking CLI sessions
-  public private(set) lazy var monitorService: CLISessionMonitorService = {
-    CLISessionMonitorService(claudeDataPath: configuration.claudeDataPath, metadataStore: metadataStore)
-  }()
+  public private(set) lazy var monitorService: CLISessionMonitorService = .init(claudeDataPath: configuration.claudeDataPath, metadataStore: metadataStore)
 
   /// Monitor service for tracking Codex sessions
-  public private(set) lazy var codexMonitorService: CodexSessionMonitorService = {
-    CodexSessionMonitorService(codexDataPath: configuration.codexDataPath, metadataStore: metadataStore)
-  }()
+  public private(set) lazy var codexMonitorService: CodexSessionMonitorService = .init(codexDataPath: configuration.codexDataPath, metadataStore: metadataStore)
 
   /// Git worktree service for branch/worktree operations
-  public private(set) lazy var gitService: GitWorktreeService = {
-    GitWorktreeService()
-  }()
+  public private(set) lazy var gitService: GitWorktreeService = .init()
 
   /// Global stats service for Claude usage metrics
-  public private(set) lazy var statsService: GlobalStatsService = {
-    GlobalStatsService(claudePath: configuration.claudeDataPath)
-  }()
+  public private(set) lazy var statsService: GlobalStatsService = .init(claudePath: configuration.claudeDataPath)
 
   /// Global stats service for Codex usage metrics
-  public private(set) lazy var codexStatsService: CodexGlobalStatsService = {
-    CodexGlobalStatsService(codexPath: configuration.codexDataPath)
-  }()
+  public private(set) lazy var codexStatsService: CodexGlobalStatsService = .init(codexPath: configuration.codexDataPath)
 
   /// Codex file watcher for real-time monitoring
-  private lazy var codexFileWatcher: CodexSessionFileWatcher = {
-    CodexSessionFileWatcher(codexPath: configuration.codexDataPath)
-  }()
+  private lazy var codexFileWatcher: CodexSessionFileWatcher = .init(codexPath: configuration.codexDataPath)
 
   /// Claude file watcher for real-time monitoring. Wired to the approval hook
   /// sidecar so pending-approval state can be surfaced while Claude Code CLI
   /// buffers its JSONL writes.
-  private lazy var claudeFileWatcher: SessionFileWatcher = {
-    SessionFileWatcher(
-      claudePath: configuration.claudeDataPath,
-      hookSidecarWatcher: claudeHookSidecarWatcher
-    )
-  }()
+  private lazy var claudeFileWatcher: SessionFileWatcher = .init(
+    claudePath: configuration.claudeDataPath,
+    hookSidecarWatcher: claudeHookSidecarWatcher
+  )
 
   /// Shared claim store gating the approval hook script.
-  public private(set) lazy var approvalClaimStore: any ApprovalClaimStoreProtocol = {
-    ApprovalClaimStore()
-  }()
+  public private(set) lazy var approvalClaimStore: any ApprovalClaimStoreProtocol = ApprovalClaimStore()
 
   /// Watches the approval sidecar directory populated by the installed hook.
-  public private(set) lazy var claudeHookSidecarWatcher: any ClaudeHookSidecarWatcherProtocol = {
-    ClaudeHookSidecarWatcher()
-  }()
+  public private(set) lazy var claudeHookSidecarWatcher: any ClaudeHookSidecarWatcherProtocol = ClaudeHookSidecarWatcher()
 
   /// Installs/uninstalls the AgentHub approval hook per worktree.
   public private(set) lazy var claudeHookInstaller: any ClaudeHookInstallerProtocol = {
@@ -115,41 +97,27 @@ public final class AgentHubProvider {
   }()
 
   /// Claude search service
-  private lazy var claudeSearchService: GlobalSearchService = {
-    GlobalSearchService(claudeDataPath: configuration.claudeDataPath)
-  }()
+  private lazy var claudeSearchService: GlobalSearchService = .init(claudeDataPath: configuration.claudeDataPath)
 
   /// Codex search service
-  private lazy var codexSearchService: CodexSearchService = {
-    CodexSearchService(codexDataPath: configuration.codexDataPath)
-  }()
+  private lazy var codexSearchService: CodexSearchService = .init(codexDataPath: configuration.codexDataPath)
 
   /// Display settings for stats visualization
-  public private(set) lazy var displaySettings: StatsDisplaySettings = {
-    StatsDisplaySettings(configuration.statsDisplayMode)
-  }()
+  public private(set) lazy var displaySettings: StatsDisplaySettings = .init(configuration.statsDisplayMode)
 
   /// Cached project-level detector for web preview button visibility.
-  lazy var webPreviewCandidateService: any WebPreviewCandidateServiceProtocol = {
-    WebPreviewCandidateService.shared
-  }()
+  lazy var webPreviewCandidateService: any WebPreviewCandidateServiceProtocol = WebPreviewCandidateService.shared
 
   /// Discovers and routes MCP App UI resources exposed by configured MCP servers.
-  public private(set) lazy var mcpAppDiscoveryService: any MCPAppDiscoveryServiceProtocol = {
-    MCPAppDiscoveryService.shared
-  }()
+  public private(set) lazy var mcpAppDiscoveryService: any MCPAppDiscoveryServiceProtocol = MCPAppDiscoveryService.shared
 
   /// Cached project-level detector for inline diff tab visibility.
-  lazy var diffAvailabilityService: any DiffAvailabilityServiceProtocol = {
-    DiffAvailabilityService.shared
-  }()
+  lazy var diffAvailabilityService: any DiffAvailabilityServiceProtocol = DiffAvailabilityService.shared
 
   /// Live in-app iOS Simulator capture/streaming. All capture stays in-process;
   /// no network, no Screen Recording/Accessibility permissions. See the
   /// `SimulatorPreview` module README for the privacy contract.
-  public private(set) lazy var simulatorStreamService: any SimulatorStreamServiceProtocol = {
-    SimulatorStreamService.shared
-  }()
+  public private(set) lazy var simulatorStreamService: any SimulatorStreamServiceProtocol = SimulatorStreamService.shared
 
   /// Session metadata store for user-provided session names
   public private(set) lazy var metadataStore: SessionMetadataStore? = {
@@ -172,110 +140,82 @@ public final class AgentHubProvider {
 
   /// Shared `claude -p` invocation service used by short, non-interactive
   /// callers (branch naming, inline-edit style reconciliation, etc.).
-  public private(set) lazy var programmaticClaudeService: any ClaudeProgrammaticServiceProtocol = {
-    ClaudeProgrammaticService(
-      additionalPaths: ClaudeCodePathResolver.searchPaths(additionalPaths: configuration.additionalCLIPaths)
-    )
-  }()
+  public private(set) lazy var programmaticClaudeService: any ClaudeProgrammaticServiceProtocol = ClaudeProgrammaticService(
+    additionalPaths: ClaudeCodePathResolver.searchPaths(additionalPaths: configuration.additionalCLIPaths)
+  )
 
   /// Claude-backed service for naming launcher-generated worktree branches.
-  public private(set) lazy var worktreeBranchNamingService: any WorktreeBranchNamingServiceProtocol = {
-    ClaudeWorktreeBranchNamingService(programmaticService: programmaticClaudeService)
-  }()
+  public private(set) lazy var worktreeBranchNamingService: any WorktreeBranchNamingServiceProtocol = ClaudeWorktreeBranchNamingService(programmaticService: programmaticClaudeService)
 
   /// Claude-backed local audit of AgentHub's current session/worktree state.
-  public private(set) lazy var sessionInvestigationService: any SessionInvestigationServiceProtocol = {
-    ClaudeSessionInvestigationService(programmaticService: programmaticClaudeService)
-  }()
+  public private(set) lazy var sessionInvestigationService: any SessionInvestigationServiceProtocol = ClaudeSessionInvestigationService(programmaticService: programmaticClaudeService)
 
   /// Reformats Canvas inline-toolbar edits so the persisted file matches the
   /// project's existing code style. Runs Haiku via `claude -p` after the
   /// debounced direct write so the UX stays snappy.
-  public private(set) lazy var inlineEditReconciler: any InlineEditStyleReconcilerProtocol = {
-    ClaudeInlineEditStyleReconciler(programmaticService: programmaticClaudeService)
-  }()
+  public private(set) lazy var inlineEditReconciler: any InlineEditStyleReconcilerProtocol = ClaudeInlineEditStyleReconciler(programmaticService: programmaticClaudeService)
 
   /// Success sound service for completed launcher-created worktrees.
-  public private(set) lazy var worktreeSuccessSoundService: any WorktreeSuccessSoundServiceProtocol = {
-    WorktreeSuccessSoundService()
-  }()
+  public private(set) lazy var worktreeSuccessSoundService: any WorktreeSuccessSoundServiceProtocol = WorktreeSuccessSoundService()
 
   /// Watches requests written by the bundled `agenthub` helper.
-  public private(set) lazy var worktreeLaunchRequestMonitor: any WorktreeLaunchRequestMonitorProtocol = {
-    worktreeLaunchRequestMonitorOverride ?? WorktreeLaunchRequestMonitor()
-  }()
+  public private(set) lazy var worktreeLaunchRequestMonitor: any WorktreeLaunchRequestMonitorProtocol = worktreeLaunchRequestMonitorOverride ?? WorktreeLaunchRequestMonitor()
 
   /// Watches worktree deletion cleanup requests written by the bundled `agenthub` helper.
-  public private(set) lazy var worktreeDeletionRequestMonitor: any WorktreeDeletionRequestMonitorProtocol = {
-    worktreeDeletionRequestMonitorOverride ?? WorktreeDeletionRequestMonitor()
-  }()
+  public private(set) lazy var worktreeDeletionRequestMonitor: any WorktreeDeletionRequestMonitorProtocol = worktreeDeletionRequestMonitorOverride ?? WorktreeDeletionRequestMonitor()
 
-  public private(set) lazy var worktreeLaunchRequestHandler: any WorktreeLaunchRequestHandlingProtocol = {
-    WorktreeLaunchRequestHandler(
-      claudeViewModel: claudeSessionsViewModel,
-      codexViewModel: codexSessionsViewModel
-    )
-  }()
+  /// Watches simulator Build & Run requests written by the bundled `agenthub` helper.
+  public private(set) lazy var simulatorRunRequestMonitor: any SimulatorRunRequestMonitorProtocol = simulatorRunRequestMonitorOverride ?? SimulatorRunRequestMonitor()
 
-  public private(set) lazy var worktreeDeletionRequestHandler: any WorktreeDeletionRequestHandlingProtocol = {
-    WorktreeDeletionRequestHandler(
-      claudeViewModel: claudeSessionsViewModel,
-      codexViewModel: codexSessionsViewModel
-    )
-  }()
+  public private(set) lazy var worktreeLaunchRequestHandler: any WorktreeLaunchRequestHandlingProtocol = WorktreeLaunchRequestHandler(
+    claudeViewModel: claudeSessionsViewModel,
+    codexViewModel: codexSessionsViewModel
+  )
+
+  public private(set) lazy var worktreeDeletionRequestHandler: any WorktreeDeletionRequestHandlingProtocol = WorktreeDeletionRequestHandler(
+    claudeViewModel: claudeSessionsViewModel,
+    codexViewModel: codexSessionsViewModel
+  )
+
+  public private(set) lazy var simulatorRunRequestHandler: any SimulatorRunRequestHandlingProtocol = SimulatorRunRequestHandler(simulatorService: SimulatorService.shared)
 
   /// Watches the worktree-progress sidecar directory the `agenthub` CLI writes
   /// during MCP-initiated creations, so the app can surface live git progress.
-  public private(set) lazy var worktreeProgressSidecarWatcher: any WorktreeProgressSidecarWatcherProtocol = {
-    WorktreeProgressSidecarWatcher()
-  }()
+  public private(set) lazy var worktreeProgressSidecarWatcher: any WorktreeProgressSidecarWatcherProtocol = WorktreeProgressSidecarWatcher()
 
   /// Posts the "worktrees ready" macOS notification when a batch completes.
-  public private(set) lazy var worktreeReadyNotificationService: any WorktreeReadyNotificationServiceProtocol = {
-    WorktreeReadyNotificationService()
-  }()
+  public private(set) lazy var worktreeReadyNotificationService: any WorktreeReadyNotificationServiceProtocol = WorktreeReadyNotificationService()
 
   /// App-wide coordinator unifying worktree creation progress (side panel + MCP)
   /// for the top bar; fires the completion sound/notification once per batch.
-  public private(set) lazy var worktreeGenerationProgressCoordinator: WorktreeGenerationProgressCoordinator = {
-    WorktreeGenerationProgressCoordinator(
-      soundService: worktreeSuccessSoundService,
-      notificationService: worktreeReadyNotificationService
-    )
-  }()
+  public private(set) lazy var worktreeGenerationProgressCoordinator: WorktreeGenerationProgressCoordinator = .init(
+    soundService: worktreeSuccessSoundService,
+    notificationService: worktreeReadyNotificationService
+  )
 
   private var isWorktreeLaunchRequestMonitoringStarted = false
   private var isWorktreeDeletionRequestMonitoringStarted = false
+  private var isSimulatorRunRequestMonitoringStarted = false
   private var isWorktreeProgressMonitoringStarted = false
 
   // MARK: - GitHub Integration
 
   /// GitHub CLI service for PR/issue operations
-  public private(set) lazy var gitHubService: any GitHubCLIServiceProtocol = {
-    GitHubCLIService()
-  }()
+  public private(set) lazy var gitHubService: any GitHubCLIServiceProtocol = GitHubCLIService()
 
   /// Shared session-card GitHub quick access coordinator
-  public private(set) lazy var gitHubQuickAccessCoordinator: any SessionGitHubQuickAccessCoordinatorProtocol = {
-    SessionGitHubQuickAccessCoordinator(service: gitHubService)
-  }()
+  public private(set) lazy var gitHubQuickAccessCoordinator: any SessionGitHubQuickAccessCoordinatorProtocol = SessionGitHubQuickAccessCoordinator(service: gitHubService)
 
   /// Shared GitHub PR/check observation service for panels and session rows
-  public private(set) lazy var gitHubPRObservationService: any GitHubPRObservationServiceProtocol = {
-    GitHubPRObservationService(service: gitHubService)
-  }()
+  public private(set) lazy var gitHubPRObservationService: any GitHubPRObservationServiceProtocol = GitHubPRObservationService(service: gitHubService)
 
   // MARK: - Global Session Control Panel
 
   /// Routes global-panel session selections into the main sessions UI.
-  public private(set) lazy var globalSessionSelectionRouter: GlobalSessionSelectionRouter = {
-    GlobalSessionSelectionRouter()
-  }()
+  public private(set) lazy var globalSessionSelectionRouter: GlobalSessionSelectionRouter = .init()
 
   /// Coordinates the opt-in global hotkey and floating sessions panel.
-  public private(set) lazy var globalSessionControlPanelCoordinator: GlobalSessionControlPanelCoordinator = {
-    GlobalSessionControlPanelCoordinator(provider: self)
-  }()
+  public private(set) lazy var globalSessionControlPanelCoordinator: GlobalSessionControlPanelCoordinator = .init(provider: self)
 
   public func makeGlobalSessionControlPanelPresenter(
     defaults: UserDefaults = .standard
@@ -286,31 +226,21 @@ public final class AgentHubProvider {
   // MARK: - Theme Management
 
   /// Theme manager for YAML and built-in themes
-  public private(set) lazy var themeManager: ThemeManager = {
-    ThemeManager()
-  }()
+  public private(set) lazy var themeManager: ThemeManager = .init()
 
   // MARK: - View Models
 
   /// Claude sessions view model - created lazily and cached
-  public private(set) lazy var claudeSessionsViewModel: CLISessionsViewModel = {
-    makeSessionsViewModel(providerKind: .claude)
-  }()
+  public private(set) lazy var claudeSessionsViewModel: CLISessionsViewModel = makeSessionsViewModel(providerKind: .claude)
 
   /// Codex sessions view model - created lazily and cached
-  public private(set) lazy var codexSessionsViewModel: CLISessionsViewModel = {
-    makeSessionsViewModel(providerKind: .codex)
-  }()
+  public private(set) lazy var codexSessionsViewModel: CLISessionsViewModel = makeSessionsViewModel(providerKind: .codex)
 
   /// Backwards-compatible default sessions view model (Claude)
-  public private(set) lazy var sessionsViewModel: CLISessionsViewModel = {
-    claudeSessionsViewModel
-  }()
+  public private(set) lazy var sessionsViewModel: CLISessionsViewModel = claudeSessionsViewModel
 
   /// Intelligence view model - created lazily and cached
-  public private(set) lazy var intelligenceViewModel: IntelligenceViewModel = {
-    IntelligenceViewModel(processService: createProcessService())
-  }()
+  public private(set) lazy var intelligenceViewModel: IntelligenceViewModel = .init(processService: createProcessService())
 
   // MARK: - Initialization
 
@@ -329,15 +259,17 @@ public final class AgentHubProvider {
     },
     metadataStore: SessionMetadataStore? = nil,
     worktreeLaunchRequestMonitor: (any WorktreeLaunchRequestMonitorProtocol)? = nil,
-    worktreeDeletionRequestMonitor: (any WorktreeDeletionRequestMonitorProtocol)? = nil
+    worktreeDeletionRequestMonitor: (any WorktreeDeletionRequestMonitorProtocol)? = nil,
+    simulatorRunRequestMonitor: (any SimulatorRunRequestMonitorProtocol)? = nil
   ) {
     self.configuration = configuration
-    self.terminalBackend = .storedPreference
+    terminalBackend = .storedPreference
     self.terminalSurfaceFactory = terminalSurfaceFactory
     self.globalSessionControlPanelPresenterFactory = globalSessionControlPanelPresenterFactory
-    self.metadataStoreOverride = metadataStore
-    self.worktreeLaunchRequestMonitorOverride = worktreeLaunchRequestMonitor
-    self.worktreeDeletionRequestMonitorOverride = worktreeDeletionRequestMonitor
+    metadataStoreOverride = metadataStore
+    worktreeLaunchRequestMonitorOverride = worktreeLaunchRequestMonitor
+    worktreeDeletionRequestMonitorOverride = worktreeDeletionRequestMonitor
+    simulatorRunRequestMonitorOverride = simulatorRunRequestMonitor
     if let metadataStore {
       Task {
         await TerminalProcessRegistry.shared.configure(store: metadataStore)
@@ -348,7 +280,7 @@ public final class AgentHubProvider {
     let defaults = UserDefaults.standard
     defaults.register(defaults: [
       AgentHubDefaults.globalSessionPanelEnabled: true,
-      AgentHubDefaults.globalSessionPanelDisplayMode: 0
+      AgentHubDefaults.globalSessionPanelDisplayMode: 0,
     ])
 
     // Claude command: if developer provided non-default, lock it
@@ -496,6 +428,7 @@ public final class AgentHubProvider {
     startWorktreeLaunchQueueMonitoring()
     startWorktreeDeletionQueueMonitoring()
     startWorktreeProgressMonitoring()
+    startSimulatorRunQueueMonitoring()
   }
 
   private func startWorktreeProgressMonitoring() {
@@ -545,6 +478,21 @@ public final class AgentHubProvider {
     }
   }
 
+  private func startSimulatorRunQueueMonitoring() {
+    guard !isSimulatorRunRequestMonitoringStarted else { return }
+    isSimulatorRunRequestMonitoringStarted = true
+
+    let monitor = simulatorRunRequestMonitor
+    Task {
+      await monitor.start { [weak self] queued in
+        guard let self else {
+          throw SimulatorRunRequestHandlingError.invalidTarget
+        }
+        try await self.simulatorRunRequestHandler.handle(queued.request)
+      }
+    }
+  }
+
   public func stopWorktreeLaunchRequestMonitoring() {
     if isWorktreeLaunchRequestMonitoringStarted {
       isWorktreeLaunchRequestMonitoringStarted = false
@@ -563,6 +511,16 @@ public final class AgentHubProvider {
         await monitor.stop()
       }
     }
+
+    if isSimulatorRunRequestMonitoringStarted {
+      isSimulatorRunRequestMonitoringStarted = false
+
+      let monitor = simulatorRunRequestMonitor
+      Task {
+        await monitor.stop()
+      }
+    }
+
   }
 
   /// Sweeps any previously-installed approval hooks, wipes stale claim files,
@@ -640,21 +598,21 @@ public final class AgentHubProvider {
 
   public func relaunchApplication() {
     #if canImport(AppKit)
-    let bundlePath = Bundle.main.bundlePath
-    let escapedBundlePath = shellEscapedPath(bundlePath)
-    let script = "sleep 1; /usr/bin/open -n \(escapedBundlePath)"
-    let process = Process()
-    process.executableURL = URL(fileURLWithPath: "/bin/sh")
-    process.arguments = ["-c", script]
+      let bundlePath = Bundle.main.bundlePath
+      let escapedBundlePath = shellEscapedPath(bundlePath)
+      let script = "sleep 1; /usr/bin/open -n \(escapedBundlePath)"
+      let process = Process()
+      process.executableURL = URL(fileURLWithPath: "/bin/sh")
+      process.arguments = ["-c", script]
 
-    do {
-      try process.run()
-      NSApplication.shared.terminate(nil)
-    } catch {
-      AppLogger.session.error("Failed to relaunch AgentHub: \(error.localizedDescription)")
-    }
+      do {
+        try process.run()
+        NSApplication.shared.terminate(nil)
+      } catch {
+        AppLogger.session.error("Failed to relaunch AgentHub: \(error.localizedDescription)")
+      }
     #else
-    AppLogger.session.error("Relaunch is unavailable outside AppKit")
+      AppLogger.session.error("Relaunch is unavailable outside AppKit")
     #endif
   }
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/Models/SimulatorRecordingPromptBuilder.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Models/SimulatorRecordingPromptBuilder.swift
@@ -1,0 +1,55 @@
+import AgentHubCLIKit
+import Foundation
+
+enum SimulatorRecordingPromptBuilder {
+  static func prompt(
+    for recording: SimulatorRecordingResult,
+    deviceName: String?,
+    issue: String
+  ) -> String {
+    let trimmedIssue = issue.trimmingCharacters(in: .whitespacesAndNewlines)
+
+    guard recording.isUsable else {
+      var lines = [
+        "The simulator recording could not be audited because AgentHub did not produce a finalized MP4:",
+        recording.outputPath,
+      ]
+
+      if !trimmedIssue.isEmpty {
+        lines.append(contentsOf: [
+          "",
+          "User issue:",
+          trimmedIssue,
+        ])
+      }
+
+      lines.append(contentsOf: [
+        "",
+        recording.validationError ?? "Recording did not finalize. Try recording again.",
+      ])
+
+      return lines.joined(separator: "\n")
+    }
+
+    var lines = [
+      "Review this simulator recording and address the user's issue:",
+      trimmedIssue.isEmpty ? "No issue was provided." : trimmedIssue,
+      "",
+      "Recording:",
+      recording.outputPath,
+      "",
+      "Use ffprobe or ffmpeg to inspect timing and sampled frames as needed before changing code.",
+    ]
+
+    if let deviceName, !deviceName.isEmpty {
+      lines.append("Device: \(deviceName)")
+    }
+
+    if recording.duration > 0 {
+      let duration = recording.duration.formatted(.number.precision(.fractionLength(1)))
+      lines.append("Duration: \(duration) seconds")
+    }
+
+    return lines.joined(separator: "\n")
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/SimulatorRunRequestHandler.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/SimulatorRunRequestHandler.swift
@@ -1,0 +1,65 @@
+import AgentHubCLIKit
+import Foundation
+import SimulatorPreview
+
+@MainActor
+public protocol SimulatorRunRequestHandlingProtocol: AnyObject {
+  func handle(_ request: SimulatorRunRequest) async throws
+}
+
+@MainActor
+public protocol SimulatorRunExecuting: AnyObject {
+  func isBooted(udid: String) -> Bool
+  func bootDevice(udid: String) async
+  func buildAndRunOnSimulator(
+    udid: String,
+    projectPath: String,
+    hotReload: HotReloadLaunchPlan?
+  ) async -> Bool
+}
+
+extension SimulatorService: SimulatorRunExecuting {}
+
+enum SimulatorRunRequestHandlingError: LocalizedError, Equatable {
+  case invalidTarget
+  case runFailed(projectPath: String, udid: String)
+
+  var errorDescription: String? {
+    switch self {
+    case .invalidTarget:
+      return "Simulator run request is missing a project path or UDID."
+    case .runFailed(let projectPath, let udid):
+      return "Simulator Build & Run failed for \(projectPath) on \(udid)."
+    }
+  }
+}
+
+@MainActor
+public final class SimulatorRunRequestHandler: SimulatorRunRequestHandlingProtocol {
+  private let simulatorService: any SimulatorRunExecuting
+
+  public init(simulatorService: any SimulatorRunExecuting = SimulatorService.shared) {
+    self.simulatorService = simulatorService
+  }
+
+  public func handle(_ request: SimulatorRunRequest) async throws {
+    let projectPath = request.projectPath.trimmingCharacters(in: .whitespacesAndNewlines)
+    let udid = request.udid.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !projectPath.isEmpty, !udid.isEmpty else {
+      throw SimulatorRunRequestHandlingError.invalidTarget
+    }
+
+    if !simulatorService.isBooted(udid: udid) {
+      await simulatorService.bootDevice(udid: udid)
+    }
+
+    let success = await simulatorService.buildAndRunOnSimulator(
+      udid: udid,
+      projectPath: projectPath,
+      hotReload: nil
+    )
+    guard success else {
+      throw SimulatorRunRequestHandlingError.runFailed(projectPath: projectPath, udid: udid)
+    }
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/SimulatorRunRequestMonitor.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/SimulatorRunRequestMonitor.swift
@@ -1,0 +1,71 @@
+import AgentHubCLIKit
+import Foundation
+
+public protocol SimulatorRunRequestMonitorProtocol: AnyObject, Sendable {
+  func start(handler: @escaping @MainActor @Sendable (QueuedSimulatorRunRequest) async throws -> Void) async
+  func stop() async
+}
+
+public actor SimulatorRunRequestMonitor: SimulatorRunRequestMonitorProtocol {
+  private let queue: SimulatorRunRequestQueue
+  private let pollInterval: Duration
+  private var task: Task<Void, Never>?
+  private var activeRequestIds: Set<String> = []
+
+  public init(
+    queue: SimulatorRunRequestQueue = SimulatorRunRequestQueue(),
+    pollInterval: Duration = .seconds(1)
+  ) {
+    self.queue = queue
+    self.pollInterval = pollInterval
+  }
+
+  public func start(
+    handler: @escaping @MainActor @Sendable (QueuedSimulatorRunRequest) async throws -> Void
+  ) async {
+    guard task == nil else { return }
+
+    task = Task { [queue, pollInterval] in
+      while !Task.isCancelled {
+        await self.processPendingRequests(queue: queue, handler: handler)
+        try? await Task.sleep(for: pollInterval)
+      }
+    }
+  }
+
+  public func stop() async {
+    task?.cancel()
+    task = nil
+    activeRequestIds.removeAll()
+  }
+
+  private func processPendingRequests(
+    queue: SimulatorRunRequestQueue,
+    handler: @escaping @MainActor @Sendable (QueuedSimulatorRunRequest) async throws -> Void
+  ) async {
+    let queuedRequests: [QueuedSimulatorRunRequest]
+    do {
+      queuedRequests = try queue.pendingRequests()
+    } catch {
+      AppLogger.simulator.error("Failed to read AgentHub simulator run requests: \(error.localizedDescription)")
+      return
+    }
+
+    for queued in queuedRequests {
+      guard activeRequestIds.insert(queued.request.id).inserted else { continue }
+      defer { activeRequestIds.remove(queued.request.id) }
+
+      do {
+        try await handler(queued)
+        try queue.remove(queued)
+      } catch {
+        AppLogger.simulator.error("Failed to handle AgentHub simulator run request: \(error.localizedDescription)")
+        do {
+          try queue.markFailed(queued)
+        } catch {
+          AppLogger.simulator.error("Failed to mark AgentHub simulator run request failed: \(error.localizedDescription)")
+        }
+      }
+    }
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/SimulatorPreviewSidePanelView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/SimulatorPreviewSidePanelView.swift
@@ -22,6 +22,7 @@
 //
 
 import AppKit
+import AgentHubCLIKit
 import SimulatorPreview
 import SwiftUI
 
@@ -53,15 +54,27 @@ struct SimulatorPreviewSidePanelView: View {
   @State private var displayMode: SimulatorPanelDisplayMode = .live
   @State private var hotReload = SimulatorHotReloadController()
   @State private var annotationRefreshTask: Task<Void, Never>?
+  @State private var recordingState: SimulatorRecordingPanelState = .idle
+  @State private var lastRecordingResult: SimulatorRecordingResult?
+  @State private var recordingAuditIssue = ""
+  @State private var recordingFailureDismissTask: Task<Void, Never>?
+  @State private var streamRefreshGeneration = 0
   /// The failure message the user explicitly dismissed; the banner stays
   /// hidden for that exact message but reappears for any new/different error.
   @State private var dismissedFailureMessage: String?
+
+  private let simulatorContextStore = SimulatorSessionContextStore()
+  private let simulatorRecordingService = SimulatorRecordingService.shared
 
   @AppStorage(AgentHubDefaults.simulatorPreviewsEnabled)
   private var simulatorPreviewsEnabled: Bool = true
 
   private var streamService: any SimulatorStreamServiceProtocol {
     agentHub?.simulatorStreamService ?? SimulatorStreamService.shared
+  }
+
+  private var simulatorContextProvider: WorktreeLaunchProvider? {
+    WorktreeLaunchProvider(commandLineValue: providerKind.rawValue)
   }
 
   /// The device to preview: explicit selection, else the project's preferred
@@ -112,7 +125,8 @@ struct SimulatorPreviewSidePanelView: View {
   private var liveStreamVerticalOffset: CGFloat {
     guard effectiveDisplayMode == .live,
           !annotationModel.annotations.isEmpty,
-          !isAnnotationTrayExpanded else {
+          !isAnnotationTrayExpanded
+    else {
       return 0
     }
     return -56
@@ -164,6 +178,19 @@ struct SimulatorPreviewSidePanelView: View {
     return activeFailureMessage
   }
 
+  private var simulatorContextSignature: String {
+    [
+      simulatorContextProvider?.commandLineValue ?? "unknown",
+      session.id,
+      projectPath,
+      activeUDID ?? "",
+      activeDevice?.name ?? "",
+      activeRuntimeName ?? "",
+      isActiveDeviceBooted ? "booted" : "not-booted",
+      effectiveDisplayMode.rawValue,
+    ].joined(separator: "|")
+  }
+
   var body: some View {
     VStack(spacing: 0) {
       header
@@ -185,6 +212,12 @@ struct SimulatorPreviewSidePanelView: View {
       cancelAnnotationElementRefresh()
       hotReload.stopTracking()
       hotReload.sessionDidStop()
+      removeSimulatorContext()
+      stopRecordingOnPanelClose()
+      recordingFailureDismissTask?.cancel()
+    }
+    .task(id: simulatorContextSignature) {
+      persistSimulatorContext()
     }
     .onChange(of: activeUDID) { _, _ in
       cancelAnnotationElementRefresh()
@@ -301,7 +334,7 @@ struct SimulatorPreviewSidePanelView: View {
           value: .previews,
           title: "Previews",
           helpText: "Show SwiftUI previews"
-        )
+        ),
       ],
       selectedColor: Color.brandSecondary,
       accessibilityLabel: "Panel display mode"
@@ -417,8 +450,11 @@ struct SimulatorPreviewSidePanelView: View {
   @ViewBuilder
   private var content: some View {
     contentBody
+      .overlay(alignment: .bottom) {
+        recordingStatusOverlay
+      }
       .overlay(alignment: .bottomTrailing) {
-        annotationCommentsOverlay
+        bottomTrailingControlsOverlay
       }
       .overlay(alignment: .top) {
         simulatorFailureBannerOverlay
@@ -436,6 +472,44 @@ struct SimulatorPreviewSidePanelView: View {
   }
 
   @ViewBuilder
+  private var recordingStatusOverlay: some View {
+    if recordingState != .idle || lastRecordingResult != nil {
+      HStack(alignment: .bottom, spacing: 0) {
+        recordingOverlay
+          .allowsHitTesting(recordingOverlayAllowsHitTesting)
+
+        Spacer(minLength: 58)
+      }
+      .padding(14)
+      .frame(maxWidth: .infinity, alignment: .bottomLeading)
+    }
+  }
+
+  private var bottomTrailingControlsOverlay: some View {
+    VStack(alignment: .trailing, spacing: 10) {
+      if activeUDID != nil {
+        floatingRecordingControl
+          .padding(.trailing, 14)
+          .padding(.bottom, annotationModel.annotations.isEmpty ? 14 : 0)
+      }
+
+      annotationCommentsOverlay
+    }
+  }
+
+  private var floatingRecordingControl: some View {
+    SimulatorFloatingActionButton(
+      systemImage: recordingButtonSystemImage,
+      tint: .red,
+      isDisabled: isRecordingButtonDisabled,
+      isWorking: recordingState.isBusy,
+      help: recordingButtonHelp,
+      accessibilityLabel: recordingButtonAccessibilityLabel,
+      action: toggleRecording
+    )
+  }
+
+  @ViewBuilder
   private var contentBody: some View {
     if let activeUDID, isShowingLiveStream {
       // Both surfaces stay mounted so flipping tabs doesn't tear down and
@@ -445,6 +519,7 @@ struct SimulatorPreviewSidePanelView: View {
           .opacity(effectiveDisplayMode == .live ? 1 : 0)
           .allowsHitTesting(effectiveDisplayMode == .live)
           .offset(y: liveStreamVerticalOffset)
+          .id("\(activeUDID)-\(streamRefreshGeneration)")
           .animation(
             .spring(response: 0.34, dampingFraction: 0.85),
             value: liveStreamVerticalOffset
@@ -516,7 +591,7 @@ struct SimulatorPreviewSidePanelView: View {
               )
             }
           )
-            .allowsHitTesting(annotationModel.isAnnotating)
+          .allowsHitTesting(annotationModel.isAnnotating)
         }
       }
     } topAccessory: {
@@ -616,7 +691,6 @@ struct SimulatorPreviewSidePanelView: View {
         Text(activeDevice.map { "\($0.name) is not running" } ?? "Select a simulator")
           .font(.subheadline)
       }
-
     }
     .frame(maxWidth: .infinity, maxHeight: .infinity)
   }
@@ -643,6 +717,34 @@ struct SimulatorPreviewSidePanelView: View {
     simulatorService.setPreferredSimulator(udid: udid, for: projectPath)
   }
 
+  private func persistSimulatorContext() {
+    guard let activeUDID else {
+      removeSimulatorContext()
+      return
+    }
+
+    let context = SimulatorSessionContext(
+      provider: simulatorContextProvider,
+      sessionId: session.id.isEmpty ? nil : session.id,
+      projectPath: projectPath,
+      udid: activeUDID,
+      deviceName: activeDevice?.name,
+      runtimeName: activeRuntimeName,
+      isBooted: isActiveDeviceBooted,
+      displayMode: effectiveDisplayMode.rawValue,
+      panelVisible: true
+    )
+    try? simulatorContextStore.write(context)
+  }
+
+  private func removeSimulatorContext() {
+    try? simulatorContextStore.remove(
+      provider: simulatorContextProvider,
+      sessionId: session.id.isEmpty ? nil : session.id,
+      projectPath: projectPath
+    )
+  }
+
   private func buildAndRun() {
     guard let activeUDID else { return }
     Task {
@@ -664,10 +766,12 @@ struct SimulatorPreviewSidePanelView: View {
         enablePreviews: simulatorPreviewsEnabled
       )
       let success = await simulatorService.buildAndRunOnSimulator(
-        udid: activeUDID, projectPath: projectPath, hotReload: plan)
+        udid: activeUDID, projectPath: projectPath, hotReload: plan
+      )
       if success, let plan {
         hotReload.sessionDidLaunch(
-          udid: activeUDID, projectPath: projectPath, plan: plan)
+          udid: activeUDID, projectPath: projectPath, plan: plan
+        )
       }
     }
   }
@@ -676,6 +780,214 @@ struct SimulatorPreviewSidePanelView: View {
     guard let activeUDID else { return }
     hotReload.sessionDidStop()
     Task { await simulatorService.shutdownDevice(udid: activeUDID) }
+  }
+
+  private var recordingButtonSystemImage: String {
+    switch recordingState {
+    case .recording:
+      return "stop.fill"
+    case .idle, .starting, .stopping, .failed:
+      return "record.circle"
+    }
+  }
+
+  private var recordingButtonHelp: String {
+    recordingState.isRecording
+      ? "Stop recording simulator video"
+      : "Record simulator video"
+  }
+
+  private var recordingButtonAccessibilityLabel: String {
+    recordingState.isRecording
+      ? "Stop simulator recording"
+      : "Start simulator recording"
+  }
+
+  private var isRecordingButtonDisabled: Bool {
+    switch recordingState {
+    case .starting, .stopping:
+      return true
+    case .recording:
+      return false
+    case .idle, .failed:
+      return activeUDID == nil || !isActiveDeviceBooted
+    }
+  }
+
+  private var recordingOverlayAllowsHitTesting: Bool {
+    switch recordingState {
+    case .starting, .stopping:
+      return false
+    case .recording:
+      return true
+    case .failed:
+      return true
+    case .idle:
+      return lastRecordingResult != nil
+    }
+  }
+
+  @ViewBuilder
+  private var recordingOverlay: some View {
+    if recordingState != .idle || lastRecordingResult != nil {
+      SimulatorRecordingOverlayView(
+        state: recordingState,
+        lastRecording: lastRecordingResult,
+        auditIssue: $recordingAuditIssue,
+        canSendToAgent: onSendToSession != nil,
+        onSendToAgent: sendRecordingAudit,
+        onReveal: revealRecording,
+        onDiscard: discardRecordingOverlay,
+        onDismiss: dismissRecordingOverlay
+      )
+      .transition(.move(edge: .bottom).combined(with: .opacity))
+    }
+  }
+
+  private func toggleRecording() {
+    if recordingState.isRecording {
+      stopRecording()
+    } else {
+      startRecording()
+    }
+  }
+
+  private func startRecording() {
+    guard let activeUDID else { return }
+    recordingFailureDismissTask?.cancel()
+    lastRecordingResult = nil
+    recordingAuditIssue = ""
+    recordingState = .starting
+
+    Task {
+      do {
+        let started = try await simulatorRecordingService.startRecording(udid: activeUDID)
+        recordingState = .recording(started)
+        refreshLiveStreamAfterRecordingEvent(udid: activeUDID)
+      } catch {
+        presentRecordingFailure(error.localizedDescription)
+      }
+    }
+  }
+
+  private func stopRecording() {
+    guard let recording = recordingState.activeRecording else { return }
+    recordingState = .stopping(recording)
+
+    Task {
+      do {
+        let result = try await simulatorRecordingService.stopRecording(udid: recording.udid)
+        refreshLiveStreamAfterRecordingEvent(udid: recording.udid)
+        if result.isUsable {
+          recordingAuditIssue = ""
+          lastRecordingResult = result
+          recordingState = .idle
+        } else {
+          try? SimulatorRecordingService.deleteRecordingFile(at: result.outputPath)
+          lastRecordingResult = nil
+          recordingAuditIssue = ""
+          presentRecordingFailure(result.validationError ?? "Recording did not finalize. Try recording again.")
+        }
+      } catch {
+        refreshLiveStreamAfterRecordingEvent(udid: recording.udid)
+        presentRecordingFailure(error.localizedDescription)
+      }
+    }
+  }
+
+  private func stopRecordingOnPanelClose() {
+    guard let recording = recordingState.activeRecording else { return }
+    Task {
+      _ = try? await simulatorRecordingService.stopRecording(udid: recording.udid)
+      refreshLiveStreamAfterRecordingEvent(udid: recording.udid)
+    }
+  }
+
+  private func refreshLiveStreamAfterRecordingEvent(udid: String) {
+    guard effectiveDisplayMode == .live else { return }
+    streamService.discardSession(forDeviceUDID: udid)
+    streamRefreshGeneration += 1
+  }
+
+  private func sendRecordingAudit(_ recording: SimulatorRecordingResult, issue: String) {
+    let trimmedIssue = issue.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard let onSendToSession, recording.isUsable, !trimmedIssue.isEmpty else { return }
+    let prompt = SimulatorRecordingPromptBuilder.prompt(
+      for: recording,
+      deviceName: activeDevice?.name,
+      issue: trimmedIssue
+    )
+    onSendToSession(prompt, session)
+    recordingAuditIssue = ""
+  }
+
+  private func revealRecording(_ recording: SimulatorRecordingResult) {
+    NSWorkspace.shared.activateFileViewerSelecting([
+      URL(fileURLWithPath: recording.outputPath),
+    ])
+  }
+
+  private func dismissRecordingOverlay() {
+    recordingFailureDismissTask?.cancel()
+    recordingFailureDismissTask = nil
+    lastRecordingResult = nil
+    recordingAuditIssue = ""
+    if case .failed = recordingState {
+      recordingState = .idle
+    }
+  }
+
+  private func discardRecordingOverlay() {
+    recordingFailureDismissTask?.cancel()
+    recordingFailureDismissTask = nil
+
+    if let recording = recordingState.activeRecording {
+      recordingState = .stopping(recording)
+      Task {
+        do {
+          _ = try await simulatorRecordingService.discardRecording(udid: recording.udid)
+        } catch {
+          AppLogger.simulator.error("Failed to discard simulator recording: \(error.localizedDescription)")
+          try? SimulatorRecordingService.deleteRecordingFile(at: recording.outputPath)
+        }
+        refreshLiveStreamAfterRecordingEvent(udid: recording.udid)
+        lastRecordingResult = nil
+        recordingAuditIssue = ""
+        recordingState = .idle
+      }
+      return
+    }
+
+    if let recording = lastRecordingResult {
+      do {
+        try SimulatorRecordingService.deleteRecordingFile(at: recording.outputPath)
+      } catch {
+        AppLogger.simulator.error("Failed to delete simulator recording: \(error.localizedDescription)")
+      }
+    }
+
+    lastRecordingResult = nil
+    recordingAuditIssue = ""
+    if case .failed = recordingState {
+      recordingState = .idle
+    }
+  }
+
+  private func presentRecordingFailure(_ message: String) {
+    recordingFailureDismissTask?.cancel()
+    lastRecordingResult = nil
+    recordingAuditIssue = ""
+    recordingState = .failed(message)
+    recordingFailureDismissTask = Task {
+      try? await Task.sleep(for: .seconds(5))
+      guard !Task.isCancelled else { return }
+      await MainActor.run {
+        if case .failed(let currentMessage) = recordingState, currentMessage == message {
+          recordingState = .idle
+        }
+        recordingFailureDismissTask = nil
+      }
+    }
   }
 
   private func sendBuildError(_ error: String) {
@@ -733,10 +1045,12 @@ struct SimulatorPreviewSidePanelView: View {
       )
       guard let plan else { return } // support build in progress — pill reports it
       let success = await simulatorService.relaunchWithHotReload(
-        udid: activeUDID, projectPath: projectPath, hotReload: plan)
+        udid: activeUDID, projectPath: projectPath, hotReload: plan
+      )
       if success {
         hotReload.sessionDidLaunch(
-          udid: activeUDID, projectPath: projectPath, plan: plan)
+          udid: activeUDID, projectPath: projectPath, plan: plan
+        )
       } else {
         // No resolvable built app — the full pipeline is the only path.
         buildAndRun()
@@ -772,19 +1086,22 @@ struct SimulatorPreviewSidePanelView: View {
       normalized = SimulatorPointMapper.normalizedPoint(
         viewPoint: location,
         contentSize: annotationModel.contentPixelSize,
-        viewSize: viewSize)
+        viewSize: viewSize
+      )
     case .moved, .ended:
       normalized = SimulatorPointMapper.clampedNormalizedPoint(
         viewPoint: location,
         contentSize: annotationModel.contentPixelSize,
-        viewSize: viewSize)
+        viewSize: viewSize
+      )
     }
     guard let normalized else { return false }
 
     streamSession.sendTouch(
       phase: phase,
       normalizedX: normalized.x,
-      normalizedY: normalized.y)
+      normalizedY: normalized.y
+    )
     switch phase {
     case .began:
       break
@@ -858,7 +1175,8 @@ struct SimulatorPreviewSidePanelView: View {
     if showsSpinner { model.isFetchingElements = true }
     Task {
       let tree = try? await SimulatorAXInspector.shared.fetchFrontmostTree(
-        udid: udid, developerDir: XcodeDeveloperDirectory.resolved)
+        udid: udid, developerDir: XcodeDeveloperDirectory.resolved
+      )
       model.axTree = tree
       model.isRefreshInFlight = false
       model.isFetchingElements = false
@@ -881,14 +1199,16 @@ struct SimulatorPreviewSidePanelView: View {
       // longer resolvable, fall back to the original drop coordinates.
       let point = SimulatorAnnotationPinLocator.placement(
         for: annotation,
-        in: annotationModel.axTree)?.viewportNormalizedPoint
+        in: annotationModel.axTree
+      )?.viewportNormalizedPoint
         ?? CGPoint(x: annotation.normalizedX, y: annotation.normalizedY)
       return SimulatorAnnotation(
         id: annotation.id,
         normalizedX: point.x,
         normalizedY: point.y,
         text: annotation.text,
-        target: annotation.target)
+        target: annotation.target
+      )
     }
     let deviceName = activeDevice?.name
     let pixelSize = annotationModel.hasContentSize ? annotationModel.contentPixelSize : nil
@@ -898,7 +1218,8 @@ struct SimulatorPreviewSidePanelView: View {
     Task {
       // Best-effort: the prompt still goes out without the screenshot.
       let screenshotURL = await SimulatorScreenshotCapture.writeAnnotatedScreenshot(
-        udid: udid, annotations: screenshotAnnotations)
+        udid: udid, annotations: screenshotAnnotations
+      )
       let prompt = SimulatorAnnotationPromptBuilder.prompt(
         annotations: annotations,
         deviceName: deviceName,

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/SimulatorRecordingAuditComposerView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/SimulatorRecordingAuditComposerView.swift
@@ -1,0 +1,61 @@
+import Foundation
+import SwiftUI
+
+struct SimulatorRecordingAuditComposerView: View {
+  @Binding var issue: String
+  let onSend: () -> Void
+
+  private var trimmedIssue: String {
+    issue.trimmingCharacters(in: .whitespacesAndNewlines)
+  }
+
+  private var canSend: Bool {
+    !trimmedIssue.isEmpty
+  }
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      TextField("What should the agent audit in this recording?", text: $issue, axis: .vertical)
+        .textFieldStyle(.plain)
+        .lineLimit(3...6)
+        .padding(8)
+        .background(
+          Color(nsColor: .textBackgroundColor).opacity(0.82),
+          in: RoundedRectangle(cornerRadius: 8, style: .continuous)
+        )
+        .overlay(
+          RoundedRectangle(cornerRadius: 8, style: .continuous)
+            .stroke(Color.secondary.opacity(0.16), lineWidth: 1)
+        )
+
+      HStack {
+        Spacer()
+        Button(action: onSend) {
+          HStack(spacing: 6) {
+            Image(systemName: "paperplane.fill")
+            Text("Send")
+            Text("⌘ Return")
+              .font(.caption2.monospaced().weight(.semibold))
+              .padding(.horizontal, 5)
+              .padding(.vertical, 2)
+              .background(Color.white.opacity(0.18), in: RoundedRectangle(cornerRadius: 4, style: .continuous))
+          }
+        }
+        .buttonStyle(.borderedProminent)
+        .controlSize(.small)
+        .tint(Color.brandPrimary)
+        .disabled(!canSend)
+        .keyboardShortcut(.return, modifiers: [.command])
+        .accessibilityLabel("Send recording audit")
+        .accessibilityHint("Sends with Command Return")
+      }
+    }
+    .padding(10)
+    .background(.thinMaterial, in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+    .overlay(
+      RoundedRectangle(cornerRadius: 8, style: .continuous)
+        .stroke(Color.secondary.opacity(0.16), lineWidth: 1)
+    )
+    .shadow(color: Color.black.opacity(0.16), radius: 10, y: 4)
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/SimulatorRecordingOverlayView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/SimulatorRecordingOverlayView.swift
@@ -1,0 +1,182 @@
+import AgentHubCLIKit
+import SwiftUI
+
+enum SimulatorRecordingPanelState: Equatable {
+  case idle
+  case starting
+  case recording(SimulatorRecordingStarted)
+  case stopping(SimulatorRecordingStarted)
+  case failed(String)
+
+  var activeRecording: SimulatorRecordingStarted? {
+    switch self {
+    case .recording(let recording), .stopping(let recording):
+      return recording
+    case .idle, .starting, .failed:
+      return nil
+    }
+  }
+
+  var isBusy: Bool {
+    switch self {
+    case .starting, .stopping:
+      return true
+    case .idle, .recording, .failed:
+      return false
+    }
+  }
+
+  var isRecording: Bool {
+    if case .recording = self { return true }
+    return false
+  }
+}
+
+struct SimulatorRecordingOverlayView: View {
+  let state: SimulatorRecordingPanelState
+  let lastRecording: SimulatorRecordingResult?
+  @Binding var auditIssue: String
+  let canSendToAgent: Bool
+  let onSendToAgent: (SimulatorRecordingResult, String) -> Void
+  let onReveal: (SimulatorRecordingResult) -> Void
+  let onDiscard: () -> Void
+  let onDismiss: () -> Void
+
+  var body: some View {
+    Group {
+      switch state {
+      case .starting:
+        recordingPill(title: "Starting recording", detail: nil, showsProgress: true)
+
+      case .recording(let recording):
+        recordingPill(
+          title: "Recording simulator",
+          detail: recording.outputPath,
+          showsProgress: false,
+          trailing: {
+            Button(action: onDiscard) {
+              Image(systemName: "xmark")
+            }
+            .buttonStyle(.borderless)
+            .controlSize(.small)
+            .help("Stop and delete recording")
+            .accessibilityLabel("Stop and delete recording")
+          }
+        )
+
+      case .stopping:
+        recordingPill(title: "Finishing recording", detail: nil, showsProgress: true)
+
+      case .failed(let message):
+        recordingPill(
+          title: "Recording failed",
+          detail: message,
+          showsProgress: false,
+          trailing: {
+            Button(action: onDismiss) {
+              Image(systemName: "xmark")
+            }
+            .buttonStyle(.borderless)
+            .controlSize(.small)
+            .accessibilityLabel("Dismiss recording error")
+          }
+        )
+
+      case .idle:
+        if let lastRecording {
+          savedRecordingPill(lastRecording)
+        }
+      }
+    }
+    .frame(maxWidth: 520, alignment: .leading)
+  }
+
+  private func savedRecordingPill(_ recording: SimulatorRecordingResult) -> some View {
+    VStack(alignment: .leading, spacing: 8) {
+      recordingPill(
+        title: recording.isUsable ? "Recording saved" : "Recording unavailable",
+        detail: recording.isUsable ? recording.outputPath : recording.validationError,
+        showsProgress: false,
+        trailing: {
+          if recording.fileExists {
+            Button(action: { onReveal(recording) }) {
+              Image(systemName: "folder")
+            }
+            .buttonStyle(.borderless)
+            .controlSize(.small)
+            .help("Reveal recording in Finder")
+            .accessibilityLabel("Reveal recording in Finder")
+          }
+
+          Button(action: onDiscard) {
+            Image(systemName: "xmark")
+          }
+          .buttonStyle(.borderless)
+          .controlSize(.small)
+          .help("Delete recording")
+          .accessibilityLabel("Delete recording")
+        }
+      )
+
+      if canSendToAgent, recording.isUsable {
+        SimulatorRecordingAuditComposerView(
+          issue: $auditIssue,
+          onSend: { onSendToAgent(recording, auditIssue) }
+        )
+      }
+    }
+  }
+
+  private func recordingPill<Trailing: View>(
+    title: String,
+    detail: String?,
+    showsProgress: Bool,
+    @ViewBuilder trailing: () -> Trailing
+  ) -> some View {
+    HStack(spacing: 10) {
+      if showsProgress {
+        ProgressView()
+          .controlSize(.small)
+      } else {
+        Circle()
+          .fill(Color.red)
+          .frame(width: 8, height: 8)
+          .accessibilityHidden(true)
+      }
+
+      VStack(alignment: .leading, spacing: 2) {
+        Text(title)
+          .font(.caption.weight(.semibold))
+        if let detail {
+          Text(detail)
+            .font(.caption2)
+            .foregroundStyle(.secondary)
+            .lineLimit(1)
+            .truncationMode(.middle)
+            .textSelection(.enabled)
+        }
+      }
+      .frame(maxWidth: .infinity, alignment: .leading)
+
+      trailing()
+    }
+    .padding(.horizontal, 10)
+    .padding(.vertical, 8)
+    .background(.thinMaterial, in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+    .overlay(
+      RoundedRectangle(cornerRadius: 8, style: .continuous)
+        .stroke(Color.secondary.opacity(0.16), lineWidth: 1)
+    )
+    .shadow(color: Color.black.opacity(0.16), radius: 10, y: 4)
+  }
+
+  private func recordingPill(
+    title: String,
+    detail: String?,
+    showsProgress: Bool
+  ) -> some View {
+    recordingPill(title: title, detail: detail, showsProgress: showsProgress) {
+      EmptyView()
+    }
+  }
+}

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/SimulatorModelsTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/SimulatorModelsTests.swift
@@ -1,11 +1,12 @@
-import Testing
+import AgentHubCLIKit
 @testable import AgentHubCore
+import Foundation
+import Testing
 
 // MARK: - SimulatorDevice
 
 @Suite("SimulatorDevice")
 struct SimulatorDeviceTests {
-
   @Test func isBootedTrueWhenStateEqualsBooted() {
     let device = SimulatorDevice(
       udid: "ABCD-1234",
@@ -45,7 +46,6 @@ struct SimulatorDeviceTests {
 
 @Suite("SimulatorRuntime")
 struct SimulatorRuntimeTests {
-
   @Test func availableDevicesFiltersUnavailableOnes() {
     let available = SimulatorDevice(
       udid: "A1",
@@ -97,7 +97,6 @@ struct SimulatorRuntimeTests {
 
 @Suite("SimulatorState")
 struct SimulatorStateTests {
-
   @Test func equalityForSimpleCases() {
     #expect(SimulatorState.idle == .idle)
     #expect(SimulatorState.booting == .booting)
@@ -124,7 +123,6 @@ struct SimulatorStateTests {
 
 @Suite("MacRunState")
 struct MacRunStateTests {
-
   @Test func equalityForAllCases() {
     #expect(MacRunState.idle == .idle)
     #expect(MacRunState.building == .building)
@@ -143,7 +141,6 @@ struct MacRunStateTests {
 
 @Suite("XcodePlatform")
 struct XcodePlatformTests {
-
   @Test func hashableInSet() {
     var set: Set<XcodePlatform> = []
     set.insert(.iOS)
@@ -163,7 +160,6 @@ struct XcodePlatformTests {
 
 @Suite("SimulatorBuildErrorPromptBuilder")
 struct SimulatorBuildErrorPromptBuilderTests {
-
   @Test func wrapsCompilerErrorForAgentRepair() {
     let error = "/tmp/App/ContentView.swift:12:3: error: cannot find 'foo' in scope"
 
@@ -185,5 +181,56 @@ struct SimulatorBuildErrorPromptBuilderTests {
 
     #expect(prompt.contains("ContentView.swift:9:7: error: type 'Demo' has no member 'missing'"))
     #expect(prompt.contains("simctl launch failed (exit 4)"))
+  }
+}
+
+// MARK: - SimulatorRecordingPromptBuilder
+
+@Suite("SimulatorRecordingPromptBuilder")
+struct SimulatorRecordingPromptBuilderTests {
+  @Test func includesRecordingPathAndFFmpegGuidance() {
+    let prompt = SimulatorRecordingPromptBuilder.prompt(
+      for: SimulatorRecordingResult(
+        udid: "UDID-1",
+        outputPath: "/tmp/demo.mp4",
+        startedAt: Date(timeIntervalSince1970: 1_000),
+        endedAt: Date(timeIntervalSince1970: 1_012),
+        duration: 12,
+        fileExists: true,
+        fileSizeBytes: 1_024,
+        isFinalized: true,
+        validationError: nil
+      ),
+      deviceName: "iPhone 17 Pro",
+      issue: "The answer buttons jump after the recording starts."
+    )
+
+    #expect(prompt.contains("/tmp/demo.mp4"))
+    #expect(prompt.contains("The answer buttons jump after the recording starts."))
+    #expect(prompt.contains("ffprobe or ffmpeg"))
+    #expect(prompt.contains("Device: iPhone 17 Pro"))
+    #expect(prompt.contains("Duration: 12.0 seconds"))
+  }
+
+  @Test func explainsWhenRecordingIsNotFinalized() {
+    let prompt = SimulatorRecordingPromptBuilder.prompt(
+      for: SimulatorRecordingResult(
+        udid: "UDID-1",
+        outputPath: "/tmp/demo.mp4",
+        startedAt: Date(timeIntervalSince1970: 1_000),
+        endedAt: Date(timeIntervalSince1970: 1_001),
+        duration: 1,
+        fileExists: true,
+        fileSizeBytes: 1_024,
+        isFinalized: false,
+        validationError: "The MP4 file did not finalize correctly; missing top-level moov atom."
+      ),
+      deviceName: nil,
+      issue: "The recording fails when I stop capture."
+    )
+
+    #expect(prompt.contains("could not be audited"))
+    #expect(prompt.contains("The recording fails when I stop capture."))
+    #expect(prompt.contains("missing top-level moov atom"))
   }
 }

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/SimulatorRunRequestHandlerTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/SimulatorRunRequestHandlerTests.swift
@@ -1,0 +1,90 @@
+import AgentHubCLIKit
+import Foundation
+import SimulatorPreview
+import Testing
+
+@testable import AgentHubCore
+
+@Suite("SimulatorRunRequestHandler")
+@MainActor
+struct SimulatorRunRequestHandlerTests {
+  @Test("Handler boots target simulator before Build and Run")
+  func handlerBootsBeforeBuildAndRun() async throws {
+    let executor = MockSimulatorRunExecutor(isBooted: false, buildResult: true)
+    let handler = SimulatorRunRequestHandler(simulatorService: executor)
+
+    try await handler.handle(SimulatorRunRequest(
+      projectPath: "/tmp/App",
+      udid: "UDID-1",
+      reason: "verify"
+    ))
+
+    #expect(executor.bootedUDIDs == ["UDID-1"])
+    #expect(executor.buildRequests == [MockSimulatorRunExecutor.BuildRequest(
+      udid: "UDID-1",
+      projectPath: "/tmp/App",
+      hotReloadWasProvided: false
+    )])
+  }
+
+  @Test("Handler skips boot for already booted simulator")
+  func handlerSkipsBootForBootedSimulator() async throws {
+    let executor = MockSimulatorRunExecutor(isBooted: true, buildResult: true)
+    let handler = SimulatorRunRequestHandler(simulatorService: executor)
+
+    try await handler.handle(SimulatorRunRequest(projectPath: "/tmp/App", udid: "UDID-1"))
+
+    #expect(executor.bootedUDIDs.isEmpty)
+    #expect(executor.buildRequests.count == 1)
+  }
+
+  @Test("Handler throws when Build and Run fails")
+  func handlerThrowsWhenBuildFails() async {
+    let executor = MockSimulatorRunExecutor(isBooted: true, buildResult: false)
+    let handler = SimulatorRunRequestHandler(simulatorService: executor)
+
+    await #expect(throws: SimulatorRunRequestHandlingError.runFailed(projectPath: "/tmp/App", udid: "UDID-1")) {
+      try await handler.handle(SimulatorRunRequest(projectPath: "/tmp/App", udid: "UDID-1"))
+    }
+  }
+}
+
+@MainActor
+private final class MockSimulatorRunExecutor: SimulatorRunExecuting {
+  struct BuildRequest: Equatable {
+    let udid: String
+    let projectPath: String
+    let hotReloadWasProvided: Bool
+  }
+
+  private let booted: Bool
+  private let buildResult: Bool
+  var bootedUDIDs: [String] = []
+  var buildRequests: [BuildRequest] = []
+
+  init(isBooted: Bool, buildResult: Bool) {
+    self.booted = isBooted
+    self.buildResult = buildResult
+  }
+
+  func isBooted(udid: String) -> Bool {
+    booted
+  }
+
+  func bootDevice(udid: String) async {
+    bootedUDIDs.append(udid)
+  }
+
+  func buildAndRunOnSimulator(
+    udid: String,
+    projectPath: String,
+    hotReload: HotReloadLaunchPlan?
+  ) async -> Bool {
+    buildRequests.append(BuildRequest(
+      udid: udid,
+      projectPath: projectPath,
+      hotReloadWasProvided: hotReload != nil
+    ))
+    return buildResult
+  }
+}

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/SimulatorRunRequestMonitorTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/SimulatorRunRequestMonitorTests.swift
@@ -1,0 +1,91 @@
+import AgentHubCLIKit
+import Foundation
+import Testing
+
+@testable import AgentHubCore
+
+@Suite("SimulatorRunRequestMonitor")
+struct SimulatorRunRequestMonitorTests {
+  @Test("Monitor handles queued simulator request and removes it")
+  func monitorHandlesQueuedRequestAndRemovesIt() async throws {
+    let directory = try temporarySimulatorMonitorRequestDirectory()
+    defer { try? FileManager.default.removeItem(at: directory.deletingLastPathComponent()) }
+
+    let queue = SimulatorRunRequestQueue(directoryURL: directory)
+    let request = SimulatorRunRequest(
+      id: "sim-run-1",
+      projectPath: "/tmp/App",
+      udid: "UDID-1",
+      sourceProvider: .codex,
+      sourceSessionId: "session-1"
+    )
+    try queue.enqueue(request)
+
+    let recorder = SimulatorRunRequestRecorder()
+    let monitor = SimulatorRunRequestMonitor(queue: queue, pollInterval: .milliseconds(20))
+    await monitor.start { queued in
+      await recorder.record(queued.request)
+    }
+
+    await waitForSimulatorMonitorCondition {
+      await recorder.requests() == [request]
+        && ((try? queue.pendingRequests().isEmpty) == true)
+    }
+    await monitor.stop()
+  }
+
+  @Test("Monitor marks failed simulator request out of pending queue")
+  func monitorMarksFailedRequestOutOfPendingQueue() async throws {
+    let directory = try temporarySimulatorMonitorRequestDirectory()
+    defer { try? FileManager.default.removeItem(at: directory.deletingLastPathComponent()) }
+
+    let queue = SimulatorRunRequestQueue(directoryURL: directory)
+    let queued = try queue.enqueue(SimulatorRunRequest(
+      id: "sim-run-1",
+      projectPath: "/tmp/App",
+      udid: "UDID-1"
+    ))
+
+    let monitor = SimulatorRunRequestMonitor(queue: queue, pollInterval: .milliseconds(20))
+    await monitor.start { _ in
+      throw SimulatorRunRequestHandlingError.invalidTarget
+    }
+
+    await waitForSimulatorMonitorCondition {
+      let failedURL = queued.fileURL.deletingPathExtension().appendingPathExtension("failed")
+      return ((try? queue.pendingRequests().isEmpty) == true)
+        && FileManager.default.fileExists(atPath: failedURL.path)
+    }
+    await monitor.stop()
+  }
+}
+
+private actor SimulatorRunRequestRecorder {
+  private var recordedRequests: [SimulatorRunRequest] = []
+
+  func record(_ request: SimulatorRunRequest) {
+    recordedRequests.append(request)
+  }
+
+  func requests() -> [SimulatorRunRequest] {
+    recordedRequests
+  }
+}
+
+private func waitForSimulatorMonitorCondition(
+  timeout: Duration = .seconds(2),
+  condition: @escaping () async -> Bool
+) async {
+  let start = ContinuousClock.now
+  while !(await condition()), ContinuousClock.now - start < timeout {
+    try? await Task.sleep(for: .milliseconds(20))
+  }
+  #expect(await condition())
+}
+
+private func temporarySimulatorMonitorRequestDirectory() throws -> URL {
+  let root = FileManager.default.temporaryDirectory
+    .appendingPathComponent("agenthub-simulator-monitor-tests-\(UUID().uuidString)", isDirectory: true)
+  try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+  return root.appendingPathComponent("requests", isDirectory: true)
+}


### PR DESCRIPTION
## Summary
- add AgentHub simulator status/run/record MCP tools backed by panel context and request queues
- add simulator recording service with MP4 finalization validation, discard cleanup, and ffmpeg/ffprobe audit prompt generation
- add recording tray UI with required audit text, Cmd+Return send, persistent side panel after send, and delete-on-dismiss behavior

## Tests
- `swift test --package-path app/modules/AgentHubCLI --filter SimulatorRecordingServiceTests`
- `swift test --package-path app/modules/AgentHubCLI --filter 'SimulatorRecordingServiceTests|SimulatorRunRequestQueueTests|SimulatorSessionContextStoreTests'`\n- `xcodebuild test -scheme AgentHubCore-Tests -destination 'platform=macOS' -test-timeouts-enabled YES -skipPackagePluginValidation -only-testing:AgentHubTests/SimulatorRunRequestHandlerTests -only-testing:AgentHubTests/SimulatorRunRequestMonitorTests`\n- `xcodebuild test -scheme AgentHubCore-Tests -destination 'platform=macOS' -test-timeouts-enabled YES -skipPackagePluginValidation -only-testing:AgentHubTests/SimulatorRecordingPromptBuilderTests`\n\nNote: Core xcodebuild test commands report `TEST SUCCEEDED`; Xcode still prints existing SwiftLint plugin `Output folder doesn’t exist` lines for CodeEdit dependencies.