### PR TITLE
[codex] Harden worktree restore and removal

### DIFF
--- a/app/modules/AgentHubCLI/Sources/AgentHubCLIKit/WorktreeManagementService.swift
+++ b/app/modules/AgentHubCLI/Sources/AgentHubCLIKit/WorktreeManagementService.swift
@@ -676,7 +676,7 @@ public actor WorktreeManagementService: WorktreeManagementServiceProtocol {
       return
     }
 
-    let registeredInfo = try await registeredWorktree(at: worktreePath, relativeTo: mainRepoPath)
+    let registeredInfo = try? await registeredWorktree(at: worktreePath, relativeTo: mainRepoPath)
     if let registeredInfo, !registeredInfo.isWorktree {
       throw WorktreeManagementError.gitCommandFailed("Refusing to delete the main worktree: \(worktreePath)")
     }
@@ -698,20 +698,34 @@ public actor WorktreeManagementService: WorktreeManagementServiceProtocol {
     // still bounding a genuine git hang (the old sync path waited forever).
     do {
       try await runGitCommand(args, at: mainRepoPath, timeout: Self.gitWorktreeTimeout)
-    } catch {
-      guard force, registeredInfo?.isWorktree == true else {
-        throw error
+    } catch let gitError {
+      guard force else {
+        throw gitError
       }
-      try await forceRemoveRegisteredWorktreeDirectory(worktreePath, parentRepoPath: mainRepoPath)
+      do {
+        try Self.validateFilesystemForceRemoval(
+          of: worktreePath,
+          mainRepoPath: mainRepoPath,
+          isRegisteredLinkedWorktree: registeredInfo?.isWorktree == true
+        )
+      } catch {
+        throw gitError
+      }
+      try await forceRemoveWorktreeDirectory(worktreePath, parentRepoPath: mainRepoPath)
     }
 
     if FileManager.default.fileExists(atPath: worktreePath) {
-      guard force, registeredInfo?.isWorktree == true else {
+      guard force else {
         throw WorktreeManagementError.gitCommandFailed(
           "Git reported success but the worktree directory still exists: \(worktreePath)"
         )
       }
-      try await forceRemoveRegisteredWorktreeDirectory(worktreePath, parentRepoPath: mainRepoPath)
+      try Self.validateFilesystemForceRemoval(
+        of: worktreePath,
+        mainRepoPath: mainRepoPath,
+        isRegisteredLinkedWorktree: registeredInfo?.isWorktree == true
+      )
+      try await forceRemoveWorktreeDirectory(worktreePath, parentRepoPath: mainRepoPath)
     }
 
     if let stillRegistered = try await registeredWorktree(at: worktreePath, relativeTo: mainRepoPath),
@@ -783,7 +797,17 @@ public actor WorktreeManagementService: WorktreeManagementServiceProtocol {
     guard FileManager.default.fileExists(atPath: worktreePath) else {
       return
     }
-    try FileManager.default.removeItem(atPath: worktreePath)
+    try Self.validateFilesystemForceRemoval(
+      of: worktreePath,
+      mainRepoPath: parentRepoPath,
+      isRegisteredLinkedWorktree: false
+    )
+    await forceRemoveDirectory(worktreePath)
+    if FileManager.default.fileExists(atPath: worktreePath) {
+      throw WorktreeManagementError.gitCommandFailed(
+        "Worktree directory still exists after orphan delete: \(worktreePath)"
+      )
+    }
   }
 }
 
@@ -1067,14 +1091,97 @@ private extension WorktreeManagementService {
     }
   }
 
-  func forceRemoveRegisteredWorktreeDirectory(_ worktreePath: String, parentRepoPath: String) async throws {
-    if FileManager.default.fileExists(atPath: worktreePath) {
-      try FileManager.default.removeItem(atPath: worktreePath)
+  /// Last line of defense before the filesystem fallback deletes a directory git
+  /// refused to remove. Require evidence the path is a linked worktree and can
+  /// never be the main checkout.
+  nonisolated static func validateFilesystemForceRemoval(
+    of worktreePath: String,
+    mainRepoPath: String,
+    isRegisteredLinkedWorktree: Bool
+  ) throws {
+    let target = (worktreePath as NSString).standardizingPath
+    let mainRoot = (mainRepoPath as NSString).standardizingPath
+    if target == mainRoot || mainRoot.hasPrefix(target + "/") {
+      throw WorktreeManagementError.gitCommandFailed(
+        "Refusing to force-delete \(worktreePath): it is or contains the main repository"
+      )
     }
+
+    guard isRegisteredLinkedWorktree || hasLinkedWorktreeMarker(at: worktreePath) else {
+      throw WorktreeManagementError.gitCommandFailed(
+        "Refusing to force-delete \(worktreePath): it is not a registered worktree and has no linked-worktree .git marker"
+      )
+    }
+  }
+
+  /// Whether the directory's `.git` entry is a linked-worktree marker file.
+  nonisolated static func hasLinkedWorktreeMarker(at path: String) -> Bool {
+    let gitEntry = (path as NSString).appendingPathComponent(".git")
+    var isDirectory: ObjCBool = false
+    guard FileManager.default.fileExists(atPath: gitEntry, isDirectory: &isDirectory),
+          !isDirectory.boolValue,
+          let contents = try? String(contentsOfFile: gitEntry, encoding: .utf8),
+          let gitdirLine = contents.components(separatedBy: .newlines).first(where: { $0.hasPrefix("gitdir:") }) else {
+      return false
+    }
+    return gitdirLine.contains("/.git/worktrees/")
+  }
+
+  func forceRemoveWorktreeDirectory(_ worktreePath: String, parentRepoPath: String) async throws {
+    await forceRemoveDirectory(worktreePath)
     try await pruneStaleWorktreeMetadata(for: worktreePath, parentRepoPath: parentRepoPath)
     if FileManager.default.fileExists(atPath: worktreePath) {
       throw WorktreeManagementError.gitCommandFailed(
         "Worktree directory still exists after force delete: \(worktreePath)"
+      )
+    }
+  }
+
+  /// Removes a directory tree even when it contains read-only files. `chmod -R`
+  /// and `rm -rf` do not traverse symlinked directories on macOS, so symlinked
+  /// caches outside the tree are left untouched. Callers must validate the path
+  /// with `validateFilesystemForceRemoval` first.
+  func forceRemoveDirectory(_ path: String) async {
+    guard FileManager.default.fileExists(atPath: path) else { return }
+    _ = try? await runShellCommand("/bin/chmod", arguments: ["-R", "u+w", path], timeout: 30)
+    _ = try? await runShellCommand("/bin/rm", arguments: ["-rf", path], timeout: 60)
+  }
+
+  func runShellCommand(
+    _ executablePath: String,
+    arguments: [String],
+    timeout: TimeInterval
+  ) async throws {
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: executablePath)
+    process.arguments = arguments
+
+    try process.run()
+    let exitCode = await withTaskCancellationHandler {
+      await withTaskGroup(of: Int32.self) { group in
+        group.addTask {
+          process.waitUntilExit()
+          return process.terminationStatus
+        }
+        group.addTask {
+          try? await Task.sleep(for: .seconds(timeout))
+          if process.isRunning {
+            process.terminate()
+          }
+          return Int32(-1)
+        }
+
+        let result = await group.next() ?? Int32(-1)
+        group.cancelAll()
+        return result
+      }
+    } onCancel: {
+      Self.terminateIfRunning(process)
+    }
+
+    if exitCode != 0 {
+      throw WorktreeManagementError.gitCommandFailed(
+        "\(executablePath) failed with exit code \(exitCode)"
       )
     }
   }

--- a/app/modules/AgentHubCLI/Tests/AgentHubCLIKitTests/WorktreeManagementServiceTests.swift
+++ b/app/modules/AgentHubCLI/Tests/AgentHubCLIKitTests/WorktreeManagementServiceTests.swift
@@ -709,6 +709,54 @@ struct WorktreeRemovalTests {
     #expect(!listAfter.contains("test-branch"))
   }
 
+  @Test("Force delete refuses a directory that is not a linked worktree")
+  func forceDeleteRefusesNonWorktreeDirectory() async throws {
+    let fixture = try GitRepoFixture.create()
+    defer { fixture.cleanup() }
+
+    let plainDir = fixture.repoPath + "-not-a-worktree"
+    try FileManager.default.createDirectory(atPath: plainDir, withIntermediateDirectories: true)
+    try "irreplaceable".write(toFile: plainDir + "/data.txt", atomically: true, encoding: .utf8)
+
+    let service = WorktreeManagementService()
+    await #expect(throws: (any Error).self) {
+      try await service.removeWorktree(at: plainDir, relativeTo: fixture.repoPath, force: true)
+    }
+
+    #expect(FileManager.default.fileExists(atPath: plainDir + "/data.txt"))
+  }
+
+  @Test("Force delete refuses the main repository root")
+  func forceDeleteRefusesMainRepositoryRoot() async throws {
+    let fixture = try GitRepoFixture.create()
+    defer { fixture.cleanup() }
+
+    let service = WorktreeManagementService()
+    await #expect(throws: (any Error).self) {
+      try await service.removeWorktree(at: fixture.repoPath, relativeTo: fixture.repoPath, force: true)
+    }
+
+    #expect(FileManager.default.fileExists(atPath: fixture.repoPath + "/README.md"))
+    #expect(FileManager.default.fileExists(atPath: fixture.repoPath + "/.git"))
+  }
+
+  @Test("Orphan removal refuses a directory without the linked-worktree marker")
+  func orphanRemovalRefusesUnmarkedDirectory() async throws {
+    let fixture = try GitRepoFixture.create()
+    defer { fixture.cleanup() }
+
+    let plainDir = fixture.repoPath + "-orphan-imposter"
+    try FileManager.default.createDirectory(atPath: plainDir, withIntermediateDirectories: true)
+    try "keep me".write(toFile: plainDir + "/data.txt", atomically: true, encoding: .utf8)
+
+    let service = WorktreeManagementService()
+    await #expect(throws: (any Error).self) {
+      try await service.removeOrphanedWorktree(at: plainDir, parentRepoPath: fixture.repoPath)
+    }
+
+    #expect(FileManager.default.fileExists(atPath: plainDir + "/data.txt"))
+  }
+
   @Test("Force removes dirty worktree from disk")
   func forceRemovesDirtyWorktreeFromDisk() async throws {
     let fixture = try GitRepoFixture.create()

--- a/app/modules/AgentHubCore/Sources/AgentHub/Models/WorktreeSettingsInventory.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Models/WorktreeSettingsInventory.swift
@@ -28,6 +28,7 @@ struct WorktreeSettingsWorktree: Identifiable, Equatable {
   let monitoredSessionCount: Int
   let activeMonitoredSessionCount: Int
   let historicalSessionCount: Int
+  let diskSizeBytes: Int64?
 
   var providerLabel: String {
     providerKinds.map(\.rawValue).joined(separator: " + ")
@@ -147,7 +148,8 @@ enum WorktreeSettingsInventoryBuilder {
         isFocusedInAgentHub: !providerMatches.isEmpty,
         monitoredSessionCount: monitoredSessionsById.count,
         activeMonitoredSessionCount: monitoredSessionsById.values.filter(\.isActive).count,
-        historicalSessionCount: historicalSessionCount
+        historicalSessionCount: historicalSessionCount,
+        diskSizeBytes: nil
       )
     }
   }

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/WorktreeDiskSize.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/WorktreeDiskSize.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+/// Computes the approximate on-disk footprint for a worktree directory.
+///
+/// The walk is tolerant of unreadable entries and does not descend into
+/// symlinked subtrees, so out-of-tree caches are not double-counted. Hidden
+/// entries are included because build products such as `.build` and `.swiftpm`
+/// are often the bulk of a worktree's reclaimable space.
+enum WorktreeDiskSize {
+  static func bytes(at url: URL) -> Int64 {
+    let keys: Set<URLResourceKey> = [
+      .isDirectoryKey,
+      .isSymbolicLinkKey,
+      .totalFileAllocatedSizeKey,
+      .fileAllocatedSizeKey,
+    ]
+
+    guard let enumerator = FileManager.default.enumerator(
+      at: url,
+      includingPropertiesForKeys: Array(keys),
+      options: []
+    ) else {
+      return 0
+    }
+
+    var total: Int64 = 0
+    for case let fileURL as URL in enumerator {
+      do {
+        let values = try fileURL.resourceValues(forKeys: keys)
+        if values.isSymbolicLink == true {
+          enumerator.skipDescendants()
+        }
+        total += Int64(values.totalFileAllocatedSize ?? values.fileAllocatedSize ?? 0)
+      } catch {
+        continue
+      }
+    }
+
+    return total
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/SessionsBrowserPanel.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/SessionsBrowserPanel.swift
@@ -2,8 +2,8 @@
 //  SessionsBrowserPanel.swift
 //  AgentHub
 //
-//  Sidebar view showing monitored sessions grouped by module.
-//  Used when sidebar mode is "Hub Sessions".
+//  Sidebar view showing monitored sessions with selectable grouping, sorting,
+//  and status filtering. Used when sidebar mode is "Hub Sessions".
 //
 
 import Foundation

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/WorktreeInventorySection.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/WorktreeInventorySection.swift
@@ -351,6 +351,8 @@ private struct WorktreeInventoryRow: View {
           )
         }
 
+        diskSizeView
+
         Spacer(minLength: 12)
 
         sessionImportControl
@@ -361,6 +363,23 @@ private struct WorktreeInventoryRow: View {
       RoundedRectangle(cornerRadius: 8, style: .continuous)
         .fill(Color.primary.opacity(0.04))
     )
+  }
+
+  @ViewBuilder
+  private var diskSizeView: some View {
+    if let diskSizeBytes = worktree.diskSizeBytes {
+      WorktreeInventoryBadge(
+        title: ByteCountFormatter.string(fromByteCount: diskSizeBytes, countStyle: .file),
+        systemImage: "externaldrive",
+        isProminent: false,
+        helpText: "Approximate disk space reclaimed by deleting this worktree."
+      )
+    } else {
+      ProgressView()
+        .scaleEffect(0.55)
+        .frame(width: 18, height: 18)
+        .help("Calculating worktree size")
+    }
   }
 
   @ViewBuilder

--- a/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/CLISessionsViewModel.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/CLISessionsViewModel.swift
@@ -144,6 +144,10 @@ public final class CLISessionsViewModel {
   private var existingSessionIdsBeforeTerminal: Set<String> = []
   /// Session IDs awaiting progressive restoration on app launch
   private var pendingRestorationSessionIds: Set<String> = []
+  /// Persisted session IDs this launch could not restore. They stay out of the
+  /// UI but remain part of workspace-state writes so a transient launch failure
+  /// cannot permanently forget a monitored session.
+  private var unrestoredSessionIds: Set<String> = []
 
   /// Maps session IDs to prompts that should be sent to the terminal when it becomes ready.
   ///
@@ -2064,6 +2068,10 @@ public final class CLISessionsViewModel {
     Task {
       let workspaceState = metadataStore?.getWorkspaceStateSync(for: providerKind) ?? SessionWorkspaceState()
       let paths = workspaceState.selectedRepositoryPaths
+      // Retain every saved session ID before any restore step can fail. Even if
+      // repositories or worktrees are unavailable this launch, the IDs keep
+      // riding along in workspace-state writes and retry on the next launch.
+      unrestoredSessionIds.formUnion(workspaceState.monitoredSessionIds)
       guard !paths.isEmpty else {
         return
       }
@@ -2141,8 +2149,11 @@ public final class CLISessionsViewModel {
       isLaunchRestoreInProgress = false
       loadDeferredBrowseSessionsIfNeeded()
 
-      // Safety timeout: stop trying to restore after 10 seconds
+      // Safety timeout: stop actively retrying after 10 seconds, but keep the
+      // still-unrestored IDs persisted so slow or partially failed launches do
+      // not forget sessions.
       try? await Task.sleep(for: .seconds(10))
+      unrestoredSessionIds.formUnion(pendingRestorationSessionIds)
       pendingRestorationSessionIds.removeAll()
       persistMonitoredSessions()
     }
@@ -2157,6 +2168,13 @@ public final class CLISessionsViewModel {
     let rejectedIds = Set(sessions.map(\.id)).subtracting(restorableSessions.map(\.id))
     if !rejectedIds.isEmpty {
       pendingRestorationSessionIds.subtract(rejectedIds)
+      let confirmedGoneIds = Set(
+        sessions
+          .filter { rejectedIds.contains($0.id) && !FileManager.default.fileExists(atPath: $0.projectPath) }
+          .map(\.id)
+      )
+      unrestoredSessionIds.subtract(confirmedGoneIds)
+      unrestoredSessionIds.formUnion(rejectedIds.subtracting(confirmedGoneIds))
       persistMonitoredSessions()
     }
 
@@ -2173,6 +2191,7 @@ public final class CLISessionsViewModel {
     }
 
     pendingRestorationSessionIds.subtract(restoredIds)
+    unrestoredSessionIds.subtract(restoredIds)
     expandItemsContainingLoadedSessions(restorableSessions)
     loadCustomNames()
     loadPinnedSessions()
@@ -2231,6 +2250,7 @@ public final class CLISessionsViewModel {
 
     if !restoredIds.isEmpty {
       pendingRestorationSessionIds.subtract(restoredIds)
+      unrestoredSessionIds.subtract(restoredIds)
       expandItemsContainingMonitoredSessions()
       loadCustomNames()
       loadPinnedSessions()
@@ -2263,7 +2283,9 @@ public final class CLISessionsViewModel {
       }
     }
 
-    let sessionIdsToPersist = monitoredSessionIds.union(pendingRestorationSessionIds)
+    let sessionIdsToPersist = monitoredSessionIds
+      .union(pendingRestorationSessionIds)
+      .union(unrestoredSessionIds)
 
     return SessionWorkspaceState(
       selectedRepositoryPaths: selectedRepositories.map(\.path),
@@ -3774,6 +3796,8 @@ public final class CLISessionsViewModel {
   /// Stop monitoring by session ID
   public func stopMonitoring(sessionId: String) {
     monitoredSessionIds.remove(sessionId)
+    unrestoredSessionIds.remove(sessionId)
+    pendingRestorationSessionIds.remove(sessionId)
     monitoredSessionBackup.removeValue(forKey: sessionId)
     removeMonitorState(for: sessionId)
     monitoringCancellables.removeValue(forKey: sessionId)

--- a/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/WorktreeInventoryViewModel.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/WorktreeInventoryViewModel.swift
@@ -12,6 +12,8 @@ final class WorktreeInventoryViewModel {
   @ObservationIgnored private let inventoryService: any GitWorktreeInventoryServiceProtocol
   @ObservationIgnored private let removalService: any GitWorktreeRemovalServiceProtocol
   @ObservationIgnored private var locallyDeletedWorktreePaths: Set<String> = []
+  @ObservationIgnored private var diskSizesByPath: [String: Int64] = [:]
+  @ObservationIgnored private var sizeComputationTask: Task<Void, Never>?
 
   init(
     inventoryService: any GitWorktreeInventoryServiceProtocol = GitWorktreeService(),
@@ -19,6 +21,10 @@ final class WorktreeInventoryViewModel {
   ) {
     self.inventoryService = inventoryService
     self.removalService = removalService
+  }
+
+  deinit {
+    sizeComputationTask?.cancel()
   }
 
   func reload(
@@ -33,6 +39,7 @@ final class WorktreeInventoryViewModel {
       claudeMonitoredSessions: claudeMonitoredSessions,
       codexMonitoredSessions: codexMonitoredSessions
     )
+    snapshot = applyDiskSizes(to: snapshot)
 
     let repositoryPaths = Self.repositoryPaths(
       claudeRepositories: claudeRepositories,
@@ -86,8 +93,10 @@ final class WorktreeInventoryViewModel {
       codexMonitoredSessions: codexMonitoredSessions,
       discoveredWorktreesByRepositoryPath: loadResult.0
     )
+    snapshot = applyDiskSizes(to: snapshot)
     loadFailuresByRepositoryPath = loadResult.1
     isLoading = false
+    startDiskSizeComputation()
   }
 
   @discardableResult
@@ -102,6 +111,7 @@ final class WorktreeInventoryViewModel {
         force: force
       )
       locallyDeletedWorktreePaths.insert(Self.normalized(worktree.path))
+      diskSizesByPath.removeValue(forKey: Self.normalized(worktree.path))
       snapshot = filteredSnapshot(snapshot)
       deletingWorktreePath = nil
       return true
@@ -123,6 +133,7 @@ final class WorktreeInventoryViewModel {
         parentRepoPath: parentRepoPath
       )
       locallyDeletedWorktreePaths.insert(Self.normalized(worktree.path))
+      diskSizesByPath.removeValue(forKey: Self.normalized(worktree.path))
       snapshot = filteredSnapshot(snapshot)
       deletingWorktreePath = nil
       return true
@@ -197,6 +208,59 @@ final class WorktreeInventoryViewModel {
           path: module.path,
           worktrees: module.worktrees.filter {
             !locallyDeletedWorktreePaths.contains(Self.normalized($0.path))
+          }
+        )
+      }
+    )
+  }
+
+  private func startDiskSizeComputation() {
+    sizeComputationTask?.cancel()
+
+    let pathsNeedingSize = snapshot.modules
+      .flatMap(\.worktrees)
+      .map { Self.normalized($0.path) }
+      .filter { diskSizesByPath[$0] == nil }
+
+    guard !pathsNeedingSize.isEmpty else { return }
+
+    // Walk one worktree at a time off the main actor, caching and applying each
+    // result as it lands. Reloads are common while sessions are active; applying
+    // progressively prevents a canceled coordinator from discarding a whole
+    // batch of completed filesystem work.
+    sizeComputationTask = Task { [weak self] in
+      for path in pathsNeedingSize {
+        if Task.isCancelled { return }
+        let size = await Task.detached(priority: .utility) {
+          WorktreeDiskSize.bytes(at: URL(fileURLWithPath: path))
+        }.value
+
+        guard let self else { return }
+        self.diskSizesByPath[path] = size
+        self.snapshot = self.applyDiskSizes(to: self.snapshot)
+      }
+    }
+  }
+
+  private func applyDiskSizes(to snapshot: WorktreeSettingsSnapshot) -> WorktreeSettingsSnapshot {
+    WorktreeSettingsSnapshot(
+      modules: snapshot.modules.map { module in
+        WorktreeSettingsModule(
+          name: module.name,
+          path: module.path,
+          worktrees: module.worktrees.map { worktree in
+            WorktreeSettingsWorktree(
+              branchName: worktree.branchName,
+              path: worktree.path,
+              worktree: worktree.worktree,
+              parentModulePath: worktree.parentModulePath,
+              providerKinds: worktree.providerKinds,
+              isFocusedInAgentHub: worktree.isFocusedInAgentHub,
+              monitoredSessionCount: worktree.monitoredSessionCount,
+              activeMonitoredSessionCount: worktree.activeMonitoredSessionCount,
+              historicalSessionCount: worktree.historicalSessionCount,
+              diskSizeBytes: diskSizesByPath[Self.normalized(worktree.path)]
+            )
           }
         )
       }

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/LaunchRestoreSessionRetentionTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/LaunchRestoreSessionRetentionTests.swift
@@ -1,0 +1,118 @@
+import Combine
+import Foundation
+import Testing
+
+@testable import AgentHubCore
+
+private actor RetentionStubMonitorService: SessionMonitorServiceProtocol {
+  private let skeletonRepositories: [SelectedRepository]
+  private let loadableSessions: [CLISession]
+
+  init(skeletonRepositories: [SelectedRepository], loadableSessions: [CLISession]) {
+    self.skeletonRepositories = skeletonRepositories
+    self.loadableSessions = loadableSessions
+  }
+
+  nonisolated var repositoriesPublisher: AnyPublisher<[SelectedRepository], Never> {
+    Empty<[SelectedRepository], Never>().eraseToAnyPublisher()
+  }
+
+  func addRepository(_ path: String) async -> SelectedRepository? { nil }
+  func removeRepository(_ path: String) async {}
+  func getSelectedRepositories() async -> [SelectedRepository] { skeletonRepositories }
+  func setSelectedRepositories(_ repositories: [SelectedRepository]) async {}
+  func refreshSessions(skipWorktreeRedetection: Bool) async {}
+
+  func restoreRepositoriesSkeleton(_ paths: [String]) async -> [SelectedRepository] {
+    skeletonRepositories
+  }
+
+  func loadSessions(ids: Set<String>) async -> [CLISession] {
+    loadableSessions.filter { ids.contains($0.id) }
+  }
+}
+
+private actor RetentionStubFileWatcher: SessionFileWatcherProtocol {
+  private nonisolated let subject = PassthroughSubject<SessionFileWatcher.StateUpdate, Never>()
+
+  nonisolated var statePublisher: AnyPublisher<SessionFileWatcher.StateUpdate, Never> {
+    subject.eraseToAnyPublisher()
+  }
+
+  func startMonitoring(sessionId: String, projectPath: String, sessionFilePath: String?) async {}
+  func stopMonitoring(sessionId: String) async {}
+  func getState(sessionId: String) async -> SessionMonitorState? { nil }
+  func refreshState(sessionId: String) async {}
+  func setApprovalTimeout(_ seconds: Int) async {}
+}
+
+@Suite("Launch restore session retention")
+@MainActor
+struct LaunchRestoreSessionRetentionTests {
+  @Test("Keeps a rejected worktree session whose directory still exists; drops one confirmed gone")
+  func keepsTransientlyUnrestorableWorktreeSession() async throws {
+    let base = URL(fileURLWithPath: NSTemporaryDirectory())
+      .appendingPathComponent("RestoreRetention-\(UUID().uuidString)")
+    let repoDir = base.appendingPathComponent("repo")
+    let worktreeDir = base.appendingPathComponent("repo-feature")
+    try FileManager.default.createDirectory(at: repoDir, withIntermediateDirectories: true)
+    try FileManager.default.createDirectory(at: worktreeDir, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: base) }
+    let deletedWorktreePath = base.appendingPathComponent("repo-deleted").path
+
+    let dbPath = FileManager.default.temporaryDirectory
+      .appending(path: "restore_retention_\(UUID().uuidString).sqlite")
+      .path
+    let store = try SessionMetadataStore(path: dbPath)
+    try await store.saveWorkspaceState(
+      SessionWorkspaceState(
+        selectedRepositoryPaths: [repoDir.path],
+        monitoredSessionIds: ["gone-session", "wt-session"],
+        ownedWorktreePaths: []
+      ),
+      for: .claude
+    )
+
+    let monitorService = RetentionStubMonitorService(
+      skeletonRepositories: [SelectedRepository(path: repoDir.path)],
+      loadableSessions: [
+        CLISession(
+          id: "wt-session",
+          projectPath: worktreeDir.path,
+          branchName: "feature",
+          isWorktree: true,
+          isActive: false,
+          sessionFilePath: "/tmp/wt-session.jsonl"
+        ),
+        CLISession(
+          id: "gone-session",
+          projectPath: deletedWorktreePath,
+          branchName: "deleted",
+          isWorktree: true,
+          isActive: false,
+          sessionFilePath: "/tmp/gone-session.jsonl"
+        ),
+      ]
+    )
+
+    let viewModel = CLISessionsViewModel(
+      monitorService: monitorService,
+      fileWatcher: RetentionStubFileWatcher(),
+      searchService: nil,
+      cliConfiguration: CLICommandConfiguration(command: "claude", mode: .claude),
+      providerKind: .claude,
+      metadataStore: store,
+      approvalNotificationService: NoOpApprovalNotificationService()
+    )
+
+    var persisted: [String] = ["gone-session"]
+    for _ in 0..<400 where persisted.contains("gone-session") {
+      persisted = store.getWorkspaceStateSync(for: .claude).monitoredSessionIds
+      try await Task.sleep(for: .milliseconds(10))
+    }
+
+    #expect(persisted.contains("wt-session"))
+    #expect(!persisted.contains("gone-session"))
+    #expect(!viewModel.isMonitoring(sessionId: "wt-session"))
+  }
+}

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/WorktreeDiskSizeTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/WorktreeDiskSizeTests.swift
@@ -1,0 +1,22 @@
+import Foundation
+import Testing
+
+@testable import AgentHubCore
+
+@Suite("Worktree disk size")
+struct WorktreeDiskSizeTests {
+  @Test("Counts hidden files and directories")
+  func countsHiddenEntries() throws {
+    let base = URL(fileURLWithPath: NSTemporaryDirectory())
+      .appendingPathComponent("WorktreeDiskSizeTests-hidden-\(UUID().uuidString)")
+    let hiddenDir = base.appendingPathComponent(".build")
+    try FileManager.default.createDirectory(at: hiddenDir, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: base) }
+
+    try Data(repeating: 0xEF, count: 8192).write(to: hiddenDir.appendingPathComponent("artifact.o"))
+    try Data(repeating: 0x01, count: 4096).write(to: base.appendingPathComponent(".hidden-file"))
+
+    let total = WorktreeDiskSize.bytes(at: base)
+    #expect(total >= Int64(8192 + 4096))
+  }
+}

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/WorktreeInventoryViewModelTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/WorktreeInventoryViewModelTests.swift
@@ -36,6 +36,46 @@ struct WorktreeInventoryViewModelTests {
     #expect(!worktree.isFocusedInAgentHub)
   }
 
+  @Test("Reload computes worktree disk sizes and applies them to the snapshot")
+  func reloadComputesAndAppliesDiskSizes() async throws {
+    let base = URL(fileURLWithPath: NSTemporaryDirectory())
+      .appendingPathComponent("WorktreeInventorySize-\(UUID().uuidString)")
+    let repoDir = base.appendingPathComponent("AgentHub")
+    let worktreeDir = base.appendingPathComponent("AgentHub-feature")
+    try FileManager.default.createDirectory(at: repoDir, withIntermediateDirectories: true)
+    try FileManager.default.createDirectory(at: worktreeDir, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: base) }
+    try Data(repeating: 0xAB, count: 4096).write(to: worktreeDir.appendingPathComponent("file.bin"))
+
+    let repoPath = repoDir.path
+    let inventory = StubWorktreeInventoryService(results: [
+      WorktreeModuleResolver.normalizedDirectoryPath(repoPath): .success([
+        inventoryItem(path: worktreeDir.path, branchName: "feature/size", mainRepoPath: repoPath)
+      ])
+    ])
+    let viewModel = WorktreeInventoryViewModel(
+      inventoryService: inventory,
+      removalService: RecordingInventoryRemovalService()
+    )
+
+    await viewModel.reload(
+      claudeRepositories: [SelectedRepository(path: repoPath)],
+      codexRepositories: [],
+      claudeMonitoredSessions: [],
+      codexMonitoredSessions: []
+    )
+
+    var size: Int64?
+    for _ in 0..<300 {
+      size = viewModel.snapshot.modules.first?.worktrees.first?.diskSizeBytes
+      if size != nil { break }
+      try await Task.sleep(for: .milliseconds(10))
+    }
+
+    let resolved = try #require(size)
+    #expect(resolved >= 4096)
+  }
+
   @Test("Keeps focused rows when git inventory loading fails")
   func keepsFocusedRowsWhenInventoryLoadingFails() async throws {
     let focusedSession = session("focused-session", path: "/tmp/AgentHub-focused")

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/WorktreeSessionImportCoordinatorTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/WorktreeSessionImportCoordinatorTests.swift
@@ -214,7 +214,8 @@ private func settingsWorktree() -> WorktreeSettingsWorktree {
     isFocusedInAgentHub: false,
     monitoredSessionCount: 0,
     activeMonitoredSessionCount: 0,
-    historicalSessionCount: 0
+    historicalSessionCount: 0,
+    diskSizeBytes: nil
   )
 }
 


### PR DESCRIPTION
## Summary
- retain unrestored monitored session IDs across launch restore failures so transient worktree/repository issues do not permanently drop sessions
- validate force/orphan worktree filesystem deletion with linked-worktree evidence before removing directories
- compute Settings worktree disk sizes progressively and include hidden build products in reclaimable size

## Root Cause
- launch restore previously persisted only monitored/pending IDs, so rejected or timed-out restores could shrink saved state permanently
- force/orphan worktree deletion could fall back to direct filesystem removal without independently proving the target was a linked worktree
- Settings size computation was missing in this checkout; sizes now fill row-by-row and are cached per path for the app session

## Validation
- `cd app/modules/AgentHubCLI && swift test --filter WorktreeRemovalTests --filter WorktreeConventionTests` passed: 22 tests in 2 suites
- `cd app/modules/AgentHubCore && xcodebuild test -scheme AgentHubCore-Tests -destination 'platform=macOS' -test-timeouts-enabled YES -skipPackagePluginValidation -only-testing:AgentHubTests/LaunchRestoreSessionRetentionTests -only-testing:AgentHubTests/WorktreeDiskSizeTests -only-testing:AgentHubTests/WorktreeInventoryViewModelTests -only-testing:AgentHubTests/WorktreeSettingsInventoryTests -only-testing:AgentHubTests/WorktreeSessionImportCoordinatorTests -only-testing:AgentHubTests/SessionWorkspaceStatePersistenceTests` passed: 17 tests in 6 suites, `** TEST SUCCEEDED **`
- side-effect sweep passed: 39 tests in 3 suites, `** TEST SUCCEEDED **`

Note: Xcode still prints the known third-party SwiftLint plugin "build commands failed" lines after `** TEST SUCCEEDED **`.
