### PR TITLE
[codex] Support physical iOS run destinations

### DIFF
--- a/SimulatorPreview.md
+++ b/SimulatorPreview.md
@@ -14,13 +14,21 @@ same capability Codex shipped via its "Build iOS Apps" plugin (which used
 `serve-sim` + `SnapshotPreviews`), but native, in-process, and private by default.
 
 The user clicks **Simulator** (shown only for Xcode projects). The side panel lets
-them pick/boot a device and Build & Run, then mirrors the device's screen and
-forwards mouse/keyboard back to it. The old per-card Simulator button that opened
-the `SimulatorPickerView` sheet is deprecated: the panel is now the single entry
-point, and the management sheet code remains wired but hidden while it can drift
-out of sync with the panel picker. Build/run failures surface directly in the
-side panel with a send-to-agent action. (The legacy `MonitoringPanelView` path,
-which doesn't wire the side-panel callback, still falls back to the sheet.)
+them pick/boot a simulator and Build & Run, then mirrors the simulator's screen
+and forwards mouse/keyboard back to it. Connected physical iOS/iPadOS devices are
+also valid run destinations: AgentHub can build, install, and launch on them via
+`xcodebuild` + `devicectl`, but live mirroring, input forwarding, recording,
+annotation, hot reload, and previews remain simulator-only. The old per-card
+Simulator button that opened the `SimulatorPickerView` sheet is deprecated: the
+panel is now the single entry point, and the management sheet code remains wired
+but hidden while it can drift out of sync with the panel picker. Build/run
+failures surface directly in the side panel with a send-to-agent action. (The
+legacy `MonitoringPanelView` path, which doesn't wire the side-panel callback,
+still falls back to the sheet.)
+
+When a physical device is selected, keep the panel quiet: do not warm
+hot-reload artifacts, start preview source watchers, arm the preview host, or
+display simulator-only hot-reload state.
 
 ## Annotation feedback (element-aware pins sent to the agent)
 
@@ -160,7 +168,8 @@ This is the design constraint, not an afterthought:
   The one exception is explicit and user-initiated: sending annotations writes a
   single pin-stamped screenshot to the app's temp directory so the agent can read
   it — never automatically, never anywhere else.
-- Device lifecycle stays on public `xcrun simctl` / `xcodebuild`.
+- Simulator lifecycle stays on public `xcrun simctl` / `xcodebuild`; physical
+  device runs use Xcode's public `devicectl` CLI after the device build.
 
 ## Private-API risk
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/Models/SimulatorModels.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Models/SimulatorModels.swift
@@ -31,6 +31,25 @@ struct SimulatorRuntime: Identifiable, Sendable {
   var availableDevices: [SimulatorDevice] { devices.filter { $0.isAvailable } }
 }
 
+// MARK: - PhysicalIOSDevice
+
+/// A connected iOS/iPadOS hardware run destination reported by Xcode.
+struct PhysicalIOSDevice: Identifiable, Sendable, Hashable, Codable {
+  let identifier: String
+  let name: String
+  let modelName: String
+  let operatingSystemVersion: String
+  let interface: String?
+
+  var id: String { identifier }
+
+  var subtitle: String {
+    let model = modelName.isEmpty || modelName == name ? nil : modelName
+    let version = operatingSystemVersion.isEmpty ? nil : operatingSystemVersion
+    return [model, version].compactMap { $0 }.joined(separator: " - ")
+  }
+}
+
 // MARK: - SimulatorState
 
 public enum SimulatorState: Equatable, Sendable {

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/SimulatorService.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/SimulatorService.swift
@@ -43,6 +43,12 @@ private final class DataAccumulator: @unchecked Sendable {
   }
 }
 
+private struct ProcessExecutionResult: Sendable {
+  let exitCode: Int32
+  let outputText: String
+  let errorText: String
+}
+
 /// Result of the detection phase — workspace/project path, scheme, and xcodebuild path.
 private struct BuildSetup: Sendable {
   let targetPath: String
@@ -70,6 +76,7 @@ struct BuiltAppInfo: Sendable {
 enum BuildPlatform {
   case macOS
   case iOSSimulator
+  case iOSDevice
 
   var productsDirectoryName: String {
     switch self {
@@ -77,6 +84,8 @@ enum BuildPlatform {
       return "Debug"
     case .iOSSimulator:
       return "Debug-iphonesimulator"
+    case .iOSDevice:
+      return "Debug-iphoneos"
     }
   }
 
@@ -113,6 +122,11 @@ enum BuildPlatform {
         return nil
       }
       return 30
+    case .iOSDevice:
+      guard lowercased.contains(where: { $0.contains("iphoneos") }) else {
+        return nil
+      }
+      return 30
     }
   }
 }
@@ -140,8 +154,14 @@ public final class SimulatorService {
   /// Per-(projectPath|UDID) build state — isolated per worktree session
   private(set) var sessionBuildStates: [String: SimulatorState] = [:]
 
+  /// Per-(projectPath|hardware device ID) build state for physical iOS devices.
+  private(set) var physicalRunStates: [String: SimulatorState] = [:]
+
   /// Cached list of runtimes with their available devices
   private(set) var runtimes: [SimulatorRuntime] = []
+
+  /// Connected physical iOS/iPadOS run destinations.
+  private(set) var physicalDevices: [PhysicalIOSDevice] = []
 
   /// True while the device list is being fetched
   private(set) var isLoadingDevices: Bool = false
@@ -152,14 +172,23 @@ public final class SimulatorService {
   /// Per-projectPath preferred simulator UDID — shared across all views
   private(set) var preferredSimulatorUDIDs: [String: String] = [:]
 
+  /// Per-projectPath preferred physical iOS device identifier.
+  private(set) var preferredPhysicalDeviceIDs: [String: String] = [:]
+
   /// Live process references for in-flight Mac builds, keyed by projectPath
   private var macBuildProcesses: [String: ProcessRef] = [:]
 
   /// Live process references for in-flight simulator builds, keyed by projectPath|UDID
   private var simulatorBuildProcesses: [String: ProcessRef] = [:]
 
+  /// Live process references for in-flight physical-device builds.
+  private var physicalBuildProcesses: [String: ProcessRef] = [:]
+
   /// In-flight Phase 3 tasks for simulator builds, keyed by projectPath|UDID
   private var simulatorRunTasks: [String: Task<Result<Void, Error>, Never>] = [:]
+
+  /// In-flight Phase 3 tasks for physical-device builds.
+  private var physicalRunTasks: [String: Task<Result<Void, Error>, Never>] = [:]
 
   /// Cached workspace/project and scheme selection per project path.
   private var buildSetupCache: [String: BuildSetup] = [:]
@@ -169,6 +198,11 @@ public final class SimulatorService {
   /// Sets the preferred simulator UDID for a given project path.
   public func setPreferredSimulator(udid: String?, for projectPath: String) {
     preferredSimulatorUDIDs[projectPath] = udid
+  }
+
+  /// Sets the preferred physical iOS device for a given project path.
+  public func setPreferredPhysicalDevice(identifier: String?, for projectPath: String) {
+    preferredPhysicalDeviceIDs[projectPath] = identifier
   }
 
   /// Returns the SimulatorDevice for a given UDID, if it exists in the loaded runtimes.
@@ -203,16 +237,26 @@ public final class SimulatorService {
     return deviceStates[udid] ?? .idle
   }
 
-  /// Fetches the device list from `xcrun simctl list devices --json`.
-  /// Filters to iOS runtimes only, sorts newest first.
+  /// Returns the build/install/launch state for a physical iOS device.
+  public func physicalDeviceState(for identifier: String, projectPath: String) -> SimulatorState {
+    physicalRunStates[sessionKey(projectPath: projectPath, udid: identifier)] ?? .idle
+  }
+
+  /// Fetches simulator runtimes plus connected physical iOS devices.
   public func listDevices() async {
     guard !isLoadingDevices else { return }
     isLoadingDevices = true
     defer { isLoadingDevices = false }
 
-    let result = await Task.detached {
+    let simulatorTask = Task.detached {
       SimulatorService.fetchDeviceList()
-    }.value
+    }
+    let physicalDeviceTask = Task.detached {
+      SimulatorService.fetchPhysicalDeviceList()
+    }
+
+    let result = await simulatorTask.value
+    let physicalResult = await physicalDeviceTask.value
 
     switch result {
     case .success(let runtimes):
@@ -232,6 +276,14 @@ public final class SimulatorService {
       AppLogger.simulator.info("Loaded \(runtimes.count) runtimes")
     case .failure(let error):
       AppLogger.simulator.error("Failed to list devices: \(error.localizedDescription)")
+    }
+
+    switch physicalResult {
+    case .success(let devices):
+      physicalDevices = devices
+      AppLogger.simulator.info("Loaded \(devices.count) physical iOS devices")
+    case .failure(let error):
+      AppLogger.simulator.error("Failed to list physical iOS devices: \(error.localizedDescription)")
     }
   }
 
@@ -463,6 +515,71 @@ public final class SimulatorService {
     }
   }
 
+  /// Builds for a connected physical iOS/iPadOS device, installs, and launches the app.
+  @discardableResult
+  public func buildAndRunOnPhysicalDevice(
+    identifier: String,
+    projectPath: String
+  ) async -> Bool {
+    let key = sessionKey(projectPath: projectPath, udid: identifier)
+    physicalRunStates[key] = .building
+    AppLogger.simulator.info("Building for physical iOS device \(identifier)")
+
+    let detectResult = await buildSetup(for: projectPath)
+
+    guard case .success(let setup) = detectResult else {
+      if case .failure(let e) = detectResult {
+        physicalRunStates[key] = .failed(error: e.localizedDescription)
+        AppLogger.simulator.error("Physical device build setup failed: \(e.localizedDescription)")
+      }
+      return false
+    }
+
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: setup.xcodebuild)
+    let buildArgs = SimulatorService.physicalDeviceBuildArguments(
+      scheme: setup.scheme,
+      targetPath: setup.targetPath,
+      isWorkspace: setup.isWorkspace,
+      identifier: identifier,
+      derivedDataPath: setup.derivedDataPath
+    )
+    process.arguments = buildArgs
+    let outputPipe = Pipe()
+    process.standardOutput = outputPipe
+    let errorPipe = Pipe()
+    process.standardError = errorPipe
+
+    let ref = ProcessRef(process: process, outputPipe: outputPipe, errorPipe: errorPipe)
+    physicalBuildProcesses[key] = ref
+
+    let phase3Task = Task.detached {
+      await SimulatorService.executePhysicalDeviceBuild(
+        ref: ref,
+        deviceIdentifier: identifier,
+        sessionKey: key,
+        setup: setup
+      )
+    }
+    physicalRunTasks[key] = phase3Task
+    let result = await phase3Task.value
+    physicalRunTasks.removeValue(forKey: key)
+    physicalBuildProcesses.removeValue(forKey: key)
+
+    guard physicalRunStates[key] != nil else { return false }
+
+    switch result {
+    case .success:
+      physicalRunStates[key] = .booted
+      AppLogger.simulator.info("Physical device build+run succeeded for \(identifier)")
+      return true
+    case .failure(let error):
+      physicalRunStates[key] = .failed(error: error.localizedDescription)
+      AppLogger.simulator.error("Physical device build failed: \(error.localizedDescription)")
+      return false
+    }
+  }
+
   /// Relaunches the project's already-installed app with the hot-reload
   /// dylibs inserted — no rebuild, ~1s. Used by the Previews tab to
   /// self-heal when the running app was launched without the preview host
@@ -531,6 +648,17 @@ public final class SimulatorService {
     simulatorRunTasks.removeValue(forKey: key)
     sessionBuildStates.removeValue(forKey: key)
     AppLogger.simulator.info("Cancelled simulator build for \(udid)")
+  }
+
+  /// Terminates an in-flight physical-device build and clears this session's run state.
+  public func cancelPhysicalDeviceRun(identifier: String, projectPath: String) {
+    let key = sessionKey(projectPath: projectPath, udid: identifier)
+    physicalBuildProcesses[key]?.process.terminate()
+    physicalBuildProcesses.removeValue(forKey: key)
+    physicalRunTasks[key]?.cancel()
+    physicalRunTasks.removeValue(forKey: key)
+    physicalRunStates.removeValue(forKey: key)
+    AppLogger.simulator.info("Cancelled physical device build for \(identifier)")
   }
 
   // MARK: - Key Helpers
@@ -616,6 +744,44 @@ public final class SimulatorService {
     }
   }
 
+  /// Runs `xcrun devicectl <arguments>` and captures output for diagnostics.
+  private nonisolated static func runDeviceCtl(arguments: [String]) -> ProcessExecutionResult {
+    guard let xcrun = findExecutable(named: "xcrun") else {
+      AppLogger.simulator.error("xcrun not found in PATH")
+      return ProcessExecutionResult(
+        exitCode: -1,
+        outputText: "",
+        errorText: "xcrun not found"
+      )
+    }
+
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: xcrun)
+    process.arguments = ["devicectl"] + arguments
+    let outputPipe = Pipe()
+    process.standardOutput = outputPipe
+    let errorPipe = Pipe()
+    process.standardError = errorPipe
+
+    do {
+      try process.run()
+      process.waitUntilExit()
+    } catch {
+      AppLogger.simulator.error("Failed to run xcrun devicectl: \(error.localizedDescription)")
+      return ProcessExecutionResult(
+        exitCode: -1,
+        outputText: "",
+        errorText: error.localizedDescription
+      )
+    }
+
+    return ProcessExecutionResult(
+      exitCode: process.terminationStatus,
+      outputText: String(data: outputPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? "",
+      errorText: String(data: errorPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+    )
+  }
+
   /// Runs `open -a <name>` to bring an app to the foreground.
   private nonisolated static func runOpenApp(name: String) {
     guard let open = findExecutable(named: "open") else { return }
@@ -689,6 +855,20 @@ public final class SimulatorService {
       .components(separatedBy: "\n")
       .filter { !$0.isEmpty }
       .last ?? "Build failed (exit \(exitCode))"
+  }
+
+  private nonisolated static func devicectlFailureMessage(
+    prefix: String,
+    result: ProcessExecutionResult
+  ) -> String {
+    let details = [result.errorText, result.outputText]
+      .flatMap { $0.components(separatedBy: "\n") }
+      .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+      .filter { !$0.isEmpty }
+    guard let lastDetail = details.last else {
+      return "\(prefix) (exit \(result.exitCode))"
+    }
+    return "\(prefix): \(lastDetail)"
   }
 
   /// Phase 3: runs the already-configured process, waits for it, finds and opens the app.
@@ -839,6 +1019,64 @@ public final class SimulatorService {
     return result
   }
 
+  /// Runs xcodebuild for a physical iOS device, then installs and launches the app.
+  private nonisolated static func executePhysicalDeviceBuild(
+    ref: ProcessRef,
+    deviceIdentifier: String,
+    sessionKey: String,
+    setup: BuildSetup
+  ) async -> Result<Void, Error> {
+    let totalStart = phaseTimestamp()
+    let buildStart = phaseTimestamp()
+    let stdoutChunks = DataAccumulator()
+    ref.outputPipe.fileHandleForReading.readabilityHandler = { handle in
+      let chunk = handle.availableData
+      guard !chunk.isEmpty else { return }
+      stdoutChunks.append(chunk)
+    }
+    do {
+      try ref.process.run()
+      ref.process.waitUntilExit()
+    } catch {
+      ref.outputPipe.fileHandleForReading.readabilityHandler = nil
+      return .failure(error)
+    }
+    ref.outputPipe.fileHandleForReading.readabilityHandler = nil
+    let tail = ref.outputPipe.fileHandleForReading.readDataToEndOfFile()
+    if !tail.isEmpty { stdoutChunks.append(tail) }
+
+    guard ref.process.terminationStatus == 0 else {
+      if ref.process.terminationReason == .uncaughtSignal {
+        return .failure(NSError(domain: "SimulatorService", code: -7,
+          userInfo: [NSLocalizedDescriptionKey: "Build cancelled"]))
+      }
+      let outputText = String(data: stdoutChunks.combinedData(), encoding: .utf8) ?? ""
+      let stderrText = String(data: ref.errorPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+      let msg = SimulatorService.extractBuildError(outputText: outputText, stderrText: stderrText, exitCode: ref.process.terminationStatus)
+      return .failure(NSError(domain: "SimulatorService",
+        code: Int(ref.process.terminationStatus),
+        userInfo: [NSLocalizedDescriptionKey: msg]))
+    }
+
+    AppLogger.simulator.info(
+      "xcodebuild finished for physical device scheme \(setup.scheme, privacy: .public) in \(formattedElapsed(since: buildStart), privacy: .public)s"
+    )
+
+    let result = await installAndLaunchPhysicalDevice(
+      identifier: deviceIdentifier,
+      sessionKey: sessionKey,
+      setup: setup
+    )
+
+    if case .success = result {
+      AppLogger.simulator.info(
+        "Physical device run completed in \(formattedElapsed(since: totalStart), privacy: .public)s for scheme \(setup.scheme, privacy: .public)"
+      )
+    }
+
+    return result
+  }
+
   /// Locates the built simulator app, installs it, and launches it.
   private nonisolated static func installAndLaunch(
     udid: String,
@@ -909,6 +1147,77 @@ public final class SimulatorService {
 
     // Bring Simulator.app to foreground
     runOpenApp(name: "Simulator")
+    return .success(())
+  }
+
+  /// Locates the built device app, installs it with devicectl, and launches it.
+  private nonisolated static func installAndLaunchPhysicalDevice(
+    identifier: String,
+    sessionKey: String,
+    setup: BuildSetup
+  ) async -> Result<Void, Error> {
+    guard let builtApp = resolveBuiltApp(
+      derivedDataPath: setup.derivedDataPath,
+      scheme: setup.scheme,
+      platform: .iOSDevice,
+      requiresBundleIdentifier: true
+    ),
+    let bundle = builtApp.bundleIdentifier else {
+      return .failure(NSError(domain: "SimulatorService", code: -11,
+        userInfo: [NSLocalizedDescriptionKey: "Could not locate built device app"]))
+    }
+
+    AppLogger.simulator.info(
+      "Resolved physical device app at \(builtApp.appPath, privacy: .public) with bundle \(bundle, privacy: .public)"
+    )
+
+    await MainActor.run {
+      SimulatorService.shared.physicalRunStates[sessionKey] = .installing
+    }
+
+    let installStart = phaseTimestamp()
+    let installResult = runDeviceCtl(arguments: [
+      "device", "install", "app",
+      "--device", identifier,
+      builtApp.appPath
+    ])
+    guard installResult.exitCode == 0 else {
+      return .failure(NSError(domain: "SimulatorService", code: Int(installResult.exitCode),
+        userInfo: [
+          NSLocalizedDescriptionKey: devicectlFailureMessage(
+            prefix: "devicectl install failed",
+            result: installResult
+          )
+        ]))
+    }
+    AppLogger.simulator.info(
+      "Installed app on physical device in \(formattedElapsed(since: installStart), privacy: .public)s"
+    )
+
+    await MainActor.run {
+      SimulatorService.shared.physicalRunStates[sessionKey] = .launching
+    }
+
+    let launchStart = phaseTimestamp()
+    let launchResult = runDeviceCtl(arguments: [
+      "device", "process", "launch",
+      "--device", identifier,
+      "--terminate-existing",
+      bundle
+    ])
+    guard launchResult.exitCode == 0 else {
+      return .failure(NSError(domain: "SimulatorService", code: Int(launchResult.exitCode),
+        userInfo: [
+          NSLocalizedDescriptionKey: devicectlFailureMessage(
+            prefix: "devicectl launch failed",
+            result: launchResult
+          )
+        ]))
+    }
+    AppLogger.simulator.info(
+      "Launched app on physical device in \(formattedElapsed(since: launchStart), privacy: .public)s"
+    )
+
     return .success(())
   }
 
@@ -1016,6 +1325,31 @@ public final class SimulatorService {
       .map { String(format: "%02x", $0) }
       .joined()
     return buildsDirectory.appendingPathComponent(digest, isDirectory: true).path
+  }
+
+  nonisolated static func physicalDeviceBuildArguments(
+    scheme: String,
+    targetPath: String,
+    isWorkspace: Bool,
+    identifier: String,
+    derivedDataPath: String
+  ) -> [String] {
+    var arguments = [
+      "build",
+      "-quiet",
+      "-scheme", scheme,
+      "-destination", "id=\(identifier)",
+      "-destination-timeout", "30",
+      "-derivedDataPath", derivedDataPath,
+      "-allowProvisioningUpdates",
+      "-allowProvisioningDeviceRegistration"
+    ]
+    if isWorkspace {
+      arguments += ["-workspace", targetPath]
+    } else {
+      arguments += ["-project", targetPath]
+    }
+    return arguments
   }
 
   nonisolated static func preferredAppBundlePath(
@@ -1207,6 +1541,93 @@ public final class SimulatorService {
     }
   }
 
+  /// Lists connected physical iOS devices, preferring CoreDevice's stable JSON output.
+  private nonisolated static func fetchPhysicalDeviceList() -> Result<[PhysicalIOSDevice], Error> {
+    let devicectlResult = fetchPhysicalDeviceListFromDeviceCtl()
+    if case .success = devicectlResult {
+      return devicectlResult
+    }
+    return fetchPhysicalDeviceListFromXCDevice()
+  }
+
+  /// Parses `xcrun devicectl list devices --json-output` and returns connected physical iOS devices.
+  private nonisolated static func fetchPhysicalDeviceListFromDeviceCtl() -> Result<[PhysicalIOSDevice], Error> {
+    guard let xcrun = findExecutable(named: "xcrun") else {
+      return .failure(NSError(domain: "SimulatorService", code: -1,
+                              userInfo: [NSLocalizedDescriptionKey: "xcrun not found"]))
+    }
+
+    let outputURL = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+      .appendingPathComponent("agenthub-devicectl-\(UUID().uuidString).json")
+    defer { try? FileManager.default.removeItem(at: outputURL) }
+
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: xcrun)
+    process.arguments = [
+      "devicectl", "list", "devices",
+      "--timeout", "5",
+      "--json-output", outputURL.path
+    ]
+
+    process.standardOutput = Pipe()
+    let errorPipe = Pipe()
+    process.standardError = errorPipe
+
+    do {
+      try process.run()
+      process.waitUntilExit()
+    } catch {
+      return .failure(error)
+    }
+
+    guard process.terminationStatus == 0 else {
+      let errorText = String(data: errorPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+      return .failure(NSError(domain: "SimulatorService", code: Int(process.terminationStatus),
+                              userInfo: [NSLocalizedDescriptionKey: errorText.isEmpty ? "devicectl list devices failed" : errorText]))
+    }
+
+    do {
+      return .success(try parseDeviceCtlPhysicalDeviceList(from: Data(contentsOf: outputURL)))
+    } catch {
+      return .failure(error)
+    }
+  }
+
+  /// Parses `xcrun xcdevice list --timeout 5` and returns connected physical iOS devices.
+  private nonisolated static func fetchPhysicalDeviceListFromXCDevice() -> Result<[PhysicalIOSDevice], Error> {
+    guard let xcrun = findExecutable(named: "xcrun") else {
+      return .failure(NSError(domain: "SimulatorService", code: -1,
+                              userInfo: [NSLocalizedDescriptionKey: "xcrun not found"]))
+    }
+
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: xcrun)
+    process.arguments = ["xcdevice", "list", "--timeout", "5"]
+
+    let pipe = Pipe()
+    process.standardOutput = pipe
+    process.standardError = Pipe()
+
+    do {
+      try process.run()
+      process.waitUntilExit()
+    } catch {
+      return .failure(error)
+    }
+
+    guard process.terminationStatus == 0 else {
+      return .failure(NSError(domain: "SimulatorService", code: Int(process.terminationStatus),
+                              userInfo: [NSLocalizedDescriptionKey: "xcdevice list failed"]))
+    }
+
+    let data = pipe.fileHandleForReading.readDataToEndOfFile()
+    do {
+      return .success(try parsePhysicalDeviceList(from: data))
+    } catch {
+      return .failure(error)
+    }
+  }
+
   /// Parses the JSON produced by `xcrun simctl list devices --json`.
   nonisolated static func parseDeviceList(from data: Data) throws -> [SimulatorRuntime] {
     guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
@@ -1249,6 +1670,108 @@ public final class SimulatorService {
     // Sort newest iOS version first
     return result.sorted { lhs, rhs in
       lhs.identifier > rhs.identifier
+    }
+  }
+
+  /// Parses the JSON produced by `xcrun xcdevice list`.
+  nonisolated static func parsePhysicalDeviceList(from data: Data) throws -> [PhysicalIOSDevice] {
+    guard let rawDevices = try JSONSerialization.jsonObject(with: data) as? [[String: Any]] else {
+      throw NSError(domain: "SimulatorService", code: -12,
+                    userInfo: [NSLocalizedDescriptionKey: "Unexpected xcdevice JSON structure"])
+    }
+
+    let devices = rawDevices.compactMap { dict -> PhysicalIOSDevice? in
+      guard
+        (dict["simulator"] as? Bool) == false,
+        (dict["available"] as? Bool) == true,
+        let platform = dict["platform"] as? String,
+        platform == "com.apple.platform.iphoneos",
+        let identifier = dict["identifier"] as? String,
+        let name = dict["name"] as? String
+      else {
+        return nil
+      }
+
+      let modelName = dict["modelName"] as? String ?? ""
+      let operatingSystemVersion = dict["operatingSystemVersion"] as? String ?? ""
+      let interface = dict["interface"] as? String
+      return PhysicalIOSDevice(
+        identifier: identifier,
+        name: name,
+        modelName: modelName,
+        operatingSystemVersion: operatingSystemVersion,
+        interface: interface
+      )
+    }
+
+    return sortPhysicalDevices(devices)
+  }
+
+  /// Parses the JSON produced by `xcrun devicectl list devices --json-output`.
+  nonisolated static func parseDeviceCtlPhysicalDeviceList(from data: Data) throws -> [PhysicalIOSDevice] {
+    guard
+      let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+      let result = json["result"] as? [String: Any],
+      let rawDevices = result["devices"] as? [[String: Any]]
+    else {
+      throw NSError(domain: "SimulatorService", code: -13,
+                    userInfo: [NSLocalizedDescriptionKey: "Unexpected devicectl JSON structure"])
+    }
+
+    let devices = rawDevices.compactMap { dict -> PhysicalIOSDevice? in
+      guard
+        let hardware = dict["hardwareProperties"] as? [String: Any],
+        (hardware["reality"] as? String) == "physical",
+        (hardware["platform"] as? String) == "iOS",
+        let udid = hardware["udid"] as? String,
+        hasCoreDeviceRunCapabilities(dict)
+      else {
+        return nil
+      }
+
+      let deviceProperties = dict["deviceProperties"] as? [String: Any]
+      let name = deviceProperties?["name"] as? String
+        ?? hardware["marketingName"] as? String
+        ?? udid
+      let modelName = hardware["marketingName"] as? String
+        ?? hardware["productType"] as? String
+        ?? ""
+      let osVersion = deviceProperties?["osVersionNumber"] as? String ?? ""
+      let osBuild = deviceProperties?["osBuildUpdate"] as? String
+      let formattedOSVersion: String
+      if let osBuild, !osBuild.isEmpty, !osVersion.isEmpty {
+        formattedOSVersion = "\(osVersion) (\(osBuild))"
+      } else {
+        formattedOSVersion = osVersion
+      }
+
+      return PhysicalIOSDevice(
+        identifier: udid,
+        name: name,
+        modelName: modelName,
+        operatingSystemVersion: formattedOSVersion,
+        interface: nil
+      )
+    }
+
+    return sortPhysicalDevices(devices)
+  }
+
+  private nonisolated static func hasCoreDeviceRunCapabilities(_ device: [String: Any]) -> Bool {
+    guard let capabilities = device["capabilities"] as? [[String: Any]] else { return false }
+    let identifiers = Set(capabilities.compactMap { $0["featureIdentifier"] as? String })
+    return identifiers.contains("com.apple.coredevice.feature.installapp")
+      && identifiers.contains("com.apple.coredevice.feature.launchapplication")
+  }
+
+  private nonisolated static func sortPhysicalDevices(
+    _ devices: [PhysicalIOSDevice]
+  ) -> [PhysicalIOSDevice] {
+    devices.sorted {
+      if $0.name != $1.name {
+        return $0.name.localizedStandardCompare($1.name) == .orderedAscending
+      }
+      return $0.identifier < $1.identifier
     }
   }
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/SimulatorPickerView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/SimulatorPickerView.swift
@@ -22,6 +22,10 @@ public struct SimulatorPickerView: View {
     SimulatorService.shared.preferredSimulatorUDIDs[session.projectPath]
   }
 
+  private var preferredPhysicalDeviceID: String? {
+    SimulatorService.shared.preferredPhysicalDeviceIDs[session.projectPath]
+  }
+
   public init(
     session: CLISession,
     onDismiss: @escaping () -> Void,
@@ -103,7 +107,8 @@ public struct SimulatorPickerView: View {
     if isLoadingPlatforms
         || (platforms.contains(.iOS)
             && SimulatorService.shared.isLoadingDevices
-            && SimulatorService.shared.runtimes.isEmpty) {
+            && SimulatorService.shared.runtimes.isEmpty
+            && SimulatorService.shared.physicalDevices.isEmpty) {
       loadingState
     } else if !platforms.contains(.macOS) && !hasIOSDevices {
       emptyState
@@ -270,6 +275,16 @@ public struct SimulatorPickerView: View {
 
   @ViewBuilder
   private var iosDeviceSections: some View {
+    if !SimulatorService.shared.physicalDevices.isEmpty {
+      Section(header: physicalDeviceSectionHeader) {
+        ForEach(SimulatorService.shared.physicalDevices) { device in
+          physicalDeviceRow(device)
+          Divider()
+            .padding(.leading, 16)
+        }
+      }
+    }
+
     ForEach(SimulatorService.shared.runtimes) { runtime in
       if !runtime.availableDevices.isEmpty {
         Section(header: runtimeHeader(runtime)) {
@@ -281,6 +296,21 @@ public struct SimulatorPickerView: View {
         }
       }
     }
+  }
+
+  private var physicalDeviceSectionHeader: some View {
+    HStack {
+      Text("Connected Devices")
+        .font(.subheadline.weight(.semibold))
+        .foregroundColor(.secondary)
+      Spacer()
+      Text("\(SimulatorService.shared.physicalDevices.count)")
+        .font(.caption)
+        .foregroundColor(.secondary)
+    }
+    .padding(.horizontal, 16)
+    .padding(.vertical, 6)
+    .background(colorScheme == .dark ? Color(white: 0.10) : Color(white: 0.94))
   }
 
   // MARK: - Runtime Header
@@ -301,6 +331,55 @@ public struct SimulatorPickerView: View {
   }
 
   // MARK: - Device Row
+
+  private func physicalDeviceRow(_ device: PhysicalIOSDevice) -> some View {
+    let serviceState = SimulatorService.shared.physicalDeviceState(
+      for: device.identifier,
+      projectPath: session.projectPath
+    )
+
+    return HStack(alignment: .firstTextBaseline, spacing: 10) {
+      StatusDotView(
+        color: physicalStatusColor(for: serviceState),
+        isAnimating: {
+          switch serviceState {
+          case .building, .installing, .launching: return true
+          default: return false
+          }
+        }()
+      )
+
+      VStack(alignment: .leading, spacing: 2) {
+        Text(device.name)
+          .font(.system(.body, design: .default))
+          .lineLimit(1)
+        Text(physicalStateLabel(for: serviceState, device: device))
+          .font(.caption)
+          .foregroundColor(stateLabelColor(for: serviceState))
+          .lineLimit(nil)
+          .fixedSize(horizontal: false, vertical: true)
+      }
+
+      Spacer()
+
+      physicalActionButtons(for: device, state: serviceState)
+    }
+    .padding(.horizontal, 16)
+    .padding(.vertical, 10)
+    .contentShape(Rectangle())
+    .background(
+      preferredPhysicalDeviceID == device.identifier
+        ? Color.accentColor.opacity(0.08)
+        : Color.clear
+    )
+    .onTapGesture {
+      SimulatorService.shared.setPreferredPhysicalDevice(
+        identifier: device.identifier,
+        for: session.projectPath
+      )
+      SimulatorService.shared.setPreferredSimulator(udid: nil, for: session.projectPath)
+    }
+  }
 
   private func deviceRow(_ device: SimulatorDevice) -> some View {
     let serviceState = SimulatorService.shared.state(for: device.udid, projectPath: session.projectPath)
@@ -344,6 +423,67 @@ public struct SimulatorPickerView: View {
     )
     .onTapGesture {
       SimulatorService.shared.setPreferredSimulator(udid: device.udid, for: session.projectPath)
+      SimulatorService.shared.setPreferredPhysicalDevice(identifier: nil, for: session.projectPath)
+    }
+  }
+
+  @ViewBuilder
+  private func physicalActionButtons(for device: PhysicalIOSDevice, state: SimulatorState) -> some View {
+    switch state {
+    case .idle, .booted, .shuttingDown:
+      physicalRunButton(identifier: device.identifier)
+    case .building:
+      HStack(spacing: 6) {
+        ProgressView()
+          .scaleEffect(0.6)
+          .frame(width: 16, height: 16)
+        Text("Building...")
+          .font(.caption)
+          .foregroundColor(.secondary)
+        physicalCancelButton(identifier: device.identifier)
+      }
+    case .installing:
+      HStack(spacing: 6) {
+        ProgressView()
+          .scaleEffect(0.6)
+          .frame(width: 16, height: 16)
+        Text("Installing...")
+          .font(.caption)
+          .foregroundColor(.secondary)
+        physicalCancelButton(identifier: device.identifier)
+      }
+    case .launching:
+      HStack(spacing: 6) {
+        ProgressView()
+          .scaleEffect(0.6)
+          .frame(width: 16, height: 16)
+        Text("Launching...")
+          .font(.caption)
+          .foregroundColor(.secondary)
+        physicalCancelButton(identifier: device.identifier)
+      }
+    case .booting:
+      HStack(spacing: 6) {
+        ProgressView()
+          .scaleEffect(0.6)
+          .frame(width: 16, height: 16)
+        Text("Preparing...")
+          .font(.caption)
+          .foregroundColor(.secondary)
+      }
+    case .failed(let error):
+      HStack(spacing: 6) {
+        if onSendToSession != nil {
+          Button("Fix", systemImage: "wrench.and.screwdriver.fill") {
+            onSendToSession?(error)
+          }
+          .font(.caption)
+          .buttonStyle(.bordered)
+          .controlSize(.small)
+          .tint(.accentColor)
+        }
+        physicalRunButton(identifier: device.identifier)
+      }
     }
   }
 
@@ -448,9 +588,40 @@ public struct SimulatorPickerView: View {
     .controlSize(.small)
   }
 
+  private func physicalRunButton(identifier: String) -> some View {
+    Button {
+      Task {
+        await SimulatorService.shared.buildAndRunOnPhysicalDevice(
+          identifier: identifier,
+          projectPath: session.projectPath
+        )
+      }
+    } label: {
+      Image(systemName: "play.fill")
+        .font(.caption)
+    }
+    .buttonStyle(.bordered)
+    .controlSize(.small)
+  }
+
   private func cancelButton(udid: String) -> some View {
     Button {
       SimulatorService.shared.cancelSimulatorBuild(udid: udid, projectPath: session.projectPath)
+    } label: {
+      Image(systemName: "stop.fill")
+        .font(.caption)
+    }
+    .buttonStyle(.bordered)
+    .controlSize(.small)
+    .tint(.red)
+  }
+
+  private func physicalCancelButton(identifier: String) -> some View {
+    Button {
+      SimulatorService.shared.cancelPhysicalDeviceRun(
+        identifier: identifier,
+        projectPath: session.projectPath
+      )
     } label: {
       Image(systemName: "stop.fill")
         .font(.caption)
@@ -486,8 +657,8 @@ public struct SimulatorPickerView: View {
   // MARK: - Helpers
 
   private var hasIOSDevices: Bool {
-    !SimulatorService.shared.runtimes.isEmpty
-      && SimulatorService.shared.runtimes.contains(where: { !$0.availableDevices.isEmpty })
+    !SimulatorService.shared.physicalDevices.isEmpty
+      || SimulatorService.shared.runtimes.contains(where: { !$0.availableDevices.isEmpty })
   }
 
   private func macStatusColor(for state: MacRunState) -> Color {
@@ -523,6 +694,19 @@ public struct SimulatorPickerView: View {
     }
   }
 
+  private func physicalStatusColor(for state: SimulatorState) -> Color {
+    switch state {
+    case .idle, .booted:
+      return .green
+    case .booting, .building, .installing, .launching:
+      return .yellow
+    case .shuttingDown:
+      return .orange
+    case .failed:
+      return .red
+    }
+  }
+
   private func stateLabel(for state: SimulatorState, device: SimulatorDevice) -> String {
     switch state {
     case .idle:
@@ -539,6 +723,27 @@ public struct SimulatorPickerView: View {
       return "Booted"
     case .shuttingDown:
       return "Shutting Down..."
+    case .failed:
+      return "Build failed"
+    }
+  }
+
+  private func physicalStateLabel(for state: SimulatorState, device: PhysicalIOSDevice) -> String {
+    switch state {
+    case .idle:
+      return device.subtitle.isEmpty ? "Connected" : device.subtitle
+    case .booting:
+      return "Preparing..."
+    case .building:
+      return "Building..."
+    case .installing:
+      return "Installing..."
+    case .launching:
+      return "Launching..."
+    case .booted:
+      return "Running"
+    case .shuttingDown:
+      return "Stopping..."
     case .failed:
       return "Build failed"
     }

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/SimulatorPreviewSidePanelView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/SimulatorPreviewSidePanelView.swift
@@ -33,6 +33,42 @@ enum SimulatorPanelDisplayMode: String, Hashable {
   case previews
 }
 
+private enum SimulatorRunDestination: Identifiable, Hashable {
+  case simulator(SimulatorDevice)
+  case physical(PhysicalIOSDevice)
+
+  static func simulatorID(udid: String) -> String {
+    "simulator:\(udid)"
+  }
+
+  static func physicalID(identifier: String) -> String {
+    "physical:\(identifier)"
+  }
+
+  var id: String {
+    switch self {
+    case .simulator(let device):
+      return Self.simulatorID(udid: device.udid)
+    case .physical(let device):
+      return Self.physicalID(identifier: device.identifier)
+    }
+  }
+
+  var name: String {
+    switch self {
+    case .simulator(let device):
+      return device.name
+    case .physical(let device):
+      return device.name
+    }
+  }
+
+  var simulatorUDID: String? {
+    if case .simulator(let device) = self { return device.udid }
+    return nil
+  }
+}
+
 struct SimulatorPreviewSidePanelView: View {
   let session: CLISession
   let projectPath: String
@@ -46,7 +82,7 @@ struct SimulatorPreviewSidePanelView: View {
   @Environment(\.agentHub) private var agentHub
 
   @State private var simulatorService = SimulatorService.shared
-  @State private var selectedUDID: String?
+  @State private var selectedDestinationID: String?
   @State private var hasLoadedDevices = false
   @State private var annotationModel = SimulatorAnnotationModel()
   @State private var isAnnotationTrayExpanded = false
@@ -77,12 +113,36 @@ struct SimulatorPreviewSidePanelView: View {
     WorktreeLaunchProvider(commandLineValue: providerKind.rawValue)
   }
 
-  /// The device to preview: explicit selection, else the project's preferred
-  /// device, else the first booted device we can find.
+  /// The destination to run on: explicit selection, then project preferences,
+  /// then connected hardware, an already-running simulator, or any simulator.
+  private var activeDestination: SimulatorRunDestination? {
+    if let selectedDestinationID,
+       let destination = runDestinations.first(where: { $0.id == selectedDestinationID }) {
+      return destination
+    }
+    if let preferred = simulatorService.preferredSimulatorUDIDs[projectPath],
+       let device = availableDevices.first(where: { $0.udid == preferred }) {
+      return .simulator(device)
+    }
+    if let preferred = simulatorService.preferredPhysicalDeviceIDs[projectPath],
+       let device = physicalDevices.first(where: { $0.identifier == preferred }) {
+      return .physical(device)
+    }
+    if let physical = physicalDevices.first {
+      return .physical(physical)
+    }
+    if let booted = bootedDevices.first {
+      return .simulator(booted)
+    }
+    return availableDevices.first.map(SimulatorRunDestination.simulator)
+  }
+
+  private var activeDestinationID: String? {
+    activeDestination?.id
+  }
+
   private var activeUDID: String? {
-    if let selectedUDID { return selectedUDID }
-    if let preferred = simulatorService.preferredSimulatorUDIDs[projectPath] { return preferred }
-    return bootedDevices.first?.udid
+    activeDestination?.simulatorUDID
   }
 
   private var bootedDevices: [SimulatorDevice] {
@@ -93,14 +153,36 @@ struct SimulatorPreviewSidePanelView: View {
     simulatorService.runtimes.flatMap { $0.availableDevices }
   }
 
+  private var physicalDevices: [PhysicalIOSDevice] {
+    simulatorService.physicalDevices
+  }
+
+  private var runDestinations: [SimulatorRunDestination] {
+    physicalDevices.map(SimulatorRunDestination.physical)
+      + availableDevices.map(SimulatorRunDestination.simulator)
+  }
+
   private var activeDevice: SimulatorDevice? {
     guard let activeUDID else { return nil }
     return availableDevices.first { $0.udid == activeUDID }
   }
 
+  private var activePhysicalDevice: PhysicalIOSDevice? {
+    guard case .physical(let device) = activeDestination else { return nil }
+    return device
+  }
+
   private var activeState: SimulatorState {
-    guard let activeUDID else { return .idle }
-    return simulatorService.state(for: activeUDID, projectPath: projectPath)
+    if let activeUDID {
+      return simulatorService.state(for: activeUDID, projectPath: projectPath)
+    }
+    if let activePhysicalDevice {
+      return simulatorService.physicalDeviceState(
+        for: activePhysicalDevice.identifier,
+        projectPath: projectPath
+      )
+    }
+    return .idle
   }
 
   /// Live boot state — consults `SimulatorService.isBooted` (updated by boot /
@@ -203,10 +285,7 @@ struct SimulatorPreviewSidePanelView: View {
     )
     .task {
       await loadDevicesIfNeeded()
-      if simulatorPreviewsEnabled {
-        hotReload.warmUp()
-      }
-      hotReload.setPreviewObservationEnabled(simulatorPreviewsEnabled, projectPath: projectPath)
+      syncSimulatorFeatureTracking()
     }
     .onDisappear {
       cancelAnnotationElementRefresh()
@@ -219,24 +298,27 @@ struct SimulatorPreviewSidePanelView: View {
     .task(id: simulatorContextSignature) {
       persistSimulatorContext()
     }
-    .onChange(of: activeUDID) { _, _ in
+    .onChange(of: activeDestinationID) { _, _ in
       cancelAnnotationElementRefresh()
       annotationModel.reset()
       isAnnotationTrayExpanded = false
       hotReload.sessionDidStop()
-      if effectiveDisplayMode == .previews { autoArmPreviewsIfNeeded() }
+      if activeUDID == nil {
+        displayMode = .live
+        removeSimulatorContext()
+      } else if effectiveDisplayMode == .previews {
+        autoArmPreviewsIfNeeded()
+      }
+      syncSimulatorFeatureTracking()
     }
     .onChange(of: displayMode) { _, mode in
       if simulatorPreviewsEnabled, mode == .previews { autoArmPreviewsIfNeeded() }
     }
     .onChange(of: simulatorPreviewsEnabled) { _, isEnabled in
-      hotReload.setPreviewObservationEnabled(isEnabled, projectPath: projectPath)
-      if isEnabled {
-        hotReload.warmUp()
-        if displayMode == .previews {
-          autoArmPreviewsIfNeeded()
-        }
-      } else {
+      syncSimulatorFeatureTracking()
+      if isEnabled, displayMode == .previews {
+        autoArmPreviewsIfNeeded()
+      } else if !isEnabled {
         displayMode = .live
       }
     }
@@ -288,14 +370,16 @@ struct SimulatorPreviewSidePanelView: View {
         displayModePicker
       }
 
-      if !streamService.availability.isInteractive {
+      if activeUDID != nil, !streamService.availability.isInteractive {
         viewOnlyBadge
       }
 
-      HotReloadStatusPillView(
-        phase: hotReload.monitor.phase,
-        warning: hotReload.monitor.lastWarning
-      )
+      if activeUDID != nil {
+        HotReloadStatusPillView(
+          phase: hotReload.monitor.phase,
+          warning: hotReload.monitor.lastWarning
+        )
+      }
 
       Spacer(minLength: 8)
 
@@ -343,26 +427,48 @@ struct SimulatorPreviewSidePanelView: View {
 
   @ViewBuilder
   private var devicePicker: some View {
-    if !availableDevices.isEmpty {
+    if !runDestinations.isEmpty {
       Menu {
-        ForEach(availableDevices) { device in
-          Button {
-            selectDevice(udid: device.udid)
-          } label: {
-            HStack {
-              Text(device.name)
-              if device.isBooted {
-                Text("Running")
+        if !physicalDevices.isEmpty {
+          Section("Connected Devices") {
+            ForEach(physicalDevices) { device in
+              Button {
+                selectPhysicalDevice(identifier: device.identifier)
+              } label: {
+                HStack {
+                  Text(device.name)
+                  Text(device.subtitle.isEmpty ? "Device" : device.subtitle)
+                  if activeDestinationID == SimulatorRunDestination.physical(device).id {
+                    Image(systemName: "checkmark")
+                  }
+                }
               }
-              if activeUDID == device.udid {
-                Image(systemName: "checkmark")
+            }
+          }
+        }
+
+        if !availableDevices.isEmpty {
+          Section("Simulators") {
+            ForEach(availableDevices) { device in
+              Button {
+                selectSimulator(udid: device.udid)
+              } label: {
+                HStack {
+                  Text(device.name)
+                  if device.isBooted {
+                    Text("Running")
+                  }
+                  if activeUDID == device.udid {
+                    Image(systemName: "checkmark")
+                  }
+                }
               }
             }
           }
         }
       } label: {
         HStack(spacing: 6) {
-          Text(activeDevice?.name ?? "Select Simulator")
+          Text(activeDestination?.name ?? "Select Destination")
             .font(.caption.weight(.medium))
             .lineLimit(1)
             .fixedSize(horizontal: true, vertical: false)
@@ -380,7 +486,7 @@ struct SimulatorPreviewSidePanelView: View {
       .menuIndicator(.hidden)
       .fixedSize(horizontal: true, vertical: false)
       .layoutPriority(2)
-      .accessibilityLabel("Select simulator")
+      .accessibilityLabel("Select run destination")
     }
   }
 
@@ -414,22 +520,26 @@ struct SimulatorPreviewSidePanelView: View {
       SimulatorFloatingActionButton(
         systemImage: "play.fill",
         tint: Color.brandPrimary,
-        isDisabled: activeUDID == nil || isBuildAndRunInProgress,
+        isDisabled: activeDestination == nil || isBuildAndRunInProgress,
         isWorking: isBuildAndRunInProgress,
-        help: "Build & run this project on the selected simulator",
+        help: activePhysicalDevice == nil
+          ? "Build & run this project on the selected simulator"
+          : "Build & run this project on the selected device",
         accessibilityLabel: "Build and run",
         action: buildAndRun
       )
 
-      SimulatorFloatingActionButton(
-        systemImage: "stop.fill",
-        tint: .red,
-        isDisabled: !isActiveDeviceBooted || isShutdownInProgress,
-        isWorking: isShutdownInProgress,
-        help: "Shut down the simulator",
-        accessibilityLabel: "Shut down simulator",
-        action: stopSimulator
-      )
+      if activeUDID != nil {
+        SimulatorFloatingActionButton(
+          systemImage: "stop.fill",
+          tint: .red,
+          isDisabled: !isActiveDeviceBooted || isShutdownInProgress,
+          isWorking: isShutdownInProgress,
+          help: "Shut down the simulator",
+          accessibilityLabel: "Shut down simulator",
+          action: stopSimulator
+        )
+      }
     }
   }
 
@@ -460,7 +570,7 @@ struct SimulatorPreviewSidePanelView: View {
         simulatorFailureBannerOverlay
       }
       .overlay(alignment: .topTrailing) {
-        if activeUDID != nil {
+        if activeDestination != nil {
           floatingRunControls
             .padding(14)
         }
@@ -536,8 +646,10 @@ struct SimulatorPreviewSidePanelView: View {
       spotlightView
     } else if simulatorService.isLoadingDevices && !hasLoadedDevices {
       loadingState
-    } else if availableDevices.isEmpty {
+    } else if runDestinations.isEmpty {
       emptyState
+    } else if activePhysicalDevice != nil {
+      physicalDeviceStateView
     } else {
       notBootedState
     }
@@ -666,11 +778,79 @@ struct SimulatorPreviewSidePanelView: View {
 
   private var emptyState: some View {
     ContentUnavailableView(
-      "No Simulators",
+      "No Run Destinations",
       systemImage: "iphone.slash",
-      description: Text("No available iOS simulators were found on this machine.")
+      description: Text("No available iOS simulators or connected iOS devices were found on this machine.")
     )
     .frame(maxWidth: .infinity, maxHeight: .infinity)
+  }
+
+  private var physicalDeviceStateView: some View {
+    VStack(spacing: 12) {
+      Image(systemName: "iphone")
+        .font(.system(size: 40))
+        .foregroundStyle(.secondary)
+
+      if isActiveDevicePreparing {
+        Text(preparingLabel)
+          .font(.subheadline)
+        ProgressView()
+          .controlSize(.small)
+      } else {
+        Text(physicalDeviceStatusTitle)
+          .font(.subheadline)
+        Text("Live mirroring is available for simulators only.")
+          .font(.caption)
+          .foregroundStyle(.secondary)
+
+        if let activeFailureMessage {
+          Text(activeFailureMessage)
+            .font(.caption)
+            .foregroundStyle(.red)
+            .multilineTextAlignment(.center)
+            .lineLimit(4)
+            .frame(maxWidth: 420)
+        }
+
+        Button(physicalDeviceRunButtonTitle, systemImage: "play.fill", action: buildAndRun)
+          .buttonStyle(.borderedProminent)
+          .controlSize(.small)
+          .tint(Color.brandPrimary)
+          .disabled(activeDestination == nil)
+          .help("Build, install, and launch this project on the selected device")
+
+        if !bootedDevices.isEmpty {
+          Button(shutdownBootedSimulatorsButtonTitle, systemImage: "stop.fill", action: shutdownBootedSimulators)
+            .buttonStyle(.bordered)
+            .controlSize(.small)
+            .tint(.red)
+            .help("Shut down booted simulators to release memory")
+        }
+      }
+    }
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+  }
+
+  private var physicalDeviceStatusTitle: String {
+    guard let activePhysicalDevice else { return "Select a device" }
+    if case .failed = activeState {
+      return "Run failed on \(activePhysicalDevice.name)"
+    }
+    if activeState == .booted {
+      return "Running on \(activePhysicalDevice.name)"
+    }
+    return "Ready to run on \(activePhysicalDevice.name)"
+  }
+
+  private var physicalDeviceRunButtonTitle: String {
+    if case .failed = activeState {
+      return "Try Again"
+    }
+    return activeState == .booted ? "Run Again" : "Build & Run"
+  }
+
+  private var shutdownBootedSimulatorsButtonTitle: String {
+    bootedDevices.count == 1 ? "Shut Down Simulator" : "Shut Down Simulators"
   }
 
   @ViewBuilder
@@ -712,9 +892,26 @@ struct SimulatorPreviewSidePanelView: View {
     hasLoadedDevices = true
   }
 
-  private func selectDevice(udid: String) {
-    selectedUDID = udid
+  private func syncSimulatorFeatureTracking() {
+    let isSimulatorDestination = activeUDID != nil
+    let shouldObservePreviews = simulatorPreviewsEnabled && isSimulatorDestination
+    hotReload.setPreviewObservationEnabled(shouldObservePreviews, projectPath: projectPath)
+    if shouldObservePreviews {
+      hotReload.warmUp()
+    }
+  }
+
+  private func selectSimulator(udid: String) {
+    selectedDestinationID = SimulatorRunDestination.simulatorID(udid: udid)
     simulatorService.setPreferredSimulator(udid: udid, for: projectPath)
+    simulatorService.setPreferredPhysicalDevice(identifier: nil, for: projectPath)
+  }
+
+  private func selectPhysicalDevice(identifier: String) {
+    guard let device = physicalDevices.first(where: { $0.identifier == identifier }) else { return }
+    selectedDestinationID = SimulatorRunDestination.physical(device).id
+    simulatorService.setPreferredPhysicalDevice(identifier: identifier, for: projectPath)
+    simulatorService.setPreferredSimulator(udid: nil, for: projectPath)
   }
 
   private func persistSimulatorContext() {
@@ -746,6 +943,17 @@ struct SimulatorPreviewSidePanelView: View {
   }
 
   private func buildAndRun() {
+    dismissedFailureMessage = nil
+    if let activePhysicalDevice {
+      Task {
+        await simulatorService.buildAndRunOnPhysicalDevice(
+          identifier: activePhysicalDevice.identifier,
+          projectPath: projectPath
+        )
+      }
+      return
+    }
+
     guard let activeUDID else { return }
     Task {
       // Boot first so the preview switches to the live stream immediately,
@@ -780,6 +988,15 @@ struct SimulatorPreviewSidePanelView: View {
     guard let activeUDID else { return }
     hotReload.sessionDidStop()
     Task { await simulatorService.shutdownDevice(udid: activeUDID) }
+  }
+
+  private func shutdownBootedSimulators() {
+    let udids = bootedDevices.map(\.udid)
+    Task {
+      for udid in udids {
+        await simulatorService.shutdownDevice(udid: udid)
+      }
+    }
   }
 
   private var recordingButtonSystemImage: String {
@@ -1026,6 +1243,7 @@ struct SimulatorPreviewSidePanelView: View {
   /// one-time relaunch.
   private func launchPreviews() {
     guard simulatorPreviewsEnabled else { return }
+    guard activeUDID != nil else { return }
     if isActiveDeviceBooted {
       enablePreviews()
     } else {
@@ -1309,7 +1527,7 @@ private struct SimulatorBuildErrorBanner: View {
         .accessibilityHidden(true)
 
       VStack(alignment: .leading, spacing: 3) {
-        Text("Simulator error")
+        Text("Run error")
           .font(.caption.weight(.semibold))
 
         Text(message)
@@ -1330,8 +1548,8 @@ private struct SimulatorBuildErrorBanner: View {
         .buttonStyle(.borderedProminent)
         .controlSize(.small)
         .tint(Color.brandPrimary(for: providerKind))
-        .help("Ask \(providerKind.rawValue) to fix this simulator error")
-        .accessibilityLabel("Fix simulator error with \(providerKind.rawValue)")
+        .help("Ask \(providerKind.rawValue) to fix this run error")
+        .accessibilityLabel("Fix run error with \(providerKind.rawValue)")
       }
 
       Button {

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/SimulatorModelsTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/SimulatorModelsTests.swift
@@ -93,6 +93,47 @@ struct SimulatorRuntimeTests {
   }
 }
 
+// MARK: - PhysicalIOSDevice
+
+@Suite("PhysicalIOSDevice")
+struct PhysicalIOSDeviceTests {
+  @Test func idEqualsIdentifier() {
+    let device = PhysicalIOSDevice(
+      identifier: "00008150",
+      name: "Zizou2",
+      modelName: "iPhone 17 Pro",
+      operatingSystemVersion: "26.5 (23F77)",
+      interface: "usb"
+    )
+
+    #expect(device.id == "00008150")
+  }
+
+  @Test func subtitleIncludesDistinctModelAndOSVersion() {
+    let device = PhysicalIOSDevice(
+      identifier: "00008150",
+      name: "Zizou2",
+      modelName: "iPhone 17 Pro",
+      operatingSystemVersion: "26.5 (23F77)",
+      interface: "usb"
+    )
+
+    #expect(device.subtitle == "iPhone 17 Pro - 26.5 (23F77)")
+  }
+
+  @Test func subtitleAvoidsDuplicateModelName() {
+    let device = PhysicalIOSDevice(
+      identifier: "00008150",
+      name: "iPhone 17 Pro",
+      modelName: "iPhone 17 Pro",
+      operatingSystemVersion: "26.5 (23F77)",
+      interface: nil
+    )
+
+    #expect(device.subtitle == "26.5 (23F77)")
+  }
+}
+
 // MARK: - SimulatorState
 
 @Suite("SimulatorState")

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/SimulatorServiceTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/SimulatorServiceTests.swift
@@ -115,6 +115,146 @@ struct ParseDeviceListTests {
   }
 }
 
+// MARK: - parsePhysicalDeviceList
+
+@Suite("parsePhysicalDeviceList")
+struct ParsePhysicalDeviceListTests {
+  private let sampleJSON = """
+  [
+    {
+      "simulator": false,
+      "available": true,
+      "platform": "com.apple.platform.iphoneos",
+      "identifier": "00008150-000E411A1A87801C",
+      "name": "Zizou2",
+      "modelName": "iPhone 17 Pro",
+      "operatingSystemVersion": "26.5 (23F77)",
+      "interface": "usb"
+    },
+    {
+      "simulator": false,
+      "available": false,
+      "platform": "com.apple.platform.iphoneos",
+      "identifier": "00008120-000A45121EF0201E",
+      "name": "Offline iPad",
+      "modelName": "iPad (A16)",
+      "operatingSystemVersion": "18.7.1 (22H31)"
+    },
+    {
+      "simulator": true,
+      "available": true,
+      "platform": "com.apple.platform.iphonesimulator",
+      "identifier": "SIM-1",
+      "name": "iPhone 17"
+    },
+    {
+      "simulator": false,
+      "available": true,
+      "platform": "com.apple.platform.macosx",
+      "identifier": "MAC-1",
+      "name": "My Mac"
+    }
+  ]
+  """
+
+  private let deviceCtlJSON = """
+  {
+    "info": {
+      "outcome": "success"
+    },
+    "result": {
+      "devices": [
+        {
+          "capabilities": [
+            { "featureIdentifier": "com.apple.coredevice.feature.tags" }
+          ],
+          "deviceProperties": {
+            "name": "Offline iPad",
+            "osVersionNumber": "18.7.1",
+            "osBuildUpdate": "22H31"
+          },
+          "hardwareProperties": {
+            "marketingName": "iPad (A16)",
+            "platform": "iOS",
+            "reality": "physical",
+            "udid": "00008120-000A45121EF0201E"
+          }
+        },
+        {
+          "capabilities": [
+            { "featureIdentifier": "com.apple.coredevice.feature.installapp" },
+            { "featureIdentifier": "com.apple.coredevice.feature.launchapplication" }
+          ],
+          "deviceProperties": {
+            "name": "Zizou2",
+            "osVersionNumber": "26.6",
+            "osBuildUpdate": "23G5043d"
+          },
+          "hardwareProperties": {
+            "marketingName": "iPhone 17 Pro",
+            "platform": "iOS",
+            "productType": "iPhone18,1",
+            "reality": "physical",
+            "udid": "00008150-000E411A1A87801C"
+          }
+        },
+        {
+          "capabilities": [
+            { "featureIdentifier": "com.apple.coredevice.feature.installapp" },
+            { "featureIdentifier": "com.apple.coredevice.feature.launchapplication" }
+          ],
+          "deviceProperties": {
+            "name": "Vision Device",
+            "osVersionNumber": "26.0"
+          },
+          "hardwareProperties": {
+            "marketingName": "Apple Vision Pro",
+            "platform": "xrOS",
+            "reality": "physical",
+            "udid": "XR-DEVICE"
+          }
+        }
+      ]
+    }
+  }
+  """
+
+  @Test func keepsOnlyAvailablePhysicalIOSDevices() throws {
+    let devices = try SimulatorService.parsePhysicalDeviceList(from: sampleJSON.data(using: .utf8)!)
+
+    #expect(devices.count == 1)
+    #expect(devices.first?.identifier == "00008150-000E411A1A87801C")
+    #expect(devices.first?.name == "Zizou2")
+    #expect(devices.first?.modelName == "iPhone 17 Pro")
+    #expect(devices.first?.operatingSystemVersion == "26.5 (23F77)")
+    #expect(devices.first?.interface == "usb")
+  }
+
+  @Test func parsesRunCapableDevicectlPhysicalIOSDevices() throws {
+    let devices = try SimulatorService.parseDeviceCtlPhysicalDeviceList(
+      from: deviceCtlJSON.data(using: .utf8)!
+    )
+
+    #expect(devices.count == 1)
+    #expect(devices.first?.identifier == "00008150-000E411A1A87801C")
+    #expect(devices.first?.name == "Zizou2")
+    #expect(devices.first?.modelName == "iPhone 17 Pro")
+    #expect(devices.first?.operatingSystemVersion == "26.6 (23G5043d)")
+  }
+
+  @Test func throwsOnMalformedJSON() {
+    #expect(throws: (any Error).self) {
+      try SimulatorService.parsePhysicalDeviceList(from: Data("{}".utf8))
+    }
+  }
+
+  @Test func devicectlParserThrowsOnMalformedJSON() {
+    #expect(throws: (any Error).self) {
+      try SimulatorService.parseDeviceCtlPhysicalDeviceList(from: Data("[]".utf8))
+    }
+  }
+}
+
 // MARK: - state(for:)
 
 @Suite("state(for:)")
@@ -257,6 +397,50 @@ struct BuildHelperTests {
 
     #expect(URL(fileURLWithPath: builtApp.appPath).standardizedFileURL.path == launchableApp.standardizedFileURL.path)
     #expect(builtApp.bundleIdentifier == "com.agenthub.demo-preview")
+  }
+
+  @Test func resolveDeviceAppUsesIPhoneOSProducts() throws {
+    let root = URL(fileURLWithPath: NSTemporaryDirectory())
+      .appendingPathComponent("SimulatorServiceTests-\(UUID().uuidString)", isDirectory: true)
+    let deviceProducts = root.appendingPathComponent("Build/Products/Debug-iphoneos", isDirectory: true)
+    let simulatorProducts = root.appendingPathComponent("Build/Products/Debug-iphonesimulator", isDirectory: true)
+    let expectedApp = deviceProducts.appendingPathComponent("Demo.app", isDirectory: true)
+
+    try FileManager.default.createDirectory(at: expectedApp, withIntermediateDirectories: true)
+    try FileManager.default.createDirectory(
+      at: simulatorProducts.appendingPathComponent("Demo.app", isDirectory: true),
+      withIntermediateDirectories: true
+    )
+    try writeInfoPlist(bundleIdentifier: "com.agenthub.demo-device", to: expectedApp)
+
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    let builtApp = try #require(SimulatorService.resolveBuiltApp(
+      derivedDataPath: root.path,
+      scheme: "Demo",
+      platform: .iOSDevice,
+      requiresBundleIdentifier: true
+    ))
+
+    #expect(URL(fileURLWithPath: builtApp.appPath).standardizedFileURL.path == expectedApp.standardizedFileURL.path)
+    #expect(builtApp.bundleIdentifier == "com.agenthub.demo-device")
+  }
+
+  @Test func physicalDeviceBuildArgumentsAllowAutomaticProvisioning() {
+    let args = SimulatorService.physicalDeviceBuildArguments(
+      scheme: "Demo",
+      targetPath: "/tmp/Demo.xcodeproj",
+      isWorkspace: false,
+      identifier: "DEVICE-1",
+      derivedDataPath: "/tmp/DerivedData"
+    )
+
+    #expect(args.contains("-allowProvisioningUpdates"))
+    #expect(args.contains("-allowProvisioningDeviceRegistration"))
+    #expect(args.contains("-destination-timeout"))
+    #expect(args.contains("id=DEVICE-1"))
+    #expect(args.contains("-project"))
+    #expect(args.contains("/tmp/Demo.xcodeproj"))
   }
 
   @Test func bundleIdentifierReadsInfoPlist() throws {


### PR DESCRIPTION
## Summary

Adds connected iOS/iPadOS hardware as run destinations in the simulator preview flow. Physical devices now appear in the destination picker, can be selected as a preferred destination, and use a dedicated build/install/launch path through `xcodebuild` and `devicectl`.

The phone path remains intentionally separate from live simulator mirroring: hardware runs do not start simulator streaming, annotation, recording, hot reload, preview-host setup, or preview source watchers. The phone state view also surfaces run failures inline and offers a simulator shutdown action when booted simulators are still consuming memory.

The legacy `SimulatorPickerView` was updated as well because it is still the fallback from `MonitoringCardView` when the live side-panel callback is not wired.

## Root Cause

The new simulator side-panel picker only modeled CoreSimulator devices. Connected phones were visible through Xcode/CoreDevice, but AgentHub did not discover them for the new picker or route the play action to a physical-device build/install/launch pipeline.

During validation, the phone run path exposed a signing failure from the sample project. The physical-device build now passes Xcode automatic provisioning flags and renders the real error if provisioning still blocks the build.

## Validation

- `git diff --check`
- `xcodebuild test -scheme AgentHubCore-Tests -destination 'platform=macOS' -test-timeouts-enabled YES -skipPackagePluginValidation -only-testing:AgentHubTests/ParsePhysicalDeviceListTests -only-testing:AgentHubTests/BuildHelperTests -only-testing:AgentHubTests/PhysicalIOSDeviceTests`
- `xcodebuild test -scheme AgentHubCore-Tests -destination 'platform=macOS' -test-timeouts-enabled YES -skipPackagePluginValidation -only-testing:AgentHubTests/SimulatorHotReloadControllerTests`

Note: Xcode prints the existing SwiftLint footer noise for CodeEdit dependencies, but both targeted test commands exited 0 and reported `TEST SUCCEEDED`.
