### PR TITLE
Fix simulator MCP run destination context

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/Configuration/SimulatorAgentGuidance.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Configuration/SimulatorAgentGuidance.swift
@@ -19,14 +19,16 @@ public enum SimulatorAgentGuidance {
   public static let systemPrompt = """
     This project runs inside AgentHub, which embeds a live iOS Simulator the user is \
     watching. For simulator work, use the XcodeBuildMCP server that AgentHub configures \
-    for this project instead of raw xcodebuild or simctl. Before the first build, inspect \
-    the XcodeBuildMCP session defaults; if project, scheme, or simulator context is \
-    missing, set them with its discovery tools. Scale verification to the change and the \
-    user's intent: a compile check is enough for refactors and non-visual changes; build \
-    and run when runtime behavior changes, so the simulator the user is watching stays \
-    current; drive the UI with automation and confirm with screenshots or UI inspection \
-    only when the user asked for visual or end-to-end verification, or before claiming a \
-    specific visual result looks right. The full loop is slow and token-expensive — \
+    for this project instead of raw xcodebuild or simctl. In MCP, the simulator build \
+    tools are named build_sim for compile-only checks and build_run_sim for the \
+    build/install/launch path. Before the first build, inspect the XcodeBuildMCP session \
+    defaults; if project, scheme, or simulator context is missing, set them with its \
+    discovery tools. Scale verification to the change and the user's intent: a compile \
+    check is enough for refactors and non-visual changes; build and run when runtime \
+    behavior changes, so the simulator the user is watching stays current; drive the UI \
+    with automation and confirm with screenshots or UI inspection only when the user asked \
+    for visual or end-to-end verification, or before claiming a specific visual result \
+    looks right. The full loop is slow and token-expensive — \
     don't run it by default.
     """
 }

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/SimulatorPanelRunFlow.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/SimulatorPanelRunFlow.swift
@@ -15,6 +15,8 @@ import SimulatorPreview
 public protocol SimulatorPanelRunExecuting: AnyObject {
   func isBooted(udid: String) -> Bool
   func bootDevice(udid: String) async
+  func setPreferredSimulator(udid: String?, for projectPath: String)
+  func setPreferredPhysicalDevice(identifier: String?, for projectPath: String)
   func buildAndRunOnSimulator(
     udid: String,
     projectPath: String,
@@ -87,6 +89,8 @@ public struct SimulatorPanelRunFlow {
 
   @discardableResult
   public func run(udid: String) async -> SimulatorPanelRunOutcome {
+    simulatorService.setPreferredSimulator(udid: udid, for: projectPath)
+    simulatorService.setPreferredPhysicalDevice(identifier: nil, for: projectPath)
     // Boot first so the panel's preview switches to the live stream while the
     // build runs; the build's own boot is then a no-op.
     if !simulatorService.isBooted(udid: udid) {

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/SimulatorPickerView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/SimulatorPickerView.swift
@@ -574,6 +574,8 @@ public struct SimulatorPickerView: View {
 
   private func runButton(udid: String) -> some View {
     Button {
+      SimulatorService.shared.setPreferredSimulator(udid: udid, for: session.projectPath)
+      SimulatorService.shared.setPreferredPhysicalDevice(identifier: nil, for: session.projectPath)
       Task {
         await SimulatorService.shared.buildAndRunOnSimulator(
           udid: udid,
@@ -590,6 +592,8 @@ public struct SimulatorPickerView: View {
 
   private func physicalRunButton(identifier: String) -> some View {
     Button {
+      SimulatorService.shared.setPreferredPhysicalDevice(identifier: identifier, for: session.projectPath)
+      SimulatorService.shared.setPreferredSimulator(udid: nil, for: session.projectPath)
       Task {
         await SimulatorService.shared.buildAndRunOnPhysicalDevice(
           identifier: identifier,

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/AIConfigSettingsTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/AIConfigSettingsTests.swift
@@ -244,6 +244,7 @@ struct CLICommandConfigurationArgumentHandlingTests {
       return
     }
     #expect(newSession[flagIndex + 1].contains("XcodeBuildMCP"))
+    #expect(newSession[flagIndex + 1].contains("build_run_sim"))
 
     let resumed = config.argumentsForSession(
       sessionId: "existing-session",
@@ -267,6 +268,7 @@ struct CLICommandConfigurationArgumentHandlingTests {
     )
     #expect(!args.contains("--append-system-prompt"))
     #expect(args.contains { $0.hasPrefix("developer_instructions=") && $0.contains("XcodeBuildMCP") })
+    #expect(args.contains { $0.hasPrefix("developer_instructions=") && $0.contains("build_sim") })
 
     let resumed = config.argumentsForSession(
       sessionId: "existing-session",

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/SimulatorHotReloadControllerTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/SimulatorHotReloadControllerTests.swift
@@ -81,9 +81,17 @@ private struct MockPreviewClient: PreviewHostClientProtocol {
 @MainActor
 private final class FlowMockExecutor: SimulatorPanelRunExecuting {
   var foregroundFlags: [Bool] = []
+  var preferredSimulatorUpdates: [(udid: String?, projectPath: String)] = []
+  var preferredPhysicalDeviceUpdates: [(identifier: String?, projectPath: String)] = []
 
   func isBooted(udid: String) -> Bool { true }
   func bootDevice(udid: String) async {}
+  func setPreferredSimulator(udid: String?, for projectPath: String) {
+    preferredSimulatorUpdates.append((udid, projectPath))
+  }
+  func setPreferredPhysicalDevice(identifier: String?, for projectPath: String) {
+    preferredPhysicalDeviceUpdates.append((identifier, projectPath))
+  }
   func buildAndRunOnSimulator(
     udid: String,
     projectPath: String,
@@ -448,6 +456,29 @@ struct SimulatorHotReloadControllerTests {
 
     #expect(executor.foregroundFlags == [true])
     #expect(hider.hideCount == 0)
+  }
+
+  @Test("panel run flow stores the selected simulator as the project run destination")
+  func panelRunFlowStoresProjectDestination() async {
+    let (controller, _, _) = makeController(cached: Self.artifacts)
+    let executor = FlowMockExecutor()
+    let flow = SimulatorPanelRunFlow(
+      simulatorService: executor,
+      hotReload: controller,
+      projectPath: "/p",
+      previewsEnabled: { false },
+      hideSimulatorAppWhileMirroring: { true },
+      simulatorAppHider: MockSimulatorAppHider()
+    )
+
+    _ = await flow.run(udid: "UDID")
+
+    #expect(executor.preferredSimulatorUpdates.count == 1)
+    #expect(executor.preferredSimulatorUpdates.first?.udid == "UDID")
+    #expect(executor.preferredSimulatorUpdates.first?.projectPath == "/p")
+    #expect(executor.preferredPhysicalDeviceUpdates.count == 1)
+    #expect(executor.preferredPhysicalDeviceUpdates.first?.identifier == nil)
+    #expect(executor.preferredPhysicalDeviceUpdates.first?.projectPath == "/p")
   }
 
   @Test("stop tears down the console + pill; stopTracking stops the watcher")


### PR DESCRIPTION
## Summary

Fixes the simulator verification path so AgentHub keeps project/worktree simulator context available for XcodeBuildMCP-driven agent sessions.

## What changed

- Persist the selected simulator as the project run destination whenever the simulator panel Build & Run flow starts.
- Persist simulator and physical-device selections from the legacy simulator picker play buttons before running.
- Tighten the injected XcodeBuildMCP guidance to name `build_sim` and `build_run_sim` explicitly, so agents use the exposed MCP tools instead of falling back to raw `xcodebuild`.
- Add focused coverage for destination persistence and prompt/tool-name guidance.

## Why

Agents were able to run or verify against a simulator without AgentHub reliably recording that simulator as the project preference. New agent sessions could then launch XcodeBuildMCP without `XCODEBUILDMCP_SIMULATOR_ID`, forcing slow discovery or raw command fallbacks.

## Validation

- `xcodebuild test -scheme AgentHubCore-Tests -destination 'platform=macOS' -test-timeouts-enabled YES -skipPackagePluginValidation -only-testing:AgentHubTests/SimulatorHotReloadControllerTests -only-testing:AgentHubTests/EmbeddedTerminalLaunchBuilderAgentHubCLITests -only-testing:AgentHubTests/CLICommandConfigurationArgumentHandlingTests`
- 47 tests passed across the targeted suites.