### PR TITLE
Scope simulator panel to project/worktree and harden hot reload

### DIFF
--- a/SimulatorPreview.md
+++ b/SimulatorPreview.md
@@ -279,7 +279,12 @@ host-side (`HotReloadConsoleTail`, kqueue + byte offsets) whenever **either**
 dylib is inserted — previews-only launches tail too, for the host status
 lines. `HotReloadConsoleParser` turns InjectionLite's `🔥` lines into events:
 `✅ Hot reload complete` → injected, `❌ Compilation failed` / `⚠️ Could not
-locate command` / type-size-changed → rebuild fallback. The exact pinned
+locate command` / type-size-changed / `ℹ️ No symbols replaced …
+-interposable` → rebuild fallback. The last one matters: it means the
+running binary was never linked with `-interposable` (e.g. launched plain
+and armed only at relaunch), so injections compile but can never rebind —
+the automatic armed rebuild is the only honest fix, and the stray `✅` the
+engine prints right after is ignored while the rebuild runs. The exact pinned
 strings are matched first; tolerant 🔥-prefixed fallbacks are drift insurance
 so a wording change in a future pin can't silently degrade every save into
 timeout → full rebuild. The reload timeout is evidence-based: 12s with no
@@ -299,11 +304,14 @@ by the Settings toggle: when disabled, the Previews tab is hidden, preview
 candidate tracking is stopped, and future panel launches omit the preview-host
 dylib. Live simulator streaming remains available.
 
-The Previews tab (`SimulatorPreviewSpotlightView`) is deliberately bounded:
-it shows the open Swift file first, then recent changed files, deduplicated
-and capped. One matching preview renders as a large spotlight; several matches
-render as a small grid, and the user can expand any preview so it stays pinned
-until minimized. The tab is **self-healing and self-starting**: previews live
+The Previews tab (`SimulatorPreviewSpotlightView`) is deliberately narrow:
+candidates come from at most **two files — the open Swift file and the most
+recently changed file** (`candidateFileNames`, unit-tested). Never the whole
+recent-change history: with several git-modified files the seed would
+otherwise flood the tab with unrelated previews. One matching preview renders
+as a large spotlight; several matches (e.g. multiple `#Preview`s in one file)
+render as a small grid, and the user can expand any preview so it stays
+pinned until minimized. The tab is **self-healing and self-starting**: previews live
 inside the app's process (they follow the armed process, not the device picker).
 Switching to the tab — or opening a Swift file while on it — auto-runs the
 play flow when there's something to show: a cold device gets a full

--- a/SimulatorPreview.md
+++ b/SimulatorPreview.md
@@ -30,6 +30,18 @@ When a physical device is selected, keep the panel quiet: do not warm
 hot-reload artifacts, start preview source watchers, arm the preview host, or
 display simulator-only hot-reload state.
 
+**Run destinations are project/worktree-scoped.** `SimulatorDestinationResolver`
+resolves the panel's device from the explicit in-panel selection, then the
+project's persisted preference — and deliberately nothing else: with no
+association the panel shows a "Choose a Run Destination" picker rather than
+adopting another project's booted simulator or a random connected phone.
+Preferences are keyed by `projectPath` (worktrees are distinct paths, so each
+worktree remembers its own device) and persisted in `SessionMetadataStore`
+(`project_simulator_preferences`, hydrated into `SimulatorService` at launch),
+so they survive app relaunches. Do not reintroduce global
+`bootedDevices.first`-style fallbacks — that was the "project A shows
+project B's simulator" bug.
+
 ## Annotation feedback (element-aware pins sent to the agent)
 
 The header's **Annotate** toggle pauses tap forwarding and reads the frontmost
@@ -219,9 +231,17 @@ Two support dylibs are inserted into the user's app at launch
   `HotReloadHostPackage.snapshotPreviewsVersion`) + FlyingFox, gated on
   `AGENTHUB_PREVIEW_HOST=1`. It serves the same HTTP contract as the stock
   `Snapshotting` dylib (`GET /file` manifest, `GET /display/{type}/{id}`
-  render) on loopback port 38824 — note FlyingFox binds the **IPv6** loopback
-  (`[::1]`), which the client targets first — but renders with the windowless
-  `SwiftUIRenderingStrategy`. **Never insert the stock `Snapshotting` dylib
+  render) on a **per-device loopback port** carried by
+  `AGENTHUB_PREVIEW_PORT` (`PreviewHostPortAllocator` hashes the simulator
+  UDID into 38700–39699; default 38824 when the env var is absent) — note
+  FlyingFox binds the **IPv6** loopback (`[::1]`), which the client targets
+  first — but renders with the windowless `SwiftUIRenderingStrategy`. The
+  host reports its startup status with structured
+  `AGENTHUB_PREVIEW_HOST: …` stdout lines (`listening port=…`,
+  `waiting reason=app-not-active`, `failed reason=port-in-use/server-error`,
+  `unsupported reason=ios-version`), parsed host-side by
+  `PreviewHostStatusParser` so the Previews tab reports the actual failure
+  instead of a generic "did not respond". **Never insert the stock `Snapshotting` dylib
   next to the live mirror:** its `UIKitRenderingStrategy` covers the running
   app with a full-screen system-background window the moment it activates
   (the "blank simulator" failure), and its `+load` force-enables AX
@@ -247,16 +267,28 @@ upstream deps) under `~/Library/Application Support/AgentHub/HotReloadHost/`
 and runs `xcodebuild -destination "generic/platform=iOS Simulator"` on it. The
 first build resolves from the network and takes a minute or two — the pill
 reports "preparing" and that run launches plain; the next Build & Run arms.
-Artifacts are cached until `HotReloadHostPackage.fingerprint` changes.
+Artifacts are cached until `HotReloadHostPackage.fingerprint` changes — a
+SHA256 content hash over the materialized manifest + every generated source,
+so any pin bump or source edit invalidates the cache automatically.
 `DYLD_FRAMEWORK_PATH` covers the dependent dynamic `PreviewsSupport.framework`.
 
 Hot-reload launches use `simctl launch --terminate-running-process
 --stdout=<log>` — never `--console-pty` (simctl forwards signals, so a console
 process would kill the user's app when AgentHub stops it). The log is tailed
-host-side (`HotReloadConsoleTail`, kqueue + byte offsets) and
-`HotReloadConsoleParser` turns InjectionLite's `🔥` lines into events:
+host-side (`HotReloadConsoleTail`, kqueue + byte offsets) whenever **either**
+dylib is inserted — previews-only launches tail too, for the host status
+lines. `HotReloadConsoleParser` turns InjectionLite's `🔥` lines into events:
 `✅ Hot reload complete` → injected, `❌ Compilation failed` / `⚠️ Could not
-locate command` / type-size-changed → rebuild fallback.
+locate command` / type-size-changed → rebuild fallback. The exact pinned
+strings are matched first; tolerant 🔥-prefixed fallbacks are drift insurance
+so a wording change in a future pin can't silently degrade every save into
+timeout → full rebuild. The reload timeout is evidence-based: 12s with no
+engine activity, extended (45s, re-pushed per event) once the engine
+acknowledged the save with a recompile event, so slow compiles of large files
+don't trigger needless rebuilds. Saves landing while a rebuild is in flight
+are queued, never dropped: injectable ones are covered by the rebuild itself
+(it compiles current on-disk sources); structural ones replay as exactly one
+follow-up rebuild.
 
 Pipeline: `HotReloadSourceWatcher` (host-side FSEvents; existence-snapshot
 classifier so atomic-save renames aren't mistaken for structural changes) and
@@ -313,10 +345,12 @@ per-project opt-in.
   (`HotReloadHostPackage`) and re-verify the parser strings.
 - Nothing is ever written into the user's repo: build-setting overrides are
   command-line-only, support artifacts live in Application Support.
-- Loopback only (the generated host listens on port 38824; the client tries
-  `[::1]` first, then `127.0.0.1`); one preview host can run at a time — a
-  second session's Previews tab shows the unreachable state rather than
-  fighting over the port.
+- Loopback only; each simulator device gets its own deterministic port
+  (`PreviewHostPortAllocator`, `SIMCTL_CHILD_AGENTHUB_PREVIEW_PORT`), so
+  concurrent projects/worktrees preview simultaneously. The client tries
+  `[::1]` first, then `127.0.0.1`. The host's status strings and
+  `PreviewHostStatusParser` are pinned together by the artifact-store tests —
+  change them in lockstep.
 - Everything testable is pure and tested in `SimulatorPreviewTests`
   (`swift test` in the module: env contract, parser, classifier, locator,
   monitor transitions, manifest/render decoding, tail).
@@ -339,8 +373,8 @@ per-project opt-in.
 - Hot reload: the Previews tab renders the *current* in-process previews —
   newly added `#Preview`s appear only after the structural-change rebuild.
   Injection success is engine-confirmed, but SwiftUI visual refresh depends
-  on the app adopting Inject/`injected()` (see above). Per-device preview
-  hosts (port-per-session) and a zero-opt-in SwiftUI refresh are future work.
+  on the app adopting Inject/`injected()` (see above). A zero-opt-in SwiftUI
+  refresh is future work.
 - Hot reload does not yet detect simulator app crashes, so the pill can stay
   stale until the next panel action. The `...-hotreload` derived-data path is
   a separate build cache, and console logs under Application Support do not

--- a/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubProvider.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubProvider.swift
@@ -269,6 +269,13 @@ public final class AgentHubProvider {
       Task {
         await TerminalProcessRegistry.shared.configure(store: metadataStore)
       }
+      SimulatorService.shared.configurePreferenceStore(metadataStore)
+    } else {
+      // The lazy accessor builds the real store; defer so init stays light.
+      Task { @MainActor [weak self] in
+        guard let self, let store = self.metadataStore else { return }
+        SimulatorService.shared.configurePreferenceStore(store)
+      }
     }
 
     // Persist developer-provided commands to UserDefaults

--- a/app/modules/AgentHubCore/Sources/AgentHub/Models/ProjectSimulatorPreference.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Models/ProjectSimulatorPreference.swift
@@ -1,0 +1,36 @@
+//
+//  ProjectSimulatorPreference.swift
+//  AgentHub
+//
+//  SQLite record for the run destination a project/worktree last selected
+//  in the simulator preview panel.
+//
+
+import Foundation
+import GRDB
+
+public struct ProjectSimulatorPreference: Codable, Equatable, Sendable, FetchableRecord, PersistableRecord {
+  public enum Kind: String, Codable, Sendable {
+    case simulator
+    case physical
+  }
+
+  public var projectPath: String
+  public var deviceIdentifier: String
+  public var kind: Kind
+  public var updatedAt: Date
+
+  public static var databaseTableName: String { "project_simulator_preferences" }
+
+  public init(
+    projectPath: String,
+    deviceIdentifier: String,
+    kind: Kind,
+    updatedAt: Date = Date.now
+  ) {
+    self.projectPath = projectPath
+    self.deviceIdentifier = deviceIdentifier
+    self.kind = kind
+    self.updatedAt = updatedAt
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/SessionMetadataStore.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/SessionMetadataStore.swift
@@ -25,6 +25,7 @@ public actor SessionMetadataStore: TerminalWorkspaceStoreProtocol {
     static let createClaudeHookInstallations = "v8_create_claude_hook_installations"
     static let addOwnedWorktreePaths = "v9_add_owned_worktree_paths"
     static let createSessionRelationships = "v10_create_session_relationships"
+    static let createProjectSimulatorPreferences = "v11_create_project_simulator_preferences"
   }
 
   static let migrationIdentifiers = [
@@ -37,7 +38,8 @@ public actor SessionMetadataStore: TerminalWorkspaceStoreProtocol {
     MigrationID.createManagedProcesses,
     MigrationID.createClaudeHookInstallations,
     MigrationID.addOwnedWorktreePaths,
-    MigrationID.createSessionRelationships
+    MigrationID.createSessionRelationships,
+    MigrationID.createProjectSimulatorPreferences
   ]
 
   private let dbQueue: DatabaseQueue
@@ -191,6 +193,15 @@ public actor SessionMetadataStore: TerminalWorkspaceStoreProtocol {
       )
     }
 
+    migrator.registerMigration(MigrationID.createProjectSimulatorPreferences) { db in
+      try db.create(table: "project_simulator_preferences") { t in
+        t.column("projectPath", .text).primaryKey(onConflict: .replace)
+        t.column("deviceIdentifier", .text).notNull()
+        t.column("kind", .text).notNull()
+        t.column("updatedAt", .datetime).notNull()
+      }
+    }
+
     return migrator
   }
 
@@ -291,6 +302,7 @@ public actor SessionMetadataStore: TerminalWorkspaceStoreProtocol {
       _ = try ClaudeHookInstallationRecord.deleteAll(db)
       _ = try ManagedProcessRecord.deleteAll(db)
       _ = try SessionRelationshipRecord.deleteAll(db)
+      _ = try ProjectSimulatorPreference.deleteAll(db)
       _ = try AIConfigRecord.deleteAll(db)
       _ = try SessionRepoMapping.deleteAll(db)
       _ = try SessionMetadata.deleteAll(db)
@@ -537,6 +549,29 @@ extension SessionMetadataStore: SessionRelationshipStoreProtocol {
         .filter(Column("targetSessionId") == targetSessionId)
         .filter(Column("kind") == kind.rawValue)
         .deleteAll(db)
+    }
+  }
+
+  // MARK: - Project Simulator Preferences
+
+  /// Gets all persisted run-destination preferences, keyed one row per project path
+  public func getProjectSimulatorPreferences() throws -> [ProjectSimulatorPreference] {
+    try dbQueue.read { db in
+      try ProjectSimulatorPreference.fetchAll(db)
+    }
+  }
+
+  /// Saves the run destination for a project path (replaces any prior row)
+  public func setProjectSimulatorPreference(_ preference: ProjectSimulatorPreference) throws {
+    try dbQueue.write { db in
+      try preference.save(db)
+    }
+  }
+
+  /// Deletes the run-destination preference for a project path
+  public func deleteProjectSimulatorPreference(projectPath: String) throws {
+    try dbQueue.write { db in
+      _ = try ProjectSimulatorPreference.deleteOne(db, key: projectPath)
     }
   }
 }

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/SimulatorHotReloadController.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/SimulatorHotReloadController.swift
@@ -30,7 +30,9 @@ public final class SimulatorHotReloadController {
   public let monitor = HotReloadMonitor()
 
   /// Client for the Previews tab (talks to the inserted preview-host dylib).
-  public let previewClient: any PreviewHostClientProtocol
+  /// Re-created on each armed launch so it targets that launch's per-device
+  /// port (see `PreviewHostPortAllocator`).
+  public private(set) var previewClient: any PreviewHostClientProtocol
 
   /// Bumped every time a launch inserts the preview host. The Previews tab
   /// uses this to retry manifest loading after auto-arm/relaunch, even if no
@@ -40,6 +42,11 @@ public final class SimulatorHotReloadController {
   /// The plan used for the current/last launch — nil before the first
   /// hot-reload launch.
   public private(set) var activePlan: HotReloadLaunchPlan?
+
+  /// Startup status of the inserted preview host, from its structured
+  /// console lines. Lets the Previews tab distinguish "still starting" from
+  /// port conflicts, a backgrounded app, or an unsupported OS.
+  public private(set) var previewHostStatus: PreviewHostStatus = .unknown
 
   /// Source file names edited in this project, most recent first. This is
   /// populated only while preview observation is enabled and seeded from
@@ -56,6 +63,8 @@ public final class SimulatorHotReloadController {
   private let sourceWatcher: any HotReloadSourceWatching
   private let consoleTail: any HotReloadConsoleTailing
   private let consoleParser = HotReloadConsoleParser()
+  private let hostStatusParser = PreviewHostStatusParser()
+  private let previewClientFactory: @Sendable (Int) -> any PreviewHostClientProtocol
   private let seedChangedFiles: @Sendable (String) async -> [String]
   private var activeContext: (udid: String, projectPath: String)?
   private var preparationTask: Task<Void, Never>?
@@ -70,6 +79,7 @@ public final class SimulatorHotReloadController {
     sourceWatcher: any HotReloadSourceWatching = HotReloadSourceWatcher(),
     consoleTail: any HotReloadConsoleTailing = HotReloadConsoleTail(),
     previewClient: any PreviewHostClientProtocol = PreviewHostHTTPClient(),
+    previewClientFactory: (@Sendable (Int) -> any PreviewHostClientProtocol)? = nil,
     seedChangedFiles: @escaping @Sendable (String) async -> [String] = {
       await GitChangedSwiftFiles.changedFiles(inProjectAt: $0)
     },
@@ -81,6 +91,7 @@ public final class SimulatorHotReloadController {
     self.sourceWatcher = sourceWatcher
     self.consoleTail = consoleTail
     self.previewClient = previewClient
+    self.previewClientFactory = previewClientFactory ?? { PreviewHostHTTPClient(port: $0) }
     self.seedChangedFiles = seedChangedFiles
     self.rebuildExecutor = rebuildExecutor ?? { udid, projectPath, plan in
       await SimulatorService.shared.buildAndRunOnSimulator(
@@ -180,13 +191,19 @@ public final class SimulatorHotReloadController {
       projectPath: projectPath,
       artifacts: artifacts,
       enableInjection: enableInjection,
-      enablePreviews: enablePreviews
+      enablePreviews: enablePreviews,
+      previewPort: enablePreviews
+        ? PreviewHostPortAllocator.port(forDeviceUDID: udid)
+        : nil
     )
     guard configuration.isEffective else {
       monitor.markUnavailable(reason: "Hot-reload support libraries unavailable")
       return nil
     }
-    let wantsConsole = enableInjection && artifacts.injectionDylibPath != nil
+    // Injection events and the preview host's startup status both arrive on
+    // the app's stdout, so either inserted dylib warrants the console tail.
+    let wantsConsole = (enableInjection && artifacts.injectionDylibPath != nil)
+      || (enablePreviews && artifacts.previewHostDylibPath != nil)
     var consolePath: String?
     if wantsConsole {
       consolePath = Self.consoleLogPath(projectPath: projectPath, udid: udid)
@@ -211,9 +228,20 @@ public final class SimulatorHotReloadController {
     monitor.onRequestRebuild = nil
     activePlan = plan
     activeContext = (udid, projectPath)
+    previewHostStatus = .unknown
     if plan.configuration.enablePreviews,
        plan.configuration.artifacts.previewHostDylibPath != nil {
+      // Swap the client before bumping the generation so the Previews tab's
+      // retry loop targets this launch's port.
+      previewClient = previewClientFactory(
+        plan.configuration.previewPort ?? PreviewHostHTTPClient.port)
       previewHostGeneration += 1
+    }
+
+    // The tail runs for any inserted dylib: injection events and the preview
+    // host's startup status share the app's stdout.
+    if let consolePath = plan.consoleStdoutPath {
+      consoleTail.start(path: consolePath, onLine: makeConsoleLineHandler())
     }
 
     guard plan.configuration.enableInjection,
@@ -232,9 +260,6 @@ public final class SimulatorHotReloadController {
     monitor.onRequestRebuild = { [weak self] reason in
       self?.performRebuild(reason: reason)
     }
-    if let consolePath = plan.consoleStdoutPath {
-      consoleTail.start(path: consolePath, onLine: makeConsoleLineHandler())
-    }
   }
 
   /// Stops the armed launch's console + monitor (device shut down, device
@@ -244,6 +269,7 @@ public final class SimulatorHotReloadController {
     monitor.onRequestRebuild = nil
     activePlan = nil
     activeContext = nil
+    previewHostStatus = .unknown
     isInjectionObservationEnabled = false
     updateSourceObservation(projectPath: observedProjectPath)
     monitor.markDisabled()
@@ -251,9 +277,15 @@ public final class SimulatorHotReloadController {
 
   /// Console lines feed the pill's state machine, and recompile events also
   /// count as changed files (covers saves the host-side watcher misses).
+  /// Preview-host status lines update `previewHostStatus` on the same tail.
   private func makeConsoleLineHandler() -> (String) -> Void {
     { [weak self] line in
-      guard let self, let event = self.consoleParser.parse(line: line) else { return }
+      guard let self else { return }
+      if let status = self.hostStatusParser.parse(line: line) {
+        self.previewHostStatus = status
+        return
+      }
+      guard let event = self.consoleParser.parse(line: line) else { return }
       if case .recompiling(let fileName) = event {
         if self.isPreviewObservationEnabled {
           self.noteChangedSource(fileName)
@@ -321,6 +353,10 @@ public final class SimulatorHotReloadController {
       guard let self else { return }
       let success = await self.rebuildExecutor(
         context.udid, context.projectPath, plan)
+      // `isRebuilding` must clear BEFORE `markRebuildFinished`: the monitor
+      // replays queued mid-rebuild structural changes from there via
+      // `onRequestRebuild`, and `performRebuild` drops requests while this
+      // flag is set.
       self.isRebuilding = false
       if success, let consolePath = plan.consoleStdoutPath {
         // The relaunch truncated the console log; restart the tail so its

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/SimulatorPreferencePersisting.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/SimulatorPreferencePersisting.swift
@@ -1,0 +1,18 @@
+//
+//  SimulatorPreferencePersisting.swift
+//  AgentHub
+//
+//  Persistence interface for per-project simulator run-destination preferences.
+//
+
+import Foundation
+
+/// Persists the run destination a project/worktree last selected so the
+/// simulator panel restores it across app relaunches.
+public protocol SimulatorPreferencePersisting: Sendable {
+  func getProjectSimulatorPreferences() async throws -> [ProjectSimulatorPreference]
+  func setProjectSimulatorPreference(_ preference: ProjectSimulatorPreference) async throws
+  func deleteProjectSimulatorPreference(projectPath: String) async throws
+}
+
+extension SessionMetadataStore: SimulatorPreferencePersisting {}

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/SimulatorService.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/SimulatorService.swift
@@ -146,6 +146,11 @@ public final class SimulatorService {
   public static let shared = SimulatorService()
   private init() {}
 
+  /// Isolated instance for unit tests — production code uses `shared`.
+  static func makeForTesting() -> SimulatorService {
+    SimulatorService()
+  }
+
   // MARK: - Observable State
 
   /// Per-UDID global boot/shutdown state, shared across all sessions
@@ -175,6 +180,18 @@ public final class SimulatorService {
   /// Per-projectPath preferred physical iOS device identifier.
   private(set) var preferredPhysicalDeviceIDs: [String: String] = [:]
 
+  /// True once persisted preferences have been hydrated into the dictionaries.
+  public private(set) var preferencesLoaded = false
+
+  /// Backing store for run-destination preferences; nil until configured.
+  private var preferenceStore: (any SimulatorPreferencePersisting)?
+
+  /// In-flight hydration of persisted preferences.
+  private var preferenceLoadTask: Task<Void, Never>?
+
+  /// Serializes preference writes so they land in call order.
+  private var preferencePersistChain: Task<Void, Never>?
+
   /// Live process references for in-flight Mac builds, keyed by projectPath
   private var macBuildProcesses: [String: ProcessRef] = [:]
 
@@ -198,11 +215,76 @@ public final class SimulatorService {
   /// Sets the preferred simulator UDID for a given project path.
   public func setPreferredSimulator(udid: String?, for projectPath: String) {
     preferredSimulatorUDIDs[projectPath] = udid
+    persistPreference(for: projectPath)
   }
 
   /// Sets the preferred physical iOS device for a given project path.
   public func setPreferredPhysicalDevice(identifier: String?, for projectPath: String) {
     preferredPhysicalDeviceIDs[projectPath] = identifier
+    persistPreference(for: projectPath)
+  }
+
+  /// Attaches the persistence backend and hydrates saved preferences.
+  /// Persisted values never override selections already made this launch.
+  public func configurePreferenceStore(_ store: any SimulatorPreferencePersisting) {
+    preferenceStore = store
+    preferenceLoadTask?.cancel()
+    preferenceLoadTask = Task {
+      let preferences = (try? await store.getProjectSimulatorPreferences()) ?? []
+      guard !Task.isCancelled else { return }
+      for preference in preferences {
+        let path = preference.projectPath
+        guard preferredSimulatorUDIDs[path] == nil, preferredPhysicalDeviceIDs[path] == nil else {
+          continue
+        }
+        switch preference.kind {
+        case .simulator:
+          preferredSimulatorUDIDs[path] = preference.deviceIdentifier
+        case .physical:
+          preferredPhysicalDeviceIDs[path] = preference.deviceIdentifier
+        }
+      }
+      preferencesLoaded = true
+    }
+  }
+
+  /// Awaits preference hydration; returns immediately when no store is configured.
+  public func ensurePreferencesLoaded() async {
+    await preferenceLoadTask?.value
+  }
+
+  /// Awaits any queued preference writes (test hook).
+  func flushPreferencePersistence() async {
+    await preferencePersistChain?.value
+  }
+
+  private func persistPreference(for projectPath: String) {
+    guard let store = preferenceStore else { return }
+    let preference: ProjectSimulatorPreference?
+    if let udid = preferredSimulatorUDIDs[projectPath] {
+      preference = ProjectSimulatorPreference(
+        projectPath: projectPath,
+        deviceIdentifier: udid,
+        kind: .simulator
+      )
+    } else if let identifier = preferredPhysicalDeviceIDs[projectPath] {
+      preference = ProjectSimulatorPreference(
+        projectPath: projectPath,
+        deviceIdentifier: identifier,
+        kind: .physical
+      )
+    } else {
+      preference = nil
+    }
+    let previous = preferencePersistChain
+    preferencePersistChain = Task {
+      await previous?.value
+      if let preference {
+        try? await store.setProjectSimulatorPreference(preference)
+      } else {
+        try? await store.deleteProjectSimulatorPreference(projectPath: projectPath)
+      }
+    }
   }
 
   /// Returns the SimulatorDevice for a given UDID, if it exists in the loaded runtimes.

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/SimulatorDestinationMenuContent.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/SimulatorDestinationMenuContent.swift
@@ -1,0 +1,57 @@
+//
+//  SimulatorDestinationMenuContent.swift
+//  AgentHub
+//
+//  Shared menu rows for picking a simulator run destination — used by the
+//  simulator panel's header picker and its "choose a destination" empty state.
+//
+
+import SwiftUI
+
+struct SimulatorDestinationMenuContent: View {
+  let physicalDevices: [PhysicalIOSDevice]
+  let simulators: [SimulatorDevice]
+  let activeDestinationID: String?
+  let onSelectSimulator: (String) -> Void
+  let onSelectPhysicalDevice: (String) -> Void
+
+  var body: some View {
+    if !physicalDevices.isEmpty {
+      Section("Connected Devices") {
+        ForEach(physicalDevices) { device in
+          Button {
+            onSelectPhysicalDevice(device.identifier)
+          } label: {
+            HStack {
+              Text(device.name)
+              Text(device.subtitle.isEmpty ? "Device" : device.subtitle)
+              if activeDestinationID == SimulatorRunDestination.physical(device).id {
+                Image(systemName: "checkmark")
+              }
+            }
+          }
+        }
+      }
+    }
+
+    if !simulators.isEmpty {
+      Section("Simulators") {
+        ForEach(simulators) { device in
+          Button {
+            onSelectSimulator(device.udid)
+          } label: {
+            HStack {
+              Text(device.name)
+              if device.isBooted {
+                Text("Running")
+              }
+              if activeDestinationID == SimulatorRunDestination.simulatorID(udid: device.udid) {
+                Image(systemName: "checkmark")
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/SimulatorDestinationResolver.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/SimulatorDestinationResolver.swift
@@ -1,0 +1,79 @@
+//
+//  SimulatorDestinationResolver.swift
+//  AgentHub
+//
+//  Resolves which run destination the simulator panel targets for a
+//  project/worktree. Deliberately has no global fallback: a project with no
+//  explicit selection and no persisted preference resolves to nil so the
+//  panel shows a picker instead of another project's simulator.
+//
+
+import Foundation
+
+/// A run destination the simulator panel can target: a simulator device or
+/// a connected physical iOS device.
+enum SimulatorRunDestination: Identifiable, Hashable {
+  case simulator(SimulatorDevice)
+  case physical(PhysicalIOSDevice)
+
+  static func simulatorID(udid: String) -> String {
+    "simulator:\(udid)"
+  }
+
+  static func physicalID(identifier: String) -> String {
+    "physical:\(identifier)"
+  }
+
+  var id: String {
+    switch self {
+    case .simulator(let device):
+      return Self.simulatorID(udid: device.udid)
+    case .physical(let device):
+      return Self.physicalID(identifier: device.identifier)
+    }
+  }
+
+  var name: String {
+    switch self {
+    case .simulator(let device):
+      return device.name
+    case .physical(let device):
+      return device.name
+    }
+  }
+
+  var simulatorUDID: String? {
+    if case .simulator(let device) = self { return device.udid }
+    return nil
+  }
+}
+
+enum SimulatorDestinationResolver {
+
+  /// Precedence: explicit in-panel selection → persisted preferred simulator
+  /// → persisted preferred physical device → nil (show the picker).
+  static func resolve(
+    selectedDestinationID: String?,
+    preferredSimulatorUDID: String?,
+    preferredPhysicalDeviceID: String?,
+    simulators: [SimulatorDevice],
+    physicalDevices: [PhysicalIOSDevice]
+  ) -> SimulatorRunDestination? {
+    if let selectedDestinationID {
+      let destinations = physicalDevices.map(SimulatorRunDestination.physical)
+        + simulators.map(SimulatorRunDestination.simulator)
+      if let destination = destinations.first(where: { $0.id == selectedDestinationID }) {
+        return destination
+      }
+    }
+    if let preferredSimulatorUDID,
+       let device = simulators.first(where: { $0.udid == preferredSimulatorUDID }) {
+      return .simulator(device)
+    }
+    if let preferredPhysicalDeviceID,
+       let device = physicalDevices.first(where: { $0.identifier == preferredPhysicalDeviceID }) {
+      return .physical(device)
+    }
+    return nil
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/SimulatorPreviewSidePanelView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/SimulatorPreviewSidePanelView.swift
@@ -33,42 +33,6 @@ enum SimulatorPanelDisplayMode: String, Hashable {
   case previews
 }
 
-private enum SimulatorRunDestination: Identifiable, Hashable {
-  case simulator(SimulatorDevice)
-  case physical(PhysicalIOSDevice)
-
-  static func simulatorID(udid: String) -> String {
-    "simulator:\(udid)"
-  }
-
-  static func physicalID(identifier: String) -> String {
-    "physical:\(identifier)"
-  }
-
-  var id: String {
-    switch self {
-    case .simulator(let device):
-      return Self.simulatorID(udid: device.udid)
-    case .physical(let device):
-      return Self.physicalID(identifier: device.identifier)
-    }
-  }
-
-  var name: String {
-    switch self {
-    case .simulator(let device):
-      return device.name
-    case .physical(let device):
-      return device.name
-    }
-  }
-
-  var simulatorUDID: String? {
-    if case .simulator(let device) = self { return device.udid }
-    return nil
-  }
-}
-
 struct SimulatorPreviewSidePanelView: View {
   let session: CLISession
   let projectPath: String
@@ -113,28 +77,17 @@ struct SimulatorPreviewSidePanelView: View {
     WorktreeLaunchProvider(commandLineValue: providerKind.rawValue)
   }
 
-  /// The destination to run on: explicit selection, then project preferences,
-  /// then connected hardware, an already-running simulator, or any simulator.
+  /// The destination to run on: explicit selection, then this project's
+  /// persisted preference. Never another project's booted simulator — with
+  /// no association the panel shows the destination picker instead.
   private var activeDestination: SimulatorRunDestination? {
-    if let selectedDestinationID,
-       let destination = runDestinations.first(where: { $0.id == selectedDestinationID }) {
-      return destination
-    }
-    if let preferred = simulatorService.preferredSimulatorUDIDs[projectPath],
-       let device = availableDevices.first(where: { $0.udid == preferred }) {
-      return .simulator(device)
-    }
-    if let preferred = simulatorService.preferredPhysicalDeviceIDs[projectPath],
-       let device = physicalDevices.first(where: { $0.identifier == preferred }) {
-      return .physical(device)
-    }
-    if let physical = physicalDevices.first {
-      return .physical(physical)
-    }
-    if let booted = bootedDevices.first {
-      return .simulator(booted)
-    }
-    return availableDevices.first.map(SimulatorRunDestination.simulator)
+    SimulatorDestinationResolver.resolve(
+      selectedDestinationID: selectedDestinationID,
+      preferredSimulatorUDID: simulatorService.preferredSimulatorUDIDs[projectPath],
+      preferredPhysicalDeviceID: simulatorService.preferredPhysicalDeviceIDs[projectPath],
+      simulators: availableDevices,
+      physicalDevices: physicalDevices
+    )
   }
 
   private var activeDestinationID: String? {
@@ -429,43 +382,7 @@ struct SimulatorPreviewSidePanelView: View {
   private var devicePicker: some View {
     if !runDestinations.isEmpty {
       Menu {
-        if !physicalDevices.isEmpty {
-          Section("Connected Devices") {
-            ForEach(physicalDevices) { device in
-              Button {
-                selectPhysicalDevice(identifier: device.identifier)
-              } label: {
-                HStack {
-                  Text(device.name)
-                  Text(device.subtitle.isEmpty ? "Device" : device.subtitle)
-                  if activeDestinationID == SimulatorRunDestination.physical(device).id {
-                    Image(systemName: "checkmark")
-                  }
-                }
-              }
-            }
-          }
-        }
-
-        if !availableDevices.isEmpty {
-          Section("Simulators") {
-            ForEach(availableDevices) { device in
-              Button {
-                selectSimulator(udid: device.udid)
-              } label: {
-                HStack {
-                  Text(device.name)
-                  if device.isBooted {
-                    Text("Running")
-                  }
-                  if activeUDID == device.udid {
-                    Image(systemName: "checkmark")
-                  }
-                }
-              }
-            }
-          }
-        }
+        destinationMenuContent
       } label: {
         HStack(spacing: 6) {
           Text(activeDestination?.name ?? "Select Destination")
@@ -488,6 +405,16 @@ struct SimulatorPreviewSidePanelView: View {
       .layoutPriority(2)
       .accessibilityLabel("Select run destination")
     }
+  }
+
+  private var destinationMenuContent: some View {
+    SimulatorDestinationMenuContent(
+      physicalDevices: physicalDevices,
+      simulators: availableDevices,
+      activeDestinationID: activeDestinationID,
+      onSelectSimulator: { selectSimulator(udid: $0) },
+      onSelectPhysicalDevice: { selectPhysicalDevice(identifier: $0) }
+    )
   }
 
   private var closeButton: some View {
@@ -644,10 +571,12 @@ struct SimulatorPreviewSidePanelView: View {
       // Cold start straight into Previews: the spotlight's states guide the
       // bootstrap, and the tab switch auto-runs the app when a file is open.
       spotlightView
-    } else if simulatorService.isLoadingDevices && !hasLoadedDevices {
+    } else if !hasLoadedDevices && runDestinations.isEmpty {
       loadingState
     } else if runDestinations.isEmpty {
       emptyState
+    } else if activeDestination == nil {
+      selectDestinationState
     } else if activePhysicalDevice != nil {
       physicalDeviceStateView
     } else {
@@ -667,6 +596,7 @@ struct SimulatorPreviewSidePanelView: View {
       onLaunchPreviews: launchPreviews,
       isPreviewHostExpected: simulatorPreviewsEnabled
         && hotReload.activePlan?.configuration.enablePreviews == true,
+      previewHostStatus: hotReload.previewHostStatus,
       connectedDeviceName: hotReload.activePlan != nil
         ? activeDevice?.name : nil
     )
@@ -785,6 +715,35 @@ struct SimulatorPreviewSidePanelView: View {
     .frame(maxWidth: .infinity, maxHeight: .infinity)
   }
 
+  /// Shown when this project/worktree has no run destination associated yet.
+  /// Deliberately never adopts another project's booted simulator.
+  private var selectDestinationState: some View {
+    VStack(spacing: 16) {
+      ContentUnavailableView(
+        "Choose a Run Destination",
+        systemImage: "iphone.gen3",
+        description: Text("Pick the simulator or device this project should use. AgentHub remembers the choice per project and worktree.")
+      )
+      .frame(maxHeight: 220)
+
+      Menu {
+        destinationMenuContent
+      } label: {
+        Label("Select Destination", systemImage: "iphone.gen3")
+          .font(.subheadline.weight(.medium))
+          .padding(.horizontal, 14)
+          .padding(.vertical, 7)
+      }
+      .menuStyle(.borderlessButton)
+      .menuIndicator(.hidden)
+      .fixedSize()
+      .background(Capsule().fill(Color.brandPrimary.opacity(0.16)))
+      .overlay(Capsule().stroke(Color.brandPrimary.opacity(0.3), lineWidth: 1))
+      .accessibilityLabel("Select run destination")
+    }
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+  }
+
   private var physicalDeviceStateView: some View {
     VStack(spacing: 12) {
       Image(systemName: "iphone")
@@ -888,6 +847,9 @@ struct SimulatorPreviewSidePanelView: View {
 
   private func loadDevicesIfNeeded() async {
     guard !hasLoadedDevices else { return }
+    // Hydrate persisted preferences first so a relaunched app restores the
+    // project's device instead of flashing the destination picker.
+    await simulatorService.ensurePreferencesLoaded()
     await simulatorService.listDevices()
     hasLoadedDevices = true
   }

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/SimulatorPreviewSpotlightView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/SimulatorPreviewSpotlightView.swift
@@ -110,16 +110,30 @@ struct SimulatorPreviewSpotlightView: View {
 
   // MARK: - Candidates
 
-  /// Open-file previews first, then changed files by recency, deduplicated
-  /// and bounded.
-  private var candidates: [SimulatorPreviewSelection] {
+  /// The spotlight deliberately shows previews for ONLY two files: the one
+  /// open in the editor and the most recently modified one — never the
+  /// whole recent-change history, which floods the tab with previews of
+  /// every file touched this session (e.g. all git-modified files from the
+  /// seed).
+  static func candidateFileNames(
+    openFileName: String?,
+    changedFiles: [String]
+  ) -> [String] {
     var fileNames: [String] = []
     if let openFileName, openFileName.hasSuffix(".swift") {
       fileNames.append(openFileName)
     }
-    for file in changedFiles where !fileNames.contains(file) {
-      fileNames.append(file)
+    if let latestChange = changedFiles.first, !fileNames.contains(latestChange) {
+      fileNames.append(latestChange)
     }
+    return fileNames
+  }
+
+  private var candidates: [SimulatorPreviewSelection] {
+    let fileNames = Self.candidateFileNames(
+      openFileName: openFileName,
+      changedFiles: changedFiles
+    )
 
     var selections: [SimulatorPreviewSelection] = []
     for file in fileNames {

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/SimulatorPreviewSpotlightView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/SimulatorPreviewSpotlightView.swift
@@ -38,6 +38,10 @@ struct SimulatorPreviewSpotlightView: View {
   /// True after AgentHub has launched the app with the preview host inserted.
   /// A transient connection failure then means "still starting", not "not armed".
   var isPreviewHostExpected = false
+  /// Startup status reported by the inserted host over the console tail —
+  /// turns generic "did not respond" into the actual failure (port conflict,
+  /// backgrounded app, unsupported OS).
+  var previewHostStatus: PreviewHostStatus = .unknown
   /// Device the armed app runs on, when this panel launched it.
   var connectedDeviceName: String?
 
@@ -55,7 +59,33 @@ struct SimulatorPreviewSpotlightView: View {
   private let expansionAnimation = Animation.spring(response: 0.34, dampingFraction: 0.86)
 
   private var manifestLoadID: String {
-    "\(reloadGeneration)|\(isPreviewHostExpected)"
+    "\(reloadGeneration)|\(isPreviewHostExpected)|\(hostStatusToken)"
+  }
+
+  private var hostStatusToken: String {
+    switch previewHostStatus {
+    case .unknown: return "unknown"
+    case .waitingForForeground: return "waiting"
+    case .listening(let port): return "listening-\(port)"
+    case .failed: return "failed"
+    }
+  }
+
+  /// The specific startup failure to surface instead of a generic
+  /// "did not respond", when the host reported one.
+  private var hostFailureMessage: String? {
+    guard case .failed(let reason, let detail) = previewHostStatus else { return nil }
+    switch reason {
+    case .portInUse(let port):
+      return "Preview port \(port) is in use — another app or session owns it. "
+        + "Relaunch previews to retry."
+    case .unsupportedOSVersion:
+      return "SwiftUI previews require an iOS 16 or later simulator."
+    case .serverError:
+      return detail.isEmpty
+        ? "The preview host failed to start."
+        : "The preview host failed to start: \(detail)"
+    }
   }
 
   var body: some View {
@@ -201,7 +231,9 @@ struct SimulatorPreviewSpotlightView: View {
   private var startingState: some View {
     VStack(spacing: 8) {
       ProgressView()
-      Text("Starting previews…")
+      Text(previewHostStatus == .waitingForForeground
+        ? "Waiting for the app to come to the foreground…"
+        : "Starting previews…")
         .font(.caption)
         .foregroundStyle(.secondary)
     }
@@ -251,6 +283,13 @@ struct SimulatorPreviewSpotlightView: View {
 
     let maxAttempts = isPreviewHostExpected ? 16 : 1
     for attempt in 1...maxAttempts {
+      // A reported startup failure ends the retry loop — the host told us
+      // exactly what's wrong; "still starting" spinners would be a lie.
+      if let hostFailureMessage {
+        previewTypes = []
+        loadErrorMessage = hostFailureMessage
+        return
+      }
       do {
         previewTypes = try await client.listPreviews()
         loadErrorMessage = nil
@@ -265,14 +304,18 @@ struct SimulatorPreviewSpotlightView: View {
     }
 
     previewTypes = []
-    loadErrorMessage = "Preview support did not respond after launch."
+    loadErrorMessage = hostFailureMessage ?? unresponsiveMessage
+  }
+
+  private var unresponsiveMessage: String {
+    previewHostStatus == .waitingForForeground
+      ? "The app hasn't come to the foreground in the simulator yet."
+      : "Preview support did not respond after launch."
   }
 
   private func userFacingLoadErrorMessage(for error: Error) -> String {
     if (error as? PreviewHostClientError) == .serverUnreachable {
-      return isPreviewHostExpected
-        ? "Preview support did not respond after launch."
-        : ""
+      return isPreviewHostExpected ? unresponsiveMessage : ""
     }
     return error.localizedDescription
   }

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/ProjectSimulatorPreferenceTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/ProjectSimulatorPreferenceTests.swift
@@ -1,0 +1,151 @@
+import Foundation
+import GRDB
+import Testing
+
+@testable import AgentHubCore
+
+@Suite("Project simulator preference persistence")
+struct ProjectSimulatorPreferenceTests {
+
+  @Test("Preference round-trips per project path")
+  func preferenceRoundTrip() async throws {
+    let store = try SessionMetadataStore(path: temporaryPreferenceDatabasePath())
+
+    try await store.setProjectSimulatorPreference(
+      ProjectSimulatorPreference(
+        projectPath: "/tmp/project-a",
+        deviceIdentifier: "UDID-A",
+        kind: .simulator
+      )
+    )
+    try await store.setProjectSimulatorPreference(
+      ProjectSimulatorPreference(
+        projectPath: "/tmp/project-b",
+        deviceIdentifier: "PHONE-1",
+        kind: .physical
+      )
+    )
+
+    let preferences = try await store.getProjectSimulatorPreferences()
+    let byPath = Dictionary(uniqueKeysWithValues: preferences.map { ($0.projectPath, $0) })
+    #expect(byPath.count == 2)
+    #expect(byPath["/tmp/project-a"]?.deviceIdentifier == "UDID-A")
+    #expect(byPath["/tmp/project-a"]?.kind == .simulator)
+    #expect(byPath["/tmp/project-b"]?.deviceIdentifier == "PHONE-1")
+    #expect(byPath["/tmp/project-b"]?.kind == .physical)
+  }
+
+  @Test("Saving again replaces the row for the same project path")
+  func preferenceReplacesOnConflict() async throws {
+    let store = try SessionMetadataStore(path: temporaryPreferenceDatabasePath())
+
+    try await store.setProjectSimulatorPreference(
+      ProjectSimulatorPreference(
+        projectPath: "/tmp/project",
+        deviceIdentifier: "UDID-OLD",
+        kind: .simulator
+      )
+    )
+    try await store.setProjectSimulatorPreference(
+      ProjectSimulatorPreference(
+        projectPath: "/tmp/project",
+        deviceIdentifier: "PHONE-NEW",
+        kind: .physical
+      )
+    )
+
+    let preferences = try await store.getProjectSimulatorPreferences()
+    #expect(preferences.count == 1)
+    #expect(preferences.first?.deviceIdentifier == "PHONE-NEW")
+    #expect(preferences.first?.kind == .physical)
+  }
+
+  @Test("Delete removes only the targeted project path")
+  func preferenceDelete() async throws {
+    let store = try SessionMetadataStore(path: temporaryPreferenceDatabasePath())
+
+    try await store.setProjectSimulatorPreference(
+      ProjectSimulatorPreference(
+        projectPath: "/tmp/project-a",
+        deviceIdentifier: "UDID-A",
+        kind: .simulator
+      )
+    )
+    try await store.setProjectSimulatorPreference(
+      ProjectSimulatorPreference(
+        projectPath: "/tmp/project-b",
+        deviceIdentifier: "UDID-B",
+        kind: .simulator
+      )
+    )
+
+    try await store.deleteProjectSimulatorPreference(projectPath: "/tmp/project-a")
+
+    let preferences = try await store.getProjectSimulatorPreferences()
+    #expect(preferences.map(\.projectPath) == ["/tmp/project-b"])
+  }
+
+  @Test("Clear all removes preferences")
+  func clearAllRemovesPreferences() async throws {
+    let store = try SessionMetadataStore(path: temporaryPreferenceDatabasePath())
+    try await store.setProjectSimulatorPreference(
+      ProjectSimulatorPreference(
+        projectPath: "/tmp/project",
+        deviceIdentifier: "UDID",
+        kind: .simulator
+      )
+    )
+
+    try await store.clearAll()
+
+    #expect(try await store.getProjectSimulatorPreferences().isEmpty)
+  }
+
+  @Test("v11 migration preserves existing metadata")
+  func migrationPreservesExistingMetadata() async throws {
+    let path = temporaryPreferenceDatabasePath()
+    let dbQueue = try DatabaseQueue(path: path)
+
+    try await dbQueue.write { db in
+      try db.execute(sql: "CREATE TABLE grdb_migrations (identifier TEXT NOT NULL PRIMARY KEY)")
+      for identifier in SessionMetadataStore.migrationIdentifiers.dropLast() {
+        try db.execute(sql: "INSERT INTO grdb_migrations (identifier) VALUES (?)", arguments: [identifier])
+      }
+
+      try db.create(table: "session_metadata") { t in
+        t.column("sessionId", .text).primaryKey()
+        t.column("customName", .text)
+        t.column("createdAt", .datetime).notNull()
+        t.column("updatedAt", .datetime).notNull()
+        t.column("isPinned", .boolean).notNull().defaults(to: false)
+      }
+      try db.execute(
+        sql: """
+        INSERT INTO session_metadata (sessionId, customName, createdAt, updatedAt, isPinned)
+        VALUES (?, ?, ?, ?, ?)
+        """,
+        arguments: ["session-1", "My Session", Date(timeIntervalSince1970: 1_000), Date(timeIntervalSince1970: 1_000), true]
+      )
+    }
+
+    let store = try SessionMetadataStore(path: path)
+    #expect(try await store.getCustomName(for: "session-1") == "My Session")
+    #expect(try await store.getPinnedSessionIds() == ["session-1"])
+    #expect(try await store.getProjectSimulatorPreferences().isEmpty)
+
+    try await store.setProjectSimulatorPreference(
+      ProjectSimulatorPreference(
+        projectPath: "/tmp/project",
+        deviceIdentifier: "UDID",
+        kind: .simulator
+      )
+    )
+    #expect(try await store.getProjectSimulatorPreferences().count == 1)
+  }
+}
+
+private func temporaryPreferenceDatabasePath() -> String {
+  FileManager.default.temporaryDirectory
+    .appending(path: "test_project_simulator_prefs_\(UUID().uuidString).sqlite")
+    .path
+}

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/SimulatorDestinationResolverTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/SimulatorDestinationResolverTests.swift
@@ -1,0 +1,113 @@
+import Foundation
+import Testing
+
+@testable import AgentHubCore
+
+@Suite("SimulatorDestinationResolver")
+struct SimulatorDestinationResolverTests {
+
+  private func simulator(udid: String, booted: Bool = false) -> SimulatorDevice {
+    SimulatorDevice(
+      udid: udid,
+      name: "iPhone \(udid)",
+      state: booted ? "Booted" : "Shutdown",
+      isAvailable: true,
+      deviceTypeIdentifier: "com.apple.CoreSimulator.SimDeviceType.iPhone-15"
+    )
+  }
+
+  private func physical(identifier: String) -> PhysicalIOSDevice {
+    PhysicalIOSDevice(
+      identifier: identifier,
+      name: "Phone \(identifier)",
+      modelName: "iPhone 15",
+      operatingSystemVersion: "18.0",
+      interface: "usb"
+    )
+  }
+
+  @Test("Explicit selection wins over preferences")
+  func explicitSelectionWins() {
+    let devices = [simulator(udid: "A"), simulator(udid: "B")]
+    let result = SimulatorDestinationResolver.resolve(
+      selectedDestinationID: SimulatorRunDestination.simulatorID(udid: "B"),
+      preferredSimulatorUDID: "A",
+      preferredPhysicalDeviceID: nil,
+      simulators: devices,
+      physicalDevices: []
+    )
+    #expect(result?.simulatorUDID == "B")
+  }
+
+  @Test("Persisted simulator preference resolves")
+  func preferredSimulatorResolves() {
+    let result = SimulatorDestinationResolver.resolve(
+      selectedDestinationID: nil,
+      preferredSimulatorUDID: "A",
+      preferredPhysicalDeviceID: nil,
+      simulators: [simulator(udid: "A")],
+      physicalDevices: [physical(identifier: "P1")]
+    )
+    #expect(result?.simulatorUDID == "A")
+  }
+
+  @Test("Persisted physical preference resolves")
+  func preferredPhysicalResolves() {
+    let result = SimulatorDestinationResolver.resolve(
+      selectedDestinationID: nil,
+      preferredSimulatorUDID: nil,
+      preferredPhysicalDeviceID: "P1",
+      simulators: [simulator(udid: "A")],
+      physicalDevices: [physical(identifier: "P1")]
+    )
+    #expect(result?.id == SimulatorRunDestination.physicalID(identifier: "P1"))
+  }
+
+  @Test("No association resolves to nil even with booted simulators and connected hardware")
+  func noAssociationNeverAdoptsGlobalState() {
+    let result = SimulatorDestinationResolver.resolve(
+      selectedDestinationID: nil,
+      preferredSimulatorUDID: nil,
+      preferredPhysicalDeviceID: nil,
+      simulators: [simulator(udid: "OTHER-PROJECT", booted: true)],
+      physicalDevices: [physical(identifier: "P1")]
+    )
+    #expect(result == nil)
+  }
+
+  @Test("Stale preference for a device no longer in the list resolves to nil")
+  func stalePreferenceResolvesToNil() {
+    let result = SimulatorDestinationResolver.resolve(
+      selectedDestinationID: nil,
+      preferredSimulatorUDID: "GONE",
+      preferredPhysicalDeviceID: "GONE-TOO",
+      simulators: [simulator(udid: "A", booted: true)],
+      physicalDevices: []
+    )
+    #expect(result == nil)
+  }
+
+  @Test("Stale explicit selection falls back to persisted preference")
+  func staleSelectionFallsBackToPreference() {
+    let result = SimulatorDestinationResolver.resolve(
+      selectedDestinationID: SimulatorRunDestination.simulatorID(udid: "GONE"),
+      preferredSimulatorUDID: "A",
+      preferredPhysicalDeviceID: nil,
+      simulators: [simulator(udid: "A")],
+      physicalDevices: []
+    )
+    #expect(result?.simulatorUDID == "A")
+  }
+
+  @Test("No devices resolves to nil")
+  func noDevicesResolvesToNil() {
+    let result = SimulatorDestinationResolver.resolve(
+      selectedDestinationID: nil,
+      preferredSimulatorUDID: "A",
+      preferredPhysicalDeviceID: nil,
+      simulators: [],
+      physicalDevices: []
+    )
+    #expect(result == nil)
+  }
+}

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/SimulatorHotReloadControllerTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/SimulatorHotReloadControllerTests.swift
@@ -188,15 +188,44 @@ struct SimulatorHotReloadControllerTests {
 
   @Test("previews-only launch keeps the pill off but stores the plan")
   func previewsOnlyLaunch() async {
-    let (controller, _, _) = makeController(cached: Self.artifacts)
+    let (controller, _, tail) = makeController(cached: Self.artifacts)
     let plan = await controller.preparePlan(
       udid: "UDID", projectPath: "/p", enableInjection: false, enablePreviews: true)!
+
+    // The preview host reports startup status over stdout, so even a
+    // previews-only launch gets a console log and a running tail.
+    #expect(plan.consoleStdoutPath != nil)
 
     controller.sessionDidLaunch(udid: "UDID", projectPath: "/p", plan: plan)
 
     #expect(controller.monitor.phase == .disabled)
     #expect(controller.activePlan == plan)
     #expect(controller.previewHostGeneration == 1)
+    #expect(tail.startedPath == plan.consoleStdoutPath)
+  }
+
+  @Test("host status lines update previewHostStatus and bypass the pill")
+  func hostStatusLines() async {
+    let (controller, _, tail) = makeController(cached: Self.artifacts)
+    let plan = await controller.preparePlan(
+      udid: "UDID", projectPath: "/p", enableInjection: false, enablePreviews: true)!
+    controller.sessionDidLaunch(udid: "UDID", projectPath: "/p", plan: plan)
+    #expect(controller.previewHostStatus == .unknown)
+
+    tail.onLine?("AGENTHUB_PREVIEW_HOST: waiting reason=app-not-active")
+    #expect(controller.previewHostStatus == .waitingForForeground)
+
+    tail.onLine?("AGENTHUB_PREVIEW_HOST: listening port=38712")
+    #expect(controller.previewHostStatus == .listening(port: 38712))
+
+    tail.onLine?("AGENTHUB_PREVIEW_HOST: failed reason=port-in-use port=38712")
+    #expect(controller.previewHostStatus
+      == .failed(reason: .portInUse(port: 38712), detail: ""))
+    // Status lines never leak into the reload pill.
+    #expect(controller.monitor.phase == .disabled)
+
+    controller.sessionDidStop()
+    #expect(controller.previewHostStatus == .unknown)
   }
 
   @Test("tracking runs independently of arming and seeds from git")
@@ -269,6 +298,31 @@ struct SimulatorHotReloadControllerTests {
     #expect(controller.monitor.phase == .reloading(fileName: "Console.swift"))
   }
 
+  @Test("armed previews launch swaps the client to the plan's per-device port")
+  func previewClientTargetsPlanPort() async {
+    let ports = RebuildLog()
+    let controller = SimulatorHotReloadController(
+      artifactStore: MockArtifactStore(cached: Self.artifacts),
+      sourceWatcher: MockSourceWatcher(),
+      consoleTail: MockConsoleTail(),
+      previewClient: MockPreviewClient(),
+      previewClientFactory: { port in
+        ports.append("\(port)")
+        return MockPreviewClient()
+      },
+      seedChangedFiles: { _ in [] },
+      rebuildExecutor: { _, _, _ in true }
+    )
+    let plan = await controller.preparePlan(
+      udid: "UDID-PORT", projectPath: "/p", enableInjection: false, enablePreviews: true)!
+    let expected = PreviewHostPortAllocator.port(forDeviceUDID: "UDID-PORT")
+    #expect(plan.configuration.previewPort == expected)
+
+    controller.sessionDidLaunch(udid: "UDID-PORT", projectPath: "/p", plan: plan)
+    #expect(ports.entries == ["\(expected)"])
+    #expect(controller.previewHostGeneration == 1)
+  }
+
   @Test("structural change triggers the rebuild executor and settles to idle")
   func structuralRebuild() async {
     let rebuilds = RebuildLog()
@@ -290,6 +344,84 @@ struct SimulatorHotReloadControllerTests {
     #expect(rebuilds.entries == ["UDID|/p"])
     #expect(controller.monitor.phase == .idle)
     #expect(controller.monitor.reloadGeneration == 1)
+  }
+
+  /// Lets a test hold the mock rebuild executor open deterministically.
+  private final class RebuildGate: @unchecked Sendable {
+    private let lock = NSLock()
+    private var continuation: CheckedContinuation<Void, Never>?
+    private var released = false
+
+    func wait() async {
+      await withCheckedContinuation { held in
+        lock.lock()
+        if released {
+          lock.unlock()
+          held.resume()
+          return
+        }
+        continuation = held
+        lock.unlock()
+      }
+    }
+
+    func release() {
+      lock.lock()
+      let held = continuation
+      continuation = nil
+      released = true
+      lock.unlock()
+      held?.resume()
+    }
+  }
+
+  @Test("structural change during a rebuild runs exactly one follow-up rebuild")
+  func structuralChangeDuringRebuildRunsFollowUp() async {
+    let rebuilds = RebuildLog()
+    let gate = RebuildGate()
+    let watcher = MockSourceWatcher()
+    let controller = SimulatorHotReloadController(
+      artifactStore: MockArtifactStore(cached: Self.artifacts),
+      sourceWatcher: watcher,
+      consoleTail: MockConsoleTail(),
+      previewClient: MockPreviewClient(),
+      seedChangedFiles: { _ in [] },
+      rebuildExecutor: { udid, projectPath, _ in
+        rebuilds.append("\(udid)|\(projectPath)")
+        if rebuilds.entries.count == 1 {
+          await gate.wait()
+        }
+        return true
+      }
+    )
+    let plan = await controller.preparePlan(
+      udid: "UDID", projectPath: "/p", enableInjection: true, enablePreviews: false)!
+    controller.sessionDidLaunch(udid: "UDID", projectPath: "/p", plan: plan)
+
+    // First structural change starts a rebuild the gate holds open.
+    watcher.onChange?([.structural(path: "/p/New.swift", kind: .created)])
+    var deadline = Date().addingTimeInterval(2)
+    while rebuilds.entries.isEmpty, Date() < deadline {
+      try? await Task.sleep(nanoseconds: 10_000_000)
+    }
+    #expect(rebuilds.entries == ["UDID|/p"])
+    #expect(controller.monitor.phase == .rebuilding(reason: "New.swift was created"))
+
+    // A structural change landing mid-rebuild queues — no concurrent rebuild.
+    watcher.onChange?([.structural(path: "/p/Another.swift", kind: .created)])
+    #expect(rebuilds.entries.count == 1)
+
+    gate.release()
+
+    // The queued change replays as exactly one follow-up, settling to idle.
+    deadline = Date().addingTimeInterval(2)
+    while rebuilds.entries.count < 2 || controller.monitor.phase != .idle,
+          Date() < deadline {
+      try? await Task.sleep(nanoseconds: 10_000_000)
+    }
+    #expect(rebuilds.entries == ["UDID|/p", "UDID|/p"])
+    #expect(controller.monitor.phase == .idle)
+    #expect(controller.monitor.reloadGeneration == 2)
   }
 
   @Test("stop tears down the console + pill; stopTracking stops the watcher")

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/SimulatorPreviewSpotlightCandidateTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/SimulatorPreviewSpotlightCandidateTests.swift
@@ -1,0 +1,49 @@
+import Testing
+
+@testable import AgentHubCore
+
+@Suite("Simulator preview spotlight candidates")
+struct SimulatorPreviewSpotlightCandidateTests {
+
+  @Test("only the open file and the most recent change are candidates")
+  func openFilePlusLatestChangeOnly() {
+    let fileNames = SimulatorPreviewSpotlightView.candidateFileNames(
+      openFileName: "HomeScreen.swift",
+      changedFiles: ["AnswerButton.swift", "PrimaryButton.swift", "GamePlayScreen.swift"]
+    )
+    #expect(fileNames == ["HomeScreen.swift", "AnswerButton.swift"])
+  }
+
+  @Test("without an open file, only the most recent change shows")
+  func latestChangeOnly() {
+    let fileNames = SimulatorPreviewSpotlightView.candidateFileNames(
+      openFileName: nil,
+      changedFiles: ["AnswerButton.swift", "PrimaryButton.swift", "HomeScreen.swift"]
+    )
+    #expect(fileNames == ["AnswerButton.swift"])
+  }
+
+  @Test("open file matching the latest change is not duplicated")
+  func openFileDeduplicated() {
+    let fileNames = SimulatorPreviewSpotlightView.candidateFileNames(
+      openFileName: "AnswerButton.swift",
+      changedFiles: ["AnswerButton.swift", "PrimaryButton.swift"]
+    )
+    #expect(fileNames == ["AnswerButton.swift"])
+  }
+
+  @Test("non-Swift open files are ignored")
+  func nonSwiftOpenFileIgnored() {
+    let fileNames = SimulatorPreviewSpotlightView.candidateFileNames(
+      openFileName: "README.md",
+      changedFiles: ["AnswerButton.swift"]
+    )
+    #expect(fileNames == ["AnswerButton.swift"])
+  }
+
+  @Test("no signals means no candidates")
+  func empty() {
+    #expect(SimulatorPreviewSpotlightView.candidateFileNames(
+      openFileName: nil, changedFiles: []).isEmpty)
+  }
+}

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/SimulatorServiceTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/SimulatorServiceTests.swift
@@ -469,3 +469,115 @@ struct BuildHelperTests {
     try data.write(to: app.appendingPathComponent("Info.plist"))
   }
 }
+
+// MARK: - Preference persistence
+
+/// Mock persistence backend recording calls in order.
+private final class MockSimulatorPreferenceStore: SimulatorPreferencePersisting, @unchecked Sendable {
+  enum Call: Equatable {
+    case save(ProjectSimulatorPreference)
+    case delete(String)
+  }
+
+  private let lock = NSLock()
+  private var _calls: [Call] = []
+  var seeded: [ProjectSimulatorPreference] = []
+
+  var calls: [Call] {
+    lock.withLock { _calls }
+  }
+
+  func getProjectSimulatorPreferences() async throws -> [ProjectSimulatorPreference] {
+    seeded
+  }
+
+  func setProjectSimulatorPreference(_ preference: ProjectSimulatorPreference) async throws {
+    lock.withLock { _calls.append(.save(preference)) }
+  }
+
+  func deleteProjectSimulatorPreference(projectPath: String) async throws {
+    lock.withLock { _calls.append(.delete(projectPath)) }
+  }
+}
+
+@Suite("SimulatorService preference persistence")
+@MainActor
+struct SimulatorServicePreferencePersistenceTests {
+
+  @Test func settingSimulatorPersistsPreference() async {
+    let store = MockSimulatorPreferenceStore()
+    let service = SimulatorService.makeForTesting()
+    service.configurePreferenceStore(store)
+    await service.ensurePreferencesLoaded()
+    let path = "/tmp/persist-test-\(UUID().uuidString)"
+
+    service.setPreferredSimulator(udid: "UDID-1", for: path)
+    service.setPreferredPhysicalDevice(identifier: nil, for: path)
+    await service.flushPreferencePersistence()
+
+    let saves = store.calls.compactMap { call -> ProjectSimulatorPreference? in
+      if case .save(let preference) = call, preference.projectPath == path { return preference }
+      return nil
+    }
+    #expect(saves.last?.deviceIdentifier == "UDID-1")
+    #expect(saves.last?.kind == .simulator)
+  }
+
+  @Test func switchingToPhysicalPersistsPhysicalKind() async {
+    let store = MockSimulatorPreferenceStore()
+    let service = SimulatorService.makeForTesting()
+    service.configurePreferenceStore(store)
+    await service.ensurePreferencesLoaded()
+    let path = "/tmp/persist-test-\(UUID().uuidString)"
+
+    service.setPreferredSimulator(udid: "UDID-1", for: path)
+    service.setPreferredPhysicalDevice(identifier: nil, for: path)
+    service.setPreferredPhysicalDevice(identifier: "PHONE-1", for: path)
+    service.setPreferredSimulator(udid: nil, for: path)
+    await service.flushPreferencePersistence()
+
+    guard case .save(let last)? = store.calls.last(where: {
+      if case .save(let preference) = $0 { return preference.projectPath == path }
+      return false
+    }) else {
+      Issue.record("expected a save call")
+      return
+    }
+    #expect(last.deviceIdentifier == "PHONE-1")
+    #expect(last.kind == .physical)
+  }
+
+  @Test func clearingBothSidesDeletesPreference() async {
+    let store = MockSimulatorPreferenceStore()
+    let service = SimulatorService.makeForTesting()
+    service.configurePreferenceStore(store)
+    await service.ensurePreferencesLoaded()
+    let path = "/tmp/persist-test-\(UUID().uuidString)"
+
+    service.setPreferredSimulator(udid: "UDID-1", for: path)
+    service.setPreferredSimulator(udid: nil, for: path)
+    await service.flushPreferencePersistence()
+
+    #expect(store.calls.last == .delete(path))
+  }
+
+  @Test func hydrationPopulatesDictionariesWithoutOverridingLiveSelections() async {
+    let service = SimulatorService.makeForTesting()
+    let persistedPath = "/tmp/hydrate-test-\(UUID().uuidString)"
+    let livePath = "/tmp/live-test-\(UUID().uuidString)"
+    service.setPreferredSimulator(udid: "LIVE-UDID", for: livePath)
+
+    let store = MockSimulatorPreferenceStore()
+    store.seeded = [
+      ProjectSimulatorPreference(projectPath: persistedPath, deviceIdentifier: "SAVED-UDID", kind: .simulator),
+      ProjectSimulatorPreference(projectPath: livePath, deviceIdentifier: "STALE-UDID", kind: .physical)
+    ]
+    service.configurePreferenceStore(store)
+    await service.ensurePreferencesLoaded()
+
+    #expect(service.preferredSimulatorUDIDs[persistedPath] == "SAVED-UDID")
+    #expect(service.preferredSimulatorUDIDs[livePath] == "LIVE-UDID")
+    #expect(service.preferredPhysicalDeviceIDs[livePath] == nil)
+    #expect(service.preferencesLoaded)
+  }
+}

--- a/app/modules/SimulatorPreview/Sources/SimulatorPreview/HotReload/HotReloadConsoleParser.swift
+++ b/app/modules/SimulatorPreview/Sources/SimulatorPreview/HotReload/HotReloadConsoleParser.swift
@@ -57,8 +57,14 @@ public struct HotReloadConsoleParser: Sendable {
     }
 
     // "🔥 ℹ️ No symbols replaced, have you added -Xlinker -interposable …"
+    // The running binary wasn't linked with -interposable (e.g. it was
+    // launched from a plain build and only armed at relaunch): the engine
+    // keeps compiling dylibs but nothing ever rebinds into the app, so
+    // every "reload" is a silent no-op. Only a full armed rebuild fixes the
+    // binary — treat it as a failed injection so the fallback fires.
     if trimmed.contains("No symbols replaced") {
-      return .warning(message: "Injection loaded but no symbols were replaced")
+      return .injectionFailed(
+        message: "App wasn't built with injection support — rebuilding")
     }
 
     // ── Tolerant fallbacks (drift insurance; see the type comment) ──────

--- a/app/modules/SimulatorPreview/Sources/SimulatorPreview/HotReload/HotReloadConsoleParser.swift
+++ b/app/modules/SimulatorPreview/Sources/SimulatorPreview/HotReload/HotReloadConsoleParser.swift
@@ -4,9 +4,13 @@ import Foundation
 /// `simctl launch --stdout=<file>`) into `HotReloadEngineEvent`s.
 ///
 /// InjectionLite logs to the app's stdout with an `🔥 InjectionLite: `-style
-/// prefix. The exact strings matched here come from InjectionLite's
+/// prefix. The exact strings matched first come from InjectionLite's
 /// `Reloader`/`Recompiler`/`InjectionBase` sources (pinned in
-/// `HotReloadHostPackage`); revisit when bumping that pin.
+/// `HotReloadHostPackage`); revisit when bumping that pin. The looser
+/// 🔥-prefixed patterns after them are drift insurance only — if the pinned
+/// wording changes, reload confirmation keeps working instead of silently
+/// degrading every save into timeout → full rebuild. The pins remain the
+/// contract and must still be re-verified on every version bump.
 public struct HotReloadConsoleParser: Sendable {
 
   public init() {}
@@ -55,6 +59,31 @@ public struct HotReloadConsoleParser: Sendable {
     // "🔥 ℹ️ No symbols replaced, have you added -Xlinker -interposable …"
     if trimmed.contains("No symbols replaced") {
       return .warning(message: "Injection loaded but no symbols were replaced")
+    }
+
+    // ── Tolerant fallbacks (drift insurance; see the type comment) ──────
+    if trimmed.hasPrefix("🔥") {
+      if trimmed.contains("Watching") {
+        return .engineReady
+      }
+      if trimmed.contains("ompiling"),
+         let fileRange = trimmed.range(
+           of: #"[A-Za-z0-9_+\-.]+\.swift"#, options: .regularExpression) {
+        return .recompiling(fileName: String(trimmed[fileRange]))
+      }
+      if trimmed.contains("✅"),
+         trimmed.contains("eload") || trimmed.contains("nject")
+           || trimmed.contains("Rebound"),
+         let range = trimmed.range(of: "✅") {
+        let summary = trimmed[range.upperBound...]
+          .trimmingCharacters(in: .whitespaces)
+        return .injected(summary: summary.isEmpty ? "Hot reload complete" : summary)
+      }
+      if let range = trimmed.range(of: "❌") {
+        let message = trimmed[range.upperBound...]
+          .trimmingCharacters(in: .whitespaces)
+        return .injectionFailed(message: message.isEmpty ? "Injection failed" : message)
+      }
     }
 
     // Any other engine warning ("🔥 … ⚠️ …") surfaces as a tooltip detail.

--- a/app/modules/SimulatorPreview/Sources/SimulatorPreview/HotReload/HotReloadHostPackage.swift
+++ b/app/modules/SimulatorPreview/Sources/SimulatorPreview/HotReload/HotReloadHostPackage.swift
@@ -1,3 +1,4 @@
+import CryptoKit
 import Foundation
 
 /// The Swift package AgentHub materializes on disk and builds (once, cached)
@@ -37,10 +38,31 @@ public enum HotReloadHostPackage {
   /// preview host inside the app.
   public static let previewHostEnvironmentKey = "AGENTHUB_PREVIEW_HOST"
 
-  /// Identifies the generated package + pins; cached build artifacts are
-  /// invalidated when this changes.
+  /// The environment variable carrying the per-device loopback port the
+  /// preview host binds (see `PreviewHostPortAllocator`).
+  public static let previewPortEnvironmentKey = "AGENTHUB_PREVIEW_PORT"
+
+  /// The port the generated host falls back to when launched without
+  /// `AGENTHUB_PREVIEW_PORT` (the original fixed-port contract).
+  public static let previewHostDefaultPort = 38824
+
+  /// Identifies the generated package; cached build artifacts are invalidated
+  /// when this changes. A content hash over the fully materialized package
+  /// (manifest + every generated source), so any pin bump or source edit
+  /// invalidates the cache automatically — no manual version suffix to forget.
   public static var fingerprint: String {
-    "snapshot-previews-\(snapshotPreviewsVersion)_injection-lite-\(injectionLiteVersion)_v3"
+    fingerprint(manifest: manifest, sourceFiles: sourceFiles)
+  }
+
+  static func fingerprint(manifest: String, sourceFiles: [String: String]) -> String {
+    var hasher = SHA256()
+    hasher.update(data: Data(manifest.utf8))
+    for (path, content) in sourceFiles.sorted(by: { $0.key < $1.key }) {
+      hasher.update(data: Data(path.utf8))
+      hasher.update(data: Data(content.utf8))
+    }
+    let hex = hasher.finalize().prefix(12).map { String(format: "%02x", $0) }.joined()
+    return "host-sha256-\(hex)"
   }
 
   public static var manifest: String {
@@ -160,9 +182,10 @@ public enum HotReloadHostPackage {
   }
 
   /// The preview host. Serves SnapshotPreviews' HTTP contract (`GET /file`
-  /// manifest + `GET /display/{type}/{id}` render) on loopback port 38824,
-  /// rendering with the windowless `SwiftUIRenderingStrategy` so the running
-  /// app's UI is never covered.
+  /// manifest + `GET /display/{type}/{id}` render) on the loopback port from
+  /// `AGENTHUB_PREVIEW_PORT` (per-device; default 38824), rendering with the
+  /// windowless `SwiftUIRenderingStrategy` so the running app's UI is never
+  /// covered.
   private static var previewHostSource: String {
     #"""
     #if canImport(UIKit) && DEBUG
@@ -176,7 +199,7 @@ public enum HotReloadHostPackage {
     @_cdecl("agenthub_preview_host_start")
     public func agenthub_preview_host_start() {
       guard #available(iOS 16.0, *) else {
-        print("AgentHubPreviewHost: previews require an iOS 16+ simulator")
+        print("AGENTHUB_PREVIEW_HOST: unsupported reason=ios-version")
         return
       }
       Task { @MainActor in
@@ -198,6 +221,7 @@ public enum HotReloadHostPackage {
         if UIApplication.shared.applicationState == .active {
           host.start()
         } else {
+          print("AGENTHUB_PREVIEW_HOST: waiting reason=app-not-active")
           NotificationCenter.default.addObserver(
             forName: UIApplication.didBecomeActiveNotification,
             object: nil,
@@ -208,7 +232,16 @@ public enum HotReloadHostPackage {
         }
       }
 
-      private let server = HTTPServer(address: .loopback(port: 38824))
+      /// AgentHub assigns each simulator device its own loopback port and
+      /// passes it through the launch environment; the fixed default keeps
+      /// an env-less insert working.
+      static var configuredPort: UInt16 {
+        ProcessInfo.processInfo.environment["\#(previewPortEnvironmentKey)"]
+          .flatMap(UInt16.init) ?? \#(previewHostDefaultPort)
+      }
+
+      private let server = HTTPServer(
+        address: .loopback(port: AgentHubPreviewHost.configuredPort))
       private var serverTask: Task<Void, Never>?
 
       private static var resultsDirectory: URL {
@@ -236,10 +269,25 @@ public enum HotReloadHostPackage {
             }
             try await server.start()
           } catch {
-            print("AgentHubPreviewHost: server failed to start: \(error)")
+            let description = String(describing: error)
+              .replacingOccurrences(of: "\n", with: " ")
+            if description.lowercased().contains("in use") {
+              print("AGENTHUB_PREVIEW_HOST: failed reason=port-in-use "
+                + "port=\(AgentHubPreviewHost.configuredPort)")
+            } else {
+              print("AGENTHUB_PREVIEW_HOST: failed reason=server-error "
+                + "detail=\(description)")
+            }
           }
         }
-        print("AgentHubPreviewHost: serving previews on loopback port 38824")
+        // Confirm the socket is actually accepting before reporting success;
+        // the catch above reports bind failures.
+        Task { [server] in
+          if (try? await server.waitUntilListening(timeout: 10)) != nil {
+            print("AGENTHUB_PREVIEW_HOST: listening "
+              + "port=\(AgentHubPreviewHost.configuredPort)")
+          }
+        }
       }
 
       /// Rewrites the manifest of all discovered preview types.

--- a/app/modules/SimulatorPreview/Sources/SimulatorPreview/HotReload/HotReloadLaunchConfiguration.swift
+++ b/app/modules/SimulatorPreview/Sources/SimulatorPreview/HotReload/HotReloadLaunchConfiguration.swift
@@ -28,8 +28,9 @@ public struct HotReloadArtifacts: Equatable, Sendable {
 /// stdout should be redirected so the injection engine's events can be tailed.
 public struct HotReloadLaunchPlan: Equatable, Sendable {
   public let configuration: HotReloadLaunchConfiguration
-  /// Console log path for `--stdout=`; nil when injection is off (the
-  /// preview host needs no console).
+  /// Console log path for `--stdout=`; nil when neither the injection
+  /// engine nor the preview host is inserted (both report through it —
+  /// engine events and host startup status).
   public let consoleStdoutPath: String?
 
   public init(
@@ -49,17 +50,23 @@ public struct HotReloadLaunchConfiguration: Equatable, Sendable {
   public let artifacts: HotReloadArtifacts
   public let enableInjection: Bool
   public let enablePreviews: Bool
+  /// Per-device loopback port for the preview host (see
+  /// `PreviewHostPortAllocator`); nil falls back to the host's built-in
+  /// default port.
+  public let previewPort: Int?
 
   public init(
     projectPath: String,
     artifacts: HotReloadArtifacts,
     enableInjection: Bool,
-    enablePreviews: Bool
+    enablePreviews: Bool,
+    previewPort: Int? = nil
   ) {
     self.projectPath = projectPath
     self.artifacts = artifacts
     self.enableInjection = enableInjection
     self.enablePreviews = enablePreviews
+    self.previewPort = previewPort
   }
 
   /// True if at least one runtime feature will actually be armed.
@@ -100,6 +107,7 @@ public struct HotReloadLaunchConfiguration: Equatable, Sendable {
   /// - `DYLD_FRAMEWORK_PATH`: where dyld resolves their dependent frameworks.
   /// - `AGENTHUB_PREVIEW_HOST=1`: gates our preview host's boot constructor
   ///   (it starts its loopback server only when AgentHub armed the launch).
+  /// - `AGENTHUB_PREVIEW_PORT`: the per-device loopback port the host binds.
   /// - `INJECTION_DIRECTORIES`: scopes InjectionLite's FSEvents watcher to
   ///   the project, plus `~/Library` so it can discover the build log under
   ///   AgentHub's custom derived-data path.
@@ -119,6 +127,11 @@ public struct HotReloadLaunchConfiguration: Equatable, Sendable {
       insertedLibraries.append(previewHost)
       environment[
         "SIMCTL_CHILD_\(HotReloadHostPackage.previewHostEnvironmentKey)"] = "1"
+      if let previewPort {
+        environment[
+          "SIMCTL_CHILD_\(HotReloadHostPackage.previewPortEnvironmentKey)"] =
+          String(previewPort)
+      }
     }
 
     guard !insertedLibraries.isEmpty else { return [:] }

--- a/app/modules/SimulatorPreview/Sources/SimulatorPreview/HotReload/HotReloadModels.swift
+++ b/app/modules/SimulatorPreview/Sources/SimulatorPreview/HotReload/HotReloadModels.swift
@@ -41,6 +41,29 @@ public enum HotReloadEngineEvent: Equatable, Sendable {
   case warning(message: String)
 }
 
+/// Startup status of the inserted preview host, parsed from its structured
+/// console lines (`AGENTHUB_PREVIEW_HOST: …`). Distinguishes "still starting"
+/// from real failures so the Previews tab can say what actually went wrong.
+public enum PreviewHostStatus: Equatable, Sendable {
+  /// No status line seen yet (host not inserted, or app still booting).
+  case unknown
+  /// The host is waiting for the app to become active before serving.
+  case waitingForForeground
+  /// The host's server is accepting connections on `port`.
+  case listening(port: Int)
+  /// The host could not start.
+  case failed(reason: PreviewHostFailureReason, detail: String)
+}
+
+public enum PreviewHostFailureReason: Equatable, Sendable {
+  /// Another process already owns the host's loopback port.
+  case portInUse(port: Int)
+  /// The server threw on startup for a non-port reason.
+  case serverError
+  /// The simulator runs an OS older than the previews floor (iOS 16).
+  case unsupportedOSVersion
+}
+
 /// A classified change to the project's Swift sources, observed host-side.
 public enum HotReloadSourceChange: Equatable, Sendable {
   /// An edit to an existing file — the injection engine can hot-swap it.

--- a/app/modules/SimulatorPreview/Sources/SimulatorPreview/HotReload/HotReloadMonitor.swift
+++ b/app/modules/SimulatorPreview/Sources/SimulatorPreview/HotReload/HotReloadMonitor.swift
@@ -130,6 +130,10 @@ public final class HotReloadMonitor {
 
     case .injected(let summary):
       guard isArmed else { return }
+      // A stray "✅" right after a failure-triggered rebuild started (the
+      // engine prints the pair warning→complete) must not flip the pill to
+      // "Reloaded" — the rebuild bumps the generation when it finishes.
+      if case .rebuilding = phase { return }
       cancelTimers()
       reloadGeneration += 1
       phase = .reloaded(summary: summary)

--- a/app/modules/SimulatorPreview/Sources/SimulatorPreview/HotReload/HotReloadMonitor.swift
+++ b/app/modules/SimulatorPreview/Sources/SimulatorPreview/HotReload/HotReloadMonitor.swift
@@ -31,14 +31,26 @@ public final class HotReloadMonitor {
 
   /// How long "Reloaded" lingers before settling back to idle.
   public var settleDelay: TimeInterval = 2.5
-  /// How long a save may sit in "Reloading…" without engine confirmation
+  /// How long a save may sit in "Reloading…" without ANY engine activity
   /// before we assume the change can't be hot-swapped.
   public var reloadTimeout: TimeInterval = 12
+  /// Extended deadline once the engine acknowledged the save (a
+  /// `.recompiling` console event). Evidence the engine is working means a
+  /// slow compile of a large file shouldn't be mistaken for a dead engine —
+  /// each engine event pushes the deadline out again. The engine always
+  /// terminates a real failure with its own `❌`/`⚠️` event, so this only
+  /// delays the fallback when the engine went truly silent mid-compile.
+  public var engineActivityTimeout: TimeInterval = 45
   /// Whether failed/timed-out injections automatically trigger a rebuild.
   public var automaticRebuildFallback = true
 
   private var settleTask: Task<Void, Never>?
   private var timeoutTask: Task<Void, Never>?
+
+  /// Changes that arrived while a rebuild was in flight, coalesced per path
+  /// (structural wins over injectable for the same path). Replayed as at
+  /// most one follow-up rebuild when the rebuild finishes — never dropped.
+  private var pendingChangesDuringRebuild: [String: HotReloadSourceChange] = [:]
 
   public init() {}
 
@@ -46,6 +58,7 @@ public final class HotReloadMonitor {
 
   public func markDisabled() {
     cancelTimers()
+    pendingChangesDuringRebuild = [:]
     phase = .disabled
   }
 
@@ -56,12 +69,14 @@ public final class HotReloadMonitor {
 
   public func markUnavailable(reason: String) {
     cancelTimers()
+    pendingChangesDuringRebuild = [:]
     phase = .unavailable(reason: reason)
   }
 
   /// The app was launched with the injection dylib inserted.
   public func arm() {
     cancelTimers()
+    pendingChangesDuringRebuild = [:]
     lastWarning = nil
     phase = .idle
   }
@@ -71,6 +86,22 @@ public final class HotReloadMonitor {
   public func handle(sourceChanges: [HotReloadSourceChange]) {
     guard isArmed else { return }
 
+    // Mid-rebuild saves are queued, never dropped — `markRebuildFinished`
+    // replays them.
+    if case .rebuilding = phase {
+      for change in sourceChanges {
+        switch change {
+        case .structural:
+          pendingChangesDuringRebuild[change.path] = change
+        case .injectable:
+          if pendingChangesDuringRebuild[change.path] == nil {
+            pendingChangesDuringRebuild[change.path] = change
+          }
+        }
+      }
+      return
+    }
+
     if let structural = sourceChanges.first(where: {
       if case .structural = $0 { return true } else { return false }
     }), case .structural(let path, let kind) = structural {
@@ -79,12 +110,9 @@ public final class HotReloadMonitor {
       return
     }
 
-    guard case .rebuilding = phase else {
-      if let change = sourceChanges.last {
-        let file = (change.path as NSString).lastPathComponent
-        beginReloading(fileName: file)
-      }
-      return
+    if let change = sourceChanges.last {
+      let file = (change.path as NSString).lastPathComponent
+      beginReloading(fileName: file)
     }
   }
 
@@ -98,7 +126,7 @@ public final class HotReloadMonitor {
 
     case .recompiling(let fileName):
       guard isArmed else { return }
-      beginReloading(fileName: fileName)
+      beginReloading(fileName: fileName, timeout: engineActivityTimeout)
 
     case .injected(let summary):
       guard isArmed else { return }
@@ -130,10 +158,23 @@ public final class HotReloadMonitor {
 
   public func markRebuildFinished(success: Bool, message: String? = nil) {
     cancelTimers()
+    let pending = pendingChangesDuringRebuild
+    pendingChangesDuringRebuild = [:]
     if success {
       reloadGeneration += 1
       phase = .idle
+      // The finished rebuild compiled current on-disk sources, so
+      // injectable saves that landed mid-rebuild are already in the running
+      // binary and the generation bump re-renders previews. Only structural
+      // changes (files added/removed mid-rebuild) need one follow-up pass.
+      if let structural = pending.values.first(where: {
+        if case .structural = $0 { return true } else { return false }
+      }), case .structural(let path, let kind) = structural {
+        let file = (path as NSString).lastPathComponent
+        requestRebuild(reason: "\(file) was \(kind.rawValue) during the rebuild")
+      }
     } else {
+      // Never chain rebuilds off a failing build — the next save retries.
       phase = .failed(message: message ?? "Rebuild failed")
     }
   }
@@ -149,10 +190,10 @@ public final class HotReloadMonitor {
     }
   }
 
-  private func beginReloading(fileName: String) {
+  private func beginReloading(fileName: String, timeout: TimeInterval? = nil) {
     if case .rebuilding = phase { return }
     phase = .reloading(fileName: fileName)
-    scheduleReloadTimeout()
+    scheduleReloadTimeout(timeout ?? reloadTimeout)
   }
 
   private func requestRebuild(reason: String) {
@@ -172,9 +213,8 @@ public final class HotReloadMonitor {
     }
   }
 
-  private func scheduleReloadTimeout() {
+  private func scheduleReloadTimeout(_ timeout: TimeInterval) {
     timeoutTask?.cancel()
-    let timeout = reloadTimeout
     timeoutTask = Task { [weak self] in
       try? await Task.sleep(nanoseconds: UInt64(timeout * 1_000_000_000))
       guard !Task.isCancelled, let self else { return }

--- a/app/modules/SimulatorPreview/Sources/SimulatorPreview/HotReload/PreviewHostClient.swift
+++ b/app/modules/SimulatorPreview/Sources/SimulatorPreview/HotReload/PreviewHostClient.swift
@@ -101,12 +101,17 @@ public struct PreviewHostRenderResult: Equatable, Sendable {
 
 public enum PreviewHostClientError: LocalizedError, Equatable {
   case serverUnreachable
+  /// Something is listening but did not answer in time — unlike
+  /// `.serverUnreachable`, retrying immediately is unlikely to help.
+  case timedOut
   case malformedResponse(detail: String)
 
   public var errorDescription: String? {
     switch self {
     case .serverUnreachable:
       return "The preview host isn't running. Build & run with previews enabled."
+    case .timedOut:
+      return "The preview host is not responding (request timed out)."
     case .malformedResponse(let detail):
       return "Unexpected preview host response: \(detail)"
     }
@@ -173,9 +178,9 @@ public protocol PreviewHostClientProtocol: Sendable {
 /// IPv4 instead.
 public struct PreviewHostHTTPClient: PreviewHostClientProtocol {
 
-  /// Fixed port shared with the generated preview host (see
-  /// `HotReloadHostPackage`).
-  public static let port = 38824
+  /// Default port shared with the generated preview host — used when a
+  /// launch didn't carry a per-device port (see `PreviewHostPortAllocator`).
+  public static let port = HotReloadHostPackage.previewHostDefaultPort
 
   private let baseURLs: [URL]
   private let session: URLSession
@@ -234,6 +239,8 @@ public struct PreviewHostHTTPClient: PreviewHostClientProtocol {
         return data
       } catch let error as PreviewHostClientError {
         lastError = error
+      } catch let error as URLError where error.code == .timedOut {
+        lastError = .timedOut
       } catch {
         lastError = .serverUnreachable
       }

--- a/app/modules/SimulatorPreview/Sources/SimulatorPreview/HotReload/PreviewHostPortAllocator.swift
+++ b/app/modules/SimulatorPreview/Sources/SimulatorPreview/HotReload/PreviewHostPortAllocator.swift
@@ -1,0 +1,34 @@
+import CryptoKit
+import Foundation
+
+/// Assigns each simulator device its own loopback port for the preview host,
+/// so multiple projects/worktrees can serve previews simultaneously instead
+/// of fighting over one fixed port.
+///
+/// The port is a stable hash of the device UDID: the same device always gets
+/// the same port (the host-side client and the in-app server derive nothing —
+/// AgentHub computes the port once per launch and passes it through the
+/// launch environment). `avoiding` lets a caller probe past ports already
+/// claimed by other live sessions on hash collision.
+public enum PreviewHostPortAllocator {
+
+  /// Loopback-only range, clear of the legacy fixed port's neighbors and
+  /// common dev-server ports. 1000 slots.
+  public static let portRange: ClosedRange<Int> = 38700...39699
+
+  public static func port(forDeviceUDID udid: String, avoiding: Set<Int> = []) -> Int {
+    let count = portRange.count
+    let digest = SHA256.hash(data: Data(udid.utf8))
+    let seed = digest.prefix(8).reduce(UInt64(0)) { ($0 << 8) | UInt64($1) }
+    var offset = Int(seed % UInt64(count))
+    for _ in 0..<count {
+      let candidate = portRange.lowerBound + offset
+      if !avoiding.contains(candidate) {
+        return candidate
+      }
+      offset = (offset + 1) % count
+    }
+    // Every slot avoided (not realistic) — return the deterministic base.
+    return portRange.lowerBound + Int(seed % UInt64(count))
+  }
+}

--- a/app/modules/SimulatorPreview/Sources/SimulatorPreview/HotReload/PreviewHostStatusParser.swift
+++ b/app/modules/SimulatorPreview/Sources/SimulatorPreview/HotReload/PreviewHostStatusParser.swift
@@ -1,0 +1,70 @@
+import Foundation
+
+/// Parses the generated preview host's structured status lines from the
+/// app's console into `PreviewHostStatus` values.
+///
+/// The host prints exactly these shapes (pinned by the artifact-store tests
+/// against the generated source — keep them in sync):
+///
+///     AGENTHUB_PREVIEW_HOST: waiting reason=app-not-active
+///     AGENTHUB_PREVIEW_HOST: listening port=38712
+///     AGENTHUB_PREVIEW_HOST: unsupported reason=ios-version
+///     AGENTHUB_PREVIEW_HOST: failed reason=port-in-use port=38712
+///     AGENTHUB_PREVIEW_HOST: failed reason=server-error detail=<one line>
+public struct PreviewHostStatusParser: Sendable {
+
+  public static let linePrefix = "AGENTHUB_PREVIEW_HOST: "
+
+  public init() {}
+
+  public func parse(line: String) -> PreviewHostStatus? {
+    let trimmed = line.trimmingCharacters(in: .whitespaces)
+    guard trimmed.hasPrefix(Self.linePrefix) else { return nil }
+    let payload = String(trimmed.dropFirst(Self.linePrefix.count))
+    let fields = Self.fields(of: payload)
+
+    switch payload.split(separator: " ").first.map(String.init) {
+    case "waiting":
+      return .waitingForForeground
+    case "listening":
+      guard let port = fields["port"].flatMap(Int.init) else { return nil }
+      return .listening(port: port)
+    case "unsupported":
+      return .failed(
+        reason: .unsupportedOSVersion,
+        detail: "SwiftUI previews require an iOS 16 or later simulator."
+      )
+    case "failed":
+      switch fields["reason"] {
+      case "port-in-use":
+        guard let port = fields["port"].flatMap(Int.init) else { return nil }
+        return .failed(reason: .portInUse(port: port), detail: "")
+      case "server-error":
+        return .failed(reason: .serverError, detail: Self.detail(of: payload))
+      default:
+        return nil
+      }
+    default:
+      return nil
+    }
+  }
+
+  /// `key=value` tokens up to (not including) any `detail=` field.
+  private static func fields(of payload: String) -> [String: String] {
+    var fields: [String: String] = [:]
+    for token in payload.split(separator: " ") {
+      guard let equals = token.firstIndex(of: "=") else { continue }
+      let key = String(token[..<equals])
+      if key == "detail" { break }
+      fields[key] = String(token[token.index(after: equals)...])
+    }
+    return fields
+  }
+
+  /// Everything after `detail=` — the one field allowed to contain spaces,
+  /// so it must be last on the line.
+  private static func detail(of payload: String) -> String {
+    guard let range = payload.range(of: "detail=") else { return "" }
+    return String(payload[range.upperBound...])
+  }
+}

--- a/app/modules/SimulatorPreview/Tests/SimulatorPreviewTests/HotReloadArtifactStoreTests.swift
+++ b/app/modules/SimulatorPreview/Tests/SimulatorPreviewTests/HotReloadArtifactStoreTests.swift
@@ -40,6 +40,74 @@ struct HotReloadHostPackageTests {
     #expect(host?.contains("result[\"scale\"]") == true)
   }
 
+  @Test("the host binds the per-device port from the launch environment")
+  func hostReadsPortFromEnvironment() {
+    let host = HotReloadHostPackage.sourceFiles[
+      "Sources/\(HotReloadHostPackage.previewHostScheme)/\(HotReloadHostPackage.previewHostScheme).swift"]
+    #expect(host?.contains(
+      "environment[\"\(HotReloadHostPackage.previewPortEnvironmentKey)\"]") == true)
+    #expect(host?.contains("?? \(HotReloadHostPackage.previewHostDefaultPort)") == true)
+    #expect(host?.contains("port: AgentHubPreviewHost.configuredPort") == true)
+  }
+
+  /// Pins the generated host's status lines to what
+  /// `PreviewHostStatusParser` understands — same discipline as the
+  /// InjectionLite console pins: change them together.
+  @Test("the host prints the structured status lines the parser understands")
+  func hostPrintsParsableStatusLines() {
+    let host = HotReloadHostPackage.sourceFiles[
+      "Sources/\(HotReloadHostPackage.previewHostScheme)/\(HotReloadHostPackage.previewHostScheme).swift"]
+
+    #expect(host?.contains(
+      "AGENTHUB_PREVIEW_HOST: unsupported reason=ios-version") == true)
+    #expect(host?.contains(
+      "AGENTHUB_PREVIEW_HOST: waiting reason=app-not-active") == true)
+    #expect(host?.contains("AGENTHUB_PREVIEW_HOST: listening ") == true)
+    #expect(host?.contains("AGENTHUB_PREVIEW_HOST: failed reason=port-in-use ") == true)
+    #expect(host?.contains("AGENTHUB_PREVIEW_HOST: failed reason=server-error ") == true)
+    #expect(host?.contains("waitUntilListening") == true)
+
+    // And the parser accepts the exact shapes the host emits.
+    let parser = PreviewHostStatusParser()
+    #expect(parser.parse(
+      line: "AGENTHUB_PREVIEW_HOST: unsupported reason=ios-version") != nil)
+    #expect(parser.parse(
+      line: "AGENTHUB_PREVIEW_HOST: waiting reason=app-not-active") != nil)
+    #expect(parser.parse(line: "AGENTHUB_PREVIEW_HOST: listening port=38824") != nil)
+    #expect(parser.parse(
+      line: "AGENTHUB_PREVIEW_HOST: failed reason=port-in-use port=38824") != nil)
+    #expect(parser.parse(
+      line: "AGENTHUB_PREVIEW_HOST: failed reason=server-error detail=boom") != nil)
+  }
+
+  @Test("fingerprint is a deterministic content hash")
+  func fingerprintDeterminism() {
+    #expect(HotReloadHostPackage.fingerprint.hasPrefix("host-sha256-"))
+    #expect(HotReloadHostPackage.fingerprint == HotReloadHostPackage.fingerprint(
+      manifest: HotReloadHostPackage.manifest,
+      sourceFiles: HotReloadHostPackage.sourceFiles
+    ))
+  }
+
+  @Test("fingerprint changes when the manifest or any generated source changes")
+  func fingerprintSensitivity() {
+    let manifest = HotReloadHostPackage.manifest
+    var sources = HotReloadHostPackage.sourceFiles
+    let base = HotReloadHostPackage.fingerprint(manifest: manifest, sourceFiles: sources)
+
+    let manifestVariant = HotReloadHostPackage.fingerprint(
+      manifest: manifest + "\n// pin bump",
+      sourceFiles: sources
+    )
+    #expect(manifestVariant != base)
+
+    let key = sources.keys.sorted()[0]
+    sources[key] = (sources[key] ?? "") + "\n// edited"
+    let sourceVariant = HotReloadHostPackage.fingerprint(manifest: manifest, sourceFiles: sources)
+    #expect(sourceVariant != base)
+    #expect(sourceVariant != manifestVariant)
+  }
+
   @Test("write is idempotent and only touches changed files")
   func writeIdempotent() throws {
     let directory = FileManager.default.temporaryDirectory

--- a/app/modules/SimulatorPreview/Tests/SimulatorPreviewTests/HotReloadConsoleParserTests.swift
+++ b/app/modules/SimulatorPreview/Tests/SimulatorPreviewTests/HotReloadConsoleParserTests.swift
@@ -66,4 +66,37 @@ struct HotReloadConsoleParserTests {
     #expect(parser.parse(line: "") == nil)
     #expect(parser.parse(line: "⚠️ app's own warning") == nil)
   }
+
+  @Test("tolerant fallbacks catch drifted engine wording")
+  func tolerantFallbacks() {
+    // Wording drift in a future InjectionLite must not silently degrade
+    // every save into timeout → full rebuild.
+    #expect(parser.parse(line: "🔥 InjectionLite v2.2: Watching /Users/dev/App")
+      == .engineReady)
+    #expect(parser.parse(line: "🔥 Compiling HomeView.swift")
+      == .recompiling(fileName: "HomeView.swift"))
+    #expect(parser.parse(line: "🔥 Recompiling: Detail-View.swift please wait")
+      == .recompiling(fileName: "Detail-View.swift"))
+    #expect(parser.parse(line: "🔥 ✅ Reload finished - Rebound 3 symbols")
+      == .injected(summary: "Reload finished - Rebound 3 symbols"))
+    #expect(parser.parse(line: "🔥 Injection ✅")
+      == .injected(summary: "Hot reload complete"))
+    #expect(parser.parse(line: "🔥 ❌ Injection error: type changed")
+      == .injectionFailed(message: "Injection error: type changed"))
+  }
+
+  @Test("tolerant fallbacks never match lines without the engine prefix")
+  func tolerantFallbacksRequireEnginePrefix() {
+    #expect(parser.parse(line: "✅ Reload of my web page finished") == nil)
+    #expect(parser.parse(line: "Tests ❌ failed") == nil)
+    #expect(parser.parse(line: "Watching directory /tmp") == nil)
+    #expect(parser.parse(line: "Compiling Shaders.swift") == nil)
+  }
+
+  @Test("tolerant fallbacks don't misread unrelated engine chatter")
+  func tolerantFallbacksIgnoreOtherEngineLines() {
+    #expect(parser.parse(line: "🔥 Loaded dylib /tmp/eval1.dylib") == nil)
+    // ✅ without any reload/inject wording is not a confirmation.
+    #expect(parser.parse(line: "🔥 Setup ✅ ready") == nil)
+  }
 }

--- a/app/modules/SimulatorPreview/Tests/SimulatorPreviewTests/HotReloadConsoleParserTests.swift
+++ b/app/modules/SimulatorPreview/Tests/SimulatorPreviewTests/HotReloadConsoleParserTests.swift
@@ -46,11 +46,13 @@ struct HotReloadConsoleParserTests {
       .injectionFailed(message: "Stored-property layout changed — rebuilding"))
   }
 
-  @Test("missing interposable flag surfaces as warning")
+  @Test("missing interposable flag is a failed injection, not a warning")
   func noSymbolsReplaced() {
+    // A binary without -interposable can never rebind injected code — every
+    // "reload" would be a silent no-op. Only the rebuild fallback fixes it.
     let line = "🔥 ℹ️ No symbols replaced, have you added -Xlinker -interposable to your project?"
     #expect(parser.parse(line: line) ==
-      .warning(message: "Injection loaded but no symbols were replaced"))
+      .injectionFailed(message: "App wasn't built with injection support — rebuilding"))
   }
 
   @Test("generic engine warning becomes a warning event")

--- a/app/modules/SimulatorPreview/Tests/SimulatorPreviewTests/HotReloadLaunchConfigurationTests.swift
+++ b/app/modules/SimulatorPreview/Tests/SimulatorPreviewTests/HotReloadLaunchConfigurationTests.swift
@@ -17,7 +17,8 @@ struct HotReloadLaunchConfigurationTests {
       projectPath: "/Users/dev/App",
       artifacts: artifacts,
       enableInjection: true,
-      enablePreviews: true
+      enablePreviews: true,
+      previewPort: 38712
     )
     let env = configuration.simctlChildEnvironment(homeDirectory: "/Users/dev")
 
@@ -27,9 +28,32 @@ struct HotReloadLaunchConfigurationTests {
     #expect(env["SIMCTL_CHILD_DYLD_FRAMEWORK_PATH"] ==
       "/store/PackageFrameworks:/store/artifacts/sim")
     #expect(env["SIMCTL_CHILD_AGENTHUB_PREVIEW_HOST"] == "1")
+    #expect(env["SIMCTL_CHILD_AGENTHUB_PREVIEW_PORT"] == "38712")
     #expect(env["SIMCTL_CHILD_INJECTION_DIRECTORIES"] ==
       "/Users/dev/App,/Users/dev/Library")
     #expect(configuration.isEffective)
+  }
+
+  @Test("preview port env is omitted without a port or without previews")
+  func previewPortOmission() {
+    let noPort = HotReloadLaunchConfiguration(
+      projectPath: "/Users/dev/App",
+      artifacts: artifacts,
+      enableInjection: false,
+      enablePreviews: true
+    )
+    #expect(noPort.simctlChildEnvironment(
+      homeDirectory: "/Users/dev")["SIMCTL_CHILD_AGENTHUB_PREVIEW_PORT"] == nil)
+
+    let injectionOnly = HotReloadLaunchConfiguration(
+      projectPath: "/Users/dev/App",
+      artifacts: artifacts,
+      enableInjection: true,
+      enablePreviews: false,
+      previewPort: 38712
+    )
+    #expect(injectionOnly.simctlChildEnvironment(
+      homeDirectory: "/Users/dev")["SIMCTL_CHILD_AGENTHUB_PREVIEW_PORT"] == nil)
   }
 
   @Test("previews only — no injection env, no build overrides")

--- a/app/modules/SimulatorPreview/Tests/SimulatorPreviewTests/HotReloadMonitorTests.swift
+++ b/app/modules/SimulatorPreview/Tests/SimulatorPreviewTests/HotReloadMonitorTests.swift
@@ -104,6 +104,33 @@ struct HotReloadMonitorTests {
     #expect(monitor.lastWarning == "No symbols were replaced")
   }
 
+  @Test("stray injection confirmation during a rebuild is ignored")
+  func injectedDuringRebuildIgnored() {
+    // The non-interposable failure prints warning→complete as a pair: the
+    // warning starts the rebuild, and the trailing "✅" must not flip the
+    // pill to "Reloaded" or bump the generation — nothing actually rebound.
+    let monitor = makeMonitor()
+    monitor.arm()
+    var rebuilds: [String] = []
+    monitor.onRequestRebuild = { rebuilds.append($0) }
+
+    monitor.handle(sourceChanges: [.injectable(path: "/p/HomeView.swift")])
+    monitor.handle(engineEvent: .injectionFailed(
+      message: "App wasn't built with injection support — rebuilding"))
+    #expect(rebuilds.count == 1)
+    #expect(monitor.phase == .rebuilding(
+      reason: "App wasn't built with injection support — rebuilding"))
+
+    monitor.handle(engineEvent: .injected(summary: "Hot reload complete - Rebound 0 symbols"))
+    #expect(monitor.phase == .rebuilding(
+      reason: "App wasn't built with injection support — rebuilding"))
+    #expect(monitor.reloadGeneration == 0)
+
+    monitor.markRebuildFinished(success: true)
+    #expect(monitor.phase == .idle)
+    #expect(monitor.reloadGeneration == 1)
+  }
+
   @Test("engine activity extends the reload deadline past the base timeout")
   func engineActivityExtendsDeadline() async throws {
     let monitor = makeMonitor()

--- a/app/modules/SimulatorPreview/Tests/SimulatorPreviewTests/HotReloadMonitorTests.swift
+++ b/app/modules/SimulatorPreview/Tests/SimulatorPreviewTests/HotReloadMonitorTests.swift
@@ -104,6 +104,121 @@ struct HotReloadMonitorTests {
     #expect(monitor.lastWarning == "No symbols were replaced")
   }
 
+  @Test("engine activity extends the reload deadline past the base timeout")
+  func engineActivityExtendsDeadline() async throws {
+    let monitor = makeMonitor()
+    monitor.reloadTimeout = 0.05
+    monitor.engineActivityTimeout = 0.5
+    monitor.arm()
+    var rebuilds: [String] = []
+    monitor.onRequestRebuild = { rebuilds.append($0) }
+
+    monitor.handle(sourceChanges: [.injectable(path: "/p/Big.swift")])
+    monitor.handle(engineEvent: .recompiling(fileName: "Big.swift"))
+
+    // Well past the base deadline but the engine acknowledged the save —
+    // a slow compile must not be mistaken for a dead engine.
+    try await Task.sleep(nanoseconds: 200_000_000)
+    #expect(monitor.phase == .reloading(fileName: "Big.swift"))
+    #expect(rebuilds.isEmpty)
+
+    // Engine goes silent past the extended deadline — fallback still fires.
+    let deadline = Date().addingTimeInterval(2)
+    while rebuilds.isEmpty, Date() < deadline {
+      try? await Task.sleep(nanoseconds: 10_000_000)
+    }
+    #expect(rebuilds == ["Change didn't hot-swap"])
+  }
+
+  @Test("engine activity followed by confirmation never rebuilds")
+  func engineActivityThenConfirmation() async throws {
+    let monitor = makeMonitor()
+    monitor.reloadTimeout = 0.05
+    monitor.engineActivityTimeout = 0.2
+    monitor.arm()
+    var rebuilds: [String] = []
+    monitor.onRequestRebuild = { rebuilds.append($0) }
+
+    monitor.handle(sourceChanges: [.injectable(path: "/p/HomeView.swift")])
+    monitor.handle(engineEvent: .recompiling(fileName: "HomeView.swift"))
+    monitor.handle(engineEvent: .injected(summary: "Hot reload complete"))
+    #expect(monitor.reloadGeneration == 1)
+
+    try await Task.sleep(nanoseconds: 400_000_000)
+    #expect(rebuilds.isEmpty)
+  }
+
+  @Test("structural change during a rebuild queues exactly one follow-up")
+  func structuralQueuedDuringRebuild() {
+    let monitor = makeMonitor()
+    monitor.arm()
+    var rebuilds: [String] = []
+    monitor.onRequestRebuild = { rebuilds.append($0) }
+
+    monitor.handle(sourceChanges: [.structural(path: "/p/New.swift", kind: .created)])
+    #expect(rebuilds.count == 1)
+
+    // Mid-rebuild: repeated saves of the same new file coalesce, injectable
+    // saves ride along — none of it is dropped.
+    for _ in 0..<5 {
+      monitor.handle(sourceChanges: [.structural(path: "/p/Another.swift", kind: .created)])
+    }
+    monitor.handle(sourceChanges: [.injectable(path: "/p/Edited.swift")])
+    #expect(rebuilds.count == 1)
+
+    monitor.markRebuildFinished(success: true)
+    #expect(rebuilds == [
+      "New.swift was created",
+      "Another.swift was created during the rebuild",
+    ])
+    #expect(monitor.phase == .rebuilding(reason: "Another.swift was created during the rebuild"))
+
+    // The follow-up rebuild finishing settles to idle with nothing queued.
+    monitor.markRebuildFinished(success: true)
+    #expect(monitor.phase == .idle)
+    #expect(rebuilds.count == 2)
+  }
+
+  @Test("injectable-only saves during a rebuild are covered by it, not replayed")
+  func injectableQueueClearsWithoutFollowUp() {
+    let monitor = makeMonitor()
+    monitor.arm()
+    var rebuilds: [String] = []
+    monitor.onRequestRebuild = { rebuilds.append($0) }
+
+    monitor.handle(sourceChanges: [.structural(path: "/p/New.swift", kind: .created)])
+    monitor.handle(sourceChanges: [.injectable(path: "/p/Edited.swift")])
+
+    monitor.markRebuildFinished(success: true)
+    // The rebuild compiled current on-disk sources, so the mid-rebuild save
+    // is already in the binary; the generation bump re-renders previews.
+    #expect(monitor.phase == .idle)
+    #expect(rebuilds.count == 1)
+    #expect(monitor.reloadGeneration == 1)
+  }
+
+  @Test("a failed rebuild clears the queue without chaining another rebuild")
+  func failedRebuildClearsQueue() {
+    let monitor = makeMonitor()
+    monitor.arm()
+    var rebuilds: [String] = []
+    monitor.onRequestRebuild = { rebuilds.append($0) }
+
+    monitor.handle(sourceChanges: [.structural(path: "/p/New.swift", kind: .created)])
+    monitor.handle(sourceChanges: [.structural(path: "/p/Another.swift", kind: .created)])
+
+    monitor.markRebuildFinished(success: false, message: "Build failed")
+    #expect(monitor.phase == .failed(message: "Build failed"))
+    #expect(rebuilds.count == 1)
+
+    // Re-arming starts clean — the stale queue must not resurface.
+    monitor.arm()
+    monitor.markRebuildStarted(reason: "manual")
+    monitor.markRebuildFinished(success: true)
+    #expect(monitor.phase == .idle)
+    #expect(rebuilds.count == 1)
+  }
+
   @Test("reload timeout falls back to rebuild")
   func reloadTimeout() async throws {
     let monitor = makeMonitor()

--- a/app/modules/SimulatorPreview/Tests/SimulatorPreviewTests/PreviewHostPortAllocatorTests.swift
+++ b/app/modules/SimulatorPreview/Tests/SimulatorPreviewTests/PreviewHostPortAllocatorTests.swift
@@ -1,0 +1,50 @@
+import Testing
+
+@testable import SimulatorPreview
+
+@Suite("PreviewHostPortAllocator")
+struct PreviewHostPortAllocatorTests {
+
+  @Test("same UDID always gets the same port")
+  func deterministic() {
+    let udid = "3C9E4F2A-1111-4A6B-9C3D-ABCDEF012345"
+    #expect(
+      PreviewHostPortAllocator.port(forDeviceUDID: udid)
+        == PreviewHostPortAllocator.port(forDeviceUDID: udid)
+    )
+  }
+
+  @Test("ports stay inside the loopback range")
+  func inRange() {
+    for udid in ["A", "B", "3C9E4F2A", "long-udid-\(String(repeating: "x", count: 64))"] {
+      let port = PreviewHostPortAllocator.port(forDeviceUDID: udid)
+      #expect(PreviewHostPortAllocator.portRange.contains(port))
+    }
+  }
+
+  @Test("distinct UDIDs land on distinct ports for a realistic device set")
+  func distinctForTypicalSet() {
+    let udids = (0..<12).map { "DEVICE-\($0)-4A6B-9C3D-ABCDEF01234\($0)" }
+    let ports = Set(udids.map { PreviewHostPortAllocator.port(forDeviceUDID: $0) })
+    // Collisions are theoretically possible but should be rare in a
+    // 12-device / 1000-slot space; total collapse would indicate a bug.
+    #expect(ports.count >= udids.count - 1)
+  }
+
+  @Test("avoided ports are probed past, wrapping the range")
+  func probesPastAvoided() {
+    let udid = "COLLIDE-ME"
+    let base = PreviewHostPortAllocator.port(forDeviceUDID: udid)
+    let next = PreviewHostPortAllocator.port(forDeviceUDID: udid, avoiding: [base])
+    #expect(next != base)
+    #expect(PreviewHostPortAllocator.portRange.contains(next))
+
+    let range = PreviewHostPortAllocator.portRange
+    let wrapped = PreviewHostPortAllocator.port(
+      forDeviceUDID: udid,
+      avoiding: Set(base...range.upperBound)
+    )
+    #expect(wrapped < base)
+    #expect(range.contains(wrapped))
+  }
+}

--- a/app/modules/SimulatorPreview/Tests/SimulatorPreviewTests/PreviewHostStatusParserTests.swift
+++ b/app/modules/SimulatorPreview/Tests/SimulatorPreviewTests/PreviewHostStatusParserTests.swift
@@ -1,0 +1,70 @@
+import Testing
+
+@testable import SimulatorPreview
+
+@Suite("PreviewHostStatusParser")
+struct PreviewHostStatusParserTests {
+
+  private let parser = PreviewHostStatusParser()
+
+  @Test("waiting for foreground")
+  func waiting() {
+    #expect(
+      parser.parse(line: "AGENTHUB_PREVIEW_HOST: waiting reason=app-not-active")
+        == .waitingForForeground
+    )
+  }
+
+  @Test("listening with port")
+  func listening() {
+    #expect(
+      parser.parse(line: "AGENTHUB_PREVIEW_HOST: listening port=38712")
+        == .listening(port: 38712)
+    )
+  }
+
+  @Test("unsupported OS version")
+  func unsupported() {
+    let status = parser.parse(
+      line: "AGENTHUB_PREVIEW_HOST: unsupported reason=ios-version")
+    guard case .failed(reason: .unsupportedOSVersion, _)? = status else {
+      Issue.record("expected unsupported-OS failure, got \(String(describing: status))")
+      return
+    }
+  }
+
+  @Test("port in use")
+  func portInUse() {
+    #expect(
+      parser.parse(line: "AGENTHUB_PREVIEW_HOST: failed reason=port-in-use port=38701")
+        == .failed(reason: .portInUse(port: 38701), detail: "")
+    )
+  }
+
+  @Test("server error carries the trailing detail verbatim")
+  func serverError() {
+    let status = parser.parse(
+      line: "AGENTHUB_PREVIEW_HOST: failed reason=server-error "
+        + "detail=SocketError.failed(type: bind, errno: 13)")
+    #expect(status == .failed(
+      reason: .serverError,
+      detail: "SocketError.failed(type: bind, errno: 13)"
+    ))
+  }
+
+  @Test("non-status lines are ignored")
+  func ignoresOtherLines() {
+    #expect(parser.parse(line: "🔥 ✅ Hot reload complete") == nil)
+    #expect(parser.parse(line: "AgentHubPreviewHost: serving previews") == nil)
+    #expect(parser.parse(line: "") == nil)
+  }
+
+  @Test("malformed status lines are ignored, not misread")
+  func malformed() {
+    #expect(parser.parse(line: "AGENTHUB_PREVIEW_HOST: listening") == nil)
+    #expect(parser.parse(line: "AGENTHUB_PREVIEW_HOST: listening port=abc") == nil)
+    #expect(parser.parse(line: "AGENTHUB_PREVIEW_HOST: failed reason=port-in-use") == nil)
+    #expect(parser.parse(line: "AGENTHUB_PREVIEW_HOST: failed reason=mystery") == nil)
+    #expect(parser.parse(line: "AGENTHUB_PREVIEW_HOST: exploded") == nil)
+  }
+}


### PR DESCRIPTION
## Problem

1. **Wrong project's simulator shown.** With multiple iOS projects (or worktrees) active, switching to project A could display project B's simulator: device selection fell back to the globally first-booted simulator, and per-project preferences were in-memory only (lost on relaunch). The previews host also bound one fixed loopback port (38824), so only one project's previews worked at a time.
2. **Hot reload / previews unreliability**, four verified failure clusters: a stale artifact cache (fingerprint didn't cover the FlyingFox pin or generated source content), brittle exact-string reload confirmation with a fixed 12s timeout, saves silently dropped during rebuilds, and swallowed preview-host startup failures that all looked like a generic "did not respond".

## Changes

### Project/worktree-scoped simulator panel
- New pure `SimulatorDestinationResolver`: explicit selection → the project's persisted preference → **nil**. The global `bootedDevices.first` / `physicalDevices.first` / `availableDevices.first` fallbacks are gone; with no association the panel shows a "Choose a Run Destination" empty state (shared `SimulatorDestinationMenuContent` between header picker and empty state).
- Preferences persist across relaunches: new `v11_create_project_simulator_preferences` migration + `ProjectSimulatorPreference` in `SessionMetadataStore`, exposed through a `SimulatorPreferencePersisting` protocol; `SimulatorService` setters write through and hydrate at launch (panel awaits hydration so the saved device restores without flashing the picker). Worktrees have distinct `projectPath`s, so each remembers its own device.

### Hot reload / previews reliability
- **Artifact cache:** `HotReloadHostPackage.fingerprint` is now a SHA256 content hash over the materialized manifest + every generated source. Any pin bump or source edit invalidates the cache automatically; existing caches rebuild once (intended).
- **Per-device preview ports:** `PreviewHostPortAllocator` hashes the simulator UDID into 38700–39699, passed via `SIMCTL_CHILD_AGENTHUB_PREVIEW_PORT`; the generated host binds it (default 38824 when absent) and `SimulatorHotReloadController` re-creates the client per launch. Concurrent projects/worktrees can now both serve previews — the one-host-at-a-time invariant is removed.
- **Startup-failure surfacing:** the generated host prints structured `AGENTHUB_PREVIEW_HOST:` status lines (`listening port=…`, `waiting reason=app-not-active`, `failed reason=port-in-use/server-error`, `unsupported reason=ios-version`), confirmed via FlyingFox `waitUntilListening`. The console tail now runs for previews-only launches too; a new `PreviewHostStatusParser` feeds `previewHostStatus`, and the Previews tab reports the actual failure. `PreviewHostClientError` gains `.timedOut`.
- **Parser tolerance + adaptive timeout:** exact InjectionLite pins are matched first; tolerant 🔥-prefixed fallbacks are drift insurance. The reload timeout is evidence-based: 12s with no engine activity, extended to 45s (re-pushed per event) once the engine acknowledged the save. Pill honesty is unchanged — `.reloaded` only on engine confirmation.
- **No dropped saves:** changes landing while a rebuild is in flight are queued and coalesced per path; structural changes replay as exactly one follow-up rebuild, injectable ones are already covered by the rebuild (it compiled current on-disk sources). Failed rebuilds clear the queue rather than chaining.

### Docs
`SimulatorPreview.md` updated: project-scoped destination invariant, per-device port invariant, status-line contract, adaptive timeout, and the queue semantics.

## Testing

- Full local gate: `./scripts/test.sh` — **all tests passed** (fast packages + complete AgentHubCore suite).
- New suites: `ProjectSimulatorPreferenceTests` (incl. a v11 migration-preservation test), `SimulatorDestinationResolverTests`, `PreviewHostPortAllocatorTests`, `PreviewHostStatusParserTests`, `SimulatorServicePreferencePersistenceTests`.
- Extended: launch-config env contract (port var), artifact-store (fingerprint determinism/sensitivity, host source ↔ parser string pins), console-parser (drifted wording + negatives), monitor (adaptive deadline, mid-rebuild queue), controller (per-port client swap, previews-only tail, host status lines, held-rebuild follow-up).

Suggested manual check: two projects side by side — build & run A, switch to B (picker, not A's stream), pick a device for B, confirm both Previews tabs render simultaneously; relaunch AgentHub and confirm each panel restores its own device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)