### PR TITLE
[codex] Scope simulator run destinations per project

### DIFF
--- a/SimulatorPreview.md
+++ b/SimulatorPreview.md
@@ -30,6 +30,18 @@ When a physical device is selected, keep the panel quiet: do not warm
 hot-reload artifacts, start preview source watchers, arm the preview host, or
 display simulator-only hot-reload state.
 
+**Run destinations are project/worktree-scoped.** `SimulatorDestinationResolver`
+resolves the panel's device from the explicit in-panel selection, then the
+project's persisted preference — and deliberately nothing else: with no
+association the panel shows a "Choose a Run Destination" picker rather than
+adopting another project's booted simulator or a random connected phone.
+Preferences are keyed by `projectPath` (worktrees are distinct paths, so each
+worktree remembers its own device) and persisted in `SessionMetadataStore`
+(`project_simulator_preferences`, hydrated into `SimulatorService` at launch),
+so they survive app relaunches. Do not reintroduce global
+`bootedDevices.first`-style fallbacks — that was the "project A shows
+project B's simulator" bug.
+
 ## Annotation feedback (element-aware pins sent to the agent)
 
 The header's **Annotate** toggle pauses tap forwarding and reads the frontmost

--- a/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubProvider.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubProvider.swift
@@ -269,6 +269,13 @@ public final class AgentHubProvider {
       Task {
         await TerminalProcessRegistry.shared.configure(store: metadataStore)
       }
+      SimulatorService.shared.configurePreferenceStore(metadataStore)
+    } else {
+      // The lazy accessor builds the real store; defer so init stays light.
+      Task { @MainActor [weak self] in
+        guard let self, let store = self.metadataStore else { return }
+        SimulatorService.shared.configurePreferenceStore(store)
+      }
     }
 
     // Persist developer-provided commands to UserDefaults

--- a/app/modules/AgentHubCore/Sources/AgentHub/Models/ProjectSimulatorPreference.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Models/ProjectSimulatorPreference.swift
@@ -1,0 +1,36 @@
+//
+//  ProjectSimulatorPreference.swift
+//  AgentHub
+//
+//  SQLite record for the run destination a project/worktree last selected
+//  in the simulator preview panel.
+//
+
+import Foundation
+import GRDB
+
+public struct ProjectSimulatorPreference: Codable, Equatable, Sendable, FetchableRecord, PersistableRecord {
+  public enum Kind: String, Codable, Sendable {
+    case simulator
+    case physical
+  }
+
+  public var projectPath: String
+  public var deviceIdentifier: String
+  public var kind: Kind
+  public var updatedAt: Date
+
+  public static var databaseTableName: String { "project_simulator_preferences" }
+
+  public init(
+    projectPath: String,
+    deviceIdentifier: String,
+    kind: Kind,
+    updatedAt: Date = Date.now
+  ) {
+    self.projectPath = projectPath
+    self.deviceIdentifier = deviceIdentifier
+    self.kind = kind
+    self.updatedAt = updatedAt
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/SessionMetadataStore.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/SessionMetadataStore.swift
@@ -25,6 +25,7 @@ public actor SessionMetadataStore: TerminalWorkspaceStoreProtocol {
     static let createClaudeHookInstallations = "v8_create_claude_hook_installations"
     static let addOwnedWorktreePaths = "v9_add_owned_worktree_paths"
     static let createSessionRelationships = "v10_create_session_relationships"
+    static let createProjectSimulatorPreferences = "v11_create_project_simulator_preferences"
   }
 
   static let migrationIdentifiers = [
@@ -37,7 +38,8 @@ public actor SessionMetadataStore: TerminalWorkspaceStoreProtocol {
     MigrationID.createManagedProcesses,
     MigrationID.createClaudeHookInstallations,
     MigrationID.addOwnedWorktreePaths,
-    MigrationID.createSessionRelationships
+    MigrationID.createSessionRelationships,
+    MigrationID.createProjectSimulatorPreferences
   ]
 
   private let dbQueue: DatabaseQueue
@@ -191,6 +193,15 @@ public actor SessionMetadataStore: TerminalWorkspaceStoreProtocol {
       )
     }
 
+    migrator.registerMigration(MigrationID.createProjectSimulatorPreferences) { db in
+      try db.create(table: "project_simulator_preferences") { t in
+        t.column("projectPath", .text).primaryKey(onConflict: .replace)
+        t.column("deviceIdentifier", .text).notNull()
+        t.column("kind", .text).notNull()
+        t.column("updatedAt", .datetime).notNull()
+      }
+    }
+
     return migrator
   }
 
@@ -291,6 +302,7 @@ public actor SessionMetadataStore: TerminalWorkspaceStoreProtocol {
       _ = try ClaudeHookInstallationRecord.deleteAll(db)
       _ = try ManagedProcessRecord.deleteAll(db)
       _ = try SessionRelationshipRecord.deleteAll(db)
+      _ = try ProjectSimulatorPreference.deleteAll(db)
       _ = try AIConfigRecord.deleteAll(db)
       _ = try SessionRepoMapping.deleteAll(db)
       _ = try SessionMetadata.deleteAll(db)
@@ -537,6 +549,29 @@ extension SessionMetadataStore: SessionRelationshipStoreProtocol {
         .filter(Column("targetSessionId") == targetSessionId)
         .filter(Column("kind") == kind.rawValue)
         .deleteAll(db)
+    }
+  }
+
+  // MARK: - Project Simulator Preferences
+
+  /// Gets all persisted run-destination preferences, keyed one row per project path
+  public func getProjectSimulatorPreferences() throws -> [ProjectSimulatorPreference] {
+    try dbQueue.read { db in
+      try ProjectSimulatorPreference.fetchAll(db)
+    }
+  }
+
+  /// Saves the run destination for a project path (replaces any prior row)
+  public func setProjectSimulatorPreference(_ preference: ProjectSimulatorPreference) throws {
+    try dbQueue.write { db in
+      try preference.save(db)
+    }
+  }
+
+  /// Deletes the run-destination preference for a project path
+  public func deleteProjectSimulatorPreference(projectPath: String) throws {
+    try dbQueue.write { db in
+      _ = try ProjectSimulatorPreference.deleteOne(db, key: projectPath)
     }
   }
 }

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/SimulatorPreferencePersisting.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/SimulatorPreferencePersisting.swift
@@ -1,0 +1,18 @@
+//
+//  SimulatorPreferencePersisting.swift
+//  AgentHub
+//
+//  Persistence interface for per-project simulator run-destination preferences.
+//
+
+import Foundation
+
+/// Persists the run destination a project/worktree last selected so the
+/// simulator panel restores it across app relaunches.
+public protocol SimulatorPreferencePersisting: Sendable {
+  func getProjectSimulatorPreferences() async throws -> [ProjectSimulatorPreference]
+  func setProjectSimulatorPreference(_ preference: ProjectSimulatorPreference) async throws
+  func deleteProjectSimulatorPreference(projectPath: String) async throws
+}
+
+extension SessionMetadataStore: SimulatorPreferencePersisting {}

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/SimulatorService.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/SimulatorService.swift
@@ -146,6 +146,11 @@ public final class SimulatorService {
   public static let shared = SimulatorService()
   private init() {}
 
+  /// Isolated instance for unit tests — production code uses `shared`.
+  static func makeForTesting() -> SimulatorService {
+    SimulatorService()
+  }
+
   // MARK: - Observable State
 
   /// Per-UDID global boot/shutdown state, shared across all sessions
@@ -175,6 +180,18 @@ public final class SimulatorService {
   /// Per-projectPath preferred physical iOS device identifier.
   private(set) var preferredPhysicalDeviceIDs: [String: String] = [:]
 
+  /// True once persisted preferences have been hydrated into the dictionaries.
+  public private(set) var preferencesLoaded = false
+
+  /// Backing store for run-destination preferences; nil until configured.
+  private var preferenceStore: (any SimulatorPreferencePersisting)?
+
+  /// In-flight hydration of persisted preferences.
+  private var preferenceLoadTask: Task<Void, Never>?
+
+  /// Serializes preference writes so they land in call order.
+  private var preferencePersistChain: Task<Void, Never>?
+
   /// Live process references for in-flight Mac builds, keyed by projectPath
   private var macBuildProcesses: [String: ProcessRef] = [:]
 
@@ -198,11 +215,76 @@ public final class SimulatorService {
   /// Sets the preferred simulator UDID for a given project path.
   public func setPreferredSimulator(udid: String?, for projectPath: String) {
     preferredSimulatorUDIDs[projectPath] = udid
+    persistPreference(for: projectPath)
   }
 
   /// Sets the preferred physical iOS device for a given project path.
   public func setPreferredPhysicalDevice(identifier: String?, for projectPath: String) {
     preferredPhysicalDeviceIDs[projectPath] = identifier
+    persistPreference(for: projectPath)
+  }
+
+  /// Attaches the persistence backend and hydrates saved preferences.
+  /// Persisted values never override selections already made this launch.
+  public func configurePreferenceStore(_ store: any SimulatorPreferencePersisting) {
+    preferenceStore = store
+    preferenceLoadTask?.cancel()
+    preferenceLoadTask = Task {
+      let preferences = (try? await store.getProjectSimulatorPreferences()) ?? []
+      guard !Task.isCancelled else { return }
+      for preference in preferences {
+        let path = preference.projectPath
+        guard preferredSimulatorUDIDs[path] == nil, preferredPhysicalDeviceIDs[path] == nil else {
+          continue
+        }
+        switch preference.kind {
+        case .simulator:
+          preferredSimulatorUDIDs[path] = preference.deviceIdentifier
+        case .physical:
+          preferredPhysicalDeviceIDs[path] = preference.deviceIdentifier
+        }
+      }
+      preferencesLoaded = true
+    }
+  }
+
+  /// Awaits preference hydration; returns immediately when no store is configured.
+  public func ensurePreferencesLoaded() async {
+    await preferenceLoadTask?.value
+  }
+
+  /// Awaits any queued preference writes (test hook).
+  func flushPreferencePersistence() async {
+    await preferencePersistChain?.value
+  }
+
+  private func persistPreference(for projectPath: String) {
+    guard let store = preferenceStore else { return }
+    let preference: ProjectSimulatorPreference?
+    if let udid = preferredSimulatorUDIDs[projectPath] {
+      preference = ProjectSimulatorPreference(
+        projectPath: projectPath,
+        deviceIdentifier: udid,
+        kind: .simulator
+      )
+    } else if let identifier = preferredPhysicalDeviceIDs[projectPath] {
+      preference = ProjectSimulatorPreference(
+        projectPath: projectPath,
+        deviceIdentifier: identifier,
+        kind: .physical
+      )
+    } else {
+      preference = nil
+    }
+    let previous = preferencePersistChain
+    preferencePersistChain = Task {
+      await previous?.value
+      if let preference {
+        try? await store.setProjectSimulatorPreference(preference)
+      } else {
+        try? await store.deleteProjectSimulatorPreference(projectPath: projectPath)
+      }
+    }
   }
 
   /// Returns the SimulatorDevice for a given UDID, if it exists in the loaded runtimes.

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/SimulatorDestinationMenuContent.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/SimulatorDestinationMenuContent.swift
@@ -1,0 +1,57 @@
+//
+//  SimulatorDestinationMenuContent.swift
+//  AgentHub
+//
+//  Shared menu rows for picking a simulator run destination — used by the
+//  simulator panel's header picker and its "choose a destination" empty state.
+//
+
+import SwiftUI
+
+struct SimulatorDestinationMenuContent: View {
+  let physicalDevices: [PhysicalIOSDevice]
+  let simulators: [SimulatorDevice]
+  let activeDestinationID: String?
+  let onSelectSimulator: (String) -> Void
+  let onSelectPhysicalDevice: (String) -> Void
+
+  var body: some View {
+    if !physicalDevices.isEmpty {
+      Section("Connected Devices") {
+        ForEach(physicalDevices) { device in
+          Button {
+            onSelectPhysicalDevice(device.identifier)
+          } label: {
+            HStack {
+              Text(device.name)
+              Text(device.subtitle.isEmpty ? "Device" : device.subtitle)
+              if activeDestinationID == SimulatorRunDestination.physical(device).id {
+                Image(systemName: "checkmark")
+              }
+            }
+          }
+        }
+      }
+    }
+
+    if !simulators.isEmpty {
+      Section("Simulators") {
+        ForEach(simulators) { device in
+          Button {
+            onSelectSimulator(device.udid)
+          } label: {
+            HStack {
+              Text(device.name)
+              if device.isBooted {
+                Text("Running")
+              }
+              if activeDestinationID == SimulatorRunDestination.simulatorID(udid: device.udid) {
+                Image(systemName: "checkmark")
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/SimulatorDestinationResolver.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/SimulatorDestinationResolver.swift
@@ -1,0 +1,79 @@
+//
+//  SimulatorDestinationResolver.swift
+//  AgentHub
+//
+//  Resolves which run destination the simulator panel targets for a
+//  project/worktree. Deliberately has no global fallback: a project with no
+//  explicit selection and no persisted preference resolves to nil so the
+//  panel shows a picker instead of another project's simulator.
+//
+
+import Foundation
+
+/// A run destination the simulator panel can target: a simulator device or
+/// a connected physical iOS device.
+enum SimulatorRunDestination: Identifiable, Hashable {
+  case simulator(SimulatorDevice)
+  case physical(PhysicalIOSDevice)
+
+  static func simulatorID(udid: String) -> String {
+    "simulator:\(udid)"
+  }
+
+  static func physicalID(identifier: String) -> String {
+    "physical:\(identifier)"
+  }
+
+  var id: String {
+    switch self {
+    case .simulator(let device):
+      return Self.simulatorID(udid: device.udid)
+    case .physical(let device):
+      return Self.physicalID(identifier: device.identifier)
+    }
+  }
+
+  var name: String {
+    switch self {
+    case .simulator(let device):
+      return device.name
+    case .physical(let device):
+      return device.name
+    }
+  }
+
+  var simulatorUDID: String? {
+    if case .simulator(let device) = self { return device.udid }
+    return nil
+  }
+}
+
+enum SimulatorDestinationResolver {
+
+  /// Precedence: explicit in-panel selection → persisted preferred simulator
+  /// → persisted preferred physical device → nil (show the picker).
+  static func resolve(
+    selectedDestinationID: String?,
+    preferredSimulatorUDID: String?,
+    preferredPhysicalDeviceID: String?,
+    simulators: [SimulatorDevice],
+    physicalDevices: [PhysicalIOSDevice]
+  ) -> SimulatorRunDestination? {
+    if let selectedDestinationID {
+      let destinations = physicalDevices.map(SimulatorRunDestination.physical)
+        + simulators.map(SimulatorRunDestination.simulator)
+      if let destination = destinations.first(where: { $0.id == selectedDestinationID }) {
+        return destination
+      }
+    }
+    if let preferredSimulatorUDID,
+       let device = simulators.first(where: { $0.udid == preferredSimulatorUDID }) {
+      return .simulator(device)
+    }
+    if let preferredPhysicalDeviceID,
+       let device = physicalDevices.first(where: { $0.identifier == preferredPhysicalDeviceID }) {
+      return .physical(device)
+    }
+    return nil
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/SimulatorPreviewSidePanelView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/SimulatorPreviewSidePanelView.swift
@@ -33,42 +33,6 @@ enum SimulatorPanelDisplayMode: String, Hashable {
   case previews
 }
 
-private enum SimulatorRunDestination: Identifiable, Hashable {
-  case simulator(SimulatorDevice)
-  case physical(PhysicalIOSDevice)
-
-  static func simulatorID(udid: String) -> String {
-    "simulator:\(udid)"
-  }
-
-  static func physicalID(identifier: String) -> String {
-    "physical:\(identifier)"
-  }
-
-  var id: String {
-    switch self {
-    case .simulator(let device):
-      return Self.simulatorID(udid: device.udid)
-    case .physical(let device):
-      return Self.physicalID(identifier: device.identifier)
-    }
-  }
-
-  var name: String {
-    switch self {
-    case .simulator(let device):
-      return device.name
-    case .physical(let device):
-      return device.name
-    }
-  }
-
-  var simulatorUDID: String? {
-    if case .simulator(let device) = self { return device.udid }
-    return nil
-  }
-}
-
 struct SimulatorPreviewSidePanelView: View {
   let session: CLISession
   let projectPath: String
@@ -113,28 +77,17 @@ struct SimulatorPreviewSidePanelView: View {
     WorktreeLaunchProvider(commandLineValue: providerKind.rawValue)
   }
 
-  /// The destination to run on: explicit selection, then project preferences,
-  /// then connected hardware, an already-running simulator, or any simulator.
+  /// The destination to run on: explicit selection, then this project's
+  /// persisted preference. Never another project's booted simulator — with
+  /// no association the panel shows the destination picker instead.
   private var activeDestination: SimulatorRunDestination? {
-    if let selectedDestinationID,
-       let destination = runDestinations.first(where: { $0.id == selectedDestinationID }) {
-      return destination
-    }
-    if let preferred = simulatorService.preferredSimulatorUDIDs[projectPath],
-       let device = availableDevices.first(where: { $0.udid == preferred }) {
-      return .simulator(device)
-    }
-    if let preferred = simulatorService.preferredPhysicalDeviceIDs[projectPath],
-       let device = physicalDevices.first(where: { $0.identifier == preferred }) {
-      return .physical(device)
-    }
-    if let physical = physicalDevices.first {
-      return .physical(physical)
-    }
-    if let booted = bootedDevices.first {
-      return .simulator(booted)
-    }
-    return availableDevices.first.map(SimulatorRunDestination.simulator)
+    SimulatorDestinationResolver.resolve(
+      selectedDestinationID: selectedDestinationID,
+      preferredSimulatorUDID: simulatorService.preferredSimulatorUDIDs[projectPath],
+      preferredPhysicalDeviceID: simulatorService.preferredPhysicalDeviceIDs[projectPath],
+      simulators: availableDevices,
+      physicalDevices: physicalDevices
+    )
   }
 
   private var activeDestinationID: String? {
@@ -429,43 +382,7 @@ struct SimulatorPreviewSidePanelView: View {
   private var devicePicker: some View {
     if !runDestinations.isEmpty {
       Menu {
-        if !physicalDevices.isEmpty {
-          Section("Connected Devices") {
-            ForEach(physicalDevices) { device in
-              Button {
-                selectPhysicalDevice(identifier: device.identifier)
-              } label: {
-                HStack {
-                  Text(device.name)
-                  Text(device.subtitle.isEmpty ? "Device" : device.subtitle)
-                  if activeDestinationID == SimulatorRunDestination.physical(device).id {
-                    Image(systemName: "checkmark")
-                  }
-                }
-              }
-            }
-          }
-        }
-
-        if !availableDevices.isEmpty {
-          Section("Simulators") {
-            ForEach(availableDevices) { device in
-              Button {
-                selectSimulator(udid: device.udid)
-              } label: {
-                HStack {
-                  Text(device.name)
-                  if device.isBooted {
-                    Text("Running")
-                  }
-                  if activeUDID == device.udid {
-                    Image(systemName: "checkmark")
-                  }
-                }
-              }
-            }
-          }
-        }
+        destinationMenuContent
       } label: {
         HStack(spacing: 6) {
           Text(activeDestination?.name ?? "Select Destination")
@@ -488,6 +405,16 @@ struct SimulatorPreviewSidePanelView: View {
       .layoutPriority(2)
       .accessibilityLabel("Select run destination")
     }
+  }
+
+  private var destinationMenuContent: some View {
+    SimulatorDestinationMenuContent(
+      physicalDevices: physicalDevices,
+      simulators: availableDevices,
+      activeDestinationID: activeDestinationID,
+      onSelectSimulator: { selectSimulator(udid: $0) },
+      onSelectPhysicalDevice: { selectPhysicalDevice(identifier: $0) }
+    )
   }
 
   private var closeButton: some View {
@@ -644,10 +571,12 @@ struct SimulatorPreviewSidePanelView: View {
       // Cold start straight into Previews: the spotlight's states guide the
       // bootstrap, and the tab switch auto-runs the app when a file is open.
       spotlightView
-    } else if simulatorService.isLoadingDevices && !hasLoadedDevices {
+    } else if !hasLoadedDevices && runDestinations.isEmpty {
       loadingState
     } else if runDestinations.isEmpty {
       emptyState
+    } else if activeDestination == nil {
+      selectDestinationState
     } else if activePhysicalDevice != nil {
       physicalDeviceStateView
     } else {
@@ -785,6 +714,35 @@ struct SimulatorPreviewSidePanelView: View {
     .frame(maxWidth: .infinity, maxHeight: .infinity)
   }
 
+  /// Shown when this project/worktree has no run destination associated yet.
+  /// Deliberately never adopts another project's booted simulator.
+  private var selectDestinationState: some View {
+    VStack(spacing: 16) {
+      ContentUnavailableView(
+        "Choose a Run Destination",
+        systemImage: "iphone.gen3",
+        description: Text("Pick the simulator or device this project should use. AgentHub remembers the choice per project and worktree.")
+      )
+      .frame(maxHeight: 220)
+
+      Menu {
+        destinationMenuContent
+      } label: {
+        Label("Select Destination", systemImage: "iphone.gen3")
+          .font(.subheadline.weight(.medium))
+          .padding(.horizontal, 14)
+          .padding(.vertical, 7)
+      }
+      .menuStyle(.borderlessButton)
+      .menuIndicator(.hidden)
+      .fixedSize()
+      .background(Capsule().fill(Color.brandPrimary.opacity(0.16)))
+      .overlay(Capsule().stroke(Color.brandPrimary.opacity(0.3), lineWidth: 1))
+      .accessibilityLabel("Select run destination")
+    }
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+  }
+
   private var physicalDeviceStateView: some View {
     VStack(spacing: 12) {
       Image(systemName: "iphone")
@@ -888,6 +846,9 @@ struct SimulatorPreviewSidePanelView: View {
 
   private func loadDevicesIfNeeded() async {
     guard !hasLoadedDevices else { return }
+    // Hydrate persisted preferences first so a relaunched app restores the
+    // project's device instead of flashing the destination picker.
+    await simulatorService.ensurePreferencesLoaded()
     await simulatorService.listDevices()
     hasLoadedDevices = true
   }

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/ProjectSimulatorPreferenceTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/ProjectSimulatorPreferenceTests.swift
@@ -1,0 +1,151 @@
+import Foundation
+import GRDB
+import Testing
+
+@testable import AgentHubCore
+
+@Suite("Project simulator preference persistence")
+struct ProjectSimulatorPreferenceTests {
+
+  @Test("Preference round-trips per project path")
+  func preferenceRoundTrip() async throws {
+    let store = try SessionMetadataStore(path: temporaryPreferenceDatabasePath())
+
+    try await store.setProjectSimulatorPreference(
+      ProjectSimulatorPreference(
+        projectPath: "/tmp/project-a",
+        deviceIdentifier: "UDID-A",
+        kind: .simulator
+      )
+    )
+    try await store.setProjectSimulatorPreference(
+      ProjectSimulatorPreference(
+        projectPath: "/tmp/project-b",
+        deviceIdentifier: "PHONE-1",
+        kind: .physical
+      )
+    )
+
+    let preferences = try await store.getProjectSimulatorPreferences()
+    let byPath = Dictionary(uniqueKeysWithValues: preferences.map { ($0.projectPath, $0) })
+    #expect(byPath.count == 2)
+    #expect(byPath["/tmp/project-a"]?.deviceIdentifier == "UDID-A")
+    #expect(byPath["/tmp/project-a"]?.kind == .simulator)
+    #expect(byPath["/tmp/project-b"]?.deviceIdentifier == "PHONE-1")
+    #expect(byPath["/tmp/project-b"]?.kind == .physical)
+  }
+
+  @Test("Saving again replaces the row for the same project path")
+  func preferenceReplacesOnConflict() async throws {
+    let store = try SessionMetadataStore(path: temporaryPreferenceDatabasePath())
+
+    try await store.setProjectSimulatorPreference(
+      ProjectSimulatorPreference(
+        projectPath: "/tmp/project",
+        deviceIdentifier: "UDID-OLD",
+        kind: .simulator
+      )
+    )
+    try await store.setProjectSimulatorPreference(
+      ProjectSimulatorPreference(
+        projectPath: "/tmp/project",
+        deviceIdentifier: "PHONE-NEW",
+        kind: .physical
+      )
+    )
+
+    let preferences = try await store.getProjectSimulatorPreferences()
+    #expect(preferences.count == 1)
+    #expect(preferences.first?.deviceIdentifier == "PHONE-NEW")
+    #expect(preferences.first?.kind == .physical)
+  }
+
+  @Test("Delete removes only the targeted project path")
+  func preferenceDelete() async throws {
+    let store = try SessionMetadataStore(path: temporaryPreferenceDatabasePath())
+
+    try await store.setProjectSimulatorPreference(
+      ProjectSimulatorPreference(
+        projectPath: "/tmp/project-a",
+        deviceIdentifier: "UDID-A",
+        kind: .simulator
+      )
+    )
+    try await store.setProjectSimulatorPreference(
+      ProjectSimulatorPreference(
+        projectPath: "/tmp/project-b",
+        deviceIdentifier: "UDID-B",
+        kind: .simulator
+      )
+    )
+
+    try await store.deleteProjectSimulatorPreference(projectPath: "/tmp/project-a")
+
+    let preferences = try await store.getProjectSimulatorPreferences()
+    #expect(preferences.map(\.projectPath) == ["/tmp/project-b"])
+  }
+
+  @Test("Clear all removes preferences")
+  func clearAllRemovesPreferences() async throws {
+    let store = try SessionMetadataStore(path: temporaryPreferenceDatabasePath())
+    try await store.setProjectSimulatorPreference(
+      ProjectSimulatorPreference(
+        projectPath: "/tmp/project",
+        deviceIdentifier: "UDID",
+        kind: .simulator
+      )
+    )
+
+    try await store.clearAll()
+
+    #expect(try await store.getProjectSimulatorPreferences().isEmpty)
+  }
+
+  @Test("v11 migration preserves existing metadata")
+  func migrationPreservesExistingMetadata() async throws {
+    let path = temporaryPreferenceDatabasePath()
+    let dbQueue = try DatabaseQueue(path: path)
+
+    try await dbQueue.write { db in
+      try db.execute(sql: "CREATE TABLE grdb_migrations (identifier TEXT NOT NULL PRIMARY KEY)")
+      for identifier in SessionMetadataStore.migrationIdentifiers.dropLast() {
+        try db.execute(sql: "INSERT INTO grdb_migrations (identifier) VALUES (?)", arguments: [identifier])
+      }
+
+      try db.create(table: "session_metadata") { t in
+        t.column("sessionId", .text).primaryKey()
+        t.column("customName", .text)
+        t.column("createdAt", .datetime).notNull()
+        t.column("updatedAt", .datetime).notNull()
+        t.column("isPinned", .boolean).notNull().defaults(to: false)
+      }
+      try db.execute(
+        sql: """
+        INSERT INTO session_metadata (sessionId, customName, createdAt, updatedAt, isPinned)
+        VALUES (?, ?, ?, ?, ?)
+        """,
+        arguments: ["session-1", "My Session", Date(timeIntervalSince1970: 1_000), Date(timeIntervalSince1970: 1_000), true]
+      )
+    }
+
+    let store = try SessionMetadataStore(path: path)
+    #expect(try await store.getCustomName(for: "session-1") == "My Session")
+    #expect(try await store.getPinnedSessionIds() == ["session-1"])
+    #expect(try await store.getProjectSimulatorPreferences().isEmpty)
+
+    try await store.setProjectSimulatorPreference(
+      ProjectSimulatorPreference(
+        projectPath: "/tmp/project",
+        deviceIdentifier: "UDID",
+        kind: .simulator
+      )
+    )
+    #expect(try await store.getProjectSimulatorPreferences().count == 1)
+  }
+}
+
+private func temporaryPreferenceDatabasePath() -> String {
+  FileManager.default.temporaryDirectory
+    .appending(path: "test_project_simulator_prefs_\(UUID().uuidString).sqlite")
+    .path
+}

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/SimulatorDestinationResolverTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/SimulatorDestinationResolverTests.swift
@@ -1,0 +1,113 @@
+import Foundation
+import Testing
+
+@testable import AgentHubCore
+
+@Suite("SimulatorDestinationResolver")
+struct SimulatorDestinationResolverTests {
+
+  private func simulator(udid: String, booted: Bool = false) -> SimulatorDevice {
+    SimulatorDevice(
+      udid: udid,
+      name: "iPhone \(udid)",
+      state: booted ? "Booted" : "Shutdown",
+      isAvailable: true,
+      deviceTypeIdentifier: "com.apple.CoreSimulator.SimDeviceType.iPhone-15"
+    )
+  }
+
+  private func physical(identifier: String) -> PhysicalIOSDevice {
+    PhysicalIOSDevice(
+      identifier: identifier,
+      name: "Phone \(identifier)",
+      modelName: "iPhone 15",
+      operatingSystemVersion: "18.0",
+      interface: "usb"
+    )
+  }
+
+  @Test("Explicit selection wins over preferences")
+  func explicitSelectionWins() {
+    let devices = [simulator(udid: "A"), simulator(udid: "B")]
+    let result = SimulatorDestinationResolver.resolve(
+      selectedDestinationID: SimulatorRunDestination.simulatorID(udid: "B"),
+      preferredSimulatorUDID: "A",
+      preferredPhysicalDeviceID: nil,
+      simulators: devices,
+      physicalDevices: []
+    )
+    #expect(result?.simulatorUDID == "B")
+  }
+
+  @Test("Persisted simulator preference resolves")
+  func preferredSimulatorResolves() {
+    let result = SimulatorDestinationResolver.resolve(
+      selectedDestinationID: nil,
+      preferredSimulatorUDID: "A",
+      preferredPhysicalDeviceID: nil,
+      simulators: [simulator(udid: "A")],
+      physicalDevices: [physical(identifier: "P1")]
+    )
+    #expect(result?.simulatorUDID == "A")
+  }
+
+  @Test("Persisted physical preference resolves")
+  func preferredPhysicalResolves() {
+    let result = SimulatorDestinationResolver.resolve(
+      selectedDestinationID: nil,
+      preferredSimulatorUDID: nil,
+      preferredPhysicalDeviceID: "P1",
+      simulators: [simulator(udid: "A")],
+      physicalDevices: [physical(identifier: "P1")]
+    )
+    #expect(result?.id == SimulatorRunDestination.physicalID(identifier: "P1"))
+  }
+
+  @Test("No association resolves to nil even with booted simulators and connected hardware")
+  func noAssociationNeverAdoptsGlobalState() {
+    let result = SimulatorDestinationResolver.resolve(
+      selectedDestinationID: nil,
+      preferredSimulatorUDID: nil,
+      preferredPhysicalDeviceID: nil,
+      simulators: [simulator(udid: "OTHER-PROJECT", booted: true)],
+      physicalDevices: [physical(identifier: "P1")]
+    )
+    #expect(result == nil)
+  }
+
+  @Test("Stale preference for a device no longer in the list resolves to nil")
+  func stalePreferenceResolvesToNil() {
+    let result = SimulatorDestinationResolver.resolve(
+      selectedDestinationID: nil,
+      preferredSimulatorUDID: "GONE",
+      preferredPhysicalDeviceID: "GONE-TOO",
+      simulators: [simulator(udid: "A", booted: true)],
+      physicalDevices: []
+    )
+    #expect(result == nil)
+  }
+
+  @Test("Stale explicit selection falls back to persisted preference")
+  func staleSelectionFallsBackToPreference() {
+    let result = SimulatorDestinationResolver.resolve(
+      selectedDestinationID: SimulatorRunDestination.simulatorID(udid: "GONE"),
+      preferredSimulatorUDID: "A",
+      preferredPhysicalDeviceID: nil,
+      simulators: [simulator(udid: "A")],
+      physicalDevices: []
+    )
+    #expect(result?.simulatorUDID == "A")
+  }
+
+  @Test("No devices resolves to nil")
+  func noDevicesResolvesToNil() {
+    let result = SimulatorDestinationResolver.resolve(
+      selectedDestinationID: nil,
+      preferredSimulatorUDID: "A",
+      preferredPhysicalDeviceID: nil,
+      simulators: [],
+      physicalDevices: []
+    )
+    #expect(result == nil)
+  }
+}

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/SimulatorServiceTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/SimulatorServiceTests.swift
@@ -469,3 +469,115 @@ struct BuildHelperTests {
     try data.write(to: app.appendingPathComponent("Info.plist"))
   }
 }
+
+// MARK: - Preference persistence
+
+/// Mock persistence backend recording calls in order.
+private final class MockSimulatorPreferenceStore: SimulatorPreferencePersisting, @unchecked Sendable {
+  enum Call: Equatable {
+    case save(ProjectSimulatorPreference)
+    case delete(String)
+  }
+
+  private let lock = NSLock()
+  private var _calls: [Call] = []
+  var seeded: [ProjectSimulatorPreference] = []
+
+  var calls: [Call] {
+    lock.withLock { _calls }
+  }
+
+  func getProjectSimulatorPreferences() async throws -> [ProjectSimulatorPreference] {
+    seeded
+  }
+
+  func setProjectSimulatorPreference(_ preference: ProjectSimulatorPreference) async throws {
+    lock.withLock { _calls.append(.save(preference)) }
+  }
+
+  func deleteProjectSimulatorPreference(projectPath: String) async throws {
+    lock.withLock { _calls.append(.delete(projectPath)) }
+  }
+}
+
+@Suite("SimulatorService preference persistence")
+@MainActor
+struct SimulatorServicePreferencePersistenceTests {
+
+  @Test func settingSimulatorPersistsPreference() async {
+    let store = MockSimulatorPreferenceStore()
+    let service = SimulatorService.makeForTesting()
+    service.configurePreferenceStore(store)
+    await service.ensurePreferencesLoaded()
+    let path = "/tmp/persist-test-\(UUID().uuidString)"
+
+    service.setPreferredSimulator(udid: "UDID-1", for: path)
+    service.setPreferredPhysicalDevice(identifier: nil, for: path)
+    await service.flushPreferencePersistence()
+
+    let saves = store.calls.compactMap { call -> ProjectSimulatorPreference? in
+      if case .save(let preference) = call, preference.projectPath == path { return preference }
+      return nil
+    }
+    #expect(saves.last?.deviceIdentifier == "UDID-1")
+    #expect(saves.last?.kind == .simulator)
+  }
+
+  @Test func switchingToPhysicalPersistsPhysicalKind() async {
+    let store = MockSimulatorPreferenceStore()
+    let service = SimulatorService.makeForTesting()
+    service.configurePreferenceStore(store)
+    await service.ensurePreferencesLoaded()
+    let path = "/tmp/persist-test-\(UUID().uuidString)"
+
+    service.setPreferredSimulator(udid: "UDID-1", for: path)
+    service.setPreferredPhysicalDevice(identifier: nil, for: path)
+    service.setPreferredPhysicalDevice(identifier: "PHONE-1", for: path)
+    service.setPreferredSimulator(udid: nil, for: path)
+    await service.flushPreferencePersistence()
+
+    guard case .save(let last)? = store.calls.last(where: {
+      if case .save(let preference) = $0 { return preference.projectPath == path }
+      return false
+    }) else {
+      Issue.record("expected a save call")
+      return
+    }
+    #expect(last.deviceIdentifier == "PHONE-1")
+    #expect(last.kind == .physical)
+  }
+
+  @Test func clearingBothSidesDeletesPreference() async {
+    let store = MockSimulatorPreferenceStore()
+    let service = SimulatorService.makeForTesting()
+    service.configurePreferenceStore(store)
+    await service.ensurePreferencesLoaded()
+    let path = "/tmp/persist-test-\(UUID().uuidString)"
+
+    service.setPreferredSimulator(udid: "UDID-1", for: path)
+    service.setPreferredSimulator(udid: nil, for: path)
+    await service.flushPreferencePersistence()
+
+    #expect(store.calls.last == .delete(path))
+  }
+
+  @Test func hydrationPopulatesDictionariesWithoutOverridingLiveSelections() async {
+    let service = SimulatorService.makeForTesting()
+    let persistedPath = "/tmp/hydrate-test-\(UUID().uuidString)"
+    let livePath = "/tmp/live-test-\(UUID().uuidString)"
+    service.setPreferredSimulator(udid: "LIVE-UDID", for: livePath)
+
+    let store = MockSimulatorPreferenceStore()
+    store.seeded = [
+      ProjectSimulatorPreference(projectPath: persistedPath, deviceIdentifier: "SAVED-UDID", kind: .simulator),
+      ProjectSimulatorPreference(projectPath: livePath, deviceIdentifier: "STALE-UDID", kind: .physical)
+    ]
+    service.configurePreferenceStore(store)
+    await service.ensurePreferencesLoaded()
+
+    #expect(service.preferredSimulatorUDIDs[persistedPath] == "SAVED-UDID")
+    #expect(service.preferredSimulatorUDIDs[livePath] == "LIVE-UDID")
+    #expect(service.preferredPhysicalDeviceIDs[livePath] == nil)
+    #expect(service.preferencesLoaded)
+  }
+}


### PR DESCRIPTION
## Summary

Scopes simulator run destination management to the current project/worktree instead of falling back to another project's booted simulator or connected device.

- persists the selected simulator or physical device per `projectPath` in SQLite via `SessionMetadataStore`
- hydrates those preferences into `SimulatorService` on launch and before panel device loading
- extracts simulator destination resolution/menu content and shows an explicit picker when a project has no association
- adds focused tests for preference persistence, migration preservation, resolver precedence, and service persistence

This PR intentionally excludes the preview spotlight and hot-reload reliability changes from `simulator-project-scoping-hot-reload-reliability`.

## Validation

- `cd app/modules/AgentHubCore && xcodebuild test -scheme AgentHubCore-Tests -destination 'platform=macOS' -test-timeouts-enabled YES -skipPackagePluginValidation -only-testing:AgentHubTests/ProjectSimulatorPreferenceTests -only-testing:AgentHubTests/SimulatorDestinationResolverTests -only-testing:AgentHubTests/SimulatorServicePreferencePersistenceTests`

Result: passed, 16 Swift Testing tests in 3 suites.