### PR TITLE
[codex] Add Canvas tweaks to web preview

### DIFF
--- a/app/AgentHub.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/app/AgentHub.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "c6603929f49445c1b719a9629a5a8450366353422abbdc98fc156845dc35bb03",
+  "originHash" : "5a43a0a027ff402ac9f13b384378e85dea913837eebe5a20954105491bb2c8cc",
   "pins" : [
     {
       "identity" : "beautiful-mermaid-swift",
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/jamesrochabrun/Canvas",
       "state" : {
-        "revision" : "1d002c84e3acb4ac76a051e70f7618cf495e888f",
-        "version" : "1.2.2"
+        "revision" : "1ec719b8ad3f79cd4a9128c999f36d2790fe5d49",
+        "version" : "1.3.0"
       }
     },
     {

--- a/app/modules/AgentHubCore/Package.resolved
+++ b/app/modules/AgentHubCore/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "32dc1b5be00552bdb29eab161d379680c9107ee5dd7b5e7e17d3dff67608f1f3",
+  "originHash" : "e3e8f2a407d044f71c9d9556b5607f36736cc53e9a67d3397434df29324e2d30",
   "pins" : [
     {
       "identity" : "beautiful-mermaid-swift",
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/jamesrochabrun/Canvas",
       "state" : {
-        "revision" : "1d002c84e3acb4ac76a051e70f7618cf495e888f",
-        "version" : "1.2.2"
+        "revision" : "1ec719b8ad3f79cd4a9128c999f36d2790fe5d49",
+        "version" : "1.3.0"
       }
     },
     {

--- a/app/modules/AgentHubCore/Package.swift
+++ b/app/modules/AgentHubCore/Package.swift
@@ -46,7 +46,7 @@ let package = Package(
     .package(path: "../AgentHubGitHub"),
     .package(path: "../Storybook"),
     .package(path: "../SimulatorPreview"),
-    .package(url: "https://github.com/jamesrochabrun/Canvas", exact: "1.2.2"),
+    .package(url: "https://github.com/jamesrochabrun/Canvas", exact: "1.3.0"),
     .package(url: "https://github.com/jamesrochabrun/PierreDiffsSwift", exact: "1.2.2"),
     .package(url: "https://github.com/jamesrochabrun/SwiftTerm", exact: "1.13.0-agenthub.8"),
     .package(url: "https://github.com/gonzalezreal/swift-markdown-ui", from: "2.0.0"),

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/TweaksDefaultsWriteCoordinator.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/TweaksDefaultsWriteCoordinator.swift
@@ -1,0 +1,118 @@
+//
+//  TweaksDefaultsWriteCoordinator.swift
+//  AgentHub
+//
+//  Debounced persistence for Canvas tweakable-prop values. Live changes are
+//  applied in the WKWebView immediately; this coordinator makes direct-file
+//  HTML/SVG previews keep the latest value as the next declared default.
+//
+
+import Canvas
+import Foundation
+
+enum TweaksDefaultsWriteOutcome: Equatable, Sendable {
+  case written
+  case noChange
+  case invalidPropName
+  case propNotDeclared
+  case editFailed(String)
+}
+
+actor TweaksDefaultsWriteCoordinator {
+  static let debounceDuration: Duration = .milliseconds(350)
+  static let reloadSuppressionDuration: TimeInterval = 1.5
+
+  private let fileService: any ProjectFileServiceProtocol
+  private let debounceDuration: Duration
+  private var pendingWriteTask: Task<Void, Never>?
+
+  init(
+    fileService: any ProjectFileServiceProtocol = ProjectFileService.shared,
+    debounceDuration: Duration = TweaksDefaultsWriteCoordinator.debounceDuration
+  ) {
+    self.fileService = fileService
+    self.debounceDuration = debounceDuration
+  }
+
+  deinit {
+    pendingWriteTask?.cancel()
+  }
+
+  func scheduleValueWrite(
+    propName: String,
+    value: TweakPropValue,
+    filePath: String,
+    projectPath: String
+  ) {
+    pendingWriteTask?.cancel()
+    pendingWriteTask = Task { [debounceDuration] in
+      try? await Task.sleep(for: debounceDuration)
+      guard !Task.isCancelled else { return }
+      _ = await self.writeValue(
+        propName: propName,
+        value: value,
+        filePath: filePath,
+        projectPath: projectPath
+      )
+    }
+  }
+
+  func cancelPendingWrite() {
+    pendingWriteTask?.cancel()
+    pendingWriteTask = nil
+  }
+
+  func writeValue(
+    propName: String,
+    value: TweakPropValue,
+    filePath: String,
+    projectPath: String
+  ) async -> TweaksDefaultsWriteOutcome {
+    guard Self.isValidPropName(propName) else { return .invalidPropName }
+
+    let source: String
+    do {
+      source = try await fileService.readFile(at: filePath, projectPath: projectPath)
+    } catch {
+      return .editFailed("Could not read \(filePath): \(error.localizedDescription)")
+    }
+
+    do {
+      let declaredNames = try TweakPropsSourceEditor.parsePropNames(fromSource: source)
+      guard declaredNames.contains(propName) else { return .propNotDeclared }
+
+      let edited = try TweakPropsSourceEditor.applyingValueEdit(
+        propName: propName,
+        newValue: value,
+        toSource: source
+      )
+      guard edited != source else { return .noChange }
+
+      let verifiedProps = try TweakPropsSourceEditor.parseProps(fromSource: edited)
+      guard verifiedProps.contains(where: { $0.name == propName && $0.value == value }) else {
+        return .editFailed("Edited source failed tweak prop verification")
+      }
+
+      try await fileService.writeFile(at: filePath, content: edited, projectPath: projectPath)
+      return .written
+    } catch TweakPropsSourceEditorError.propNotFound {
+      return .propNotDeclared
+    } catch {
+      return .editFailed("Tweak default edit rejected: \(error)")
+    }
+  }
+
+  static func isValidPropName(_ name: String) -> Bool {
+    guard !name.isEmpty, name.count <= 80 else { return false }
+    return name.unicodeScalars.allSatisfy { scalar in
+      switch scalar.value {
+      case 48...57, 65...90, 97...122:
+        return true
+      case 36, 45, 95:
+        return true
+      default:
+        return false
+      }
+    }
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/WebPreviewFileWatcher.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/WebPreviewFileWatcher.swift
@@ -17,6 +17,7 @@ final class WebPreviewFileWatcher {
   private var source: DispatchSourceFileSystemObject?
   private var fileDescriptor: Int32 = -1
   private var debounceWorkItem: DispatchWorkItem?
+  private var suppressedReloadsUntil: Date?
 
   func watch(directory: String) {
     stop()
@@ -53,6 +54,24 @@ final class WebPreviewFileWatcher {
     source?.cancel()
     source = nil
     fileDescriptor = -1
+    suppressedReloadsUntil = nil
+  }
+
+  func suppressReloads(for duration: TimeInterval) {
+    guard duration > 0 else { return }
+    suppressReloads(until: Date().addingTimeInterval(duration))
+  }
+
+  func suppressReloads(until date: Date) {
+    if let suppressedReloadsUntil, suppressedReloadsUntil >= date { return }
+    suppressedReloadsUntil = date
+  }
+
+  func isReloadSuppressed(at date: Date = Date()) -> Bool {
+    guard let suppressedReloadsUntil else { return false }
+    if suppressedReloadsUntil > date { return true }
+    self.suppressedReloadsUntil = nil
+    return false
   }
 
   deinit {
@@ -69,7 +88,8 @@ final class WebPreviewFileWatcher {
     debounceWorkItem?.cancel()
     let work = DispatchWorkItem { [weak self] in
       DispatchQueue.main.async {
-        self?.reloadToken = UUID()
+        guard let self, !self.isReloadSuppressed() else { return }
+        self.reloadToken = UUID()
       }
     }
     debounceWorkItem = work

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/WebPreviewView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/WebPreviewView.swift
@@ -153,6 +153,9 @@ public struct WebPreviewView: View {
   @State private var previewWebView: WKWebView?
   @State private var consoleMessageHandler = WebPreviewConsoleMessageHandler()
   @State private var scrollRestorationCoordinator = WebPreviewScrollRestorationCoordinator()
+  @State private var tweaksState = TweaksState()
+  @State private var tweaksDefaultsWriteCoordinator = TweaksDefaultsWriteCoordinator()
+  @State private var isTweaksPopoverPresented = false
   @State private var launchOptionsStatusOverride: String?
   @State private var askAgentReprobeTask: Task<Void, Never>?
   @State private var queueSendFailureMessage: String?
@@ -383,6 +386,7 @@ public struct WebPreviewView: View {
       deactivateInspector()
       Task {
         await inspectorViewModel.flushPendingWriteIfNeeded()
+        await tweaksDefaultsWriteCoordinator.cancelPendingWrite()
       }
       localhostReloadTask?.cancel()
       askAgentReprobeTask?.cancel()
@@ -516,15 +520,16 @@ public struct WebPreviewView: View {
   @ViewBuilder
   private var headerControls: some View {
     HStack(spacing: 12) {
-      // Inspect toggle
-      Button {
-        toggleInspector()
-      } label: {
-        Image(systemName: "cursorarrow.rays")
-          .font(.system(size: 14, weight: .medium))
-          .foregroundColor(inspectState.isActive ? .accentColor : .secondary)
-      }
-      .buttonStyle(.plain)
+      WebPreviewToolbarIconButton(
+        title: "\(inspectState.isActive ? "Stop" : "Start") \(inspectBehavior.modeName) mode",
+        systemImage: "cursorarrow.rays",
+        isActive: inspectState.isActive,
+        width: 28,
+        height: 28,
+        font: .system(size: 14, weight: .medium),
+        activeColor: .accentColor,
+        action: toggleInspector
+      )
       .help(
         inspectState.isActive
           ? "Stop \(inspectBehavior.modeName) mode. ⌘⇧I cycles modes."
@@ -534,26 +539,27 @@ public struct WebPreviewView: View {
       if inspectState.isActive {
         let availableModes = WebPreviewInspectBehavior.availableCases(advancedEditingEnabled: isAdvancedEditingEnabled)
         if availableModes.count > 1 {
-          HStack(spacing: 6) {
+          WebPreviewToolbarGroup {
             ForEach(availableModes) { behavior in
-              Button {
+              WebPreviewToolbarIconButton(
+                title: behavior.accessibilityLabel,
+                systemImage: behavior.icon,
+                isActive: inspectBehavior == behavior,
+                width: 32,
+                height: 28,
+                font: .system(size: 14, weight: .medium),
+                activeColor: .accentColor
+              ) {
                 inspectBehavior = behavior
-              } label: {
-                Image(systemName: behavior.icon)
-                  .font(.caption)
-                  .frame(width: 26, height: 20)
-                  .foregroundColor(inspectBehavior == behavior ? .accentColor : .secondary)
-                  .contentShape(Rectangle())
               }
-              .buttonStyle(.plain)
-              .accessibilityLabel(behavior.accessibilityLabel)
               .help(behavior.helpText)
             }
           }
-          .padding(4)
-          .background(Color.secondary.opacity(0.12))
-          .clipShape(RoundedRectangle(cornerRadius: 6))
         }
+      }
+
+      WebPreviewToolbarGroup {
+        tweaksButton
       }
 
       if canRefreshCurrentPreview {
@@ -648,6 +654,29 @@ public struct WebPreviewView: View {
     }
     .webPreviewSecondaryButtonStyle()
     .controlSize(.small)
+  }
+
+  private var tweaksButton: some View {
+    WebPreviewToolbarIconButton(
+      title: "Tweaks",
+      systemImage: "slider.horizontal.3",
+      isActive: isTweaksPopoverPresented,
+      width: 32,
+      height: 28,
+      font: .system(size: 14, weight: .medium),
+      activeColor: .purple,
+      action: { isTweaksPopoverPresented.toggle() }
+    )
+    .help("Tweak this design with live controls")
+    .popover(isPresented: $isTweaksPopoverPresented, arrowEdge: .bottom) {
+      TweaksPanelView(
+        state: tweaksState,
+        onSubmitDescription: sendCustomTweaksPrompt,
+        onIdeas: sendTweaksIdeasPrompt,
+        onValueChange: handleTweakValueChange
+      )
+      .frame(width: 320)
+    }
   }
 
   // MARK: - Content
@@ -1208,6 +1237,7 @@ public struct WebPreviewView: View {
     resolution = newResolution
     previewWebView = nil
     isLoading = false
+    tweaksState.clear()
     syncReloadCoordinatorBaseline()
 
     switch newResolution {
@@ -1306,7 +1336,8 @@ public struct WebPreviewView: View {
           isInspectModeActive: $inspectState.isActive,
           selectedElementId: inspectState.selectedElement?.id,
           selectorToRestore: activeSelectorToRestore,
-          onWebViewReady: handleWebViewReady
+          onWebViewReady: handleWebViewReady,
+          onTweakPropsChange: handleTweakPropsChange
         )
         .overlay(alignment: .top) {
           if inspectState.isActive {
@@ -1386,7 +1417,8 @@ public struct WebPreviewView: View {
           inspectMode: inspectBehavior.canvasMode,
           selectedElementId: inspectState.selectedElement?.id,
           selectorToRestore: activeSelectorToRestore,
-          onWebViewReady: handleWebViewReady
+          onWebViewReady: handleWebViewReady,
+          onTweakPropsChange: handleTweakPropsChange
         )
         .webInspectorOverlay(
           state: inspectState,
@@ -1455,6 +1487,70 @@ public struct WebPreviewView: View {
       return "dev server preview"
     case .launchOptions, .noContent, nil:
       return nil
+    }
+  }
+
+  private var tweakPromptTargetName: String {
+    if let selectedFilePath {
+      return URL(fileURLWithPath: selectedFilePath).lastPathComponent
+    }
+    return "\(session.projectName)'s current preview"
+  }
+
+  private func handleTweakPropsChange(_ props: [TweakProp]) {
+    tweaksState.updateSchema(props)
+  }
+
+  private func handleTweakValueChange(prop: TweakProp, value: TweakPropValue) {
+    tweaksState.updateValue(name: prop.name, value)
+    if let previewWebView {
+      TweaksBridge.setProp(name: prop.name, value: value, in: previewWebView)
+    }
+    persistTweakDefaultIfPossible(propName: prop.name, value: value)
+  }
+
+  private func sendTweaksIdeasPrompt() {
+    sendTweaksPrompt(TweaksPromptBuilder.ideasPrompt(fileName: tweakPromptTargetName))
+  }
+
+  private func sendCustomTweaksPrompt(_ instruction: String) {
+    sendTweaksPrompt(TweaksPromptBuilder.customPrompt(
+      fileName: tweakPromptTargetName,
+      instruction: instruction
+    ))
+  }
+
+  private func sendTweaksPrompt(_ prompt: String) {
+    isTweaksPopoverPresented = false
+    queueSendFailureMessage = nil
+
+    if let onInspectSubmit {
+      onInspectSubmit(prompt, session)
+      onCollapseExpandedAfterSend?()
+      return
+    }
+
+    guard let onQueuedSubmit, onQueuedSubmit(prompt, session) else {
+      queueSendFailureMessage = "Could not find an active terminal for this session. Keep the preview open and try again when the terminal is ready."
+      return
+    }
+    onCollapseExpandedAfterSend?()
+  }
+
+  private func persistTweakDefaultIfPossible(propName: String, value: TweakPropValue) {
+    guard case .directFile = resolution,
+          let selectedFilePath else {
+      return
+    }
+
+    fileWatcher.suppressReloads(for: TweaksDefaultsWriteCoordinator.reloadSuppressionDuration)
+    Task {
+      await tweaksDefaultsWriteCoordinator.scheduleValueWrite(
+        propName: propName,
+        value: value,
+        filePath: selectedFilePath,
+        projectPath: projectPath
+      )
     }
   }
 
@@ -1568,7 +1664,10 @@ public struct WebPreviewView: View {
     isLoading = loading
     handleOverlayReloadingState(loading)
 
-    guard !loading else { return }
+    guard !loading else {
+      tweaksState.clear()
+      return
+    }
 
     restorePendingScrollPositionIfNeeded()
     lastSelectedSelector = nil
@@ -2023,6 +2122,88 @@ private struct InspectOverlayCursorModifier: ViewModifier {
 private extension View {
   func inspectOverlayCursor(label: String, onHoverChange: @escaping (Bool) -> Void) -> some View {
     modifier(InspectOverlayCursorModifier(label: label, onHoverChange: onHoverChange))
+  }
+}
+
+private struct WebPreviewToolbarGroup<Content: View>: View {
+  @Environment(\.colorScheme) private var colorScheme
+  let content: Content
+
+  init(@ViewBuilder content: () -> Content) {
+    self.content = content()
+  }
+
+  var body: some View {
+    HStack(spacing: 6) {
+      content
+    }
+    .padding(4)
+    .background(groupBackground, in: RoundedRectangle(cornerRadius: 10))
+    .overlay {
+      RoundedRectangle(cornerRadius: 10)
+        .stroke(groupBorder, lineWidth: 1)
+    }
+  }
+
+  private var groupBackground: Color {
+    colorScheme == .dark
+      ? Color.black.opacity(0.28)
+      : Color.secondary.opacity(0.10)
+  }
+
+  private var groupBorder: Color {
+    colorScheme == .dark
+      ? Color.white.opacity(0.06)
+      : Color.black.opacity(0.08)
+  }
+}
+
+private struct WebPreviewToolbarIconButton: View {
+  let title: String
+  let systemImage: String
+  let isActive: Bool
+  let width: CGFloat
+  let height: CGFloat
+  let font: Font
+  let activeColor: Color
+  let action: () -> Void
+
+  @Environment(\.colorScheme) private var colorScheme
+
+  var body: some View {
+    Button(action: action) {
+      ZStack {
+        RoundedRectangle(cornerRadius: 8)
+          .fill(backgroundColor)
+
+        Image(systemName: systemImage)
+          .font(font)
+          .foregroundStyle(iconColor)
+      }
+      .frame(width: width, height: height)
+      .overlay {
+        RoundedRectangle(cornerRadius: 8)
+          .stroke(borderColor, lineWidth: isActive ? 1 : 0)
+      }
+      .contentShape(Rectangle())
+    }
+    .buttonStyle(.plain)
+    .accessibilityLabel(title)
+    .accessibilityValue(isActive ? "On" : "Off")
+  }
+
+  private var iconColor: Color {
+    isActive ? activeColor : .secondary
+  }
+
+  private var backgroundColor: Color {
+    guard isActive else { return .clear }
+    return activeColor.opacity(colorScheme == .dark ? 0.16 : 0.12)
+  }
+
+  private var borderColor: Color {
+    guard isActive else { return .clear }
+    return activeColor.opacity(colorScheme == .dark ? 0.32 : 0.22)
   }
 }
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/WebPreviewView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/WebPreviewView.swift
@@ -558,9 +558,7 @@ public struct WebPreviewView: View {
         }
       }
 
-      WebPreviewToolbarGroup {
-        tweaksButton
-      }
+      tweaksButton
 
       if canRefreshCurrentPreview {
         headerActionButton("Reload", systemImage: "arrow.clockwise", action: refreshPreview)
@@ -657,16 +655,14 @@ public struct WebPreviewView: View {
   }
 
   private var tweaksButton: some View {
-    WebPreviewToolbarIconButton(
-      title: "Tweaks",
-      systemImage: "slider.horizontal.3",
-      isActive: isTweaksPopoverPresented,
-      width: 32,
-      height: 28,
-      font: .system(size: 14, weight: .medium),
-      activeColor: .purple,
-      action: { isTweaksPopoverPresented.toggle() }
-    )
+    Button {
+      isTweaksPopoverPresented.toggle()
+    } label: {
+      Label("Tweaks", systemImage: "slider.horizontal.3")
+        .font(.caption)
+    }
+    .webPreviewSecondaryButtonStyle()
+    .controlSize(.small)
     .help("Tweak this design with live controls")
     .popover(isPresented: $isTweaksPopoverPresented, arrowEdge: .bottom) {
       TweaksPanelView(

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/TweaksDefaultsWriteCoordinatorTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/TweaksDefaultsWriteCoordinatorTests.swift
@@ -1,0 +1,137 @@
+import Canvas
+import Foundation
+import Testing
+
+@testable import AgentHubCore
+
+private actor TweaksMockFileService: ProjectFileServiceProtocol {
+  struct WriteCall: Equatable, Sendable {
+    let path: String
+    let content: String
+  }
+
+  enum MockError: Error {
+    case missingFile
+  }
+
+  private var files: [String: String]
+  private var writes: [WriteCall] = []
+
+  init(files: [String: String]) {
+    self.files = files
+  }
+
+  func readFile(at path: String, projectPath: String) async throws -> String {
+    guard let content = files[path] else { throw MockError.missingFile }
+    return content
+  }
+
+  func writeFile(at path: String, content: String, projectPath: String) async throws {
+    files[path] = content
+    writes.append(WriteCall(path: path, content: content))
+  }
+
+  func listTextFiles(in projectPath: String, extensions: Set<String>) async -> [String] {
+    files.keys.sorted()
+  }
+
+  func recordedWrites() -> [WriteCall] {
+    writes
+  }
+}
+
+@Suite("TweaksDefaultsWriteCoordinator")
+struct TweaksDefaultsWriteCoordinatorTests {
+  private let filePath = "/project/index.html"
+  private let html = """
+  <script>
+    dc_set_props({
+      "warmth": { "label": "Warmth", "type": "slider", "min": 0, "max": 100, "step": 1, "value": 60 },
+      "accent": { "label": "Accent", "type": "color", "value": "#ff6b35" }
+    });
+  </script>
+  """
+
+  @Test("Writes a declared prop value into the source")
+  func writesDeclaredPropValue() async throws {
+    let fileService = TweaksMockFileService(files: [filePath: html])
+    let coordinator = TweaksDefaultsWriteCoordinator(fileService: fileService)
+
+    let outcome = await coordinator.writeValue(
+      propName: "warmth",
+      value: .number(72),
+      filePath: filePath,
+      projectPath: "/project"
+    )
+
+    #expect(outcome == .written)
+    let writes = await fileService.recordedWrites()
+    #expect(writes.count == 1)
+    #expect(writes.first?.content.contains("\"value\": 72") == true)
+    #expect(writes.first?.content.contains(
+      "\"accent\": { \"label\": \"Accent\", \"type\": \"color\", \"value\": \"#ff6b35\" }"
+    ) == true)
+  }
+
+  @Test("Rejects undeclared prop names without writing")
+  func rejectsUndeclaredPropName() async throws {
+    let fileService = TweaksMockFileService(files: [filePath: html])
+    let coordinator = TweaksDefaultsWriteCoordinator(fileService: fileService)
+
+    let outcome = await coordinator.writeValue(
+      propName: "missing",
+      value: .string("retro"),
+      filePath: filePath,
+      projectPath: "/project"
+    )
+
+    #expect(outcome == .propNotDeclared)
+    let writes = await fileService.recordedWrites()
+    #expect(writes.isEmpty)
+  }
+
+  @Test("Rejects unsafe prop names before parsing")
+  func rejectsUnsafePropName() async throws {
+    let fileService = TweaksMockFileService(files: [filePath: html])
+    let coordinator = TweaksDefaultsWriteCoordinator(fileService: fileService)
+
+    let outcome = await coordinator.writeValue(
+      propName: "warmth;alert(1)",
+      value: .number(72),
+      filePath: filePath,
+      projectPath: "/project"
+    )
+
+    #expect(outcome == .invalidPropName)
+    let writes = await fileService.recordedWrites()
+    #expect(writes.isEmpty)
+  }
+}
+
+@Suite("WebPreviewFileWatcher reload suppression")
+@MainActor
+struct WebPreviewFileWatcherSuppressionTests {
+  @Test("Suppression lasts until the requested date and then clears")
+  func suppressionWindowClearsAfterDate() {
+    let watcher = WebPreviewFileWatcher()
+    let now = Date()
+
+    watcher.suppressReloads(until: now.addingTimeInterval(1))
+
+    #expect(watcher.isReloadSuppressed(at: now.addingTimeInterval(0.5)))
+    #expect(watcher.isReloadSuppressed(at: now.addingTimeInterval(1.1)) == false)
+    #expect(watcher.isReloadSuppressed(at: now.addingTimeInterval(1.2)) == false)
+  }
+
+  @Test("Later suppression windows extend the active suppression")
+  func suppressionWindowExtends() {
+    let watcher = WebPreviewFileWatcher()
+    let now = Date()
+
+    watcher.suppressReloads(until: now.addingTimeInterval(1))
+    watcher.suppressReloads(until: now.addingTimeInterval(2))
+
+    #expect(watcher.isReloadSuppressed(at: now.addingTimeInterval(1.5)))
+    #expect(watcher.isReloadSuppressed(at: now.addingTimeInterval(2.1)) == false)
+  }
+}


### PR DESCRIPTION
## Summary

Adds Canvas 1.3.0 support to AgentHub's web preview and wires the new reusable Tweaks runtime into the existing preview surface.

## Changes

- Pins Canvas to exact `1.3.0` and updates resolved package metadata.
- Captures `dc_set_props` schemas from `InspectableWebView` into `TweaksState`.
- Hosts `TweaksPanelView` from the preview toolbar, routes Ideas/custom prompts through AgentHub's existing session prompt pipeline, and applies live values with `TweaksBridge.setProp`.
- Persists direct-file tweak values back into HTML defaults with a debounced `TweaksDefaultsWriteCoordinator` that validates prop names and verifies the splice by reparsing.
- Suppresses preview file-watcher reloads for AgentHub-owned tweak persistence writes.
- Restyles the inspect/mode/tweaks toolbar controls to match the Easel-style compact icon button groups.

## Impact

Pages that declare tweakable props can now expose native controls in AgentHub's web preview. Slider, select, color, toggle, and text changes update the running page immediately, and direct-file previews can persist the latest value as the next default.

## Validation

- `xcodebuild test -scheme AgentHubCore-Tests -destination 'platform=macOS' -test-timeouts-enabled YES -skipPackagePluginValidation -only-testing:AgentHubTests/WebPreviewModeTests -only-testing:AgentHubTests/TweaksDefaultsWriteCoordinatorTests -only-testing:AgentHubTests/WebPreviewFileWatcherSuppressionTests`

Result: passed, 9 tests in 3 suites.