### PR TITLE
Web preview Edit Mode: deterministic semantic CSS writes + token promotion

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/Models/WebPreviewPageEnvironment.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Models/WebPreviewPageEnvironment.swift
@@ -1,0 +1,82 @@
+//
+//  WebPreviewPageEnvironment.swift
+//  AgentHub
+//
+//  Numeric context captured from the live page so deterministic edit
+//  planning can convert between CSS units (rem/em/vw/vh/unitless) exactly
+//  the way the browser would.
+//
+
+import Foundation
+
+struct WebPreviewPageEnvironment: Equatable, Sendable {
+  /// Layout viewport size in CSS pixels.
+  var viewportWidth: Double
+  var viewportHeight: Double
+  /// Computed font-size of the root element, in pixels (basis for `rem`).
+  var rootFontSize: Double
+  /// Computed font-size of the inspected element, in pixels (basis for `em`
+  /// on non-font-size properties and for unitless line-height).
+  var elementFontSize: Double
+  /// Computed font-size of the inspected element's parent, in pixels (basis
+  /// for `em` on the font-size property itself).
+  var parentFontSize: Double
+
+  init(
+    viewportWidth: Double,
+    viewportHeight: Double,
+    rootFontSize: Double,
+    elementFontSize: Double,
+    parentFontSize: Double
+  ) {
+    self.viewportWidth = viewportWidth
+    self.viewportHeight = viewportHeight
+    self.rootFontSize = rootFontSize
+    self.elementFontSize = elementFontSize
+    self.parentFontSize = parentFontSize
+  }
+
+  /// Conservative defaults used when the page could not be probed. Chosen to
+  /// match browser defaults so px-only stylesheets are unaffected.
+  static let fallback = WebPreviewPageEnvironment(
+    viewportWidth: 1280,
+    viewportHeight: 800,
+    rootFontSize: 16,
+    elementFontSize: 16,
+    parentFontSize: 16
+  )
+
+  /// Decodes the dictionary produced by `WebPreviewPageEnvironmentScript`.
+  static func parse(_ body: Any?) -> WebPreviewPageEnvironment? {
+    guard let dictionary = body as? [String: Any] else { return nil }
+
+    func positive(_ key: String) -> Double? {
+      let value: Double?
+      if let number = dictionary[key] as? Double {
+        value = number
+      } else if let number = dictionary[key] as? Int {
+        value = Double(number)
+      } else if let number = dictionary[key] as? NSNumber {
+        value = number.doubleValue
+      } else {
+        value = nil
+      }
+      guard let value, value.isFinite, value > 0 else { return nil }
+      return value
+    }
+
+    guard let viewportWidth = positive("viewportWidth"),
+          let viewportHeight = positive("viewportHeight"),
+          let rootFontSize = positive("rootFontSize") else {
+      return nil
+    }
+
+    return WebPreviewPageEnvironment(
+      viewportWidth: viewportWidth,
+      viewportHeight: viewportHeight,
+      rootFontSize: rootFontSize,
+      elementFontSize: positive("elementFontSize") ?? rootFontSize,
+      parentFontSize: positive("parentFontSize") ?? rootFontSize
+    )
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/Models/WebPreviewStyleProvenance.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Models/WebPreviewStyleProvenance.swift
@@ -82,6 +82,31 @@ struct WebPreviewStyleProvenance: Equatable, Sendable {
   let winners: [WebPreviewPropertyWinner]
   let unreadableSheetHrefs: [String]
   let hasAdoptedSheets: Bool
+  /// Every property name declared by any matched (or possibly-matched) rule,
+  /// longhands included — used to keep insertions clear of shorthand
+  /// interference.
+  let declaredPropertyNames: [String]
+  /// Property names declared on the element's `style` attribute.
+  let inlinePropertyNames: [String]
+  /// The plainest matching rule (no flags, no conditions): where a
+  /// brand-new declaration may be inserted.
+  let anchorRule: WebPreviewCSSRuleLocator?
+
+  init(
+    winners: [WebPreviewPropertyWinner],
+    unreadableSheetHrefs: [String],
+    hasAdoptedSheets: Bool,
+    declaredPropertyNames: [String] = [],
+    inlinePropertyNames: [String] = [],
+    anchorRule: WebPreviewCSSRuleLocator? = nil
+  ) {
+    self.winners = winners
+    self.unreadableSheetHrefs = unreadableSheetHrefs
+    self.hasAdoptedSheets = hasAdoptedSheets
+    self.declaredPropertyNames = declaredPropertyNames
+    self.inlinePropertyNames = inlinePropertyNames
+    self.anchorRule = anchorRule
+  }
 
   func winner(for property: String) -> WebPreviewPropertyWinner? {
     winners.first { $0.property == property }
@@ -104,21 +129,6 @@ struct WebPreviewStyleProvenance: Equatable, Sendable {
         return nil
       }
 
-      var rule: WebPreviewCSSRuleLocator?
-      if let rawRule = raw["rule"] as? [String: Any],
-         let selectorText = rawRule["selectorText"] as? String,
-         let ruleIndexPath = intArray(rawRule["ruleIndexPath"]),
-         let styleSheetIndex = intValue(rawRule["styleSheetIndex"]) {
-        rule = WebPreviewCSSRuleLocator(
-          stylesheetHref: rawRule["stylesheetHref"] as? String,
-          styleSheetIndex: styleSheetIndex,
-          ruleIndexPath: ruleIndexPath,
-          selectorText: selectorText,
-          specificity: intArray(rawRule["specificity"]) ?? [],
-          ownerNodeAttributes: rawRule["ownerNodeAttributes"] as? [String: String] ?? [:]
-        )
-      }
-
       let flags = (raw["flags"] as? [String] ?? [])
         .compactMap(WebPreviewStyleUncertainty.init(rawValue:))
 
@@ -127,7 +137,7 @@ struct WebPreviewStyleProvenance: Equatable, Sendable {
         declaredValue: declaredValue,
         isInline: raw["isInline"] as? Bool ?? false,
         isImportant: raw["isImportant"] as? Bool ?? false,
-        rule: rule,
+        rule: parseRuleLocator(raw["rule"]),
         uncertainties: Set(flags)
       )
     }
@@ -135,7 +145,27 @@ struct WebPreviewStyleProvenance: Equatable, Sendable {
     return WebPreviewStyleProvenance(
       winners: winners,
       unreadableSheetHrefs: unreadable,
-      hasAdoptedSheets: hasAdopted
+      hasAdoptedSheets: hasAdopted,
+      declaredPropertyNames: dictionary["declaredNames"] as? [String] ?? [],
+      inlinePropertyNames: dictionary["inlineNames"] as? [String] ?? [],
+      anchorRule: parseRuleLocator(dictionary["anchor"])
+    )
+  }
+
+  private static func parseRuleLocator(_ value: Any?) -> WebPreviewCSSRuleLocator? {
+    guard let rawRule = value as? [String: Any],
+          let selectorText = rawRule["selectorText"] as? String,
+          let ruleIndexPath = intArray(rawRule["ruleIndexPath"]),
+          let styleSheetIndex = intValue(rawRule["styleSheetIndex"]) else {
+      return nil
+    }
+    return WebPreviewCSSRuleLocator(
+      stylesheetHref: rawRule["stylesheetHref"] as? String,
+      styleSheetIndex: styleSheetIndex,
+      ruleIndexPath: ruleIndexPath,
+      selectorText: selectorText,
+      specificity: intArray(rawRule["specificity"]) ?? [],
+      ownerNodeAttributes: rawRule["ownerNodeAttributes"] as? [String: String] ?? [:]
     )
   }
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/Models/WebPreviewTokenPromotionOffer.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Models/WebPreviewTokenPromotionOffer.swift
@@ -1,0 +1,48 @@
+//
+//  WebPreviewTokenPromotionOffer.swift
+//  AgentHub
+//
+//  A just-written style edit that detached from a shared design token, and
+//  everything needed to instead promote it into a token-wide update: restore
+//  the element's `var(token)` reference and rewrite the token's definition.
+//
+
+import Foundation
+
+struct WebPreviewTokenPromotionOffer: Equatable, Sendable {
+  /// CSS property whose declaration detached (e.g. "background-color").
+  let property: String
+  /// The design token that was detached from (e.g. "--secondary").
+  let token: String
+  /// `var(token)` usages across the project's stylesheets.
+  let usageCount: Int
+  /// The literal value the detached write put on disk.
+  let appliedLiteral: String
+  /// Rule index path of the token's definition in the same source.
+  let definitionRuleIndexPath: [Int]
+
+  init(
+    property: String,
+    token: String,
+    usageCount: Int,
+    appliedLiteral: String,
+    definitionRuleIndexPath: [Int]
+  ) {
+    self.property = property
+    self.token = token
+    self.usageCount = usageCount
+    self.appliedLiteral = appliedLiteral
+    self.definitionRuleIndexPath = definitionRuleIndexPath
+  }
+
+  /// "Update --secondary everywhere (12 uses)"
+  var actionLabel: String {
+    let uses = usageCount == 1 ? "1 use" : "\(usageCount) uses"
+    return "Update \(token) everywhere (\(uses))"
+  }
+
+  /// "Changed this element only · detached from --secondary"
+  var contextLabel: String {
+    "Changed this element only · detached from \(token)"
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/CSSDeclarationEditPlanner.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/CSSDeclarationEditPlanner.swift
@@ -1,0 +1,1044 @@
+//
+//  CSSDeclarationEditPlanner.swift
+//  AgentHub
+//
+//  Deterministically rewrites a desired literal value so a Tier-1 direct
+//  write preserves the idioms already used by the declaration it edits:
+//  design tokens stay tokens, clamp()/min()/max() keep their responsive
+//  structure, lengths keep their declared unit, and colors keep their
+//  declared notation. Everything here is pure parsing and arithmetic — no
+//  heuristics, no agent. When a value cannot be preserved faithfully the
+//  planner passes the desired literal through unchanged, which is exactly
+//  the pre-planner behavior.
+//
+
+import Foundation
+
+// MARK: - Plan
+
+struct CSSDeclarationEditPlan: Equatable, Sendable {
+  enum Strategy: Equatable, Sendable {
+    /// The declaration already has the desired value; skip the write.
+    case noChange
+    /// Desired literal written as-is (no idiom to preserve, or one the
+    /// planner does not model).
+    case passthrough
+    /// Length converted into the unit the declaration already uses.
+    case unitConverted
+    /// Color reformatted into the notation the declaration already uses.
+    case colorFormatPreserved
+    /// clamp()/min()/max() adjusted component-wise instead of flattened.
+    case responsiveAdjusted
+    /// Value replaced with a `var()` reference to an existing token whose
+    /// resolved value equals the desired value.
+    case tokenReattached(String)
+    /// The edit was retargeted to the token's own definition because this
+    /// declaration is its only consumer.
+    case tokenDefinitionRewritten(String)
+    /// A `var()` reference replaced by a literal (multi-consumer token, so
+    /// element-scoped intent cannot be expressed through the token).
+    case tokenDetached(String)
+  }
+
+  /// The finalized edit, possibly retargeted to another rule in the same
+  /// stylesheet. Nil means the write should be skipped entirely.
+  let edit: CSSDeclarationEdit?
+  let strategy: Strategy
+  /// Set when the plan detached a `var()` usage into a literal: everything
+  /// a caller needs to later offer "update the token everywhere instead".
+  let tokenDetachment: CSSTokenDetachment?
+
+  init(
+    edit: CSSDeclarationEdit?,
+    strategy: Strategy,
+    tokenDetachment: CSSTokenDetachment? = nil
+  ) {
+    self.edit = edit
+    self.strategy = strategy
+    self.tokenDetachment = tokenDetachment
+  }
+}
+
+/// Describes a `var()` usage the planner flattened into a literal because
+/// the token has other consumers. When `definitionRuleIndexPath` is set the
+/// token's single definition lives in the edited document, so the edit can
+/// be deterministically promoted to a token-wide update: restore the usage
+/// to `var(token)` and rewrite the definition.
+struct CSSTokenDetachment: Equatable, Sendable {
+  let token: String
+  /// `var(token)` usages across the edited document and its siblings.
+  let projectUsageCount: Int
+  /// Rule index path of the token's definition within the edited document;
+  /// nil when the definition is elsewhere (promotion not offered).
+  let definitionRuleIndexPath: [Int]?
+  /// The literal the plan wrote in place of the `var()` reference.
+  let appliedLiteral: String
+
+  init(
+    token: String,
+    projectUsageCount: Int,
+    definitionRuleIndexPath: [Int]?,
+    appliedLiteral: String
+  ) {
+    self.token = token
+    self.projectUsageCount = projectUsageCount
+    self.definitionRuleIndexPath = definitionRuleIndexPath
+    self.appliedLiteral = appliedLiteral
+  }
+}
+
+protocol CSSDeclarationEditPlanning: Sendable {
+  /// Plans an edit against the document it targets. `siblings` are the other
+  /// stylesheets of the same page/project: they never receive edits, but
+  /// their `--token` definitions and `var()` usages participate in token
+  /// resolution so a definition rewrite can't silently restyle consumers in
+  /// other files.
+  func plan(
+    _ edit: CSSDeclarationEdit,
+    in document: CSSSourceDocument,
+    siblings: [CSSSourceDocument],
+    environment: WebPreviewPageEnvironment
+  ) -> CSSDeclarationEditPlan
+}
+
+extension CSSDeclarationEditPlanning {
+  func plan(
+    _ edit: CSSDeclarationEdit,
+    in document: CSSSourceDocument,
+    environment: WebPreviewPageEnvironment
+  ) -> CSSDeclarationEditPlan {
+    plan(edit, in: document, siblings: [], environment: environment)
+  }
+}
+
+// MARK: - Planner
+
+struct CSSDeclarationEditPlanner: CSSDeclarationEditPlanning {
+
+  init() {}
+
+  func plan(
+    _ edit: CSSDeclarationEdit,
+    in document: CSSSourceDocument,
+    siblings: [CSSSourceDocument],
+    environment: WebPreviewPageEnvironment
+  ) -> CSSDeclarationEditPlan {
+    guard let desired = edit.value?.trimmingCharacters(in: .whitespacesAndNewlines),
+          !desired.isEmpty else {
+      // Removals pass through untouched.
+      return CSSDeclarationEditPlan(edit: edit, strategy: .passthrough)
+    }
+
+    guard let rule = document.rule(at: edit.ruleIndexPath),
+          let declaration = rule.declarations.last(where: {
+            $0.name == CSSSourceEditor.canonicalPropertyName(edit.property)
+          }) else {
+      // Inserting a brand-new declaration: nothing declared to preserve.
+      return CSSDeclarationEditPlan(edit: edit, strategy: .passthrough)
+    }
+
+    let declared = declaration.valueText.trimmingCharacters(in: .whitespacesAndNewlines)
+
+    if valuesAreEquivalent(declared, desired, property: edit.property, environment: environment) {
+      return CSSDeclarationEditPlan(edit: nil, strategy: .noChange)
+    }
+
+    // 1. Pure design-token reference: var(--x) or var(--x, fallback).
+    if let tokenName = Self.pureVarReference(declared) {
+      return planTokenEdit(
+        edit,
+        tokenName: tokenName,
+        desired: desired,
+        in: document,
+        siblings: siblings,
+        environment: environment
+      )
+    }
+
+    // 2. Responsive expression: clamp()/min()/max() of single-term lengths.
+    if let adjusted = Self.adjustedResponsiveExpression(
+      declared: declared,
+      desired: desired,
+      property: edit.property,
+      environment: environment
+    ) {
+      return CSSDeclarationEditPlan(
+        edit: CSSDeclarationEdit(ruleIndexPath: edit.ruleIndexPath, property: edit.property, value: adjusted),
+        strategy: .responsiveAdjusted
+      )
+    }
+
+    // 3. Color notation preservation.
+    if let declaredColor = CSSColorValue.parse(declared),
+       let desiredColor = CSSColorValue.parse(desired) {
+      if declaredColor == desiredColor {
+        return CSSDeclarationEditPlan(edit: nil, strategy: .noChange)
+      }
+      let formatted = Self.colorRewrite(declared: declared, desired: desired, desiredColor: desiredColor)
+      return CSSDeclarationEditPlan(
+        edit: CSSDeclarationEdit(ruleIndexPath: edit.ruleIndexPath, property: edit.property, value: formatted),
+        strategy: .colorFormatPreserved
+      )
+    }
+
+    // 4. Single length literal: preserve the declared unit.
+    if let converted = Self.convertedLength(
+      declared: declared,
+      desired: desired,
+      property: edit.property,
+      environment: environment
+    ) {
+      if converted == declared {
+        return CSSDeclarationEditPlan(edit: nil, strategy: .noChange)
+      }
+      return CSSDeclarationEditPlan(
+        edit: CSSDeclarationEdit(ruleIndexPath: edit.ruleIndexPath, property: edit.property, value: converted),
+        strategy: .unitConverted
+      )
+    }
+
+    return CSSDeclarationEditPlan(edit: edit, strategy: .passthrough)
+  }
+
+  // MARK: - Token planning
+
+  private func planTokenEdit(
+    _ edit: CSSDeclarationEdit,
+    tokenName: String,
+    desired: String,
+    in document: CSSSourceDocument,
+    siblings: [CSSSourceDocument],
+    environment: WebPreviewPageEnvironment
+  ) -> CSSDeclarationEditPlan {
+    let table = CSSCustomPropertyTable(document: document, siblings: siblings)
+
+    // No-op: the desired value is what the token already resolves to.
+    if let resolved = table.resolvedLiteral(for: tokenName),
+       valuesAreEquivalent(resolved, desired, property: edit.property, environment: environment) {
+      return CSSDeclarationEditPlan(edit: nil, strategy: .noChange)
+    }
+
+    // Reattach: exactly one other token already resolves to the desired
+    // value — reference it instead of flattening to a literal.
+    let matches = table.tokens { candidate in
+      self.valuesAreEquivalent(candidate, desired, property: edit.property, environment: environment)
+    }
+    if matches.count == 1, let match = matches.first {
+      return CSSDeclarationEditPlan(
+        edit: CSSDeclarationEdit(
+          ruleIndexPath: edit.ruleIndexPath,
+          property: edit.property,
+          value: "var(\(match))"
+        ),
+        strategy: .tokenReattached(match)
+      )
+    }
+
+    // Single-consumer token: this declaration is the token's only usage and
+    // it has exactly one plain-literal definition — update the definition so
+    // the indirection survives.
+    if table.usageCount(of: tokenName) == 1,
+       let definition = table.singleLiteralDefinition(of: tokenName, visibleFrom: edit.ruleIndexPath) {
+      let rewritten = Self.preservingLiteralRewrite(
+        declared: definition.valueText,
+        desired: desired,
+        property: edit.property,
+        environment: environment
+      )
+      return CSSDeclarationEditPlan(
+        edit: CSSDeclarationEdit(
+          ruleIndexPath: definition.ruleIndexPath,
+          property: tokenName,
+          value: rewritten
+        ),
+        strategy: .tokenDefinitionRewritten(tokenName)
+      )
+    }
+
+    // Detach: the token has other consumers, so an element-scoped edit must
+    // become a literal here. Keep the token's notation where possible, and
+    // record enough context to offer a token-wide update afterwards.
+    let literal: String
+    if let resolved = table.resolvedLiteral(for: tokenName) {
+      literal = Self.preservingLiteralRewrite(
+        declared: resolved,
+        desired: desired,
+        property: edit.property,
+        environment: environment
+      )
+    } else {
+      literal = desired
+    }
+    return CSSDeclarationEditPlan(
+      edit: CSSDeclarationEdit(ruleIndexPath: edit.ruleIndexPath, property: edit.property, value: literal),
+      strategy: .tokenDetached(tokenName),
+      tokenDetachment: CSSTokenDetachment(
+        token: tokenName,
+        projectUsageCount: table.usageCount(of: tokenName),
+        definitionRuleIndexPath: table.promotableDefinition(of: tokenName)?.ruleIndexPath,
+        appliedLiteral: literal
+      )
+    )
+  }
+
+  /// Keyword-declared colors carry no notation to preserve, so the desired
+  /// text passes through as-is; every other notation is mirrored.
+  static func colorRewrite(declared: String, desired: String, desiredColor: CSSColorValue) -> String {
+    let keyword = declared.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    if CSSColorValue.keywords[keyword] != nil {
+      return desired
+    }
+    return desiredColor.formatted(like: declared)
+  }
+
+  /// Rewrites `desired` into the same notation as an existing literal
+  /// (color format or length unit); falls back to `desired` unchanged.
+  static func preservingLiteralRewrite(
+    declared: String,
+    desired: String,
+    property: String,
+    environment: WebPreviewPageEnvironment
+  ) -> String {
+    if CSSColorValue.parse(declared) != nil, let desiredColor = CSSColorValue.parse(desired) {
+      return colorRewrite(declared: declared, desired: desired, desiredColor: desiredColor)
+    }
+    if let converted = convertedLength(
+      declared: declared,
+      desired: desired,
+      property: property,
+      environment: environment
+    ) {
+      return converted
+    }
+    return desired
+  }
+
+  // MARK: - Equivalence
+
+  private func valuesAreEquivalent(
+    _ lhs: String,
+    _ rhs: String,
+    property: String,
+    environment: WebPreviewPageEnvironment
+  ) -> Bool {
+    if let lhsColor = CSSColorValue.parse(lhs), let rhsColor = CSSColorValue.parse(rhs) {
+      return lhsColor == rhsColor
+    }
+    if let lhsLength = CSSLengthTerm.parse(lhs),
+       let rhsLength = CSSLengthTerm.parse(rhs),
+       let lhsPx = lhsLength.pixels(property: property, environment: environment),
+       let rhsPx = rhsLength.pixels(property: property, environment: environment) {
+      return abs(lhsPx - rhsPx) < 0.05
+    }
+    return lhs.split(whereSeparator: \.isWhitespace).joined(separator: " ").lowercased()
+      == rhs.split(whereSeparator: \.isWhitespace).joined(separator: " ").lowercased()
+  }
+
+  // MARK: - var() detection
+
+  /// Returns the token name when the whole value is a single `var()`
+  /// reference (with optional fallback). Token names keep their original
+  /// case — custom properties are case-sensitive and the parser preserves
+  /// their spelling.
+  static func pureVarReference(_ value: String) -> String? {
+    let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard trimmed.lowercased().hasPrefix("var("), trimmed.hasSuffix(")") else { return nil }
+
+    let inner = String(trimmed.dropFirst(4).dropLast(1))
+    // The reference must close at the very end (no trailing operators).
+    guard Self.topLevelSplit(inner).count <= 2 else { return nil }
+    let name = Self.topLevelSplit(inner).first?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+    guard name.hasPrefix("--"), name.count > 2 else { return nil }
+    guard name.dropFirst(2).allSatisfy({ $0.isLetter || $0.isNumber || $0 == "-" || $0 == "_" }) else {
+      return nil
+    }
+    // Reject `var(--a) solid red` style compounds: the suffix check above
+    // only guarantees the string ends with ')'; ensure the closing paren
+    // belongs to this var().
+    var depth = 0
+    for (offset, character) in trimmed.enumerated() {
+      if character == "(" { depth += 1 }
+      if character == ")" {
+        depth -= 1
+        if depth == 0, offset < trimmed.count - 1 { return nil }
+      }
+    }
+    return name
+  }
+
+  // MARK: - Responsive expressions
+
+  /// Rewrites `clamp()/min()/max()` component-wise so the expression yields
+  /// the desired value at the current environment while keeping its
+  /// structure. Returns nil when the expression is not one the planner can
+  /// adjust faithfully.
+  static func adjustedResponsiveExpression(
+    declared: String,
+    desired: String,
+    property: String,
+    environment: WebPreviewPageEnvironment
+  ) -> String? {
+    let trimmed = declared.trimmingCharacters(in: .whitespacesAndNewlines)
+    let lowered = trimmed.lowercased()
+
+    let function: String
+    if lowered.hasPrefix("clamp(") {
+      function = "clamp"
+    } else if lowered.hasPrefix("min(") {
+      function = "min"
+    } else if lowered.hasPrefix("max(") {
+      function = "max"
+    } else {
+      return nil
+    }
+    guard trimmed.hasSuffix(")") else { return nil }
+
+    let innerStart = trimmed.index(trimmed.startIndex, offsetBy: function.count + 1)
+    let innerEnd = trimmed.index(before: trimmed.endIndex)
+    let inner = String(trimmed[innerStart..<innerEnd])
+
+    let arguments = topLevelSplit(inner)
+    guard !arguments.isEmpty else { return nil }
+
+    var terms: [CSSLengthTerm] = []
+    var evaluations: [Double] = []
+    for argument in arguments {
+      guard let term = CSSLengthTerm.parse(argument.trimmingCharacters(in: .whitespacesAndNewlines)),
+            let pixels = term.pixels(property: property, environment: environment) else {
+        return nil
+      }
+      terms.append(term)
+      evaluations.append(pixels)
+    }
+
+    guard let desiredTerm = CSSLengthTerm.parse(desired),
+          let desiredPx = desiredTerm.pixels(property: property, environment: environment) else {
+      return nil
+    }
+
+    var replacements: [Int: String] = [:]
+
+    switch function {
+    case "clamp":
+      guard terms.count == 3 else { return nil }
+      // The preferred expression tracks the slider; bounds widen only when
+      // the desired value crosses them, so the responsive curve survives.
+      replacements[1] = terms[1].formatted(fromPixels: desiredPx, property: property, environment: environment)
+      if desiredPx < evaluations[0] {
+        replacements[0] = terms[0].formatted(fromPixels: desiredPx, property: property, environment: environment)
+      }
+      if desiredPx > evaluations[2] {
+        replacements[2] = terms[2].formatted(fromPixels: desiredPx, property: property, environment: environment)
+      }
+
+    case "min":
+      guard terms.count >= 2, let winnerValue = evaluations.min(),
+            let winner = evaluations.firstIndex(of: winnerValue) else { return nil }
+      // Adjusting the winning argument only works while it stays the winner.
+      guard evaluations.enumerated().allSatisfy({ $0.offset == winner || desiredPx <= $0.element + 0.05 }) else {
+        return nil
+      }
+      replacements[winner] = terms[winner].formatted(fromPixels: desiredPx, property: property, environment: environment)
+
+    case "max":
+      guard terms.count >= 2, let winnerValue = evaluations.max(),
+            let winner = evaluations.firstIndex(of: winnerValue) else { return nil }
+      guard evaluations.enumerated().allSatisfy({ $0.offset == winner || desiredPx >= $0.element - 0.05 }) else {
+        return nil
+      }
+      replacements[winner] = terms[winner].formatted(fromPixels: desiredPx, property: property, environment: environment)
+
+    default:
+      return nil
+    }
+
+    guard replacements.values.allSatisfy({ !$0.isEmpty }) else { return nil }
+
+    let rebuiltArguments = arguments.enumerated().map { index, original -> String in
+      guard let replacement = replacements[index] else { return original }
+      // Preserve the original argument's surrounding whitespace.
+      let leading = original.prefix(while: \.isWhitespace)
+      let trailing = String(original.reversed().prefix(while: \.isWhitespace).reversed())
+      return leading + replacement + trailing
+    }
+
+    return "\(function)(\(rebuiltArguments.joined(separator: ",")))"
+  }
+
+  // MARK: - Lengths
+
+  /// Converts a desired length into the unit of the declared literal.
+  /// Returns nil when either side is not a single supported length term.
+  static func convertedLength(
+    declared: String,
+    desired: String,
+    property: String,
+    environment: WebPreviewPageEnvironment
+  ) -> String? {
+    guard let declaredTerm = CSSLengthTerm.parse(declared),
+          declaredTerm.pixels(property: property, environment: environment) != nil,
+          let desiredTerm = CSSLengthTerm.parse(desired),
+          let desiredPx = desiredTerm.pixels(property: property, environment: environment) else {
+      return nil
+    }
+    let formatted = declaredTerm.formatted(fromPixels: desiredPx, property: property, environment: environment)
+    return formatted.isEmpty ? nil : formatted
+  }
+
+  // MARK: - Shared parsing helpers
+
+  /// Splits on top-level commas (ignoring commas nested in parentheses,
+  /// brackets, or strings).
+  static func topLevelSplit(_ text: String) -> [String] {
+    var parts: [String] = []
+    var current = ""
+    var depth = 0
+    var stringDelimiter: Character?
+
+    for character in text {
+      if let delimiter = stringDelimiter {
+        current.append(character)
+        if character == delimiter { stringDelimiter = nil }
+        continue
+      }
+      switch character {
+      case "\"", "'":
+        stringDelimiter = character
+        current.append(character)
+      case "(", "[":
+        depth += 1
+        current.append(character)
+      case ")", "]":
+        depth -= 1
+        current.append(character)
+      case "," where depth == 0:
+        parts.append(current)
+        current = ""
+      default:
+        current.append(character)
+      }
+    }
+    parts.append(current)
+    return parts
+  }
+}
+
+// MARK: - Length terms
+
+/// A single numeric CSS length term (`17px`, `2.2vw`, `1.05rem`, `1.45`).
+struct CSSLengthTerm: Equatable {
+  let value: Double
+  /// Lowercased unit; empty for unitless numbers.
+  let unit: String
+
+  static let supportedUnits: Set<String> = ["px", "rem", "em", "vw", "vh", "vmin", "vmax", ""]
+
+  static func parse(_ text: String) -> CSSLengthTerm? {
+    let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    guard !trimmed.isEmpty else { return nil }
+
+    var numberEnd = trimmed.startIndex
+    var seenDigit = false
+    var seenDot = false
+    var index = trimmed.startIndex
+    while index < trimmed.endIndex {
+      let character = trimmed[index]
+      if character == "+" || character == "-" {
+        guard index == trimmed.startIndex else { break }
+      } else if character == "." {
+        guard !seenDot else { break }
+        seenDot = true
+      } else if character.isNumber {
+        seenDigit = true
+      } else {
+        break
+      }
+      index = trimmed.index(after: index)
+      numberEnd = index
+    }
+
+    guard seenDigit, let value = Double(trimmed[trimmed.startIndex..<numberEnd]) else { return nil }
+    let unit = String(trimmed[numberEnd...])
+    guard supportedUnits.contains(unit) else { return nil }
+    return CSSLengthTerm(value: value, unit: unit)
+  }
+
+  /// Evaluates the term to CSS pixels. Unitless terms are only meaningful
+  /// for line-height (a multiple of the element's font size); elsewhere a
+  /// bare number is treated as pixels, matching how editor toolbars emit
+  /// values.
+  func pixels(property: String, environment: WebPreviewPageEnvironment) -> Double? {
+    switch unit {
+    case "px":
+      return value
+    case "rem":
+      return value * environment.rootFontSize
+    case "em":
+      let basis = property.lowercased() == "font-size"
+        ? environment.parentFontSize
+        : environment.elementFontSize
+      return value * basis
+    case "vw":
+      return value * environment.viewportWidth / 100
+    case "vh":
+      return value * environment.viewportHeight / 100
+    case "vmin":
+      return value * min(environment.viewportWidth, environment.viewportHeight) / 100
+    case "vmax":
+      return value * max(environment.viewportWidth, environment.viewportHeight) / 100
+    case "":
+      if property.lowercased() == "line-height" {
+        return value * environment.elementFontSize
+      }
+      return value
+    default:
+      return nil
+    }
+  }
+
+  /// Formats a pixel amount in this term's unit.
+  func formatted(fromPixels pixels: Double, property: String, environment: WebPreviewPageEnvironment) -> String {
+    func output(_ value: Double, decimals: Int) -> String {
+      let rounded = (value * pow(10, Double(decimals))).rounded() / pow(10, Double(decimals))
+      guard rounded.isFinite else { return "" }
+      var text = String(format: "%.\(decimals)f", rounded)
+      while text.contains("."), text.hasSuffix("0") { text.removeLast() }
+      if text.hasSuffix(".") { text.removeLast() }
+      if text == "-0" { text = "0" }
+      return text
+    }
+
+    switch unit {
+    case "px":
+      return output(pixels, decimals: 2) + "px"
+    case "rem":
+      guard environment.rootFontSize > 0 else { return "" }
+      return output(pixels / environment.rootFontSize, decimals: 4) + "rem"
+    case "em":
+      let basis = property.lowercased() == "font-size"
+        ? environment.parentFontSize
+        : environment.elementFontSize
+      guard basis > 0 else { return "" }
+      return output(pixels / basis, decimals: 4) + "em"
+    case "vw":
+      guard environment.viewportWidth > 0 else { return "" }
+      return output(pixels / environment.viewportWidth * 100, decimals: 3) + "vw"
+    case "vh":
+      guard environment.viewportHeight > 0 else { return "" }
+      return output(pixels / environment.viewportHeight * 100, decimals: 3) + "vh"
+    case "vmin":
+      let basis = min(environment.viewportWidth, environment.viewportHeight)
+      guard basis > 0 else { return "" }
+      return output(pixels / basis * 100, decimals: 3) + "vmin"
+    case "vmax":
+      let basis = max(environment.viewportWidth, environment.viewportHeight)
+      guard basis > 0 else { return "" }
+      return output(pixels / basis * 100, decimals: 3) + "vmax"
+    case "":
+      if property.lowercased() == "line-height" {
+        guard environment.elementFontSize > 0 else { return "" }
+        return output(pixels / environment.elementFontSize, decimals: 4)
+      }
+      return output(pixels, decimals: 2)
+    default:
+      return ""
+    }
+  }
+}
+
+// MARK: - Custom property table
+
+/// Indexes every `--token` definition and `var(--token)` usage across a
+/// page's parsed stylesheets. Only the edited document may receive writes;
+/// sibling stylesheets contribute definitions and usage counts so token
+/// rewrites stay faithful to consumers the edited file can't see.
+struct CSSCustomPropertyTable {
+  struct Definition {
+    let ruleIndexPath: [Int]
+    let valueText: String
+    /// True for definitions on a top-level `:root`/`html` rule — the only
+    /// ones that are unconditionally visible everywhere and therefore safe
+    /// to reference or rewrite from any other rule. Definitions nested in
+    /// media/support blocks apply conditionally, so the planner leaves them
+    /// alone (except when the edit targets the very rule that defines them).
+    let isRootScoped: Bool
+    /// True when the definition lives in the document being edited — the
+    /// only place a definition rewrite may land.
+    let isInEditedDocument: Bool
+  }
+
+  private var definitions: [String: [Definition]] = [:]
+  private var usages: [String: Int] = [:]
+
+  init(document: CSSSourceDocument, siblings: [CSSSourceDocument] = []) {
+    index(document, isEditedDocument: true)
+    for sibling in siblings {
+      index(sibling, isEditedDocument: false)
+    }
+  }
+
+  private mutating func index(_ document: CSSSourceDocument, isEditedDocument: Bool) {
+    for rule in document.allRules {
+      let isRootScoped = rule.indexPath.count == 1
+        && (rule.normalizedSelectorText.map { selector in
+          CSSDeclarationEditPlanner.topLevelSplit(selector)
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .allSatisfy { $0 == ":root" || $0 == "html" }
+        } ?? false)
+      for declaration in rule.declarations {
+        if declaration.name.hasPrefix("--") {
+          definitions[declaration.name, default: []].append(
+            Definition(
+              ruleIndexPath: rule.indexPath,
+              valueText: declaration.valueText,
+              isRootScoped: isRootScoped,
+              isInEditedDocument: isEditedDocument
+            )
+          )
+        }
+        for reference in Self.varReferences(in: declaration.valueText) {
+          usages[reference, default: 0] += 1
+        }
+      }
+    }
+  }
+
+  /// Token names referenced via `var(...)` in a value, original case
+  /// preserved (custom property names are case-sensitive).
+  static func varReferences(in value: String) -> [String] {
+    var references: [String] = []
+    var searchRange = value.startIndex..<value.endIndex
+    while let match = value.range(of: "var(", options: .caseInsensitive, range: searchRange) {
+      var name = ""
+      var index = match.upperBound
+      while index < value.endIndex, value[index].isWhitespace {
+        index = value.index(after: index)
+      }
+      while index < value.endIndex {
+        let character = value[index]
+        if character.isLetter || character.isNumber || character == "-" || character == "_" {
+          name.append(character)
+          index = value.index(after: index)
+        } else {
+          break
+        }
+      }
+      if name.hasPrefix("--"), name.count > 2 {
+        references.append(name)
+      }
+      searchRange = match.upperBound..<value.endIndex
+    }
+    return references
+  }
+
+  func usageCount(of token: String) -> Int {
+    usages[token] ?? 0
+  }
+
+  /// The token's single plain-literal definition, or nil when it is
+  /// undefined, defined more than once (e.g. media-query overrides or a
+  /// sibling stylesheet redefining it), defined in terms of other
+  /// functions/vars, defined outside the edited document (rewrites never
+  /// cross files), or scoped somewhere the edited rule cannot rely on
+  /// (anything but `:root`/`html` or the edited rule itself).
+  func singleLiteralDefinition(of token: String, visibleFrom ruleIndexPath: [Int]) -> Definition? {
+    guard let candidates = definitions[token], candidates.count == 1,
+          let definition = candidates.first else { return nil }
+    guard definition.isInEditedDocument else { return nil }
+    guard definition.isRootScoped || definition.ruleIndexPath == ruleIndexPath else { return nil }
+    let value = definition.valueText.lowercased()
+    guard !value.contains("var("), !value.contains("calc("), !value.contains("env(") else { return nil }
+    return definition
+  }
+
+  /// The definition a token-wide promotion may rewrite: the token's single
+  /// project-wide definition, root-scoped, living in the edited document,
+  /// holding a plain literal.
+  func promotableDefinition(of token: String) -> Definition? {
+    guard let candidates = definitions[token], candidates.count == 1,
+          let definition = candidates.first,
+          definition.isInEditedDocument,
+          definition.isRootScoped else { return nil }
+    let value = definition.valueText.lowercased()
+    guard !value.contains("var("), !value.contains("calc("), !value.contains("env(") else { return nil }
+    return definition
+  }
+
+  /// Resolves a token through single-definition chains (depth-limited) to a
+  /// plain literal. Nil when any hop is ambiguous or non-literal.
+  func resolvedLiteral(for token: String, depth: Int = 0) -> String? {
+    guard depth < 8 else { return nil }
+    guard let candidates = definitions[token], candidates.count == 1,
+          let definition = candidates.first else { return nil }
+    let value = definition.valueText.trimmingCharacters(in: .whitespacesAndNewlines)
+    if let nested = CSSDeclarationEditPlanner.pureVarReference(value) {
+      return resolvedLiteral(for: nested, depth: depth + 1)
+    }
+    guard !value.lowercased().contains("var(") else { return nil }
+    return value.isEmpty ? nil : value
+  }
+
+  /// Root-scoped tokens whose resolved literal satisfies the given
+  /// equivalence test, in stable name order so reattachment is
+  /// deterministic. Only root-scoped definitions are offered because a new
+  /// `var()` reference must resolve identically wherever the edited rule
+  /// applies.
+  func tokens(where isEquivalent: (String) -> Bool) -> [String] {
+    definitions.keys.sorted().filter { token in
+      guard let candidates = definitions[token], candidates.count == 1,
+            candidates[0].isRootScoped,
+            let resolved = resolvedLiteral(for: token) else { return false }
+      return isEquivalent(resolved)
+    }
+  }
+}
+
+// MARK: - Colors
+
+/// An sRGB color parsed from any of the notations the planner preserves.
+struct CSSColorValue: Equatable {
+  /// 0-255 channel values after rounding.
+  let red: Int
+  let green: Int
+  let blue: Int
+  /// 0-1, rounded to 3 decimals.
+  let alpha: Double
+
+  // MARK: Parsing
+
+  static func parse(_ text: String) -> CSSColorValue? {
+    let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    if trimmed.hasPrefix("#") {
+      return parseHex(String(trimmed.dropFirst()))
+    }
+    if trimmed.hasPrefix("rgb(") || trimmed.hasPrefix("rgba(") {
+      return parseFunctional(trimmed, isHSL: false)
+    }
+    if trimmed.hasPrefix("hsl(") || trimmed.hasPrefix("hsla(") {
+      return parseFunctional(trimmed, isHSL: true)
+    }
+    if let keyword = Self.keywords[trimmed] {
+      return keyword
+    }
+    return nil
+  }
+
+  private static func parseHex(_ digits: String) -> CSSColorValue? {
+    guard digits.allSatisfy(\.isHexDigit) else { return nil }
+
+    func channel(_ text: Substring) -> Int? { Int(text, radix: 16) }
+
+    switch digits.count {
+    case 3, 4:
+      let expanded = digits.map { "\($0)\($0)" }.joined()
+      return parseHex(expanded)
+    case 6:
+      guard let red = channel(digits.prefix(2)),
+            let green = channel(digits.dropFirst(2).prefix(2)),
+            let blue = channel(digits.dropFirst(4).prefix(2)) else { return nil }
+      return CSSColorValue(red: red, green: green, blue: blue, alpha: 1)
+    case 8:
+      guard let red = channel(digits.prefix(2)),
+            let green = channel(digits.dropFirst(2).prefix(2)),
+            let blue = channel(digits.dropFirst(4).prefix(2)),
+            let alphaByte = channel(digits.dropFirst(6).prefix(2)) else { return nil }
+      return CSSColorValue(red: red, green: green, blue: blue, alpha: roundAlpha(Double(alphaByte) / 255))
+    default:
+      return nil
+    }
+  }
+
+  private static func parseFunctional(_ text: String, isHSL: Bool) -> CSSColorValue? {
+    guard let open = text.firstIndex(of: "("), text.hasSuffix(")") else { return nil }
+    let inner = String(text[text.index(after: open)..<text.index(before: text.endIndex)])
+
+    // Accept both comma syntax and modern space syntax with `/ alpha`.
+    var components: [String]
+    var alphaText: String?
+    if inner.contains(",") {
+      components = CSSDeclarationEditPlanner.topLevelSplit(inner).map {
+        $0.trimmingCharacters(in: .whitespacesAndNewlines)
+      }
+      if components.count == 4 {
+        alphaText = components.removeLast()
+      }
+    } else {
+      let slashParts = inner.split(separator: "/", maxSplits: 1)
+      components = slashParts[0].split(whereSeparator: \.isWhitespace).map(String.init)
+      if slashParts.count == 2 {
+        alphaText = slashParts[1].trimmingCharacters(in: .whitespacesAndNewlines)
+      }
+    }
+    guard components.count == 3 else { return nil }
+
+    func number(_ text: String) -> Double? {
+      Double(text.hasSuffix("%") ? String(text.dropLast()) : text)
+    }
+
+    let alpha: Double
+    if let alphaText {
+      guard var parsedAlpha = number(alphaText) else { return nil }
+      if alphaText.hasSuffix("%") { parsedAlpha /= 100 }
+      alpha = roundAlpha(min(max(parsedAlpha, 0), 1))
+    } else {
+      alpha = 1
+    }
+
+    if isHSL {
+      guard let hue = number(components[0].replacingOccurrences(of: "deg", with: "")),
+            components[1].hasSuffix("%"), components[2].hasSuffix("%"),
+            let saturation = number(components[1]),
+            let lightness = number(components[2]) else { return nil }
+      let (red, green, blue) = hslToRGB(hue: hue, saturation: saturation / 100, lightness: lightness / 100)
+      return CSSColorValue(red: red, green: green, blue: blue, alpha: alpha)
+    }
+
+    func rgbChannel(_ text: String) -> Int? {
+      guard let value = number(text) else { return nil }
+      let scaled = text.hasSuffix("%") ? value / 100 * 255 : value
+      return Int(min(max(scaled, 0), 255).rounded())
+    }
+
+    guard let red = rgbChannel(components[0]),
+          let green = rgbChannel(components[1]),
+          let blue = rgbChannel(components[2]) else { return nil }
+    return CSSColorValue(red: red, green: green, blue: blue, alpha: alpha)
+  }
+
+  private static func roundAlpha(_ alpha: Double) -> Double {
+    (alpha * 1000).rounded() / 1000
+  }
+
+  private static func hslToRGB(hue: Double, saturation: Double, lightness: Double) -> (Int, Int, Int) {
+    let hue = (hue.truncatingRemainder(dividingBy: 360) + 360).truncatingRemainder(dividingBy: 360) / 360
+    guard saturation > 0 else {
+      let gray = Int((lightness * 255).rounded())
+      return (gray, gray, gray)
+    }
+    let q = lightness < 0.5 ? lightness * (1 + saturation) : lightness + saturation - lightness * saturation
+    let p = 2 * lightness - q
+
+    func component(_ t: Double) -> Int {
+      var t = t
+      if t < 0 { t += 1 }
+      if t > 1 { t -= 1 }
+      let value: Double
+      if t < 1 / 6 { value = p + (q - p) * 6 * t }
+      else if t < 1 / 2 { value = q }
+      else if t < 2 / 3 { value = p + (q - p) * (2 / 3 - t) * 6 }
+      else { value = p }
+      return Int((value * 255).rounded())
+    }
+
+    return (component(hue + 1 / 3), component(hue), component(hue - 1 / 3))
+  }
+
+  private func rgbToHSL() -> (hue: Int, saturation: Int, lightness: Int) {
+    let red = Double(self.red) / 255
+    let green = Double(self.green) / 255
+    let blue = Double(self.blue) / 255
+    let maxChannel = max(red, green, blue)
+    let minChannel = min(red, green, blue)
+    let lightness = (maxChannel + minChannel) / 2
+    guard maxChannel != minChannel else {
+      return (0, 0, Int((lightness * 100).rounded()))
+    }
+    let delta = maxChannel - minChannel
+    let saturation = lightness > 0.5
+      ? delta / (2 - maxChannel - minChannel)
+      : delta / (maxChannel + minChannel)
+    var hue: Double
+    switch maxChannel {
+    case red:
+      hue = (green - blue) / delta + (green < blue ? 6 : 0)
+    case green:
+      hue = (blue - red) / delta + 2
+    default:
+      hue = (red - green) / delta + 4
+    }
+    hue *= 60
+    return (Int(hue.rounded()), Int((saturation * 100).rounded()), Int((lightness * 100).rounded()))
+  }
+
+  // MARK: Formatting
+
+  /// Renders this color in the same notation as an existing declared value.
+  func formatted(like declared: String) -> String {
+    let trimmed = declared.trimmingCharacters(in: .whitespacesAndNewlines)
+    let lowered = trimmed.lowercased()
+
+    func alphaString() -> String {
+      var text = String(format: "%.3f", alpha)
+      while text.contains("."), text.hasSuffix("0") { text.removeLast() }
+      if text.hasSuffix(".") { text.removeLast() }
+      return text
+    }
+
+    if lowered.hasPrefix("#") {
+      let usesUppercase = trimmed.dropFirst().contains(where: { $0.isLetter && $0.isUppercase })
+      var hex = String(format: "%02x%02x%02x", red, green, blue)
+      if alpha < 1 {
+        hex += String(format: "%02x", Int((alpha * 255).rounded()))
+      }
+      return "#" + (usesUppercase ? hex.uppercased() : hex)
+    }
+
+    if lowered.hasPrefix("hsl") {
+      let (hue, saturation, lightness) = rgbToHSL()
+      let usesCommas = lowered.contains(",")
+      if alpha < 1 {
+        return usesCommas
+          ? "hsla(\(hue), \(saturation)%, \(lightness)%, \(alphaString()))"
+          : "hsl(\(hue) \(saturation)% \(lightness)% / \(alphaString()))"
+      }
+      return usesCommas
+        ? "hsl(\(hue), \(saturation)%, \(lightness)%)"
+        : "hsl(\(hue) \(saturation)% \(lightness)%)"
+    }
+
+    if lowered.hasPrefix("rgb") {
+      let usesCommas = lowered.contains(",")
+      if alpha < 1 {
+        return usesCommas
+          ? "rgba(\(red), \(green), \(blue), \(alphaString()))"
+          : "rgb(\(red) \(green) \(blue) / \(alphaString()))"
+      }
+      return usesCommas
+        ? "rgb(\(red), \(green), \(blue))"
+        : "rgb(\(red) \(green) \(blue))"
+    }
+
+    // Keywords and anything else: emit lowercase hex (rgba when translucent).
+    if alpha < 1 {
+      return "rgba(\(red), \(green), \(blue), \(alphaString()))"
+    }
+    return "#" + String(format: "%02x%02x%02x", red, green, blue)
+  }
+
+  /// The common named colors, so keyword-valued declarations still get
+  /// no-op detection and format-aware rewrites.
+  static let keywords: [String: CSSColorValue] = [
+    "transparent": CSSColorValue(red: 0, green: 0, blue: 0, alpha: 0),
+    "black": CSSColorValue(red: 0, green: 0, blue: 0, alpha: 1),
+    "white": CSSColorValue(red: 255, green: 255, blue: 255, alpha: 1),
+    "red": CSSColorValue(red: 255, green: 0, blue: 0, alpha: 1),
+    "green": CSSColorValue(red: 0, green: 128, blue: 0, alpha: 1),
+    "blue": CSSColorValue(red: 0, green: 0, blue: 255, alpha: 1),
+    "yellow": CSSColorValue(red: 255, green: 255, blue: 0, alpha: 1),
+    "orange": CSSColorValue(red: 255, green: 165, blue: 0, alpha: 1),
+    "purple": CSSColorValue(red: 128, green: 0, blue: 128, alpha: 1),
+    "pink": CSSColorValue(red: 255, green: 192, blue: 203, alpha: 1),
+    "gray": CSSColorValue(red: 128, green: 128, blue: 128, alpha: 1),
+    "grey": CSSColorValue(red: 128, green: 128, blue: 128, alpha: 1),
+    "silver": CSSColorValue(red: 192, green: 192, blue: 192, alpha: 1),
+    "maroon": CSSColorValue(red: 128, green: 0, blue: 0, alpha: 1),
+    "navy": CSSColorValue(red: 0, green: 0, blue: 128, alpha: 1),
+    "teal": CSSColorValue(red: 0, green: 128, blue: 128, alpha: 1),
+    "olive": CSSColorValue(red: 128, green: 128, blue: 0, alpha: 1),
+    "lime": CSSColorValue(red: 0, green: 255, blue: 0, alpha: 1),
+    "aqua": CSSColorValue(red: 0, green: 255, blue: 255, alpha: 1),
+    "cyan": CSSColorValue(red: 0, green: 255, blue: 255, alpha: 1),
+    "fuchsia": CSSColorValue(red: 255, green: 0, blue: 255, alpha: 1),
+    "magenta": CSSColorValue(red: 255, green: 0, blue: 255, alpha: 1),
+  ]
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/CSSSourceEditor.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/CSSSourceEditor.swift
@@ -58,7 +58,9 @@ struct CSSSourceRule: Equatable, Sendable {
 }
 
 struct CSSSourceDeclaration: Equatable, Sendable {
-  /// Lowercased property name.
+  /// Canonical property name: lowercased for standard properties, original
+  /// case for `--custom-properties` (custom property names are
+  /// case-sensitive per spec).
   let name: String
   /// Trimmed value text, excluding any `!important`.
   let valueText: String
@@ -117,7 +119,7 @@ struct CSSSourceEditor: CSSSourceEditing {
       throw CSSSourceEditorError.ruleNotFound(edit.ruleIndexPath)
     }
 
-    let propertyName = edit.property.lowercased()
+    let propertyName = Self.canonicalPropertyName(edit.property)
     var bytes = Array(source.utf8)
     let matching = rule.declarations.filter { $0.name == propertyName }
 
@@ -151,6 +153,15 @@ struct CSSSourceEditor: CSSSourceEditing {
     )
 
     return edited
+  }
+
+  // MARK: - Property names
+
+  /// Standard property names are case-insensitive and canonicalize to
+  /// lowercase; custom properties (`--x`) are case-sensitive and keep their
+  /// original spelling.
+  static func canonicalPropertyName(_ name: String) -> String {
+    name.hasPrefix("--") ? name : name.lowercased()
   }
 
   // MARK: - Selector normalization
@@ -327,7 +338,7 @@ struct CSSSourceEditor: CSSSourceEditing {
     }
 
     let nameEnd = trimmedEnd(bytes, from: start, to: colon)
-    let name = string(bytes, start..<nameEnd).lowercased()
+    let name = canonicalPropertyName(string(bytes, start..<nameEnd))
     guard !name.isEmpty else {
       throw CSSSourceEditorError.parseFailed("Declaration with empty property name at offset \(start)")
     }
@@ -454,7 +465,7 @@ struct CSSSourceEditor: CSSSourceEditing {
       )
     }
 
-    let propertyName = edit.property.lowercased()
+    let propertyName = canonicalPropertyName(edit.property)
 
     for (originalRule, editedRule) in zip(originalRules, editedRules) {
       guard originalRule.indexPath == editedRule.indexPath,

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/StylesheetSourceMapper.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/StylesheetSourceMapper.swift
@@ -23,7 +23,9 @@ enum WebPreviewStylesheetPreviewContext: Equatable, Sendable {
 }
 
 enum StylesheetMappingResult: Equatable, Sendable {
-  case proven(filePath: String, contentSHA256: String)
+  /// `embeddedStyleBlockIndex` is set when the rule lives in the N-th inline
+  /// `<style>` block of an HTML file rather than a standalone stylesheet.
+  case proven(filePath: String, contentSHA256: String, embeddedStyleBlockIndex: Int?)
   case unproven(reason: String)
 }
 
@@ -50,6 +52,15 @@ actor StylesheetSourceMapper: StylesheetSourceMapping {
     ruleLocator: WebPreviewCSSRuleLocator,
     context: WebPreviewStylesheetPreviewContext
   ) async -> StylesheetMappingResult {
+    // Inline <style> blocks have no href. On a dev server that serves
+    // project files verbatim, prove them by locating the same block ordinal
+    // inside the served HTML document.
+    if ruleLocator.stylesheetHref == nil,
+       ruleLocator.ownerNodeAttributes["data-vite-dev-id"] == nil,
+       case .devServer(let baseURL, let projectPath) = context {
+      return await mapInlineBlock(ruleLocator, baseURL: baseURL, projectPath: projectPath)
+    }
+
     let candidates = Self.candidatePaths(for: ruleLocator, context: context)
     guard !candidates.isEmpty else {
       return .unproven(reason: "No mappable source file for this stylesheet")
@@ -69,10 +80,66 @@ actor StylesheetSourceMapper: StylesheetSourceMapping {
         continue
       }
 
-      return .proven(filePath: candidate, contentSHA256: Self.sha256(of: content))
+      return .proven(filePath: candidate, contentSHA256: Self.sha256(of: content), embeddedStyleBlockIndex: nil)
     }
 
     return .unproven(reason: "No candidate file matched the runtime rule")
+  }
+
+  /// Proves a rule that lives in an inline `<style>` block: the served HTML
+  /// document must contain, at the same stylesheet index, an inline block
+  /// whose parsed rule at the same index path carries the same selector.
+  private func mapInlineBlock(
+    _ ruleLocator: WebPreviewCSSRuleLocator,
+    baseURL: URL,
+    projectPath: String
+  ) async -> StylesheetMappingResult {
+    for candidate in Self.servedDocumentCandidates(baseURL: baseURL, projectPath: projectPath) {
+      guard Self.isPath(candidate, inside: projectPath),
+            let html = try? await fileService.readFile(at: candidate, projectPath: projectPath) else {
+        continue
+      }
+      let sources = HTMLStylesheetScanner.stylesheetSources(in: html)
+      guard ruleLocator.styleSheetIndex >= 0,
+            ruleLocator.styleSheetIndex < sources.count,
+            case .inlineBlock(_, let ordinal, _) = sources[ruleLocator.styleSheetIndex],
+            let block = HTMLStylesheetScanner.inlineBlockContent(ordinal: ordinal, in: html) else {
+        continue
+      }
+      guard let document = try? cssEditor.parse(block.content),
+            let rule = document.rule(at: ruleLocator.ruleIndexPath),
+            let fileSelector = rule.normalizedSelectorText,
+            fileSelector == CSSSourceEditor.normalizeSelector(ruleLocator.selectorText) else {
+        continue
+      }
+      return .proven(
+        filePath: candidate,
+        contentSHA256: Self.sha256(of: html),
+        embeddedStyleBlockIndex: ordinal
+      )
+    }
+    return .unproven(reason: "The inline <style> block couldn't be matched to a served project file")
+  }
+
+  /// Which project file the dev server most plausibly served for a URL
+  /// path, in deterministic priority order.
+  static func servedDocumentCandidates(baseURL: URL, projectPath: String) -> [String] {
+    var urlPath = baseURL.path
+    if urlPath.isEmpty { urlPath = "/" }
+
+    var paths: [String] = []
+    if urlPath.hasSuffix("/") {
+      paths.append(normalize(path: projectPath + urlPath + "index.html"))
+    } else {
+      paths.append(normalize(path: projectPath + urlPath))
+      paths.append(normalize(path: projectPath + urlPath + "/index.html"))
+      if !URL(fileURLWithPath: urlPath).lastPathComponent.contains(".") {
+        paths.append(normalize(path: projectPath + urlPath + ".html"))
+      }
+    }
+
+    var seen = Set<String>()
+    return paths.filter { seen.insert($0).inserted }
   }
 
   static func sha256(of content: String) -> String {

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/WebPreviewDirectCSSWriteCoordinator.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/WebPreviewDirectCSSWriteCoordinator.swift
@@ -7,25 +7,47 @@
 //  agent edit is never clobbered; the splice itself enforces the
 //  CSSSourceEditor post-conditions before any bytes are written.
 //
+//  Before splicing, the edit is planned against the freshly-read source so the
+//  code's idioms (design tokens, clamp(), units, color notation) survive; an
+//  edit whose declared value already matches skips the write entirely.
+//
 
 import Foundation
 
 enum DirectWriteOutcome: Equatable, Sendable {
   case written(newSHA256: String)
+  /// The write landed, but it flattened a shared design token into a
+  /// literal — carries what the caller needs to offer promoting the edit to
+  /// a token-wide update instead.
+  case writtenWithTokenDetachment(newSHA256: String, detachment: CSSTokenDetachment)
   case baselineDrift
   case editFailed(String)
+
+  /// The post-write SHA for either success case.
+  var writtenSHA256: String? {
+    switch self {
+    case .written(let sha), .writtenWithTokenDetachment(let sha, _):
+      return sha
+    case .baselineDrift, .editFailed:
+      return nil
+    }
+  }
 }
 
 protocol WebPreviewDirectCSSWriting: Sendable {
   /// Applies one declaration edit. When `embeddedStyleBlockIndex` is set,
   /// `filePath` is an HTML file and the edit targets the CSS inside its N-th
   /// inline `<style>` block (blocks are re-located at write time so earlier
-  /// writes cannot invalidate offsets).
+  /// writes cannot invalidate offsets). The edit is planned against the
+  /// freshly-read source first so declared idioms (tokens, clamp(), units,
+  /// color notation) are preserved; `environment` supplies the page's unit
+  /// conversion context.
   func write(
     edit: CSSDeclarationEdit,
     filePath: String,
     embeddedStyleBlockIndex: Int?,
     expectedSHA256: String,
+    environment: WebPreviewPageEnvironment,
     projectPath: String
   ) async -> DirectWriteOutcome
 }
@@ -33,13 +55,16 @@ protocol WebPreviewDirectCSSWriting: Sendable {
 actor WebPreviewDirectCSSWriteCoordinator: WebPreviewDirectCSSWriting {
   private let fileService: any ProjectFileServiceProtocol
   private let cssEditor: any CSSSourceEditing
+  private let planner: any CSSDeclarationEditPlanning
 
   init(
     fileService: any ProjectFileServiceProtocol = ProjectFileService.shared,
-    cssEditor: any CSSSourceEditing = CSSSourceEditor()
+    cssEditor: any CSSSourceEditing = CSSSourceEditor(),
+    planner: any CSSDeclarationEditPlanning = CSSDeclarationEditPlanner()
   ) {
     self.fileService = fileService
     self.cssEditor = cssEditor
+    self.planner = planner
   }
 
   func write(
@@ -47,6 +72,7 @@ actor WebPreviewDirectCSSWriteCoordinator: WebPreviewDirectCSSWriting {
     filePath: String,
     embeddedStyleBlockIndex: Int?,
     expectedSHA256: String,
+    environment: WebPreviewPageEnvironment,
     projectPath: String
   ) async -> DirectWriteOutcome {
     let content: String
@@ -60,15 +86,27 @@ actor WebPreviewDirectCSSWriteCoordinator: WebPreviewDirectCSSWriting {
       return .baselineDrift
     }
 
+    let detachment: CSSTokenDetachment?
     let edited: String
     if let blockIndex = embeddedStyleBlockIndex {
       guard let block = HTMLStylesheetScanner.inlineBlockContent(ordinal: blockIndex, in: content) else {
         return .editFailed("Inline <style> block \(blockIndex) not found in \(filePath)")
       }
 
+      guard let plan = await plan(
+        edit,
+        for: block.content,
+        siblingSource: .embeddedBlock(html: content, ordinal: blockIndex, htmlPath: filePath),
+        environment: environment,
+        projectPath: projectPath
+      ), let plannedEdit = plan.edit else {
+        return .written(newSHA256: expectedSHA256)
+      }
+      detachment = plan.tokenDetachment
+
       let editedBlock: String
       do {
-        editedBlock = try cssEditor.applyingDeclarationEdit(edit, to: block.content)
+        editedBlock = try cssEditor.applyingDeclarationEdit(plannedEdit, to: block.content)
       } catch {
         return .editFailed("Edit rejected: \(error)")
       }
@@ -84,8 +122,19 @@ actor WebPreviewDirectCSSWriteCoordinator: WebPreviewDirectCSSWriting {
       }
       edited = spliced
     } else {
+      guard let plan = await plan(
+        edit,
+        for: content,
+        siblingSource: .cssFile(path: filePath),
+        environment: environment,
+        projectPath: projectPath
+      ), let plannedEdit = plan.edit else {
+        return .written(newSHA256: expectedSHA256)
+      }
+      detachment = plan.tokenDetachment
+
       do {
-        edited = try cssEditor.applyingDeclarationEdit(edit, to: content)
+        edited = try cssEditor.applyingDeclarationEdit(plannedEdit, to: content)
       } catch {
         return .editFailed("Edit rejected: \(error)")
       }
@@ -101,6 +150,106 @@ actor WebPreviewDirectCSSWriteCoordinator: WebPreviewDirectCSSWriting {
       return .editFailed("Write failed: \(error.localizedDescription)")
     }
 
-    return .written(newSHA256: StylesheetSourceMapper.sha256(of: edited))
+    let newSHA256 = StylesheetSourceMapper.sha256(of: edited)
+    if let detachment {
+      return .writtenWithTokenDetachment(newSHA256: newSHA256, detachment: detachment)
+    }
+    return .written(newSHA256: newSHA256)
   }
+
+  // MARK: - Planning
+
+  /// Where the edited CSS lives, so sibling stylesheets can be gathered for
+  /// cross-file token resolution.
+  private enum EditedSource {
+    case cssFile(path: String)
+    case embeddedBlock(html: String, ordinal: Int, htmlPath: String)
+  }
+
+  /// Runs the deterministic planner against the source the edit targets.
+  /// Nil means the declaration already holds the desired value — skip the
+  /// write. If the source cannot be parsed the original edit is used and the
+  /// splice's own post-conditions remain the safety net.
+  private func plan(
+    _ edit: CSSDeclarationEdit,
+    for source: String,
+    siblingSource: EditedSource,
+    environment: WebPreviewPageEnvironment,
+    projectPath: String
+  ) async -> CSSDeclarationEditPlan? {
+    guard let document = try? cssEditor.parse(source) else {
+      return CSSDeclarationEditPlan(edit: edit, strategy: .passthrough)
+    }
+
+    // Sibling stylesheets only influence token planning; skip the project
+    // scan when the edited declaration holds no `var()` reference.
+    var siblings: [CSSSourceDocument] = []
+    if editTargetsVarReference(edit, in: document) {
+      siblings = await siblingDocuments(for: siblingSource, projectPath: projectPath)
+    }
+
+    let plan = planner.plan(edit, in: document, siblings: siblings, environment: environment)
+    if case .noChange = plan.strategy { return nil }
+    if plan.edit == nil {
+      return CSSDeclarationEditPlan(
+        edit: edit,
+        strategy: plan.strategy,
+        tokenDetachment: plan.tokenDetachment
+      )
+    }
+    return plan
+  }
+
+  private func editTargetsVarReference(_ edit: CSSDeclarationEdit, in document: CSSSourceDocument) -> Bool {
+    guard let rule = document.rule(at: edit.ruleIndexPath),
+          let declaration = rule.declarations.last(where: {
+            $0.name == CSSSourceEditor.canonicalPropertyName(edit.property)
+          }) else {
+      return false
+    }
+    return CSSDeclarationEditPlanner.pureVarReference(declaration.valueText) != nil
+  }
+
+  /// Parses every other stylesheet the page could reach: the project's CSS
+  /// files (bounded) and, when editing an inline <style> block, the sibling
+  /// blocks of the same HTML file.
+  private func siblingDocuments(
+    for source: EditedSource,
+    projectPath: String
+  ) async -> [CSSSourceDocument] {
+    var documents: [CSSSourceDocument] = []
+
+    let cssPaths = await fileService.listTextFiles(in: projectPath, extensions: ["css"])
+    let excludedPath: String? = {
+      if case .cssFile(let path) = source { return path }
+      return nil
+    }()
+    for path in cssPaths.prefix(Self.maxSiblingStylesheets) where path != excludedPath {
+      guard let css = try? await fileService.readFile(at: path, projectPath: projectPath),
+            let document = try? cssEditor.parse(css) else {
+        continue
+      }
+      documents.append(document)
+    }
+
+    if case .embeddedBlock(let html, let ordinal, _) = source {
+      for blockSource in HTMLStylesheetScanner.stylesheetSources(in: html) {
+        guard case .inlineBlock(let contentRange, let blockOrdinal, _) = blockSource,
+              blockOrdinal != ordinal else {
+          continue
+        }
+        let bytes = Array(html.utf8)
+        guard contentRange.lowerBound >= 0, contentRange.upperBound <= bytes.count,
+              let css = String(bytes: bytes[contentRange], encoding: .utf8),
+              let document = try? cssEditor.parse(css) else {
+          continue
+        }
+        documents.append(document)
+      }
+    }
+
+    return documents
+  }
+
+  private static let maxSiblingStylesheets = 64
 }

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/WebPreviewPageEnvironmentCapture.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/WebPreviewPageEnvironmentCapture.swift
@@ -1,0 +1,85 @@
+//
+//  WebPreviewPageEnvironmentCapture.swift
+//  AgentHub
+//
+//  Reads the page's unit-conversion context (viewport size, root/element/
+//  parent font sizes) so deterministic edit planning can convert between
+//  CSS units exactly as the browser would. Works on both dev-server and
+//  static previews — it needs no stylesheet access, only computed styles.
+//
+
+import Foundation
+import WebKit
+
+enum WebPreviewPageEnvironmentScript {
+
+  static func script(selector: String) -> String? {
+    guard let selectorData = try? JSONSerialization.data(withJSONObject: [selector]),
+          let selectorArray = String(data: selectorData, encoding: .utf8) else {
+      return nil
+    }
+    let selectorJSON = String(selectorArray.dropFirst().dropLast())
+
+    return """
+    (function() {
+      var SELECTOR = \(selectorJSON);
+
+      function fontSize(node) {
+        try {
+          var value = parseFloat(window.getComputedStyle(node).fontSize);
+          return isFinite(value) && value > 0 ? value : null;
+        } catch (err) { return null; }
+      }
+
+      var el = null;
+      try { el = document.querySelector(SELECTOR); } catch (err) {}
+
+      var root = fontSize(document.documentElement);
+      var element = el ? fontSize(el) : null;
+      var parent = el && el.parentElement ? fontSize(el.parentElement) : null;
+
+      return {
+        viewportWidth: window.innerWidth || null,
+        viewportHeight: window.innerHeight || null,
+        rootFontSize: root,
+        elementFontSize: element || root,
+        parentFontSize: parent || root
+      };
+    })();
+    """
+  }
+}
+
+@MainActor
+protocol WebPreviewPageEnvironmentCapturing {
+  func captureEnvironment(
+    selector: String,
+    in webView: WKWebView
+  ) async -> WebPreviewPageEnvironment?
+}
+
+@MainActor
+struct WebPreviewPageEnvironmentCapture: WebPreviewPageEnvironmentCapturing {
+  init() {}
+
+  func captureEnvironment(
+    selector: String,
+    in webView: WKWebView
+  ) async -> WebPreviewPageEnvironment? {
+    guard let script = WebPreviewPageEnvironmentScript.script(selector: selector) else {
+      return nil
+    }
+
+    let result: Any? = await withCheckedContinuation { continuation in
+      webView.evaluateJavaScript(script) { value, error in
+        if error != nil {
+          continuation.resume(returning: nil)
+          return
+        }
+        continuation.resume(returning: value)
+      }
+    }
+
+    return WebPreviewPageEnvironment.parse(result)
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/WebPreviewStaticMatchProbe.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/WebPreviewStaticMatchProbe.swift
@@ -18,6 +18,23 @@ struct WebPreviewStaticMatchVerdicts: Equatable, Sendable {
   let supportsMatches: [Bool]
   /// Property → declared value on the element's `style` attribute.
   let inlineStyles: [String: String]
+  /// Every property name the element's `style` attribute declares (longhands
+  /// included), so insertions can detect shorthand interference.
+  let inlineDeclaredNames: [String]
+
+  init(
+    selectorMatches: [Bool],
+    mediaMatches: [Bool],
+    supportsMatches: [Bool],
+    inlineStyles: [String: String],
+    inlineDeclaredNames: [String] = []
+  ) {
+    self.selectorMatches = selectorMatches
+    self.mediaMatches = mediaMatches
+    self.supportsMatches = supportsMatches
+    self.inlineStyles = inlineStyles
+    self.inlineDeclaredNames = inlineDeclaredNames
+  }
 
   static func parse(_ body: Any?) -> WebPreviewStaticMatchVerdicts? {
     guard let dictionary = body as? [String: Any],
@@ -31,7 +48,8 @@ struct WebPreviewStaticMatchVerdicts: Equatable, Sendable {
       selectorMatches: selectorMatches,
       mediaMatches: mediaMatches,
       supportsMatches: supportsMatches,
-      inlineStyles: dictionary["inline"] as? [String: String] ?? [:]
+      inlineStyles: dictionary["inline"] as? [String: String] ?? [:],
+      inlineDeclaredNames: dictionary["inlineNames"] as? [String] ?? []
     )
   }
 
@@ -128,7 +146,12 @@ struct WebPreviewStaticMatchProbe: WebPreviewStaticMatchProbing {
         } catch (err) {}
       });
 
-      return { ok: true, matches: matches, media: media, supports: supports, inline: inline };
+      var inlineNames = [];
+      try {
+        for (var n = 0; n < el.style.length; n++) { inlineNames.push(el.style[n]); }
+      } catch (err) {}
+
+      return { ok: true, matches: matches, media: media, supports: supports, inline: inline, inlineNames: inlineNames };
     })();
     """
   }

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/WebPreviewStaticStyleResolver.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/WebPreviewStaticStyleResolver.swift
@@ -154,12 +154,29 @@ struct WebPreviewStaticStyleResolver: WebPreviewStaticStyleResolving {
       return [:]
     }
 
-    let winners = Self.computeWinners(
+    var winners = Self.computeWinners(
       candidates: candidates,
       selectorIndex: selectorIndex,
       verdicts: verdicts,
       properties: properties
     )
+
+    // Properties no stylesheet declares at all still deserve an exact write:
+    // insert them into the element's best unconditioned matching rule.
+    if let anchor = Self.insertionAnchor(
+      candidates: candidates,
+      selectorIndex: selectorIndex,
+      verdicts: verdicts
+    ) {
+      for property in Self.insertableProperties(
+        candidates: candidates,
+        selectorIndex: selectorIndex,
+        verdicts: verdicts,
+        properties: properties
+      ) where winners[property] == nil {
+        winners[property] = anchor
+      }
+    }
 
     var targets: [String: WebPreviewDirectStyleTarget] = [:]
     for (property, winner) in winners {
@@ -270,6 +287,88 @@ struct WebPreviewStaticStyleResolver: WebPreviewStaticStyleResolving {
     }
 
     return winners
+  }
+
+  /// The rule a brand-new declaration should be inserted into: the matching,
+  /// unflagged, unconditioned (no media/supports) candidate with the highest
+  /// specificity, breaking ties by source order. Conditioned rules are
+  /// excluded because an inserted declaration must apply in every
+  /// environment, exactly like the live edit the user previewed.
+  nonisolated static func insertionAnchor(
+    candidates: [StaticStyleRuleCandidate],
+    selectorIndex: [String: Int],
+    verdicts: WebPreviewStaticMatchVerdicts
+  ) -> StaticStyleRuleCandidate? {
+    var best: (candidate: StaticStyleRuleCandidate, specificity: [Int], order: Int)?
+
+    for (order, candidate) in candidates.enumerated() {
+      guard !candidate.isFlagged,
+            candidate.mediaConditionIndices.isEmpty,
+            candidate.supportsConditionIndices.isEmpty else {
+        continue
+      }
+
+      var bestSpecificity: [Int]?
+      var hasComplexPart = false
+      for part in candidate.selectorParts {
+        guard let flatIndex = selectorIndex[part],
+              flatIndex < verdicts.selectorMatches.count,
+              verdicts.selectorMatches[flatIndex] else {
+          continue
+        }
+        if CSSSelectorSpecificity.hasComplexPseudo(part) {
+          hasComplexPart = true
+          break
+        }
+        let specificity = CSSSelectorSpecificity.compute(part)
+        if bestSpecificity == nil || CSSSelectorSpecificity.compare(specificity, bestSpecificity!) > 0 {
+          bestSpecificity = specificity
+        }
+      }
+      guard !hasComplexPart, let specificity = bestSpecificity else { continue }
+
+      if let current = best {
+        let comparison = CSSSelectorSpecificity.compare(specificity, current.specificity)
+        if comparison > 0 || (comparison == 0 && order >= current.order) {
+          best = (candidate, specificity, order)
+        }
+      } else {
+        best = (candidate, specificity, order)
+      }
+    }
+
+    return best?.candidate
+  }
+
+  /// Properties that are safe to insert: no rule that matches the element
+  /// (or whose match is uncertain — flagged/nested) declares them or a
+  /// related shorthand/longhand, and the element's style attribute doesn't
+  /// either. Conditioned rules count even when their condition doesn't
+  /// currently hold, so a resize can't reorder the persisted cascade.
+  nonisolated static func insertableProperties(
+    candidates: [StaticStyleRuleCandidate],
+    selectorIndex: [String: Int],
+    verdicts: WebPreviewStaticMatchVerdicts,
+    properties: [String]
+  ) -> [String] {
+    var declared = Set(verdicts.inlineDeclaredNames.map { $0.lowercased() })
+    declared.formUnion(verdicts.inlineStyles.keys.map { $0.lowercased() })
+
+    for candidate in candidates {
+      let matchIsRelevant = candidate.isFlagged || candidate.selectorParts.contains { part in
+        guard let flatIndex = selectorIndex[part],
+              flatIndex < verdicts.selectorMatches.count else {
+          return false
+        }
+        return verdicts.selectorMatches[flatIndex]
+      }
+      guard matchIsRelevant else { continue }
+      for declaration in candidate.declarations {
+        declared.insert(declaration.name.lowercased())
+      }
+    }
+
+    return properties.filter { !CSSPropertyFamily.conflicts($0, with: declared) }
   }
 
   // MARK: - Rule collection

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/WebPreviewStyleProvenanceScript.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/WebPreviewStyleProvenanceScript.swift
@@ -35,9 +35,25 @@ enum WebPreviewStyleProvenanceScript {
       var orderCounter = 0;
       var candidates = {};
       PROPERTIES.forEach(function(p) { candidates[p] = []; });
+      var declaredNames = {};
+      var anchorBest = null;
 
       var adoptedSheets = [];
       try { adoptedSheets = Array.prototype.slice.call(document.adoptedStyleSheets || []); } catch (err) {}
+
+      // Font CDNs only serve @font-face rules, which never compete in the
+      // element cascade — an unreadable sheet from one of these hosts can't
+      // contradict a computed winner or an insertion.
+      var BENIGN_SHEET_HOSTS = [
+        'fonts.googleapis.com', 'fonts.gstatic.com', 'use.typekit.net',
+        'fonts.bunny.net', 'fonts.cdnfonts.com'
+      ];
+      function isBenignUnreadableSheet(href) {
+        if (!href) { return false; }
+        try {
+          return BENIGN_SHEET_HOSTS.indexOf(new URL(href, location.href).host) >= 0;
+        } catch (err) { return false; }
+      }
 
       function isType(rule, name) {
         try {
@@ -129,6 +145,36 @@ enum WebPreviewStyleProvenanceScript {
         var isNested = selectorText.indexOf('&') >= 0 || (ctx.nestedParent === true);
         if (!matched && !isNested) { return; }
 
+        try {
+          for (var d = 0; d < rule.style.length; d++) { declaredNames[rule.style[d]] = true; }
+        } catch (err) {}
+        // Rules in inactive media/supports branches only contribute their
+        // declared names (so insertions steer clear of them) — they can't
+        // win the cascade right now.
+        if (ctx.inactive) { orderCounter += 1; return; }
+
+        // Insertion anchor: the plainest matching rule (no uncertainty
+        // flags, no media/supports condition, no complex pseudo) with the
+        // highest specificity; source order breaks ties.
+        if (matched && !isNested && !ctx.conditioned && !ctx.adopted
+            && contextFlags(ctx).length === 0
+            && !selectorHasComplexPseudo(selectorText)) {
+          var anchorSpec = matchingSpecificity(selectorText);
+          if (anchorSpec && (!anchorBest
+              || compareSpecificity(anchorSpec, anchorBest.spec) > 0
+              || (compareSpecificity(anchorSpec, anchorBest.spec) === 0 && orderCounter >= anchorBest.order))) {
+            anchorBest = {
+              spec: anchorSpec,
+              order: orderCounter,
+              sheetIndex: sheetIndex,
+              path: path,
+              selectorText: selectorText,
+              href: sheet.href || null,
+              ownerNodeAttributes: ownerNodeAttributes(sheet)
+            };
+          }
+        }
+
         for (var i = 0; i < PROPERTIES.length; i++) {
           var property = PROPERTIES[i];
           var value = '';
@@ -173,11 +219,13 @@ enum WebPreviewStyleProvenanceScript {
             try {
               mediaMatches = window.matchMedia(rule.conditionText || rule.media.mediaText).matches;
             } catch (err) {}
-            if (mediaMatches) { walkRules(rule.cssRules, path, sheetIndex, sheet, ctx); }
+            walkRules(rule.cssRules, path, sheetIndex, sheet,
+              mergeCtx(ctx, mediaMatches ? { conditioned: true } : { conditioned: true, inactive: true }));
           } else if (isType(rule, 'CSSSupportsRule')) {
             var supported = false;
             try { supported = CSS.supports(rule.conditionText); } catch (err) {}
-            if (supported) { walkRules(rule.cssRules, path, sheetIndex, sheet, ctx); }
+            walkRules(rule.cssRules, path, sheetIndex, sheet,
+              mergeCtx(ctx, supported ? { conditioned: true } : { conditioned: true, inactive: true }));
           } else if (isType(rule, 'CSSLayerBlockRule')) {
             walkRules(rule.cssRules, path, sheetIndex, sheet, mergeCtx(ctx, { layer: true }));
           } else if (isType(rule, 'CSSContainerRule')) {
@@ -197,7 +245,9 @@ enum WebPreviewStyleProvenanceScript {
         var sheet = documentSheets[s];
         var rules = null;
         try { rules = sheet.cssRules; } catch (err) {
-          unreadableSheets.push(sheet.href || '(inline)');
+          if (!isBenignUnreadableSheet(sheet.href)) {
+            unreadableSheets.push(sheet.href || '(inline)');
+          }
           continue;
         }
         walkRules(rules, [], s, sheet, {});
@@ -279,11 +329,26 @@ enum WebPreviewStyleProvenanceScript {
         if (winner) { winners.push(winner); }
       }
 
+      var inlineNames = [];
+      try {
+        for (var n = 0; n < el.style.length; n++) { inlineNames.push(el.style[n]); }
+      } catch (err) {}
+
       return {
         ok: true,
         winners: winners,
         unreadableSheets: unreadableSheets,
-        hasAdoptedSheets: adoptedSheets.length > 0
+        hasAdoptedSheets: adoptedSheets.length > 0,
+        declaredNames: Object.keys(declaredNames),
+        inlineNames: inlineNames,
+        anchor: anchorBest ? {
+          stylesheetHref: anchorBest.href,
+          styleSheetIndex: anchorBest.sheetIndex,
+          ruleIndexPath: anchorBest.path,
+          selectorText: anchorBest.selectorText,
+          specificity: anchorBest.spec,
+          ownerNodeAttributes: anchorBest.ownerNodeAttributes
+        } : null
       };
     })();
     """

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/WebPreviewTokenPromotionBar.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/WebPreviewTokenPromotionBar.swift
@@ -1,0 +1,58 @@
+//
+//  WebPreviewTokenPromotionBar.swift
+//  AgentHub
+//
+//  Floating pill offered right after a style edit detached from a shared
+//  design token: promote the edit into a token-wide update (rewriting the
+//  token's definition) or dismiss to keep the element-scoped literal.
+//
+
+import SwiftUI
+
+struct WebPreviewTokenPromotionBar: View {
+  let offer: WebPreviewTokenPromotionOffer
+  let onPromote: () -> Void
+  let onDismiss: () -> Void
+
+  init(
+    offer: WebPreviewTokenPromotionOffer,
+    onPromote: @escaping () -> Void,
+    onDismiss: @escaping () -> Void
+  ) {
+    self.offer = offer
+    self.onPromote = onPromote
+    self.onDismiss = onDismiss
+  }
+
+  var body: some View {
+    HStack(spacing: 10) {
+      Image(systemName: "circle.hexagongrid")
+        .font(.system(size: 11))
+        .foregroundStyle(.secondary)
+
+      Text(offer.contextLabel)
+        .font(.system(size: 11, weight: .medium))
+        .foregroundStyle(.primary)
+
+      Button(action: onPromote) {
+        Text(offer.actionLabel)
+          .font(.system(size: 11, weight: .semibold))
+      }
+      .controlSize(.small)
+      .help("Rewrite \(offer.token)'s definition so every element using it updates")
+
+      Button(action: onDismiss) {
+        Image(systemName: "xmark")
+          .font(.system(size: 9, weight: .semibold))
+          .foregroundStyle(.secondary)
+      }
+      .buttonStyle(.plain)
+      .help("Keep the change scoped to this element")
+    }
+    .padding(.horizontal, 12)
+    .padding(.vertical, 6)
+    .background(.ultraThinMaterial, in: Capsule())
+    .shadow(color: .black.opacity(0.08), radius: 8, y: 3)
+    .contentShape(Capsule())
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/WebPreviewView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/WebPreviewView.swift
@@ -1340,6 +1340,16 @@ public struct WebPreviewView: View {
                   handleInspectOverlayHover(hovering)
                 }
               }
+              if inspectBehavior == .edit, let offer = inspectorViewModel.tokenPromotionOffer {
+                WebPreviewTokenPromotionBar(
+                  offer: offer,
+                  onPromote: { Task { await inspectorViewModel.promoteTokenDetachment() } },
+                  onDismiss: inspectorViewModel.dismissTokenPromotionOffer
+                )
+                .inspectOverlayCursor(label: "tokenPromotionBar") { hovering in
+                  handleInspectOverlayHover(hovering)
+                }
+              }
             }
           }
         }

--- a/app/modules/AgentHubCore/Sources/AgentHub/Utils/CSSPropertyFamily.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Utils/CSSPropertyFamily.swift
@@ -1,0 +1,46 @@
+//
+//  CSSPropertyFamily.swift
+//  AgentHub
+//
+//  Shorthand/longhand interference detection for direct-write insertions.
+//  A brand-new declaration is only inserted when no related declaration
+//  exists anywhere, so the persisted cascade always matches the live
+//  preview the user approved.
+//
+
+import Foundation
+
+enum CSSPropertyFamily {
+
+  /// True when inserting `property` as a fresh declaration could interact
+  /// with any of `declaredNames`: the property itself, one of its longhands
+  /// (`margin` vs `margin-top`), or a shorthand that covers it
+  /// (`font-size` vs `font`, `top` vs `inset`).
+  static func conflicts(_ property: String, with declaredNames: Set<String>) -> Bool {
+    let name = property.lowercased()
+    if declaredNames.contains(name) {
+      return true
+    }
+    // Longhands and logical variants of an edited shorthand share its prefix
+    // (`margin-top`, `margin-block-start`, `padding-inline`, …).
+    if declaredNames.contains(where: { $0.hasPrefix(name + "-") }) {
+      return true
+    }
+
+    switch name {
+    case "background-color":
+      return declaredNames.contains("background")
+    case "font-size", "font-family", "font-weight", "line-height":
+      return declaredNames.contains("font")
+    case "border-radius":
+      // Corner longhands are not prefixed by the shorthand
+      // (`border-top-left-radius`).
+      return declaredNames.contains { $0.hasSuffix("-radius") }
+    case "top", "left":
+      return declaredNames.contains("inset")
+        || declaredNames.contains { $0.hasPrefix("inset-") }
+    default:
+      return false
+    }
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/WebPreviewInspectorViewModel.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/WebPreviewInspectorViewModel.swift
@@ -47,6 +47,7 @@ final class WebPreviewInspectorViewModel {
   private let stylesheetSourceMapper: any StylesheetSourceMapping
   private let staticStyleResolver: any WebPreviewStaticStyleResolving
   private let directWriteCoordinator: any WebPreviewDirectCSSWriting
+  private let pageEnvironmentCapture: any WebPreviewPageEnvironmentCapturing
   private let isDirectCSSWriteEnabled: () -> Bool
 
   private var pendingWriteTask: Task<Void, Never>?
@@ -62,6 +63,9 @@ final class WebPreviewInspectorViewModel {
   private var trackedStructuredTextContent: SourceTextContentMapping?
   private var userConfirmedLowConfidenceFile = false
   private weak var previewWebView: WKWebView?
+  /// Unit-conversion context read from the page for the selected element;
+  /// direct writes fall back to `.fallback` when the probe fails.
+  private var pageEnvironment: WebPreviewPageEnvironment?
 
   private(set) var selectedElement: ElementInspectorData?
   private(set) var resolution: WebPreviewSourceResolution?
@@ -71,7 +75,15 @@ final class WebPreviewInspectorViewModel {
   private(set) var consoleEntries: [String] = []
   private(set) var pendingEditBatch: WebPreviewPendingDesignEditBatch?
   private(set) var styleTiers: [String: WebPreviewStyleEditTier] = [:]
+  /// Property → short human-readable reason why it routes to the agent tier.
+  private(set) var styleTierReasons: [String: String] = [:]
+  /// Blanket reason when tier proving could not run at all (probe failed,
+  /// element inside a frame, direct writes disabled, …).
+  private(set) var styleTierGeneralReason: String?
   private(set) var sourceHints: [WebPreviewElementSourceHint] = []
+  /// Set when the latest direct write detached from a shared design token
+  /// and can be promoted to a token-wide update instead.
+  private(set) var tokenPromotionOffer: WebPreviewTokenPromotionOffer?
 
   var isPanelVisible = false
   var isResolving = false
@@ -101,6 +113,7 @@ final class WebPreviewInspectorViewModel {
     stylesheetSourceMapper: (any StylesheetSourceMapping)? = nil,
     staticStyleResolver: (any WebPreviewStaticStyleResolving)? = nil,
     directWriteCoordinator: (any WebPreviewDirectCSSWriting)? = nil,
+    pageEnvironmentCapture: (any WebPreviewPageEnvironmentCapturing)? = nil,
     isDirectCSSWriteEnabled: (() -> Bool)? = nil
   ) {
     self.sessionID = sessionID
@@ -114,6 +127,7 @@ final class WebPreviewInspectorViewModel {
     self.stylesheetSourceMapper = stylesheetSourceMapper ?? StylesheetSourceMapper(fileService: fileService)
     self.staticStyleResolver = staticStyleResolver ?? WebPreviewStaticStyleResolver(fileService: fileService)
     self.directWriteCoordinator = directWriteCoordinator ?? WebPreviewDirectCSSWriteCoordinator(fileService: fileService)
+    self.pageEnvironmentCapture = pageEnvironmentCapture ?? WebPreviewPageEnvironmentCapture()
     self.isDirectCSSWriteEnabled = isDirectCSSWriteEnabled ?? {
       UserDefaults.standard.object(forKey: AgentHubDefaults.webPreviewDirectCSSWriteEnabled) as? Bool ?? true
     }
@@ -172,7 +186,29 @@ final class WebPreviewInspectorViewModel {
     if directFileNames.count > 1 {
       return "Edits \(directFileNames.count) stylesheets directly"
     }
+    if let reason = dominantAgentTierReason {
+      return "Applies via agent · \(reason)"
+    }
     return "Applies via agent"
+  }
+
+  /// Why the pending edits route to the agent. Reasons for properties the
+  /// user actually edited take priority over the rest of the element's
+  /// properties; ties break alphabetically so the label is deterministic.
+  var dominantAgentTierReason: String? {
+    let pendingReasons = (pendingEditBatch?.styleChanges ?? [])
+      .compactMap { styleTierReasons[$0.property] }
+    let pool = pendingReasons.isEmpty ? Array(styleTierReasons.values) : pendingReasons
+    let counts = pool.reduce(into: [String: Int]()) { $0[$1, default: 0] += 1 }
+    let dominant = counts.max { lhs, rhs in
+      (lhs.value, rhs.key) < (rhs.value, lhs.key)
+    }
+    return dominant?.key ?? styleTierGeneralReason
+  }
+
+  /// The reason a specific property cannot be written directly, if known.
+  func agentTierReason(for property: String) -> String? {
+    styleTierReasons[property] ?? styleTierGeneralReason
   }
 
   /// True when the loaded source file is the file being previewed directly
@@ -381,6 +417,9 @@ final class WebPreviewInspectorViewModel {
     resolution = nil
     pendingEditBatch = nil
     styleTiers = [:]
+    styleTierReasons = [:]
+    styleTierGeneralReason = nil
+    tokenPromotionOffer = nil
     sourceHints = []
     pendingDirectWrites = [:]
     self.previewFilePath = previewFilePath
@@ -445,6 +484,9 @@ final class WebPreviewInspectorViewModel {
     resolution = nil
     pendingEditBatch = nil
     styleTiers = [:]
+    styleTierReasons = [:]
+    styleTierGeneralReason = nil
+    tokenPromotionOffer = nil
     sourceHints = []
     pendingDirectWrites = [:]
     stylesheetContext = nil
@@ -833,21 +875,43 @@ final class WebPreviewInspectorViewModel {
   private func refreshStyleTiers(for element: ElementInspectorData) {
     provenanceTask?.cancel()
     styleTiers = [:]
+    styleTierReasons = [:]
+    styleTierGeneralReason = nil
+    pageEnvironment = nil
 
-    guard isDirectCSSWriteEnabled(),
-          let stylesheetContext,
-          let previewWebView else {
+    guard isDirectCSSWriteEnabled() else {
+      styleTierGeneralReason = "direct writes are disabled"
+      return
+    }
+    guard let stylesheetContext else {
+      styleTierGeneralReason = "the preview source is unknown"
+      return
+    }
+    guard let previewWebView else {
+      styleTierGeneralReason = "the preview is not connected"
       return
     }
 
     let selector = element.cssSelector.trimmingCharacters(in: .whitespacesAndNewlines)
-    guard !selector.isEmpty else { return }
+    guard !selector.isEmpty else {
+      styleTierGeneralReason = "the element has no usable selector"
+      return
+    }
 
     let properties = WebPreviewStyleProperty.allCases.map(\.rawValue)
     provenanceTask = Task { [weak self, weak previewWebView] in
       guard let self, let previewWebView else { return }
 
+      let environment = await self.pageEnvironmentCapture.captureEnvironment(
+        selector: selector,
+        in: previewWebView
+      )
+      guard !Task.isCancelled, self.selectedElement?.id == element.id else { return }
+      self.pageEnvironment = environment
+
       let tiers: [String: WebPreviewStyleEditTier]
+      var reasons: [String: String] = [:]
+      var generalReason: String?
       switch stylesheetContext {
       case .directFile(let servedFilePath, let contextProjectPath):
         // Static previews: CSSOM cannot read file:// linked stylesheets, but
@@ -861,20 +925,32 @@ final class WebPreviewInspectorViewModel {
           in: previewWebView
         )
         tiers = targets.mapValues { .direct($0) }
+        for property in properties where targets[property] == nil {
+          reasons[property] = "no matching rule in the served stylesheets"
+        }
 
       case .devServer:
         guard let provenance = await self.styleProvenanceCapture.captureProvenance(
           selector: selector,
           properties: properties,
           in: previewWebView
-        ) else { return }
+        ) else {
+          guard !Task.isCancelled, self.selectedElement?.id == element.id else { return }
+          // The probe anchors via the top document; a frame-hosted element
+          // or a failed script leaves nothing provable.
+          self.styleTierGeneralReason = "the element's styles couldn't be probed"
+          return
+        }
         guard !Task.isCancelled, self.selectedElement?.id == element.id else { return }
 
         var resolved: [String: WebPreviewStyleEditTier] = [:]
         var mappingCache: [WebPreviewCSSRuleLocator: StylesheetMappingResult] = [:]
 
-        for winner in provenance.winners where winner.isProvable {
-          guard let rule = winner.rule else { continue }
+        for winner in provenance.winners {
+          guard winner.isProvable, let rule = winner.rule else {
+            reasons[winner.property] = Self.agentReason(for: winner)
+            continue
+          }
           let result: StylesheetMappingResult
           if let cached = mappingCache[rule] {
             result = cached
@@ -886,20 +962,123 @@ final class WebPreviewInspectorViewModel {
             mappingCache[rule] = result
           }
           guard !Task.isCancelled else { return }
-          if case .proven(let filePath, let contentSHA256) = result {
+          if case .proven(let filePath, let contentSHA256, let blockIndex) = result {
             resolved[winner.property] = .direct(WebPreviewDirectStyleTarget(
               filePath: filePath,
               ruleIndexPath: rule.ruleIndexPath,
-              contentSHA256: contentSHA256
+              contentSHA256: contentSHA256,
+              embeddedStyleBlockIndex: blockIndex
             ))
+          } else {
+            reasons[winner.property] = "the rule didn't match a project file"
           }
+        }
+
+        // Properties no rule declares at all: insert them into the
+        // element's plainest matching rule when that rule maps to a
+        // project file and no hidden sheet could contradict the proof.
+        // When insertion is impossible, record WHICH guard blocked it so
+        // the pending-edits pill can say so.
+        let coveredProperties = Set(provenance.winners.map(\.property))
+        let uncoveredProperties = properties.filter { !coveredProperties.contains($0) }
+        var insertionBlocker: String?
+        if !provenance.unreadableSheetHrefs.isEmpty {
+          insertionBlocker = "a stylesheet isn't readable, so new rules can't be proven"
+        } else if provenance.hasAdoptedSheets {
+          insertionBlocker = "the page injects styles via constructed stylesheets"
+        } else if provenance.anchorRule == nil {
+          insertionBlocker = "no plain rule matches the element"
+        }
+        if !uncoveredProperties.isEmpty, insertionBlocker == nil,
+           let anchor = provenance.anchorRule {
+          let result: StylesheetMappingResult
+          if let cached = mappingCache[anchor] {
+            result = cached
+          } else {
+            result = await self.stylesheetSourceMapper.mapToProvenFile(
+              ruleLocator: anchor,
+              context: stylesheetContext
+            )
+            mappingCache[anchor] = result
+          }
+          guard !Task.isCancelled else { return }
+          switch result {
+          case .proven(let filePath, let contentSHA256, let blockIndex):
+            let blockers = Set(
+              (provenance.declaredPropertyNames + provenance.inlinePropertyNames).map { $0.lowercased() }
+            )
+            for property in uncoveredProperties {
+              if CSSPropertyFamily.conflicts(property, with: blockers) {
+                reasons[property] = "it overlaps a property the page already sets"
+              } else {
+                resolved[property] = .direct(WebPreviewDirectStyleTarget(
+                  filePath: filePath,
+                  ruleIndexPath: anchor.ruleIndexPath,
+                  contentSHA256: contentSHA256,
+                  embeddedStyleBlockIndex: blockIndex
+                ))
+              }
+            }
+          case .unproven:
+            insertionBlocker = "the element's rule isn't in a project file"
+          }
+        }
+        for property in uncoveredProperties
+        where resolved[property] == nil && reasons[property] == nil {
+          reasons[property] = insertionBlocker ?? "no existing rule sets it"
+        }
+        if resolved.isEmpty, reasons.isEmpty {
+          generalReason = "the element's styles couldn't be probed"
         }
         tiers = resolved
       }
 
       guard !Task.isCancelled, self.selectedElement?.id == element.id else { return }
       self.styleTiers = tiers
+      self.styleTierReasons = reasons
+      self.styleTierGeneralReason = generalReason
+      self.rerouteBatchedEditsAfterTierRefresh()
     }
+  }
+
+  /// Short label for why a winning declaration is not directly writable.
+  private static func agentReason(for winner: WebPreviewPropertyWinner) -> String {
+    if winner.isInline {
+      return "an inline style attribute overrides it"
+    }
+    guard let uncertainty = winner.uncertainties.sorted(by: { $0.rawValue < $1.rawValue }).first else {
+      return "the owning rule couldn't be located"
+    }
+    switch uncertainty {
+    case .layer: return "the rule lives in an @layer block"
+    case .scope: return "the rule lives in an @scope block"
+    case .containerQuery: return "the rule lives in a container query"
+    case .unknownGroup: return "the rule lives in an unrecognized at-rule"
+    case .adoptedSheet: return "styles come from a constructed stylesheet"
+    case .unreadableSheet: return "the stylesheet isn't readable"
+    case .nestedSelector: return "the rule uses a nested selector"
+    case .complexSelector: return "the rule uses a complex selector"
+    case .importantConflict: return "an !important rule conflicts"
+    }
+  }
+
+  /// Edits recorded while tier proving was still in flight land in the agent
+  /// batch; once proving completes, move every change whose property proved
+  /// direct into the direct-write queue so it persists deterministically.
+  private func rerouteBatchedEditsAfterTierRefresh() {
+    guard let batch = pendingEditBatch else { return }
+    var rerouted = false
+    for change in batch.styleChanges {
+      guard case .direct = styleTiers[change.property] else { continue }
+      pendingDirectWrites[change.property] = change.newValue
+      pendingEditBatch?.removeStyleChange(property: change.property)
+      rerouted = true
+    }
+    guard rerouted else { return }
+    if pendingEditBatch?.isEmpty == true {
+      pendingEditBatch = nil
+    }
+    scheduleDirectWriteFlush()
   }
 
   /// Reads framework dev-build source metadata for the selected element.
@@ -954,6 +1133,7 @@ final class WebPreviewInspectorViewModel {
         filePath: target.filePath,
         embeddedStyleBlockIndex: target.embeddedStyleBlockIndex,
         expectedSHA256: target.contentSHA256,
+        environment: pageEnvironment ?? .fallback,
         projectPath: projectPath
       )
 
@@ -964,12 +1144,97 @@ final class WebPreviewInspectorViewModel {
         rebaseDirectTargets(filePath: target.filePath, to: newSHA256, excluding: property)
         await refreshCodeTabAfterDirectWrite(to: target.filePath)
         writeErrorMessage = nil
+        if tokenPromotionOffer?.property == property {
+          tokenPromotionOffer = nil
+        }
+      case .writtenWithTokenDetachment(let newSHA256, let detachment):
+        target.contentSHA256 = newSHA256
+        styleTiers[property] = .direct(target)
+        rebaseDirectTargets(filePath: target.filePath, to: newSHA256, excluding: property)
+        await refreshCodeTabAfterDirectWrite(to: target.filePath)
+        writeErrorMessage = nil
+        // Offer promoting the detached edit to a token-wide update when the
+        // definition is provably editable in the same source.
+        if let definitionRuleIndexPath = detachment.definitionRuleIndexPath {
+          tokenPromotionOffer = WebPreviewTokenPromotionOffer(
+            property: property,
+            token: detachment.token,
+            usageCount: detachment.projectUsageCount,
+            appliedLiteral: detachment.appliedLiteral,
+            definitionRuleIndexPath: definitionRuleIndexPath
+          )
+        }
       case .baselineDrift, .editFailed:
         styleTiers[property] = .agent
         downgradeToAgentBatch(property: property, value: value)
       }
     }
     isWriting = false
+  }
+
+  /// Promotes the last detached token edit into a token-wide update: the
+  /// element's declaration is restored to `var(token)` and the token's
+  /// definition is rewritten to the new value, so every consumer updates.
+  /// Both steps are ordinary proven writes with post-conditions.
+  func promoteTokenDetachment() async {
+    guard let offer = tokenPromotionOffer else { return }
+    tokenPromotionOffer = nil
+    guard case .direct(var target) = styleTiers[offer.property] else { return }
+
+    isWriting = true
+    defer { isWriting = false }
+
+    // 1. Point the element's declaration back at the token.
+    let restore = CSSDeclarationEdit(
+      ruleIndexPath: target.ruleIndexPath,
+      property: offer.property,
+      value: "var(\(offer.token))"
+    )
+    let restoreOutcome = await directWriteCoordinator.write(
+      edit: restore,
+      filePath: target.filePath,
+      embeddedStyleBlockIndex: target.embeddedStyleBlockIndex,
+      expectedSHA256: target.contentSHA256,
+      environment: pageEnvironment ?? .fallback,
+      projectPath: projectPath
+    )
+    guard let restoredSHA = restoreOutcome.writtenSHA256 else {
+      writeErrorMessage = "Couldn't update \(offer.token): the file changed underneath"
+      return
+    }
+    target.contentSHA256 = restoredSHA
+    styleTiers[offer.property] = .direct(target)
+    rebaseDirectTargets(filePath: target.filePath, to: restoredSHA, excluding: offer.property)
+
+    // 2. Rewrite the token's definition; the planner preserves the
+    // definition's notation automatically.
+    let definitionEdit = CSSDeclarationEdit(
+      ruleIndexPath: offer.definitionRuleIndexPath,
+      property: offer.token,
+      value: offer.appliedLiteral
+    )
+    let definitionOutcome = await directWriteCoordinator.write(
+      edit: definitionEdit,
+      filePath: target.filePath,
+      embeddedStyleBlockIndex: target.embeddedStyleBlockIndex,
+      expectedSHA256: restoredSHA,
+      environment: pageEnvironment ?? .fallback,
+      projectPath: projectPath
+    )
+    guard let finalSHA = definitionOutcome.writtenSHA256 else {
+      writeErrorMessage = "Couldn't update \(offer.token): the file changed underneath"
+      return
+    }
+    target.contentSHA256 = finalSHA
+    styleTiers[offer.property] = .direct(target)
+    rebaseDirectTargets(filePath: target.filePath, to: finalSHA, excluding: offer.property)
+    await refreshCodeTabAfterDirectWrite(to: target.filePath)
+    writeErrorMessage = nil
+  }
+
+  /// Dismisses the pending token-promotion offer without acting on it.
+  func dismissTokenPromotionOffer() {
+    tokenPromotionOffer = nil
   }
 
   private func rebaseDirectTargets(filePath: String, to newSHA256: String, excluding property: String) {

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/CSSDeclarationEditPlannerTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/CSSDeclarationEditPlannerTests.swift
@@ -1,0 +1,448 @@
+//
+//  CSSDeclarationEditPlannerTests.swift
+//  AgentHubTests
+//
+
+import Foundation
+import Testing
+
+@testable import AgentHubCore
+
+@Suite("CSSDeclarationEditPlanner")
+struct CSSDeclarationEditPlannerTests {
+
+  /// Environment with distinct root/element/parent font sizes so tests can
+  /// tell which basis a unit conversion actually used.
+  private let environment = WebPreviewPageEnvironment(
+    viewportWidth: 1280,
+    viewportHeight: 800,
+    rootFontSize: 16,
+    elementFontSize: 18,
+    parentFontSize: 20
+  )
+
+  private func plan(
+    css: String,
+    siblings: [String] = [],
+    ruleIndexPath: [Int] = [0],
+    property: String,
+    desired: String?
+  ) throws -> CSSDeclarationEditPlan {
+    let editor = CSSSourceEditor()
+    let document = try editor.parse(css)
+    let siblingDocuments = try siblings.map { try editor.parse($0) }
+    return CSSDeclarationEditPlanner().plan(
+      CSSDeclarationEdit(ruleIndexPath: ruleIndexPath, property: property, value: desired),
+      in: document,
+      siblings: siblingDocuments,
+      environment: environment
+    )
+  }
+
+  // MARK: - Unit preservation
+
+  @Test("A rem declaration converts a desired px value back into rem")
+  func remUnitPreserved() throws {
+    let plan = try plan(
+      css: ".hero { font-size: 1.05rem; }",
+      property: "font-size",
+      desired: "24px"
+    )
+
+    #expect(plan.strategy == .unitConverted)
+    #expect(plan.edit == CSSDeclarationEdit(ruleIndexPath: [0], property: "font-size", value: "1.5rem"))
+  }
+
+  @Test("em on font-size converts against the parent font size")
+  func emFontSizeUsesParentFontSize() throws {
+    let plan = try plan(
+      css: ".hero { font-size: 1em; }",
+      property: "font-size",
+      desired: "30px"
+    )
+
+    // parentFontSize is 20, so 30px is 1.5em (elementFontSize 18 would give 1.6667em).
+    #expect(plan.strategy == .unitConverted)
+    #expect(plan.edit?.value == "1.5em")
+  }
+
+  @Test("em on letter-spacing converts against the element font size")
+  func emLetterSpacingUsesElementFontSize() throws {
+    let plan = try plan(
+      css: ".hero { letter-spacing: 0.5em; }",
+      property: "letter-spacing",
+      desired: "27px"
+    )
+
+    // elementFontSize is 18, so 27px is 1.5em (parentFontSize 20 would give 1.35em).
+    #expect(plan.strategy == .unitConverted)
+    #expect(plan.edit?.value == "1.5em")
+  }
+
+  @Test("Unitless line-height stays unitless")
+  func unitlessLineHeightPreserved() throws {
+    let plan = try plan(
+      css: ".hero { line-height: 1.45; }",
+      property: "line-height",
+      desired: "27px"
+    )
+
+    // elementFontSize is 18, so 27px is a 1.5 multiple.
+    #expect(plan.strategy == .unitConverted)
+    #expect(plan.edit == CSSDeclarationEdit(ruleIndexPath: [0], property: "line-height", value: "1.5"))
+  }
+
+  @Test("A desired px equal to the unitless line-height's evaluation is a no-op")
+  func unitlessLineHeightNoChange() throws {
+    let plan = try plan(
+      css: ".hero { line-height: 1.45; }",
+      property: "line-height",
+      desired: "26.1px"
+    )
+
+    // 1.45 * 18 = 26.1px, so nothing needs to change.
+    #expect(plan.strategy == .noChange)
+    #expect(plan.edit == nil)
+  }
+
+  @Test("A desired length equal to the declared length is a no-op")
+  func equalLengthIsNoChange() throws {
+    let plan = try plan(
+      css: ".hero { font-size: 24px; }",
+      property: "font-size",
+      desired: "24px"
+    )
+
+    #expect(plan.strategy == .noChange)
+    #expect(plan.edit == nil)
+  }
+
+  // MARK: - Responsive expressions
+
+  @Test("clamp() adjusts only the preferred term when the desired value stays in bounds")
+  func clampAdjustsPreferred() throws {
+    let plan = try plan(
+      css: ".hero { font-size: clamp(17px, 2.2vw, 22px); }",
+      property: "font-size",
+      desired: "19.2px"
+    )
+
+    // 19.2px at a 1280px viewport is 1.5vw.
+    #expect(plan.strategy == .responsiveAdjusted)
+    #expect(plan.edit?.value == "clamp(17px, 1.5vw, 22px)")
+  }
+
+  @Test("clamp() widens the max bound when the desired value exceeds it")
+  func clampWidensMax() throws {
+    let plan = try plan(
+      css: ".hero { font-size: clamp(17px, 2.2vw, 22px); }",
+      property: "font-size",
+      desired: "30px"
+    )
+
+    // 30 / 1280 * 100 = 2.34375, rounded to 3 decimals for vw.
+    #expect(plan.strategy == .responsiveAdjusted)
+    #expect(plan.edit?.value == "clamp(17px, 2.344vw, 30px)")
+  }
+
+  @Test("clamp() widens the min bound when the desired value undershoots it")
+  func clampWidensMin() throws {
+    let plan = try plan(
+      css: ".hero { font-size: clamp(17px, 2.2vw, 22px); }",
+      property: "font-size",
+      desired: "10px"
+    )
+
+    // 10 / 1280 * 100 = 0.78125, rounded to 3 decimals for vw.
+    #expect(plan.strategy == .responsiveAdjusted)
+    #expect(plan.edit?.value == "clamp(10px, 0.781vw, 22px)")
+  }
+
+  @Test("min() adjusts the winning argument while it stays the winner")
+  func minAdjustsWinner() throws {
+    let plan = try plan(
+      css: ".panel { width: min(90vw, 640px); }",
+      property: "width",
+      desired: "600px"
+    )
+
+    // At 1280px, 90vw = 1152px, so 640px wins and can drop to 600px.
+    #expect(plan.strategy == .responsiveAdjusted)
+    #expect(plan.edit?.value == "min(90vw, 600px)")
+  }
+
+  @Test("min() passes through when the desired value would dethrone the winner")
+  func minPassthroughWhenWinnerChanges() throws {
+    let edit = CSSDeclarationEdit(ruleIndexPath: [0], property: "width", value: "1200px")
+    let document = try CSSSourceEditor().parse(".panel { width: min(90vw, 640px); }")
+    let plan = CSSDeclarationEditPlanner().plan(edit, in: document, environment: environment)
+
+    // 1200px is above 90vw = 1152px, so adjusting 640px cannot express it.
+    #expect(plan.strategy == .passthrough)
+    #expect(plan.edit == edit)
+  }
+
+  // MARK: - Design tokens
+
+  @Test("A var() declaration reattaches to the token that resolves to the desired value")
+  func varReattachesToMatchingToken() throws {
+    let css = ":root { --brand: #445566; --accent: #112233; } .cta { color: var(--accent); }"
+    let plan = try plan(
+      css: css,
+      ruleIndexPath: [1],
+      property: "color",
+      desired: "#445566"
+    )
+
+    #expect(plan.strategy == .tokenReattached("--brand"))
+    #expect(plan.edit == CSSDeclarationEdit(ruleIndexPath: [1], property: "color", value: "var(--brand)"))
+  }
+
+  @Test("A var() declaration whose token already resolves to the desired value is a no-op")
+  func varNoChangeWhenTokenResolvesToDesired() throws {
+    let css = ":root { --brand: #445566; --accent: #112233; } .cta { color: var(--accent); }"
+    let plan = try plan(
+      css: css,
+      ruleIndexPath: [1],
+      property: "color",
+      desired: "#112233"
+    )
+
+    #expect(plan.strategy == .noChange)
+    #expect(plan.edit == nil)
+  }
+
+  @Test("A single-consumer token edit retargets the token's own definition")
+  func singleUseTokenDefinitionRewritten() throws {
+    let css = ":root { --hero-size: 60px; } h1 { font-size: var(--hero-size); }"
+    let plan = try plan(
+      css: css,
+      ruleIndexPath: [1],
+      property: "font-size",
+      desired: "48px"
+    )
+
+    #expect(plan.strategy == .tokenDefinitionRewritten("--hero-size"))
+    #expect(plan.edit == CSSDeclarationEdit(ruleIndexPath: [0], property: "--hero-size", value: "48px"))
+  }
+
+  @Test("A multi-consumer token detaches into a literal that keeps the token's notation")
+  func multiUseTokenDetached() throws {
+    let css = ":root { --fg: rgb(94, 94, 94); } .a { color: var(--fg); } .b { color: var(--fg); }"
+    let plan = try plan(
+      css: css,
+      ruleIndexPath: [1],
+      property: "color",
+      desired: "#224466"
+    )
+
+    #expect(plan.strategy == .tokenDetached("--fg"))
+    #expect(plan.edit == CSSDeclarationEdit(ruleIndexPath: [1], property: "color", value: "rgb(34, 68, 102)"))
+  }
+
+  @Test("A mixed-case token keeps its exact spelling through a definition rewrite")
+  func mixedCaseTokenDefinitionRewritten() throws {
+    let css = ":root { --heroSize: 60px; } h1 { font-size: var(--heroSize); }"
+    let plan = try plan(
+      css: css,
+      ruleIndexPath: [1],
+      property: "font-size",
+      desired: "48px"
+    )
+
+    #expect(plan.strategy == .tokenDefinitionRewritten("--heroSize"))
+    #expect(plan.edit == CSSDeclarationEdit(ruleIndexPath: [0], property: "--heroSize", value: "48px"))
+  }
+
+  @Test("Tokens that differ only by case stay distinct")
+  func caseSensitiveTokensStayDistinct() throws {
+    // --FG and --fg are different custom properties; editing the --fg
+    // consumer must not treat --FG's usage as a second consumer.
+    let css = ":root { --fg: #101010; --FG: #efefef; } .a { color: var(--fg); } .b { color: var(--FG); }"
+    let plan = try plan(
+      css: css,
+      ruleIndexPath: [1],
+      property: "color",
+      desired: "#224466"
+    )
+
+    #expect(plan.strategy == .tokenDefinitionRewritten("--fg"))
+    #expect(plan.edit == CSSDeclarationEdit(ruleIndexPath: [0], property: "--fg", value: "#224466"))
+  }
+
+  // MARK: - Cross-file tokens
+
+  @Test("A token consumed by a sibling stylesheet is not rewritten at its definition")
+  func siblingUsageBlocksDefinitionRewrite() throws {
+    let css = ":root { --hero-size: 60px; } h1 { font-size: var(--hero-size); }"
+    let sibling = ".banner { font-size: var(--hero-size); }"
+    let plan = try plan(
+      css: css,
+      siblings: [sibling],
+      ruleIndexPath: [1],
+      property: "font-size",
+      desired: "48px"
+    )
+
+    // Rewriting :root's --hero-size would restyle .banner too, so the edit
+    // detaches this one consumer instead (keeping the declared unit).
+    #expect(plan.strategy == .tokenDetached("--hero-size"))
+    #expect(plan.edit == CSSDeclarationEdit(ruleIndexPath: [1], property: "font-size", value: "48px"))
+  }
+
+  @Test("Reattachment can target a token defined in a sibling stylesheet")
+  func reattachesToSiblingDefinedToken() throws {
+    let css = ":root { --accent: #112233; } .cta { color: var(--accent); } .other { color: var(--accent); }"
+    let sibling = ":root { --brand: #445566; }"
+    let plan = try plan(
+      css: css,
+      siblings: [sibling],
+      ruleIndexPath: [1],
+      property: "color",
+      desired: "#445566"
+    )
+
+    #expect(plan.strategy == .tokenReattached("--brand"))
+    #expect(plan.edit == CSSDeclarationEdit(ruleIndexPath: [1], property: "color", value: "var(--brand)"))
+  }
+
+  @Test("A token redefined by a sibling stylesheet detaches with the desired literal")
+  func siblingRedefinitionForcesLiteralDetach() throws {
+    let css = ":root { --fg: #101010; } .a { color: var(--fg); }"
+    let sibling = ":root { --fg: #efefef; }"
+    let plan = try plan(
+      css: css,
+      siblings: [sibling],
+      ruleIndexPath: [1],
+      property: "color",
+      desired: "#224466"
+    )
+
+    // Two definitions make the token's resolution ambiguous: no rewrite, no
+    // notation to mirror — the desired literal lands on the consumer.
+    #expect(plan.strategy == .tokenDetached("--fg"))
+    #expect(plan.edit == CSSDeclarationEdit(ruleIndexPath: [1], property: "color", value: "#224466"))
+  }
+
+  // MARK: - Colors
+
+  @Test("An rgb() declaration keeps rgb() notation for a desired hex value")
+  func rgbFormatPreserved() throws {
+    let plan = try plan(
+      css: ".a { color: rgb(94, 94, 94); }",
+      property: "color",
+      desired: "#224466"
+    )
+
+    #expect(plan.strategy == .colorFormatPreserved)
+    #expect(plan.edit?.value == "rgb(34, 68, 102)")
+  }
+
+  @Test("An hsl() declaration keeps hsl() notation for a desired hex value")
+  func hslFormatPreserved() throws {
+    let plan = try plan(
+      css: ".a { color: hsl(220, 50%, 40%); }",
+      property: "color",
+      desired: "#336699"
+    )
+
+    // #336699 is hsl(210, 50%, 40%).
+    #expect(plan.strategy == .colorFormatPreserved)
+    #expect(plan.edit?.value == "hsl(210, 50%, 40%)")
+  }
+
+  @Test("A keyword declaration carries no notation, so the desired text passes through")
+  func keywordDeclaredPassesDesiredText() throws {
+    let plan = try plan(
+      css: ".a { color: red; }",
+      property: "color",
+      desired: "blue"
+    )
+
+    #expect(plan.strategy == .colorFormatPreserved)
+    #expect(plan.edit?.value == "blue")
+  }
+
+  @Test("An uppercase hex declaration keeps its casing")
+  func uppercaseHexPreserved() throws {
+    let plan = try plan(
+      css: ".a { color: #ABCDEF; }",
+      property: "color",
+      desired: "#123abc"
+    )
+
+    #expect(plan.strategy == .colorFormatPreserved)
+    #expect(plan.edit?.value == "#123ABC")
+  }
+
+  @Test("Equal colors across notations are a no-op")
+  func equalColorsAcrossNotationsNoChange() throws {
+    let plan = try plan(
+      css: ".a { color: #5e5e5e; }",
+      property: "color",
+      desired: "rgb(94, 94, 94)"
+    )
+
+    #expect(plan.strategy == .noChange)
+    #expect(plan.edit == nil)
+  }
+
+  @Test("An rgba() declaration keeps rgba() notation including the desired alpha")
+  func alphaPreservedInRGBA() throws {
+    let plan = try plan(
+      css: ".a { background-color: rgba(0, 0, 0, 0.5); }",
+      property: "background-color",
+      desired: "#22446680"
+    )
+
+    // 0x80 / 255 rounds to 0.502.
+    #expect(plan.strategy == .colorFormatPreserved)
+    #expect(plan.edit?.value == "rgba(34, 68, 102, 0.502)")
+  }
+
+  // MARK: - Passthrough
+
+  @Test("A gradient declaration passes the desired literal through unchanged")
+  func gradientPassthrough() throws {
+    let edit = CSSDeclarationEdit(ruleIndexPath: [0], property: "background", value: "#123456")
+    let document = try CSSSourceEditor().parse(
+      ".a { background: linear-gradient(180deg, #ffffff, #000000); }"
+    )
+    let plan = CSSDeclarationEditPlanner().plan(edit, in: document, environment: environment)
+
+    #expect(plan.strategy == .passthrough)
+    #expect(plan.edit == edit)
+  }
+
+  @Test("Editing a property the rule does not declare passes through")
+  func missingDeclarationPassthrough() throws {
+    let edit = CSSDeclarationEdit(ruleIndexPath: [0], property: "color", value: "#ffffff")
+    let document = try CSSSourceEditor().parse(".hero { font-size: 1.05rem; }")
+    let plan = CSSDeclarationEditPlanner().plan(edit, in: document, environment: environment)
+
+    #expect(plan.strategy == .passthrough)
+    #expect(plan.edit == edit)
+  }
+
+  @Test("A clamp() containing var() passes through")
+  func clampWithVarPassthrough() throws {
+    let edit = CSSDeclarationEdit(ruleIndexPath: [0], property: "font-size", value: "20px")
+    let document = try CSSSourceEditor().parse(
+      ".hero { font-size: clamp(var(--min), 2vw, 30px); }"
+    )
+    let plan = CSSDeclarationEditPlanner().plan(edit, in: document, environment: environment)
+
+    #expect(plan.strategy == .passthrough)
+    #expect(plan.edit == edit)
+  }
+
+  @Test("A removal (nil value) passes through untouched")
+  func removalPassthrough() throws {
+    let edit = CSSDeclarationEdit(ruleIndexPath: [0], property: "font-size", value: nil)
+    let document = try CSSSourceEditor().parse(".hero { font-size: 1.05rem; }")
+    let plan = CSSDeclarationEditPlanner().plan(edit, in: document, environment: environment)
+
+    #expect(plan.strategy == .passthrough)
+    #expect(plan.edit == edit)
+  }
+}

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/StylesheetSourceMapperTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/StylesheetSourceMapperTests.swift
@@ -71,7 +71,7 @@ struct StylesheetSourceMapperTests {
     )
 
     let expectedSHA = StylesheetSourceMapper.sha256(of: css)
-    #expect(result == .proven(filePath: cssPath, contentSHA256: expectedSHA))
+    #expect(result == .proven(filePath: cssPath, contentSHA256: expectedSHA, embeddedStyleBlockIndex: nil))
   }
 
   @Test("Dev-server hrefs map through the project path")
@@ -90,7 +90,7 @@ struct StylesheetSourceMapperTests {
       context: .devServer(baseURL: URL(string: "http://localhost:5173")!, projectPath: fixture.root.path)
     )
 
-    guard case .proven(let filePath, _) = result else {
+    guard case .proven(let filePath, _, _) = result else {
       Issue.record("Expected proven mapping, got \(result)")
       return
     }
@@ -114,7 +114,7 @@ struct StylesheetSourceMapperTests {
       context: .devServer(baseURL: URL(string: "http://localhost:5173")!, projectPath: fixture.root.path)
     )
 
-    guard case .proven(let filePath, _) = result else {
+    guard case .proven(let filePath, _, _) = result else {
       Issue.record("Expected proven mapping, got \(result)")
       return
     }

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/WebPreviewDirectCSSWriteCoordinatorTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/WebPreviewDirectCSSWriteCoordinatorTests.swift
@@ -58,6 +58,7 @@ struct WebPreviewDirectCSSWriteCoordinatorTests {
       filePath: filePath,
       embeddedStyleBlockIndex: nil,
       expectedSHA256: StylesheetSourceMapper.sha256(of: css),
+      environment: .fallback,
       projectPath: "/project"
     )
 
@@ -77,6 +78,7 @@ struct WebPreviewDirectCSSWriteCoordinatorTests {
       filePath: filePath,
       embeddedStyleBlockIndex: nil,
       expectedSHA256: StylesheetSourceMapper.sha256(of: css),
+      environment: .fallback,
       projectPath: "/project"
     )
 
@@ -95,6 +97,7 @@ struct WebPreviewDirectCSSWriteCoordinatorTests {
       filePath: filePath,
       embeddedStyleBlockIndex: nil,
       expectedSHA256: StylesheetSourceMapper.sha256(of: css),
+      environment: .fallback,
       projectPath: "/project"
     )
 
@@ -117,6 +120,7 @@ struct WebPreviewDirectCSSWriteCoordinatorTests {
       filePath: filePath,
       embeddedStyleBlockIndex: nil,
       expectedSHA256: baseline,
+      environment: .fallback,
       projectPath: "/project"
     )
 

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/WebPreviewInspectorViewModelTierRoutingTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/WebPreviewInspectorViewModelTierRoutingTests.swift
@@ -91,6 +91,7 @@ private actor MockDirectWriter: WebPreviewDirectCSSWriting {
     filePath: String,
     embeddedStyleBlockIndex: Int?,
     expectedSHA256: String,
+    environment: WebPreviewPageEnvironment,
     projectPath: String
   ) async -> DirectWriteOutcome {
     calls.append(Call(edit: edit, filePath: filePath, expectedSHA256: expectedSHA256))
@@ -224,7 +225,7 @@ struct WebPreviewInspectorViewModelTierRoutingTests {
   private func makeViewModel(
     coordinator: MockDirectWriter,
     fileService: TierMockFileService,
-    mapperResult: StylesheetMappingResult = .proven(filePath: cssPath, contentSHA256: "baseline-sha"),
+    mapperResult: StylesheetMappingResult = .proven(filePath: cssPath, contentSHA256: "baseline-sha", embeddedStyleBlockIndex: nil),
     flagEnabled: Bool = true,
     sourceHints: [WebPreviewElementSourceHint] = [],
     staticTargets: [String: WebPreviewDirectStyleTarget] = [:]
@@ -341,7 +342,7 @@ struct WebPreviewInspectorViewModelTierRoutingTests {
     try await Task.sleep(for: .milliseconds(50))
 
     #expect(viewModel.styleTiers.isEmpty)
-    #expect(viewModel.persistenceTierLabel == "Applies via agent")
+    #expect(viewModel.persistenceTierLabel == "Applies via agent · direct writes are disabled")
 
     viewModel.apply(DesignEdit(element: element, action: .updateProperty(.lineHeight, value: "30px")))
     try await Task.sleep(for: .milliseconds(40))

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/WebPreviewSemanticDirectWriteTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/WebPreviewSemanticDirectWriteTests.swift
@@ -1,0 +1,379 @@
+//
+//  WebPreviewSemanticDirectWriteTests.swift
+//  AgentHubTests
+//
+//  End-to-end coverage of the deterministic semantic write path: the
+//  coordinator plans each edit against the on-disk source so declared
+//  idioms (units, clamp(), tokens) survive, and the page-environment
+//  script feeds the unit conversions.
+//
+
+import Foundation
+import JavaScriptCore
+import Testing
+
+@testable import AgentHubCore
+
+private actor SemanticMockFileService: ProjectFileServiceProtocol {
+  private var files: [String: String]
+  private var writes: [String] = []
+
+  init(files: [String: String]) {
+    self.files = files
+  }
+
+  func readFile(at path: String, projectPath: String) async throws -> String {
+    guard let content = files[path] else {
+      throw NSError(domain: "SemanticMockFileService", code: 1)
+    }
+    return content
+  }
+
+  func writeFile(at path: String, content: String, projectPath: String) async throws {
+    files[path] = content
+    writes.append(content)
+  }
+
+  func listTextFiles(in projectPath: String, extensions: Set<String>) async -> [String] {
+    files.keys.sorted()
+  }
+
+  func latestWrite() -> String? {
+    writes.last
+  }
+
+  func writeCount() -> Int {
+    writes.count
+  }
+}
+
+@Suite("Semantic direct writes")
+struct WebPreviewSemanticDirectWriteTests {
+
+  @Test("A rem declaration stays rem on disk when the toolbar sends px")
+  func remPreservedEndToEnd() async throws {
+    let css = ".hero { font-size: 1.05rem; color: #fff; }"
+    let path = "/project/styles/site.css"
+    let fileService = SemanticMockFileService(files: [path: css])
+    let coordinator = WebPreviewDirectCSSWriteCoordinator(fileService: fileService)
+
+    let outcome = await coordinator.write(
+      edit: CSSDeclarationEdit(ruleIndexPath: [0], property: "font-size", value: "24px"),
+      filePath: path,
+      embeddedStyleBlockIndex: nil,
+      expectedSHA256: StylesheetSourceMapper.sha256(of: css),
+      environment: .fallback,
+      projectPath: "/project"
+    )
+
+    let expected = ".hero { font-size: 1.5rem; color: #fff; }"
+    #expect(outcome == .written(newSHA256: StylesheetSourceMapper.sha256(of: expected)))
+    let written = await fileService.latestWrite()
+    #expect(written == expected)
+  }
+
+  @Test("clamp() inside an embedded <style> block keeps its structure")
+  func clampPreservedInEmbeddedBlock() async throws {
+    let html = """
+    <html><head>
+      <style>.hero { font-size: clamp(17px, 2.2vw, 22px); }</style>
+    </head><body><h1 class="hero">Hi</h1></body></html>
+    """
+    let path = "/project/index.html"
+    let fileService = SemanticMockFileService(files: [path: html])
+    let coordinator = WebPreviewDirectCSSWriteCoordinator(fileService: fileService)
+
+    let outcome = await coordinator.write(
+      edit: CSSDeclarationEdit(ruleIndexPath: [0], property: "font-size", value: "19.2px"),
+      filePath: path,
+      embeddedStyleBlockIndex: 0,
+      expectedSHA256: StylesheetSourceMapper.sha256(of: html),
+      environment: .fallback,
+      projectPath: "/project"
+    )
+
+    let expected = html.replacingOccurrences(of: "2.2vw", with: "1.5vw")
+    #expect(outcome == .written(newSHA256: StylesheetSourceMapper.sha256(of: expected)))
+    let written = await fileService.latestWrite()
+    #expect(written == expected)
+  }
+
+  @Test("A single-consumer token edit rewrites the token definition, not the usage")
+  func tokenDefinitionRewrittenEndToEnd() async throws {
+    let css = """
+    :root { --hero-size: 60px; }
+    h1 { font-size: var(--hero-size); }
+    """
+    let path = "/project/styles/site.css"
+    let fileService = SemanticMockFileService(files: [path: css])
+    let coordinator = WebPreviewDirectCSSWriteCoordinator(fileService: fileService)
+
+    let outcome = await coordinator.write(
+      edit: CSSDeclarationEdit(ruleIndexPath: [1], property: "font-size", value: "48px"),
+      filePath: path,
+      embeddedStyleBlockIndex: nil,
+      expectedSHA256: StylesheetSourceMapper.sha256(of: css),
+      environment: .fallback,
+      projectPath: "/project"
+    )
+
+    let written = await fileService.latestWrite()
+    #expect(written?.contains("--hero-size: 48px;") == true)
+    #expect(written?.contains("h1 { font-size: var(--hero-size); }") == true)
+    if let written {
+      #expect(outcome == .written(newSHA256: StylesheetSourceMapper.sha256(of: written)))
+    } else {
+      Issue.record("Expected a write to be recorded")
+    }
+  }
+
+  @Test("A token consumed by another stylesheet detaches instead of rewriting the definition")
+  func siblingConsumerBlocksDefinitionRewriteEndToEnd() async throws {
+    let css = """
+    :root { --hero-size: 60px; }
+    h1 { font-size: var(--hero-size); }
+    """
+    let siblingCSS = ".banner { font-size: var(--hero-size); }"
+    let path = "/project/styles/site.css"
+    let fileService = SemanticMockFileService(files: [
+      path: css,
+      "/project/styles/theme.css": siblingCSS,
+    ])
+    let coordinator = WebPreviewDirectCSSWriteCoordinator(fileService: fileService)
+
+    let outcome = await coordinator.write(
+      edit: CSSDeclarationEdit(ruleIndexPath: [1], property: "font-size", value: "48px"),
+      filePath: path,
+      embeddedStyleBlockIndex: nil,
+      expectedSHA256: StylesheetSourceMapper.sha256(of: css),
+      environment: .fallback,
+      projectPath: "/project"
+    )
+
+    // Rewriting :root's --hero-size would restyle .banner in theme.css, so
+    // only this consumer detaches to a literal — and the outcome carries
+    // the detachment so callers can offer a token-wide promotion.
+    let written = await fileService.latestWrite()
+    #expect(written?.contains("--hero-size: 60px;") == true)
+    #expect(written?.contains("h1 { font-size: 48px; }") == true)
+    if let written {
+      #expect(outcome == .writtenWithTokenDetachment(
+        newSHA256: StylesheetSourceMapper.sha256(of: written),
+        detachment: CSSTokenDetachment(
+          token: "--hero-size",
+          projectUsageCount: 2,
+          definitionRuleIndexPath: [0],
+          appliedLiteral: "48px"
+        )
+      ))
+    } else {
+      Issue.record("Expected a write to be recorded")
+    }
+  }
+
+  @Test("A color edit reattaches to the root token holding that value")
+  func tokenReattachedEndToEnd() async throws {
+    let css = ":root { --brand: #445566; --muted: #999999; } .cta { color: var(--muted); }"
+    let path = "/project/styles/site.css"
+    let fileService = SemanticMockFileService(files: [path: css])
+    let coordinator = WebPreviewDirectCSSWriteCoordinator(fileService: fileService)
+
+    _ = await coordinator.write(
+      edit: CSSDeclarationEdit(ruleIndexPath: [1], property: "color", value: "#445566"),
+      filePath: path,
+      embeddedStyleBlockIndex: nil,
+      expectedSHA256: StylesheetSourceMapper.sha256(of: css),
+      environment: .fallback,
+      projectPath: "/project"
+    )
+
+    let written = await fileService.latestWrite()
+    #expect(written?.contains(".cta { color: var(--brand); }") == true)
+    #expect(written?.contains("--brand: #445566;") == true)
+  }
+
+  @Test("A detached edit can be promoted to a token-wide update with two proven writes")
+  func tokenPromotionRewritesDefinitionAndRestoresUsage() async throws {
+    let css = ":root { --fg: rgb(94, 94, 94); } .a { color: var(--fg); } .b { color: var(--fg); }"
+    let path = "/project/styles/site.css"
+    let fileService = SemanticMockFileService(files: [path: css])
+    let coordinator = WebPreviewDirectCSSWriteCoordinator(fileService: fileService)
+
+    // The slider edit detaches .a from the shared token.
+    let detachOutcome = await coordinator.write(
+      edit: CSSDeclarationEdit(ruleIndexPath: [1], property: "color", value: "#224466"),
+      filePath: path,
+      embeddedStyleBlockIndex: nil,
+      expectedSHA256: StylesheetSourceMapper.sha256(of: css),
+      environment: .fallback,
+      projectPath: "/project"
+    )
+    guard case .writtenWithTokenDetachment(let detachedSHA, let detachment) = detachOutcome else {
+      Issue.record("Expected a detachment outcome, got \(detachOutcome)")
+      return
+    }
+    #expect(detachment.token == "--fg")
+    #expect(detachment.definitionRuleIndexPath == [0])
+
+    // Promotion step 1: point the declaration back at the token.
+    let restoreOutcome = await coordinator.write(
+      edit: CSSDeclarationEdit(ruleIndexPath: [1], property: "color", value: "var(--fg)"),
+      filePath: path,
+      embeddedStyleBlockIndex: nil,
+      expectedSHA256: detachedSHA,
+      environment: .fallback,
+      projectPath: "/project"
+    )
+    let restoredSHA = try #require(restoreOutcome.writtenSHA256)
+
+    // Promotion step 2: rewrite the token's definition with the new value.
+    let definitionOutcome = await coordinator.write(
+      edit: CSSDeclarationEdit(
+        ruleIndexPath: try #require(detachment.definitionRuleIndexPath),
+        property: detachment.token,
+        value: detachment.appliedLiteral
+      ),
+      filePath: path,
+      embeddedStyleBlockIndex: nil,
+      expectedSHA256: restoredSHA,
+      environment: .fallback,
+      projectPath: "/project"
+    )
+    #expect(definitionOutcome.writtenSHA256 != nil)
+
+    // Every consumer now updates through the token; notation is preserved.
+    let written = await fileService.latestWrite()
+    #expect(written == ":root { --fg: rgb(34, 68, 102); } .a { color: var(--fg); } .b { color: var(--fg); }")
+  }
+
+  @Test("A desired value equal to the declared value writes nothing")
+  func equivalentValueSkipsWrite() async throws {
+    let css = ".hero { font-size: 1.05rem; }"
+    let path = "/project/styles/site.css"
+    let fileService = SemanticMockFileService(files: [path: css])
+    let coordinator = WebPreviewDirectCSSWriteCoordinator(fileService: fileService)
+    let baseline = StylesheetSourceMapper.sha256(of: css)
+
+    // 1.05rem at a 16px root is exactly 16.8px.
+    let outcome = await coordinator.write(
+      edit: CSSDeclarationEdit(ruleIndexPath: [0], property: "font-size", value: "16.8px"),
+      filePath: path,
+      embeddedStyleBlockIndex: nil,
+      expectedSHA256: baseline,
+      environment: .fallback,
+      projectPath: "/project"
+    )
+
+    #expect(outcome == .written(newSHA256: baseline))
+    let writeCount = await fileService.writeCount()
+    #expect(writeCount == 0)
+  }
+
+  @Test("Viewport-relative units convert against the captured environment")
+  func environmentDrivesViewportConversion() async throws {
+    let css = ".hero { width: 2vw; }"
+    let path = "/project/styles/site.css"
+    let fileService = SemanticMockFileService(files: [path: css])
+    let coordinator = WebPreviewDirectCSSWriteCoordinator(fileService: fileService)
+    let environment = WebPreviewPageEnvironment(
+      viewportWidth: 960,
+      viewportHeight: 700,
+      rootFontSize: 16,
+      elementFontSize: 16,
+      parentFontSize: 16
+    )
+
+    _ = await coordinator.write(
+      edit: CSSDeclarationEdit(ruleIndexPath: [0], property: "width", value: "28.8px"),
+      filePath: path,
+      embeddedStyleBlockIndex: nil,
+      expectedSHA256: StylesheetSourceMapper.sha256(of: css),
+      environment: environment,
+      projectPath: "/project"
+    )
+
+    let written = await fileService.latestWrite()
+    #expect(written == ".hero { width: 3vw; }")
+  }
+}
+
+@Suite("WebPreviewPageEnvironment")
+struct WebPreviewPageEnvironmentTests {
+
+  @Test("The environment script reads viewport and font sizes from the page")
+  func scriptCapturesEnvironment() throws {
+    let context = try #require(JSContext())
+    context.evaluateScript("""
+      var window = {
+        innerWidth: 1440,
+        innerHeight: 900,
+        getComputedStyle: function(node) {
+          return { fontSize: node && node.fontSize ? node.fontSize : '16px' };
+        }
+      };
+      var document = {
+        documentElement: { fontSize: '16px' },
+        querySelector: function(selector) {
+          return { fontSize: '18px', parentElement: { fontSize: '20px' } };
+        }
+      };
+      """)
+
+    let script = try #require(WebPreviewPageEnvironmentScript.script(selector: ".hero"))
+    let result = context.evaluateScript(script)?.toObject()
+    #expect(context.exception == nil)
+
+    let environment = try #require(WebPreviewPageEnvironment.parse(result))
+    #expect(environment.viewportWidth == 1440)
+    #expect(environment.viewportHeight == 900)
+    #expect(environment.rootFontSize == 16)
+    #expect(environment.elementFontSize == 18)
+    #expect(environment.parentFontSize == 20)
+  }
+
+  @Test("A missing element falls back to the root font size")
+  func scriptFallsBackWithoutElement() throws {
+    let context = try #require(JSContext())
+    context.evaluateScript("""
+      var window = {
+        innerWidth: 1280,
+        innerHeight: 800,
+        getComputedStyle: function(node) { return { fontSize: '16px' }; }
+      };
+      var document = {
+        documentElement: {},
+        querySelector: function(selector) { return null; }
+      };
+      """)
+
+    let script = try #require(WebPreviewPageEnvironmentScript.script(selector: "#missing"))
+    let result = context.evaluateScript(script)?.toObject()
+    #expect(context.exception == nil)
+
+    let environment = try #require(WebPreviewPageEnvironment.parse(result))
+    #expect(environment.elementFontSize == 16)
+    #expect(environment.parentFontSize == 16)
+  }
+
+  @Test("Parsing rejects payloads without a usable viewport")
+  func parseRejectsMissingViewport() {
+    #expect(WebPreviewPageEnvironment.parse(["rootFontSize": 16.0]) == nil)
+    #expect(WebPreviewPageEnvironment.parse(nil) == nil)
+    #expect(WebPreviewPageEnvironment.parse([
+      "viewportWidth": 0.0,
+      "viewportHeight": 800.0,
+      "rootFontSize": 16.0,
+    ]) == nil)
+  }
+
+  @Test("Parsing defaults element and parent font sizes to the root")
+  func parseDefaultsFontSizes() throws {
+    let environment = try #require(WebPreviewPageEnvironment.parse([
+      "viewportWidth": 1280.0,
+      "viewportHeight": 800.0,
+      "rootFontSize": 18.0,
+    ]))
+    #expect(environment.elementFontSize == 18)
+    #expect(environment.parentFontSize == 18)
+  }
+}

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/WebPreviewStaticStyleResolverTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/WebPreviewStaticStyleResolverTests.swift
@@ -327,7 +327,15 @@ struct WebPreviewStaticStyleResolverTests {
       contentSHA256: StylesheetSourceMapper.sha256(of: html),
       embeddedStyleBlockIndex: 0
     ))
-    #expect(targets["padding"] == nil)
+    // `padding` is declared by no matching rule, so it inserts into the
+    // element's plainest matching anchor (the inline `.cta` block wins the
+    // source-order tie against site.css's `.cta`).
+    #expect(targets["padding"] == WebPreviewDirectStyleTarget(
+      filePath: htmlPath,
+      ruleIndexPath: [0],
+      contentSHA256: StylesheetSourceMapper.sha256(of: html),
+      embeddedStyleBlockIndex: 0
+    ))
   }
 }
 
@@ -380,6 +388,7 @@ struct WebPreviewDirectCSSWriteEmbeddedTests {
       filePath: path,
       embeddedStyleBlockIndex: 1,
       expectedSHA256: StylesheetSourceMapper.sha256(of: html),
+      environment: .fallback,
       projectPath: "/project"
     )
 
@@ -401,6 +410,7 @@ struct WebPreviewDirectCSSWriteEmbeddedTests {
       filePath: path,
       embeddedStyleBlockIndex: 3,
       expectedSHA256: StylesheetSourceMapper.sha256(of: html),
+      environment: .fallback,
       projectPath: "/project"
     )
 


### PR DESCRIPTION
## Summary

Extends the tiered Edit Mode persistence (#409) so **Tier-1 direct writes preserve the code's idioms instead of flattening them** — the "figma-like" editing behavior, ported from Easel's follow-up work. Everything stays deterministic (pure parsing/arithmetic, **no LLM** — consistent with the "never reintroduce full-file rewrites" invariant).

## What Edit Mode now does when it writes CSS directly

- **Tokens stay tokens** — an edit reattaches to an equal `var(--x)`, rewrites a single-consumer token's own definition, or detaches to a literal that keeps the token's notation.
- **Token promotion** — a detach surfaces an "Update `--token` everywhere (N uses)" pill that rewrites the `:root` definition and restores the `var()` reference (both proven writes).
- **`clamp()/min()/max()` adjust component-wise** using the live page environment (viewport + root/element/parent font sizes), instead of being flattened to a literal.
- **Units and color notation are preserved**; an edit whose value already matches skips the write entirely.
- **Undeclared properties insert** into the element's proven anchor rule (CSSOM anchor on dev servers, static insertion anchor for `file://` previews), guarded by shorthand/longhand conflict detection.
- **Inline `<style>` blocks** now prove on the dev-server path too (block-ordinal mapping).
- The pending-edits pill **explains why** an edit falls back to the agent.

## Files

**New (6):** `CSSDeclarationEditPlanner`, `CSSPropertyFamily`, `WebPreviewPageEnvironment` (+`Capture`), `WebPreviewTokenPromotionOffer`, `WebPreviewTokenPromotionBar`.

**Modified (9):** `CSSSourceEditor` (canonical custom-property names), `WebPreviewStyleProvenance` (+declared/inline/anchor), `WebPreviewStyleProvenanceScript` (JS capture), `StylesheetSourceMapper` (`embeddedStyleBlockIndex`), `WebPreviewStaticMatchProbe` (+inline names), `WebPreviewStaticStyleResolver` (anchor insertion), `WebPreviewDirectCSSWriteCoordinator` (planner + token detachment + `environment`), `WebPreviewInspectorViewModel` (env capture, token promotion, tier reasons), `WebPreviewView` (rail wiring).

## Testing

- Added suites: `CSSDeclarationEditPlanner`, semantic direct writes, `WebPreviewPageEnvironment`.
- Updated coordinator/mapper/tier-routing/static-resolver suites for the new signatures (two assertions updated to the new intended behavior: anchor insertion of an undeclared property, and the agent-reason in the tier label).
- **Full `AgentHubCore` gate (`./scripts/test.sh core`) passes** locally, `** TEST SUCCEEDED **`, zero failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)