### PR TITLE
Performance: eliminate session-watcher busy-spin and per-tick UI invalidation storms

### DIFF
--- a/app/AgentHub.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/app/AgentHub.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "0e7b327974495c6d9b2c8dfc7d5783b146b95fb8dabef46b8f733fb6de4cfe9a",
+  "originHash" : "c6603929f49445c1b719a9629a5a8450366353422abbdc98fc156845dc35bb03",
   "pins" : [
     {
       "identity" : "beautiful-mermaid-swift",
@@ -177,8 +177,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/jamesrochabrun/SwiftTerm",
       "state" : {
-        "revision" : "c53c9a0a71ccda3bcd1133f4eb8e2c165c45a8c7",
-        "version" : "1.13.0-agenthub.7"
+        "revision" : "d9b10dad741cd9b1d7d36556b4ccdad9a8b8e1ca",
+        "version" : "1.13.0-agenthub.8"
       }
     },
     {

--- a/app/modules/AgentHubCore/Package.resolved
+++ b/app/modules/AgentHubCore/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "863379ffd52112ae7de864475df606bbea1bd732f5821f532ba3357a56749ae4",
+  "originHash" : "32dc1b5be00552bdb29eab161d379680c9107ee5dd7b5e7e17d3dff67608f1f3",
   "pins" : [
     {
       "identity" : "beautiful-mermaid-swift",
@@ -159,8 +159,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/jamesrochabrun/SwiftTerm",
       "state" : {
-        "revision" : "c53c9a0a71ccda3bcd1133f4eb8e2c165c45a8c7",
-        "version" : "1.13.0-agenthub.7"
+        "revision" : "d9b10dad741cd9b1d7d36556b4ccdad9a8b8e1ca",
+        "version" : "1.13.0-agenthub.8"
       }
     },
     {

--- a/app/modules/AgentHubCore/Package.swift
+++ b/app/modules/AgentHubCore/Package.swift
@@ -48,7 +48,7 @@ let package = Package(
     .package(path: "../SimulatorPreview"),
     .package(url: "https://github.com/jamesrochabrun/Canvas", exact: "1.2.2"),
     .package(url: "https://github.com/jamesrochabrun/PierreDiffsSwift", exact: "1.2.2"),
-    .package(url: "https://github.com/jamesrochabrun/SwiftTerm", exact: "1.13.0-agenthub.7"),
+    .package(url: "https://github.com/jamesrochabrun/SwiftTerm", exact: "1.13.0-agenthub.8"),
     .package(url: "https://github.com/gonzalezreal/swift-markdown-ui", from: "2.0.0"),
     .package(url: "https://github.com/groue/GRDB.swift", from: "6.24.0"),
     .package(url: "https://github.com/appstefan/HighlightSwift", from: "1.1.0"),

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/CodexSessionFileWatcher.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/CodexSessionFileWatcher.swift
@@ -6,6 +6,7 @@
 //
 
 import Combine
+import Darwin
 import Foundation
 import os
 
@@ -130,6 +131,10 @@ public actor CodexSessionFileWatcher {
         let timeSinceLastEvent = Date().timeIntervalSince(lastFileEventTime)
         let currentFileSize = self.getFileSize(filePath)
 
+        // Tracks whether this tick changed anything worth persisting back to
+        // the actor; no-op ticks skip the updateStoredWatcherInfo Task hop.
+        var storedInfoNeedsUpdate = false
+
         if timeSinceLastEvent > 5 && currentFileSize > lastKnownFileSize {
           var tempPosition = lastKnownFileSize
           let newLines = self.readNewLines(from: filePath, startingAt: &tempPosition)
@@ -140,6 +145,7 @@ public actor CodexSessionFileWatcher {
           } else {
             lastKnownFileSize = currentFileSize
           }
+          storedInfoNeedsUpdate = true
         }
 
         let previousStatus = lastEmittedStatus
@@ -147,6 +153,7 @@ public actor CodexSessionFileWatcher {
 
         if parseResult.currentStatus != lastEmittedStatus {
           lastEmittedStatus = parseResult.currentStatus
+          storedInfoNeedsUpdate = true
           let updatedState = self.buildMonitorState(from: parseResult)
 
           Task { @MainActor in
@@ -154,18 +161,21 @@ public actor CodexSessionFileWatcher {
           }
         } else if previousStatus != parseResult.currentStatus {
           lastEmittedStatus = parseResult.currentStatus
+          storedInfoNeedsUpdate = true
         }
 
-        let parseResultSnapshot = parseResult
-        let lastFileEventSnapshot = lastFileEventTime
-        let lastKnownFileSizeSnapshot = lastKnownFileSize
-        Task {
-          await self.updateStoredWatcherInfo(
-            sessionId: sessionId,
-            parseResult: parseResultSnapshot,
-            lastFileEventTime: lastFileEventSnapshot,
-            lastKnownFileSize: lastKnownFileSizeSnapshot
-          )
+        if storedInfoNeedsUpdate {
+          let parseResultSnapshot = parseResult
+          let lastFileEventSnapshot = lastFileEventTime
+          let lastKnownFileSizeSnapshot = lastKnownFileSize
+          Task {
+            await self.updateStoredWatcherInfo(
+              sessionId: sessionId,
+              parseResult: parseResultSnapshot,
+              lastFileEventTime: lastFileEventSnapshot,
+              lastKnownFileSize: lastKnownFileSizeSnapshot
+            )
+          }
         }
 
         rescheduleStatusTimer()
@@ -232,11 +242,12 @@ public actor CodexSessionFileWatcher {
   }
 
   private nonisolated func getFileSize(_ path: String) -> UInt64 {
-    guard let attrs = try? FileManager.default.attributesOfItem(atPath: path),
-          let size = attrs[.size] as? UInt64 else {
-      return 0
-    }
-    return size
+    // Direct stat() — FileManager.attributesOfItem is far more expensive and
+    // this runs on every status-timer tick.
+    var st = stat()
+    // Unqualified call: `Darwin.stat` resolves to the struct type, not the function.
+    guard stat(path, &st) == 0 else { return 0 }
+    return UInt64(st.st_size)
   }
 
   private nonisolated func readNewLines(from path: String, startingAt position: inout UInt64) -> [String] {

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/GlobalStatsService.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/GlobalStatsService.swift
@@ -29,6 +29,9 @@ public final class GlobalStatsService: @unchecked Sendable {
   private let statsFilePath: String
   private var fileWatcher: DispatchSourceFileSystemObject?
   private var fileDescriptor: Int32 = -1
+  /// Only touched from the file-watcher source's event handler, which the
+  /// dispatch source serializes.
+  private var reloadDebounceItem: DispatchWorkItem?
 
   // MARK: - Computed Properties
 
@@ -143,6 +146,32 @@ public final class GlobalStatsService: @unchecked Sendable {
     }
   }
 
+  /// Debounced, off-main reload for watcher events. The CLI rewrites
+  /// stats-cache.json in bursts, and the previous handler did the whole file
+  /// read + decode on the main thread per event; now only the property
+  /// assignment hops to main.
+  private func scheduleDebouncedReload() {
+    reloadDebounceItem?.cancel()
+    let item = DispatchWorkItem { [weak self] in
+      guard let self else { return }
+      guard
+        let data = try? Data(contentsOf: URL(fileURLWithPath: self.statsFilePath)),
+        let decoded = try? JSONDecoder().decode(GlobalStatsCache.self, from: data)
+      else {
+        AppLogger.stats.error("Failed to reload stats after file change")
+        DispatchQueue.main.async { self.isAvailable = false }
+        return
+      }
+      DispatchQueue.main.async {
+        self.stats = decoded
+        self.isAvailable = true
+        self.lastUpdated = Date()
+      }
+    }
+    reloadDebounceItem = item
+    DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + 0.3, execute: item)
+  }
+
   private func startWatching() {
     guard FileManager.default.fileExists(atPath: statsFilePath) else {
       // Try again later when file might exist
@@ -165,9 +194,7 @@ public final class GlobalStatsService: @unchecked Sendable {
     )
 
     source.setEventHandler { [weak self] in
-      DispatchQueue.main.async {
-        self?.loadStats()
-      }
+      self?.scheduleDebouncedReload()
     }
 
     source.setCancelHandler { [weak self] in

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/SessionFileWatcher.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/SessionFileWatcher.swift
@@ -5,8 +5,9 @@
 //  Created by Assistant on 1/10/26.
 //
 
-import Foundation
 import Combine
+import Darwin
+import Foundation
 import os
 
 // MARK: - SessionFileWatcher
@@ -217,6 +218,10 @@ public actor SessionFileWatcher {
         let timeSinceLastEvent = Date().timeIntervalSince(lastFileEventTime)
         let currentFileSize = self.getFileSize(filePath)
 
+        // Tracks whether this tick changed anything worth persisting back to
+        // the actor; no-op ticks skip the updateStoredWatcherInfo Task hop.
+        var storedInfoNeedsUpdate = false
+
         // If file has grown but no events in 5+ seconds, watcher may be stale
         if timeSinceLastEvent > 5 && currentFileSize > lastKnownFileSize {
           AppLogger.watcher.warning("Stale watcher detected for \(sessionId), recovering...")
@@ -235,11 +240,16 @@ public actor SessionFileWatcher {
             // No new lines but file size changed - update tracking anyway
             lastKnownFileSize = currentFileSize
           }
+          storedInfoNeedsUpdate = true
         }
 
         // Re-evaluate status based on current time
         let previousStatus = lastEmittedStatus
+        let derivedStatusBeforeUpdate = parseResult.currentStatus
         SessionJSONLParser.updateCurrentStatus(&parseResult, approvalTimeoutSeconds: timeout)
+        if parseResult.currentStatus != derivedStatusBeforeUpdate {
+          storedInfoNeedsUpdate = true
+        }
         let updatedState = self.buildMonitorState(
           from: parseResult,
           hookPending: hookPendingInfo,
@@ -267,22 +277,25 @@ public actor SessionFileWatcher {
           }
 
           lastEmittedStatus = updatedState.status
+          storedInfoNeedsUpdate = true
 
           Task { @MainActor in
             self.stateSubject.send(StateUpdate(sessionId: sessionId, state: updatedState))
           }
         }
 
-        let parseResultSnapshot = parseResult
-        let lastFileEventSnapshot = lastFileEventTime
-        let lastKnownFileSizeSnapshot = lastKnownFileSize
-        Task {
-          await self.updateStoredWatcherInfo(
-            sessionId: sessionId,
-            parseResult: parseResultSnapshot,
-            lastFileEventTime: lastFileEventSnapshot,
-            lastKnownFileSize: lastKnownFileSizeSnapshot
-          )
+        if storedInfoNeedsUpdate {
+          let parseResultSnapshot = parseResult
+          let lastFileEventSnapshot = lastFileEventTime
+          let lastKnownFileSizeSnapshot = lastKnownFileSize
+          Task {
+            await self.updateStoredWatcherInfo(
+              sessionId: sessionId,
+              parseResult: parseResultSnapshot,
+              lastFileEventTime: lastFileEventSnapshot,
+              lastKnownFileSize: lastKnownFileSizeSnapshot
+            )
+          }
         }
 
         rescheduleStatusTimer()
@@ -468,11 +481,12 @@ public actor SessionFileWatcher {
   }
 
   private nonisolated func getFileSize(_ path: String) -> UInt64 {
-    guard let attrs = try? FileManager.default.attributesOfItem(atPath: path),
-          let size = attrs[.size] as? UInt64 else {
-      return 0
-    }
-    return size
+    // Direct stat() — FileManager.attributesOfItem is far more expensive and
+    // this runs on every status-timer tick.
+    var st = stat()
+    // Unqualified call: `Darwin.stat` resolves to the struct type, not the function.
+    guard stat(path, &st) == 0 else { return 0 }
+    return UInt64(st.st_size)
   }
 
   private nonisolated func readNewLines(from path: String, startingAt position: inout UInt64) -> [String] {

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/SessionJSONLParser.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/SessionJSONLParser.swift
@@ -129,8 +129,12 @@ public struct SessionJSONLParser {
 
     let lines = content.components(separatedBy: .newlines)
 
+    // One decoder per batch: JSONDecoder allocation per line is a measurable hot spot,
+    // and concurrent `decode` on a shared decoder is not documented thread-safe, so the
+    // decoder is scoped to this call rather than stored as a shared static.
+    let decoder = JSONDecoder()
     for line in lines where !line.isEmpty {
-      if let entry = parseEntry(line) {
+      if let entry = parseEntry(line, decoder: decoder) {
         processEntry(entry, into: &result)
       }
     }
@@ -147,8 +151,10 @@ public struct SessionJSONLParser {
   ///   - result: Parse result to update
   ///   - approvalTimeoutSeconds: Seconds to wait before considering a tool as awaiting approval (default: 5)
   public static func parseNewLines(_ lines: [String], into result: inout ParseResult, approvalTimeoutSeconds: Int = 0) {
+    // One decoder per batch — see `parseSessionFile` for the thread-safety rationale.
+    let decoder = JSONDecoder()
     for line in lines where !line.isEmpty {
-      if let entry = parseEntry(line) {
+      if let entry = parseEntry(line, decoder: decoder) {
         processEntry(entry, into: &result)
       }
     }
@@ -157,10 +163,14 @@ public struct SessionJSONLParser {
 
   /// Parse a single JSONL line
   public static func parseEntry(_ line: String) -> SessionEntry? {
+    parseEntry(line, decoder: JSONDecoder())
+  }
+
+  /// Parse a single JSONL line with a caller-provided decoder (reused per batch on the hot path)
+  private static func parseEntry(_ line: String, decoder: JSONDecoder) -> SessionEntry? {
     guard let data = line.data(using: .utf8) else { return nil }
 
     do {
-      let decoder = JSONDecoder()
       return try decoder.decode(SessionEntry.self, from: data)
     } catch {
       // Many lines may not match our expected format, that's OK
@@ -238,6 +248,13 @@ public struct SessionJSONLParser {
     default:
       break
     }
+
+    // Compact once per entry instead of once per appended activity: compaction is
+    // idempotent and depends only on the current array contents, `ParseResult` is
+    // never observed mid-entry, and any activity older than the newest five detailed
+    // code changes at an intermediate step is still older at entry end — so the
+    // final state is identical to per-activity compaction.
+    compactRecentCodeChangeActivities(in: &result)
   }
 
   private static func processContentBlocks(
@@ -448,8 +465,6 @@ public struct SessionJSONLParser {
     if result.recentActivities.count > maxRecentActivities {
       result.recentActivities.removeFirst(result.recentActivities.count - maxRecentActivities)
     }
-
-    compactRecentCodeChangeActivities(in: &result)
   }
 
   /// Extract full input parameters for code-changing tools (Edit, Write, MultiEdit)
@@ -502,18 +517,16 @@ public struct SessionJSONLParser {
   // MARK: - Helpers
 
   private static func parseTimestamp(_ string: String?) -> Date? {
-    guard let string = string else { return nil }
-
-    let formatter = ISO8601DateFormatter()
-    formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-
-    if let date = formatter.date(from: string) {
-      return date
-    }
-
-    // Try without fractional seconds
-    formatter.formatOptions = [.withInternetDateTime]
-    return formatter.date(from: string)
+    // Hot path: this runs once per streamed JSONL line, and constructing
+    // ISO8601DateFormatter per line is extremely expensive. `CodexTimestampParser`
+    // (AgentHubSessionGraph, already a dependency of this target) byte-scans the
+    // common `YYYY-MM-DDTHH:MM:SS[.fff]Z` shape Claude Code writes, and only for
+    // exotic strings falls back to the same fractional-then-plain
+    // ISO8601DateFormatter sequence this method used before — so results are
+    // identical. Thread safety: the fast path is pure stack computation and the
+    // fallback constructs fresh formatters per call (no shared mutable state), so
+    // concurrent `parseNewLines` calls from multiple watcher queues are safe.
+    CodexTimestampParser.parse(string)
   }
 
   private static func extractTextPreview(from blocks: [ContentBlock]?) -> String {
@@ -658,13 +671,17 @@ public struct SessionJSONLParser {
     }
   }
 
+  /// Matches http:// and https:// URLs. Compiled once — the pattern is constant and
+  /// NSRegularExpression is documented thread-safe, so a shared static is safe even
+  /// when `parseNewLines` runs concurrently on multiple watcher queues.
+  private static let resourceLinkRegex = try? NSRegularExpression(
+    pattern: "https?://[^\\s)\\]>\"'`]+",
+    options: []
+  )
+
   /// Extract URLs from text content and return as ResourceLink instances
   private static func extractResourceLinks(from text: String, timestamp: Date?) -> [ResourceLink] {
-    // Match http:// and https:// URLs
-    guard let regex = try? NSRegularExpression(
-      pattern: "https?://[^\\s)\\]>\"'`]+",
-      options: []
-    ) else { return [] }
+    guard let regex = resourceLinkRegex else { return [] }
 
     let range = NSRange(text.startIndex..., in: text)
     let matches = regex.matches(in: text, options: [], range: range)

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/SessionWatcherTimerPolicy.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/SessionWatcherTimerPolicy.swift
@@ -3,6 +3,9 @@ import Foundation
 
 struct SessionWatcherTimerPolicy {
   static let staleWatcherRecoveryInterval: TimeInterval = 5
+  /// Floor for any scheduled interval. Overdue deadlines would otherwise
+  /// return 0 and busy-loop the watcher's serial processing queue.
+  static let minimumInterval: TimeInterval = 1.0
   static let timerLeeway: DispatchTimeInterval = .milliseconds(200)
 
   static func nextInterval(
@@ -12,9 +15,17 @@ struct SessionWatcherTimerPolicy {
     approvalTimeoutSeconds: Int,
     now: Date = Date()
   ) -> TimeInterval? {
-    let staleRecoveryInterval = needsHealthCheck(for: currentStatus)
-      ? max(0, staleWatcherRecoveryInterval - now.timeIntervalSince(lastFileEventTime))
-      : nil
+    let staleRecoveryInterval: TimeInterval?
+    if needsHealthCheck(for: currentStatus) {
+      let sinceEvent = now.timeIntervalSince(lastFileEventTime)
+      // Once overdue, the handler firing now performs the check — the next
+      // one belongs a full period later, not immediately.
+      staleRecoveryInterval = sinceEvent >= staleWatcherRecoveryInterval
+        ? staleWatcherRecoveryInterval
+        : staleWatcherRecoveryInterval - sinceEvent
+    } else {
+      staleRecoveryInterval = nil
+    }
 
     let statusTransitionInterval = nextStatusTransitionInterval(
       lastActivity: lastActivity,
@@ -27,11 +38,11 @@ struct SessionWatcherTimerPolicy {
     case (nil, nil):
       return nil
     case let (lhs?, nil):
-      return lhs
+      return max(lhs, minimumInterval)
     case let (nil, rhs?):
-      return rhs
+      return max(rhs, minimumInterval)
     case let (lhs?, rhs?):
-      return min(lhs, rhs)
+      return max(min(lhs, rhs), minimumInterval)
     }
   }
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/EmbeddedTerminalView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/EmbeddedTerminalView.swift
@@ -227,9 +227,8 @@ public class TerminalContainerView: NSView, ManagedLocalProcessTerminalViewDeleg
   private var isConfigured = false
   private var hasDeliveredInitialPrompt = false
   private var hasPrefilledInitialInputText = false
-  private var lastAppliedFontSize: CGFloat?
-  private var lastAppliedFontFamily: String?
-  private var lastAppliedIsDark: Bool?
+  private var lastAppliedFontFingerprint: TerminalAppearanceSync.FontFingerprint?
+  private var lastAppliedColorFingerprint: TerminalAppearanceSync.ColorFingerprint?
   private var currentIsDark = true
   private var currentFontSize: CGFloat = 12
   private var currentFontFamily = "SF Mono"
@@ -496,8 +495,20 @@ public class TerminalContainerView: NSView, ManagedLocalProcessTerminalViewDeleg
   }
 
   /// Updates terminal font size and family.
+  /// Skips the (expensive) SwiftTerm font assignment when the requested font
+  /// and the set of terminal views are unchanged — `syncAppearance` runs on
+  /// every SwiftUI re-render, and SwiftTerm's font setter rebuilds the font
+  /// set, recomputes cell dimensions, and relayouts unconditionally.
   public func updateFont(size: CGFloat, family: String = "SF Mono") {
     let resolvedSize = max(size, 8)
+    let fingerprint = TerminalAppearanceSync.FontFingerprint(
+      family: family,
+      size: Double(resolvedSize),
+      surfaceIDs: appearanceSurfaceIDs
+    )
+    guard TerminalAppearanceSync.shouldApply(current: lastAppliedFontFingerprint, incoming: fingerprint) else {
+      return
+    }
 
     let font = NSFont(name: family, size: resolvedSize)
       ?? NSFont(name: "SF Mono", size: resolvedSize)
@@ -505,17 +516,27 @@ public class TerminalContainerView: NSView, ManagedLocalProcessTerminalViewDeleg
     for terminal in allTerminalViews {
       terminal.font = font
     }
-    lastAppliedFontSize = resolvedSize
-    lastAppliedFontFamily = family
+    lastAppliedFontFingerprint = fingerprint
   }
-
-  private var lastAppliedThemeId: String?
 
   /// Updates terminal colors from theme or falls back to default dark/light.
   /// Only background and cursor are themed — foreground and ANSI colors are left
   /// untouched to preserve Claude Code / Codex syntax highlighting.
+  /// Skips work (including the full-view redraw from `needsDisplay`) when the
+  /// resolved color inputs and the set of terminal views are unchanged. The
+  /// fingerprint is keyed on resolved color values — not the theme id — so
+  /// YAML theme hot-reloads that keep the id but change
+  /// `terminal.background` / `terminal.cursor` still apply.
   public func updateColors(isDark: Bool, theme: RuntimeTheme? = nil) {
-    let themeId = theme?.id
+    let fingerprint = TerminalAppearanceSync.ColorFingerprint(
+      isDark: isDark,
+      themeBackground: theme?.terminalBackground?.toHexString(),
+      themeCursor: theme?.terminalCursor?.toHexString(),
+      surfaceIDs: appearanceSurfaceIDs
+    )
+    guard TerminalAppearanceSync.shouldApply(current: lastAppliedColorFingerprint, incoming: fingerprint) else {
+      return
+    }
 
     for terminal in allTerminalViews {
       // Theme terminal colors only apply in dark mode
@@ -543,13 +564,15 @@ public class TerminalContainerView: NSView, ManagedLocalProcessTerminalViewDeleg
       terminal.needsDisplay = true
     }
 
-    lastAppliedIsDark = isDark
-    lastAppliedThemeId = themeId
+    lastAppliedColorFingerprint = fingerprint
   }
 
+  /// Applies a provisional appearance to a freshly created terminal view.
+  /// Deliberately does NOT update the appearance fingerprints: those track
+  /// full-workspace applications, and the new view changes the surface set so
+  /// the next `syncAppearance` reapplies the real font/theme to every view.
   private func applyInitialAppearance(to terminal: TerminalView, isDark: Bool) {
     let fontSize: CGFloat = 12
-    lastAppliedFontSize = fontSize
     let font = NSFont(name: "SF Mono", size: fontSize)
       ?? NSFont.monospacedSystemFont(ofSize: fontSize, weight: .regular)
     terminal.font = font
@@ -561,8 +584,6 @@ public class TerminalContainerView: NSView, ManagedLocalProcessTerminalViewDeleg
       terminal.nativeBackgroundColor = NSColor(Color.backgroundLight)
       terminal.nativeForegroundColor = NSColor(red: 0.1, green: 0.1, blue: 0.1, alpha: 1.0)
     }
-
-    lastAppliedIsDark = isDark
   }
 
   private func installInteractionMonitorIfNeeded() {
@@ -838,6 +859,14 @@ public class TerminalContainerView: NSView, ManagedLocalProcessTerminalViewDeleg
 
   private var allTerminalViews: [SafeLocalProcessTerminalView] {
     allTabs.map(\.terminalView)
+  }
+
+  /// Identity of every terminal view appearance updates apply to, keyed by the
+  /// owning tab's UUID (tabs own exactly one terminal view and tab IDs are
+  /// never reused). Part of the appearance fingerprints so newly opened
+  /// tabs/panes are painted even when font/theme inputs are unchanged.
+  private var appearanceSurfaceIDs: Set<UUID> {
+    Set(allTabs.map(\.id.rawValue))
   }
 
   private func mountInitialWorkspace(

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringCardView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringCardView.swift
@@ -58,6 +58,8 @@ public struct MonitoringCardView: View {
   @State private var showingActionsPopover = false
   @State private var showingFilePicker = false
   @State private var showingNameSheet = false
+  @State private var activityRefreshTask: Task<Void, Never>?
+  @State private var pendingActivityTimestamp: Date?
   @AppStorage(AgentHubDefaults.diffDisplayMode)
   private var diffDisplayModeRawValue: String = DiffDisplayMode.inline.rawValue
   @Environment(\.agentHub) private var agentHub
@@ -331,11 +333,23 @@ public struct MonitoringCardView: View {
     }
     .onDisappear {
       sessionGitHubQuickAccessViewModel.stopPolling()
+      activityRefreshTask?.cancel()
+      activityRefreshTask = nil
     }
     .onChange(of: state?.lastActivityAt) { _, newValue in
       guard let newValue else { return }
-      Task {
-        await sessionGitHubQuickAccessViewModel.notifySessionActivity(at: newValue)
+      // Coalesce to one refresh pass per 2s: this fires on every parsed JSONL
+      // activity while the agent streams, and per-tick forced git refreshes
+      // thrash the observable dictionaries and the diff actors. The trailing
+      // task picks up the latest timestamp at fire time.
+      pendingActivityTimestamp = newValue
+      guard activityRefreshTask == nil else { return }
+      activityRefreshTask = Task { @MainActor in
+        defer { activityRefreshTask = nil }
+        try? await Task.sleep(for: .seconds(2))
+        guard !Task.isCancelled, let timestamp = pendingActivityTimestamp else { return }
+        pendingActivityTimestamp = nil
+        await sessionGitHubQuickAccessViewModel.notifySessionActivity(at: timestamp)
         await loadWebPreviewCandidateIfNeeded()
         await viewModel?.ensureDiffAvailability(for: session.projectPath, forceRefresh: true)
         await viewModel?.ensureLocalDiffSummary(for: session.projectPath, forceRefresh: true)

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/TerminalAppearanceSync.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/TerminalAppearanceSync.swift
@@ -1,0 +1,83 @@
+//
+//  TerminalAppearanceSync.swift
+//  AgentHub
+//
+//  Pure skip/apply decision logic for embedded terminal appearance updates.
+//  AppKit-free so it can be unit tested headlessly.
+//
+
+import Foundation
+
+/// Decides whether a terminal appearance update actually needs to touch the
+/// terminal views.
+///
+/// `EmbeddedTerminalView.updateNSView` calls `syncAppearance` on every SwiftUI
+/// re-render, which happens many times per second while a session streams.
+/// Reapplying an unchanged font is expensive (SwiftTerm rebuilds its font set,
+/// recomputes cell dimensions, and relayouts) and reapplying unchanged colors
+/// forces a full-view redraw via `needsDisplay`. The fingerprints below capture
+/// the resolved inputs of each operation so redundant applications can be
+/// skipped, while any real change — including a new terminal view joining the
+/// workspace — still applies.
+enum TerminalAppearanceSync {
+
+  /// Everything that feeds `TerminalContainerView.updateFont`.
+  ///
+  /// Includes the identity set of the workspace tabs (one terminal view each)
+  /// the font was applied to, so a newly opened tab or pane still receives the
+  /// current font even when the requested family/size have not changed. Tab
+  /// IDs are UUID-backed and never reused, unlike object identities.
+  struct FontFingerprint: Equatable {
+    let family: String
+    let size: Double
+    let surfaceIDs: Set<UUID>
+
+    init(family: String, size: Double, surfaceIDs: Set<UUID>) {
+      self.family = family
+      self.size = size
+      self.surfaceIDs = surfaceIDs
+    }
+  }
+
+  /// Everything that feeds `TerminalContainerView.updateColors`.
+  ///
+  /// Keyed on *resolved color values* — never the theme id — because YAML
+  /// themes hot-reload in place via `ThemeFileWatcher`: the id stays stable
+  /// while `terminal.background` / `terminal.cursor` values change. Two themes
+  /// that resolve to identical terminal colors are also correctly treated as
+  /// equal.
+  struct ColorFingerprint: Equatable {
+    let isDark: Bool
+    /// Resolved value of the theme's custom terminal background, if any.
+    /// Normalized to nil in light mode, where theme terminal colors never apply.
+    let themeBackground: String?
+    /// Resolved value of the theme's custom terminal cursor, if any.
+    /// Normalized to nil in light mode, where theme terminal colors never apply.
+    let themeCursor: String?
+    let surfaceIDs: Set<UUID>
+
+    init(
+      isDark: Bool,
+      themeBackground: String?,
+      themeCursor: String?,
+      surfaceIDs: Set<UUID>
+    ) {
+      self.isDark = isDark
+      // Theme terminal colors only apply in dark mode. Dropping them in light
+      // mode keeps the fingerprint aligned with the effective output, so a
+      // theme switch while in light mode does not force a redundant repaint.
+      self.themeBackground = isDark ? themeBackground : nil
+      self.themeCursor = isDark ? themeCursor : nil
+      self.surfaceIDs = surfaceIDs
+    }
+  }
+
+  /// Returns true when the incoming fingerprint differs from the last applied
+  /// one. A nil `current` (nothing applied yet) always applies.
+  static func shouldApply<Fingerprint: Equatable>(
+    current: Fingerprint?,
+    incoming: Fingerprint
+  ) -> Bool {
+    current != incoming
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/CLISessionsViewModel.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/CLISessionsViewModel.swift
@@ -557,14 +557,24 @@ public final class CLISessionsViewModel {
       }
 
       if let cachedStatus = await diffAvailabilityService.cachedAvailability(for: normalizedProjectPath) {
-        diffAvailability[normalizedProjectPath] = cachedStatus
+        if diffAvailability[normalizedProjectPath] != cachedStatus {
+          diffAvailability[normalizedProjectPath] = cachedStatus
+        }
         return
       }
     }
 
-    diffAvailability[normalizedProjectPath] = .checking
+    // Only surface `.checking` for the initial load. On refreshes the previous
+    // status stays visible, and the result is written only when it changed —
+    // this method runs on every activity tick of the visible card, and each
+    // write to the observed dictionary invalidates every reader.
+    if diffAvailability[normalizedProjectPath] == nil {
+      diffAvailability[normalizedProjectPath] = .checking
+    }
     let status = await diffAvailabilityService.availability(for: normalizedProjectPath)
-    diffAvailability[normalizedProjectPath] = status
+    if diffAvailability[normalizedProjectPath] != status {
+      diffAvailability[normalizedProjectPath] = status
+    }
   }
 
   public func ensureLocalDiffSummary(
@@ -581,13 +591,18 @@ public final class CLISessionsViewModel {
       }
 
       if let cachedSummary = await localDiffSummaryService.cachedSummary(for: normalizedProjectPath) {
-        localDiffSummaries[normalizedProjectPath] = cachedSummary
+        if localDiffSummaries[normalizedProjectPath] != cachedSummary {
+          localDiffSummaries[normalizedProjectPath] = cachedSummary
+        }
         return
       }
     }
 
     let summary = await localDiffSummaryService.summary(for: normalizedProjectPath)
-    localDiffSummaries[normalizedProjectPath] = summary
+    // Write-on-change only — see `ensureDiffAvailability`.
+    if localDiffSummaries[normalizedProjectPath] != summary {
+      localDiffSummaries[normalizedProjectPath] = summary
+    }
   }
 
   /// Start polling for a session
@@ -599,10 +614,14 @@ public final class CLISessionsViewModel {
       return
     }
 
-    // Subscribe to state updates
+    // Subscribe to state updates. Throttled: while an agent streams, the
+    // watcher emits per JSONL append (many times a second) and every delivery
+    // invalidates wide slices of the view tree; 10 Hz with `latest: true`
+    // keeps the UI current without the invalidation storm. `throttle` also
+    // delivers on its scheduler, replacing the previous `receive(on:)` hop.
     let cancellable = fileWatcher.statePublisher
       .filter { $0.sessionId == session.id }
-      .receive(on: DispatchQueue.main)
+      .throttle(for: .milliseconds(100), scheduler: DispatchQueue.main, latest: true)
       .sink { [weak self] update in
         self?.updateMonitorState(update.state, for: session.id)
       }
@@ -3287,7 +3306,11 @@ public final class CLISessionsViewModel {
       let expectedWorktreePath = claudeProjectPath(for: pending)
 
       for attempt in 1...maxAttempts {
-        await monitorService.refreshSessions()
+        // Full worktree redetection (git subprocesses across every repo) only
+        // on the first pass — the new session's worktree is registered above;
+        // retries only need the session list re-read. Matters when many
+        // sessions spawn at once and each runs its own retry loop.
+        await monitorService.refreshSessions(skipWorktreeRedetection: attempt > 1)
 
         // Wait for the publisher to propagate to selectedRepositories
         // The Combine subscription updates asynchronously on MainActor
@@ -3775,17 +3798,23 @@ public final class CLISessionsViewModel {
   /// Get all currently monitored sessions with their states.
   /// Uses a backup store to preserve sessions that may not yet be in history.jsonl.
   public var monitoredSessions: [(session: CLISession, state: SessionMonitorState?)] {
-    monitoredSessionIds.compactMap { sessionId in
-      // First try to get from allSessions (authoritative source if available)
-      if let session = allSessions.first(where: { $0.id == sessionId }) {
-        return (session: session, state: monitorStates[sessionId])
+    // Single pass over allSessions: this property is recomputed by every
+    // consumer on every monitor-state publish, and a per-id `first(where:)`
+    // made it O(monitored × total sessions) with a fresh flattened array per id.
+    var sessionsById: [String: CLISession] = [:]
+    for session in allSessions where monitoredSessionIds.contains(session.id) {
+      // Keep the first occurrence, matching the previous `first(where:)` semantics
+      if sessionsById[session.id] == nil {
+        sessionsById[session.id] = session
       }
-      // Fallback to backup if not in allSessions (race condition during refresh)
-      if let backupSession = monitoredSessionBackup[sessionId] {
-        return (session: backupSession, state: monitorStates[sessionId])
+    }
+    return monitoredSessionIds.compactMap { sessionId in
+      // allSessions is authoritative; fall back to the backup for sessions not
+      // yet in history.jsonl (race during refresh); drop if in neither.
+      guard let session = sessionsById[sessionId] ?? monitoredSessionBackup[sessionId] else {
+        return nil
       }
-      // Session not found anywhere - should not happen, but handle gracefully
-      return nil
+      return (session: session, state: monitorStates[sessionId])
     }
   }
 

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/CLISessionsViewModelDiffRefreshTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/CLISessionsViewModelDiffRefreshTests.swift
@@ -1,0 +1,168 @@
+import AgentHubGitDiff
+import Combine
+import Foundation
+import Testing
+
+@testable import AgentHubCore
+
+private final class DiffRefreshMonitorService: SessionMonitorServiceProtocol, @unchecked Sendable {
+  private let subject = PassthroughSubject<[SelectedRepository], Never>()
+
+  var repositoriesPublisher: AnyPublisher<[SelectedRepository], Never> {
+    subject.eraseToAnyPublisher()
+  }
+
+  func addRepository(_ path: String) async -> SelectedRepository? { nil }
+  func removeRepository(_ path: String) async {}
+  func getSelectedRepositories() async -> [SelectedRepository] { [] }
+  func setSelectedRepositories(_ repositories: [SelectedRepository]) async {}
+  func refreshSessions(skipWorktreeRedetection: Bool) async {}
+}
+
+private final class DiffRefreshFileWatcher: SessionFileWatcherProtocol, @unchecked Sendable {
+  private let subject = PassthroughSubject<SessionFileWatcher.StateUpdate, Never>()
+
+  var statePublisher: AnyPublisher<SessionFileWatcher.StateUpdate, Never> {
+    subject.eraseToAnyPublisher()
+  }
+
+  func startMonitoring(sessionId: String, projectPath: String, sessionFilePath: String?) async {}
+  func stopMonitoring(sessionId: String) async {}
+  func getState(sessionId: String) async -> SessionMonitorState? { nil }
+  func refreshState(sessionId: String) async {}
+  func setApprovalTimeout(_ seconds: Int) async {}
+}
+
+/// Availability service whose `availability(for:)` suspends until `open()`,
+/// letting tests observe the ViewModel's published state mid-evaluation.
+private final class GatedDiffAvailabilityService: DiffAvailabilityServiceProtocol, @unchecked Sendable {
+  private let lock = NSLock()
+  private var gateOpen: Bool
+  private var waiters: [CheckedContinuation<Void, Never>] = []
+  private var availabilityRequests = 0
+  private let result: DiffAvailabilityStatus
+
+  init(result: DiffAvailabilityStatus, gateOpen: Bool = false) {
+    self.result = result
+    self.gateOpen = gateOpen
+  }
+
+  func open() {
+    lock.lock()
+    gateOpen = true
+    let resumed = waiters
+    waiters = []
+    lock.unlock()
+    resumed.forEach { $0.resume() }
+  }
+
+  func close() {
+    lock.lock()
+    gateOpen = false
+    lock.unlock()
+  }
+
+  func requestCount() -> Int {
+    lock.lock()
+    defer { lock.unlock() }
+    return availabilityRequests
+  }
+
+  func cachedAvailability(for projectPath: String) async -> DiffAvailabilityStatus? { nil }
+
+  func availability(for projectPath: String) async -> DiffAvailabilityStatus {
+    lock.lock()
+    availabilityRequests += 1
+    if gateOpen {
+      lock.unlock()
+      return result
+    }
+    lock.unlock()
+    await withCheckedContinuation { continuation in
+      lock.lock()
+      if gateOpen {
+        lock.unlock()
+        continuation.resume()
+        return
+      }
+      waiters.append(continuation)
+      lock.unlock()
+    }
+    return result
+  }
+
+  func invalidate(projectPath: String) async {}
+}
+
+@MainActor
+private func makeDiffRefreshViewModel(
+  diffAvailabilityService: any DiffAvailabilityServiceProtocol
+) -> CLISessionsViewModel {
+  CLISessionsViewModel(
+    monitorService: DiffRefreshMonitorService(),
+    fileWatcher: DiffRefreshFileWatcher(),
+    searchService: nil,
+    cliConfiguration: CLICommandConfiguration(command: "claude", mode: .claude),
+    providerKind: .claude,
+    diffAvailabilityService: diffAvailabilityService,
+    approvalNotificationService: NoOpApprovalNotificationService()
+  )
+}
+
+@MainActor
+private func waitUntil(
+  _ condition: () -> Bool,
+  timeoutAttempts: Int = 50
+) async throws {
+  for _ in 0..<timeoutAttempts {
+    if condition() {
+      return
+    }
+    try await Task.sleep(for: .milliseconds(20))
+  }
+  #expect(condition())
+}
+
+@Suite("CLISessionsViewModel diff availability refresh")
+struct CLISessionsViewModelDiffRefreshTests {
+  @Test("Initial load surfaces .checking while the evaluation runs")
+  @MainActor
+  func initialLoadSurfacesChecking() async throws {
+    let service = GatedDiffAvailabilityService(result: .available)
+    let viewModel = makeDiffRefreshViewModel(diffAvailabilityService: service)
+    let path = "/tmp/diff-refresh-project"
+    let key = DiffAvailabilityService.normalize(path)
+
+    let ensureTask = Task { await viewModel.ensureDiffAvailability(for: path) }
+    try await waitUntil { service.requestCount() == 1 }
+    #expect(viewModel.diffAvailability[key] == .checking)
+
+    service.open()
+    await ensureTask.value
+    #expect(viewModel.diffAvailability[key] == .available)
+  }
+
+  @Test("Forced refresh keeps the previous status visible instead of flip-flopping to .checking")
+  @MainActor
+  func forcedRefreshKeepsPreviousStatusVisible() async throws {
+    let service = GatedDiffAvailabilityService(result: .available, gateOpen: true)
+    let viewModel = makeDiffRefreshViewModel(diffAvailabilityService: service)
+    let path = "/tmp/diff-refresh-project"
+    let key = DiffAvailabilityService.normalize(path)
+
+    await viewModel.ensureDiffAvailability(for: path)
+    #expect(viewModel.diffAvailability[key] == .available)
+
+    // Second, forced refresh (the per-activity-tick path): the previous status
+    // must stay visible while the evaluation is in flight.
+    service.close()
+    let refreshTask = Task { await viewModel.ensureDiffAvailability(for: path, forceRefresh: true) }
+    try await waitUntil { service.requestCount() == 2 }
+    #expect(viewModel.diffAvailability[key] == .available)
+    #expect(viewModel.diffAvailability[key]?.isChecking == false)
+
+    service.open()
+    await refreshTask.value
+    #expect(viewModel.diffAvailability[key] == .available)
+  }
+}

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/SessionJSONLParserTimestampTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/SessionJSONLParserTimestampTests.swift
@@ -1,0 +1,104 @@
+import Foundation
+import Testing
+
+@testable import AgentHubCore
+
+/// Parity tests for `SessionJSONLParser`'s timestamp parsing, which now uses the
+/// `CodexTimestampParser` byte-scan fast path for the common UTC shapes Claude Code
+/// writes, with the original fractional-then-plain `ISO8601DateFormatter` sequence as
+/// fallback for exotic strings. Timestamps are exercised through the public
+/// `parseNewLines` API and observed via `sessionStartedAt` / `lastActivityAt`.
+@Suite("SessionJSONLParser timestamp parsing")
+struct SessionJSONLParserTimestampTests {
+
+  @Test("Fast path matches formatter for non-fractional UTC timestamps")
+  func nonFractionalUTC() throws {
+    let string = "2026-05-05T12:00:00Z"
+    let parsed = try #require(parsedDate(forTimestamp: string))
+    let expected = try #require(iso8601Reference(string))
+    #expect(parsed == expected)
+  }
+
+  @Test("Fast path matches formatter for millisecond UTC timestamps")
+  func millisecondFractionUTC() throws {
+    let string = "2026-05-05T12:00:00.123Z"
+    let parsed = try #require(parsedDate(forTimestamp: string))
+    let expected = try #require(iso8601Reference(string))
+    #expect(abs(parsed.timeIntervalSince1970 - expected.timeIntervalSince1970) < 0.000_001)
+  }
+
+  @Test("Fast path stays within a millisecond of the formatter for microsecond fractions")
+  func microsecondFractionUTC() throws {
+    // ISO8601DateFormatter truncates parsing to millisecond precision; the byte-scan
+    // fast path keeps the full fraction, so allow sub-millisecond drift.
+    let string = "2026-05-05T12:00:00.123456Z"
+    let parsed = try #require(parsedDate(forTimestamp: string))
+    let expected = try #require(iso8601Reference(string))
+    #expect(abs(parsed.timeIntervalSince1970 - expected.timeIntervalSince1970) < 0.001)
+  }
+
+  @Test("Falls back to the formatter for timezone-offset timestamps")
+  func offsetTimestamps() throws {
+    for string in ["2026-05-05T12:00:00+01:00", "2026-05-05T12:00:00.500+01:00"] {
+      let parsed = try #require(parsedDate(forTimestamp: string))
+      let expected = try #require(iso8601Reference(string))
+      #expect(parsed == expected)
+    }
+  }
+
+  @Test("Garbage timestamps leave activity dates unset")
+  func garbageTimestamps() {
+    for string in ["not-a-date", "", "2026-05-05 12:00:00"] {
+      var result = SessionJSONLParser.ParseResult()
+      SessionJSONLParser.parseNewLines([line(withTimestamp: string)], into: &result)
+      #expect(result.sessionStartedAt == nil)
+      #expect(result.lastActivityAt == nil)
+    }
+  }
+
+  @Test("Invalid calendar dates keep parity with the lenient formatter fallback")
+  func invalidCalendarDate() {
+    // The fast path rejects impossible dates (Feb 31) and defers to the formatter
+    // fallback — on OS versions where ISO8601DateFormatter is lenient this rolls
+    // over instead of returning nil, exactly as the pre-fast-path code did. Assert
+    // parity with the reference chain rather than a fixed outcome.
+    let string = "2026-02-31T12:00:00Z"
+    #expect(parsedDate(forTimestamp: string) == iso8601Reference(string))
+  }
+
+  @Test("Session start and last activity use the same parsed timestamp")
+  func sessionStartMatchesLastActivityForSingleEntry() throws {
+    let string = "2026-05-05T12:00:00.123Z"
+    var result = SessionJSONLParser.ParseResult()
+    SessionJSONLParser.parseNewLines([line(withTimestamp: string)], into: &result)
+    let started = try #require(result.sessionStartedAt)
+    let last = try #require(result.lastActivityAt)
+    #expect(started == last)
+  }
+
+  // MARK: - Helpers
+
+  private func line(withTimestamp timestamp: String) -> String {
+    """
+    {"type":"user","timestamp":"\(timestamp)","message":{"role":"user","content":[{"type":"text","text":"hello"}]}}
+    """
+  }
+
+  private func parsedDate(forTimestamp timestamp: String) -> Date? {
+    var result = SessionJSONLParser.ParseResult()
+    SessionJSONLParser.parseNewLines([line(withTimestamp: timestamp)], into: &result)
+    return result.lastActivityAt
+  }
+
+  /// Mirrors the documented fallback: fractional ISO8601 first, then plain.
+  private func iso8601Reference(_ string: String) -> Date? {
+    let fractional = ISO8601DateFormatter()
+    fractional.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+    if let date = fractional.date(from: string) {
+      return date
+    }
+    let plain = ISO8601DateFormatter()
+    plain.formatOptions = [.withInternetDateTime]
+    return plain.date(from: string)
+  }
+}

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/SessionWatcherTimerPolicyTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/SessionWatcherTimerPolicyTests.swift
@@ -85,4 +85,138 @@ struct SessionWatcherTimerPolicyTests {
 
     #expect(interval == 3)
   }
+
+  @Test("Floors an executing tool past its approval deadline instead of returning 0")
+  func floorsOverdueToolDeadline() {
+    let now = Date(timeIntervalSince1970: 10_000)
+    let lastActivity = ActivityEntry(
+      timestamp: now.addingTimeInterval(-120),
+      type: .toolUse(name: "Bash"),
+      description: "ls"
+    )
+
+    let interval = SessionWatcherTimerPolicy.nextInterval(
+      lastActivity: lastActivity,
+      currentStatus: .executingTool(name: "Bash"),
+      lastFileEventTime: now,
+      approvalTimeoutSeconds: 60,
+      now: now
+    )
+
+    #expect(interval == SessionWatcherTimerPolicy.minimumInterval)
+  }
+
+  @Test("Floors a Task tool past its 300s deadline instead of returning 0")
+  func floorsOverdueTaskDeadline() {
+    let now = Date(timeIntervalSince1970: 10_000)
+    let lastActivity = ActivityEntry(
+      timestamp: now.addingTimeInterval(-400),
+      type: .toolUse(name: "Task"),
+      description: "Subagent"
+    )
+
+    let interval = SessionWatcherTimerPolicy.nextInterval(
+      lastActivity: lastActivity,
+      currentStatus: .executingTool(name: "Task"),
+      lastFileEventTime: now,
+      approvalTimeoutSeconds: 60,
+      now: now
+    )
+
+    #expect(interval == SessionWatcherTimerPolicy.minimumInterval)
+  }
+
+  @Test("Floors an approval past its 300s deadline instead of returning 0")
+  func floorsOverdueApprovalDeadline() {
+    let now = Date(timeIntervalSince1970: 10_000)
+    let lastActivity = ActivityEntry(
+      timestamp: now.addingTimeInterval(-301),
+      type: .toolUse(name: "Edit"),
+      description: "Edit file"
+    )
+
+    let interval = SessionWatcherTimerPolicy.nextInterval(
+      lastActivity: lastActivity,
+      currentStatus: .awaitingApproval(tool: "Edit"),
+      lastFileEventTime: now,
+      approvalTimeoutSeconds: 60,
+      now: now
+    )
+
+    #expect(interval == SessionWatcherTimerPolicy.minimumInterval)
+  }
+
+  @Test("Overdue health check waits a full recovery period instead of returning 0")
+  func overdueHealthCheckWaitsFullPeriod() {
+    let now = Date(timeIntervalSince1970: 10_000)
+
+    let interval = SessionWatcherTimerPolicy.nextInterval(
+      lastActivity: nil,
+      currentStatus: .thinking,
+      lastFileEventTime: now.addingTimeInterval(-10),
+      approvalTimeoutSeconds: 60,
+      now: now
+    )
+
+    #expect(interval == SessionWatcherTimerPolicy.staleWatcherRecoveryInterval)
+  }
+
+  @Test("Upcoming health check returns the remaining time when no transition is sooner")
+  func upcomingHealthCheckReturnsRemainder() {
+    let now = Date(timeIntervalSince1970: 10_000)
+
+    let interval = SessionWatcherTimerPolicy.nextInterval(
+      lastActivity: nil,
+      currentStatus: .thinking,
+      lastFileEventTime: now.addingTimeInterval(-2),
+      approvalTimeoutSeconds: 60,
+      now: now
+    )
+
+    #expect(interval == 3)
+  }
+
+  @Test("Sub-deadline transition sooner than the health check passes through unclamped")
+  func subDeadlineTransitionUnclamped() {
+    let now = Date(timeIntervalSince1970: 10_000)
+    // 3s to the tool deadline, 5s to the next health check: the transition
+    // term wins and is not distorted by the minimum-interval floor.
+    let lastActivity = ActivityEntry(
+      timestamp: now.addingTimeInterval(-57),
+      type: .toolUse(name: "Bash"),
+      description: "ls"
+    )
+
+    let interval = SessionWatcherTimerPolicy.nextInterval(
+      lastActivity: lastActivity,
+      currentStatus: .executingTool(name: "Bash"),
+      lastFileEventTime: now,
+      approvalTimeoutSeconds: 60,
+      now: now
+    )
+
+    #expect(interval == 3)
+  }
+
+  @Test("Distant transition deadline is bounded by the health-check cadence")
+  func distantTransitionBoundedByHealthCheck() {
+    let now = Date(timeIntervalSince1970: 10_000)
+    // 50s to the tool deadline, but a health-checked status never waits
+    // longer than the stale-recovery interval.
+    let lastActivity = ActivityEntry(
+      timestamp: now.addingTimeInterval(-10),
+      type: .toolUse(name: "Bash"),
+      description: "ls"
+    )
+
+    let interval = SessionWatcherTimerPolicy.nextInterval(
+      lastActivity: lastActivity,
+      currentStatus: .executingTool(name: "Bash"),
+      lastFileEventTime: now,
+      approvalTimeoutSeconds: 60,
+      now: now
+    )
+
+    #expect(interval == SessionWatcherTimerPolicy.staleWatcherRecoveryInterval)
+  }
 }

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/TerminalAppearanceSyncTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/TerminalAppearanceSyncTests.swift
@@ -1,0 +1,227 @@
+import Foundation
+import Testing
+
+@testable import AgentHubCore
+
+@Suite("TerminalAppearanceSync")
+struct TerminalAppearanceSyncTests {
+  private let surfaceA = UUID()
+  private let surfaceB = UUID()
+
+  // MARK: - Font fingerprint
+
+  @Test("First font application (nil state) applies")
+  func firstFontApplicationApplies() {
+    let incoming = TerminalAppearanceSync.FontFingerprint(
+      family: "SF Mono",
+      size: 12,
+      surfaceIDs: [surfaceA]
+    )
+
+    #expect(TerminalAppearanceSync.shouldApply(current: nil, incoming: incoming))
+  }
+
+  @Test("Unchanged font fingerprint skips")
+  func unchangedFontFingerprintSkips() {
+    let current = TerminalAppearanceSync.FontFingerprint(
+      family: "SF Mono",
+      size: 12,
+      surfaceIDs: [surfaceA]
+    )
+    let incoming = TerminalAppearanceSync.FontFingerprint(
+      family: "SF Mono",
+      size: 12,
+      surfaceIDs: [surfaceA]
+    )
+
+    #expect(!TerminalAppearanceSync.shouldApply(current: current, incoming: incoming))
+  }
+
+  @Test("Font size change applies")
+  func fontSizeChangeApplies() {
+    let current = TerminalAppearanceSync.FontFingerprint(
+      family: "SF Mono",
+      size: 12,
+      surfaceIDs: [surfaceA]
+    )
+    let incoming = TerminalAppearanceSync.FontFingerprint(
+      family: "SF Mono",
+      size: 14,
+      surfaceIDs: [surfaceA]
+    )
+
+    #expect(TerminalAppearanceSync.shouldApply(current: current, incoming: incoming))
+  }
+
+  @Test("Font family change applies")
+  func fontFamilyChangeApplies() {
+    let current = TerminalAppearanceSync.FontFingerprint(
+      family: "SF Mono",
+      size: 12,
+      surfaceIDs: [surfaceA]
+    )
+    let incoming = TerminalAppearanceSync.FontFingerprint(
+      family: "Menlo",
+      size: 12,
+      surfaceIDs: [surfaceA]
+    )
+
+    #expect(TerminalAppearanceSync.shouldApply(current: current, incoming: incoming))
+  }
+
+  @Test("New terminal surface applies font even when font values are unchanged")
+  func newSurfaceAppliesFont() {
+    let current = TerminalAppearanceSync.FontFingerprint(
+      family: "SF Mono",
+      size: 12,
+      surfaceIDs: [surfaceA]
+    )
+    let incoming = TerminalAppearanceSync.FontFingerprint(
+      family: "SF Mono",
+      size: 12,
+      surfaceIDs: [surfaceA, surfaceB]
+    )
+
+    #expect(TerminalAppearanceSync.shouldApply(current: current, incoming: incoming))
+  }
+
+  // MARK: - Color fingerprint
+
+  @Test("First color application (nil state) applies")
+  func firstColorApplicationApplies() {
+    let incoming = TerminalAppearanceSync.ColorFingerprint(
+      isDark: true,
+      themeBackground: nil,
+      themeCursor: nil,
+      surfaceIDs: [surfaceA]
+    )
+
+    #expect(TerminalAppearanceSync.shouldApply(current: nil, incoming: incoming))
+  }
+
+  @Test("Unchanged color fingerprint skips")
+  func unchangedColorFingerprintSkips() {
+    let current = TerminalAppearanceSync.ColorFingerprint(
+      isDark: true,
+      themeBackground: "#181825",
+      themeCursor: "#F5E0DC",
+      surfaceIDs: [surfaceA]
+    )
+    let incoming = TerminalAppearanceSync.ColorFingerprint(
+      isDark: true,
+      themeBackground: "#181825",
+      themeCursor: "#F5E0DC",
+      surfaceIDs: [surfaceA]
+    )
+
+    #expect(!TerminalAppearanceSync.shouldApply(current: current, incoming: incoming))
+  }
+
+  @Test("YAML hot-reload: changed theme values apply even when the theme id is unchanged")
+  func themeValueChangeWithSameIdApplies() {
+    // YAML themes hot-reload in place: the theme id stays stable while the
+    // resolved terminal colors change. The fingerprint keys on resolved
+    // values (the id is intentionally not part of it), so an in-place edit
+    // of terminal.background must produce a different fingerprint.
+    let beforeReload = TerminalAppearanceSync.ColorFingerprint(
+      isDark: true,
+      themeBackground: "#181825",
+      themeCursor: "#F5E0DC",
+      surfaceIDs: [surfaceA]
+    )
+    let afterReload = TerminalAppearanceSync.ColorFingerprint(
+      isDark: true,
+      themeBackground: "#1E1E2E",
+      themeCursor: "#F5E0DC",
+      surfaceIDs: [surfaceA]
+    )
+
+    #expect(TerminalAppearanceSync.shouldApply(current: beforeReload, incoming: afterReload))
+  }
+
+  @Test("Cursor-only theme change applies")
+  func cursorOnlyThemeChangeApplies() {
+    let current = TerminalAppearanceSync.ColorFingerprint(
+      isDark: true,
+      themeBackground: "#181825",
+      themeCursor: "#F5E0DC",
+      surfaceIDs: [surfaceA]
+    )
+    let incoming = TerminalAppearanceSync.ColorFingerprint(
+      isDark: true,
+      themeBackground: "#181825",
+      themeCursor: "#CC785C",
+      surfaceIDs: [surfaceA]
+    )
+
+    #expect(TerminalAppearanceSync.shouldApply(current: current, incoming: incoming))
+  }
+
+  @Test("Color scheme flip applies")
+  func colorSchemeFlipApplies() {
+    let current = TerminalAppearanceSync.ColorFingerprint(
+      isDark: true,
+      themeBackground: nil,
+      themeCursor: nil,
+      surfaceIDs: [surfaceA]
+    )
+    let incoming = TerminalAppearanceSync.ColorFingerprint(
+      isDark: false,
+      themeBackground: nil,
+      themeCursor: nil,
+      surfaceIDs: [surfaceA]
+    )
+
+    #expect(TerminalAppearanceSync.shouldApply(current: current, incoming: incoming))
+  }
+
+  @Test("Theme terminal colors are ignored in light mode")
+  func themeColorsIgnoredInLightMode() {
+    // updateColors only honors theme background/cursor in dark mode, so a
+    // theme switch while in light mode must not force a repaint...
+    let current = TerminalAppearanceSync.ColorFingerprint(
+      isDark: false,
+      themeBackground: "#181825",
+      themeCursor: "#F5E0DC",
+      surfaceIDs: [surfaceA]
+    )
+    let incoming = TerminalAppearanceSync.ColorFingerprint(
+      isDark: false,
+      themeBackground: "#1E1E2E",
+      themeCursor: "#CC785C",
+      surfaceIDs: [surfaceA]
+    )
+
+    #expect(!TerminalAppearanceSync.shouldApply(current: current, incoming: incoming))
+
+    // ...but the same values in dark mode are honored and must apply.
+    let dark = TerminalAppearanceSync.ColorFingerprint(
+      isDark: true,
+      themeBackground: "#1E1E2E",
+      themeCursor: "#CC785C",
+      surfaceIDs: [surfaceA]
+    )
+
+    #expect(TerminalAppearanceSync.shouldApply(current: current, incoming: dark))
+    #expect(dark.themeBackground == "#1E1E2E")
+    #expect(dark.themeCursor == "#CC785C")
+  }
+
+  @Test("New terminal surface applies colors even when color values are unchanged")
+  func newSurfaceAppliesColors() {
+    let current = TerminalAppearanceSync.ColorFingerprint(
+      isDark: true,
+      themeBackground: "#181825",
+      themeCursor: "#F5E0DC",
+      surfaceIDs: [surfaceA]
+    )
+    let incoming = TerminalAppearanceSync.ColorFingerprint(
+      isDark: true,
+      themeBackground: "#181825",
+      themeCursor: "#F5E0DC",
+      surfaceIDs: [surfaceA, surfaceB]
+    )
+
+    #expect(TerminalAppearanceSync.shouldApply(current: current, incoming: incoming))
+  }
+}


### PR DESCRIPTION
## Problem

With agent sessions actively working, the app averaged **~58% of a core while visually idle** (measured: 4m05s CPU over ~7min uptime, Debug build). A live `sample` + Time Profiler capture attributed it to two paths:

- `com.agenthub.sessionwatcher.processing` at ~22% duty, with 1,134/7,971 samples inside `SessionFileWatcher.getFileSize` → `FileManager.attributesOfItem`
- ~10% of the main thread in `NSHostingView.layout()` re-evaluating `MonitoringCardView`, `MultiProviderMonitoringPanelView`, and sidebar rows on every monitor tick

## Root cause

`SessionWatcherTimerPolicy.nextInterval` returned **0** whenever a session was `.thinking`/`.executingTool`/`.awaitingApproval` and either the JSONL had been quiet >5s or the activity was past its transition deadline — i.e. exactly while a long tool call (build, MCP call, subagent Task) runs. The status timer then rescheduled itself at `+0` in a busy loop for up to 300s per episode, each spin paying an `attributesOfItem` stat, a full status rebuild, and an actor-hop `Task`, multiplied by every monitored session on one serial queue.

## Changes

**Watcher (the busy-spin)**
- 1s floor on all policy intervals; overdue health checks reschedule a full 5s period out (`SessionWatcherTimerPolicy`)
- `getFileSize` uses a direct `stat()` syscall in both watchers (note: the call must be unqualified — `Darwin.stat(...)` resolves to the struct initializer)
- No-op status-timer ticks skip the `updateStoredWatcherInfo` actor hop

**Parser hot loop (per streamed JSONL line)**
- Timestamps via the existing `CodexTimestampParser` byte-scan (was: 1–2 fresh `ISO8601DateFormatter`s per line)
- One `JSONDecoder` per batch; resource-link regex compiled once; activity compaction once per entry

**UI invalidation**
- Per-session state publishes throttled to 10 Hz (`latest: true`) with a single main-queue hop (was: unthrottled, double hop)
- `monitoredSessions` is a single pass (was O(monitored × all sessions) per observable read)
- `MonitoringCardView` coalesces its per-activity-tick git refresh to one pass per 2s; `diffAvailability`/`localDiffSummaries` writes are change-only, with no `.checking` flip-flop on forced refreshes
- `EmbeddedTerminalView.syncAppearance` guarded by value fingerprints (`TerminalAppearanceSync`) — SwiftUI re-renders no longer rebuild the SwiftTerm font set or force full redraws; keyed on resolved theme values (not theme id) so YAML hot-reload still applies, and on the workspace surface set so new tabs/panes still get painted

**SwiftTerm fork bump → `1.13.0-agenthub.8`** (jamesrochabrun/SwiftTerm#7)
- Terminal views with no window skip display scheduling, region math, and accessibility posts entirely — the emulator keeps parsing, and `viewDidMoveToWindow` performs one catch-up refresh. Only one terminal is mounted at a time, so every other streaming session previously paid full per-tick display cost on the main thread
- Oversized PTY read chunks (up to 128KB) feed in 16KB sub-slices with the 4ms budget checked between them
- `[AH-OPEN]` Cmd+click logging now opt-in

**Peripheral**
- Session-discovery retry loop passes `skipWorktreeRedetection: true` after the first attempt (was: up to 10 full worktree redetections per new session)
- `GlobalStatsService` reloads debounced 300ms with read+decode off the main thread

## Tests

- New: `SessionWatcherTimerPolicyTests` spin-case coverage (7 cases), `SessionJSONLParserTimestampTests` (fast-path/formatter parity), `TerminalAppearanceSyncTests` (11 cases incl. hot-reload and new-surface), `CLISessionsViewModelDiffRefreshTests` (gated-mock: initial `.checking`, no flip-flop on refresh)
- Targeted gate: 81 tests / 11 suites passed; terminal suites re-validated against the published `1.13.0-agenthub.8` tag
- SwiftTerm fork: 46/46 tests pass
- Full local gate (`./scripts/test.sh`): packages green; AgentHubCore had 4 failures in `WorktreeDeletionRequestMonitor`, `SessionInvestigationViewModel`, and `DiffAvailabilityService` suites — none touch this diff, all pass in isolation (0.02–0.9s vs 4.5–5.2s under load), consistent with the timing flakiness documented in `TestQuarantine.md`

## Follow-ups (intentionally out of scope)

- Wire `SessionMonitorStateModel` into the hub panels to narrow observation further (the 10 Hz throttle removes most of the urgency)

🤖 Generated with [Claude Code](https://claude.com/claude-code)