### PR TITLE
Improve tweak generation status and timeout

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/TweakAgentProgressTimeout.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/TweakAgentProgressTimeout.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+struct TweakAgentProgressTimeout<Activity: Equatable> {
+  private let interval: Duration
+  private var lastActivity: Activity
+  private var lastProgressAt: ContinuousClock.Instant
+
+  init(
+    interval: Duration,
+    initialActivity: Activity,
+    now: ContinuousClock.Instant = .now
+  ) {
+    self.interval = interval
+    self.lastActivity = initialActivity
+    self.lastProgressAt = now
+  }
+
+  mutating func hasTimedOut(
+    activity: Activity,
+    now: ContinuousClock.Instant = .now
+  ) -> Bool {
+    if activity != lastActivity {
+      lastActivity = activity
+      lastProgressAt = now
+      return false
+    }
+
+    return lastProgressAt.duration(to: now) >= interval
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/WebPreviewTweakAgentService.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/WebPreviewTweakAgentService.swift
@@ -19,7 +19,8 @@ protocol TweakAgentCommandRunning: Sendable {
     prompt: String,
     systemPrompt: String,
     workingDirectory: String,
-    cliConfiguration: CLICommandConfiguration
+    cliConfiguration: CLICommandConfiguration,
+    activityHandler: @Sendable @escaping () async -> Void
   ) async throws
 }
 
@@ -31,7 +32,7 @@ enum WebPreviewTweakAgentError: LocalizedError {
   var errorDescription: String? {
     switch self {
     case .timedOut:
-      return "The tweak agent did not finish within three minutes."
+      return "The tweak agent stopped making progress for five minutes."
     case .executableNotFound(let command):
       return "Could not find the configured \(command) command."
     case .commandFailed(let status):
@@ -55,16 +56,16 @@ actor WebPreviewTweakAgentService: WebPreviewTweakAgentRunning {
 
   private let workspaceCoordinator: any TweakWorkspaceCoordinating
   private let commandRunner: any TweakAgentCommandRunning
-  private let timeout: Duration
+  private let inactivityTimeout: Duration
 
   init(
     workspaceCoordinator: any TweakWorkspaceCoordinating = TweakWorkspaceCoordinator(),
     commandRunner: any TweakAgentCommandRunning = TweakAgentProcessRunner(),
-    timeout: Duration = .seconds(180)
+    inactivityTimeout: Duration = .seconds(300)
   ) {
     self.workspaceCoordinator = workspaceCoordinator
     self.commandRunner = commandRunner
-    self.timeout = timeout
+    self.inactivityTimeout = inactivityTimeout
   }
 
   func runTweakAgent(
@@ -94,22 +95,48 @@ actor WebPreviewTweakAgentService: WebPreviewTweakAgentRunning {
     cliConfiguration: CLICommandConfiguration
   ) async throws {
     try await withThrowingTaskGroup(of: Void.self) { group in
+      let progressMonitor = TweakAgentProgressMonitor(interval: inactivityTimeout)
       group.addTask { [commandRunner] in
         try await commandRunner.run(
           prompt: prompt,
           systemPrompt: Self.systemPrompt,
           workingDirectory: workingDirectory,
-          cliConfiguration: cliConfiguration
+          cliConfiguration: cliConfiguration,
+          activityHandler: {
+            await progressMonitor.markProgress()
+          }
         )
       }
-      group.addTask { [timeout] in
-        try await Task.sleep(for: timeout)
-        throw WebPreviewTweakAgentError.timedOut
+      group.addTask {
+        while true {
+          try await Task.sleep(for: .seconds(1))
+          if await progressMonitor.hasTimedOut() {
+            throw WebPreviewTweakAgentError.timedOut
+          }
+        }
       }
 
       _ = try await group.next()
       group.cancelAll()
     }
+  }
+}
+
+private actor TweakAgentProgressMonitor {
+  private var activityID = 0
+  private var progressTimeout: TweakAgentProgressTimeout<Int>
+
+  init(interval: Duration) {
+    progressTimeout = TweakAgentProgressTimeout(interval: interval, initialActivity: activityID)
+  }
+
+  func markProgress() {
+    activityID += 1
+    _ = progressTimeout.hasTimedOut(activity: activityID)
+  }
+
+  func hasTimedOut() -> Bool {
+    progressTimeout.hasTimedOut(activity: activityID)
   }
 }
 
@@ -121,7 +148,8 @@ final class TweakAgentProcessRunner: TweakAgentCommandRunning, @unchecked Sendab
     prompt: String,
     systemPrompt: String,
     workingDirectory: String,
-    cliConfiguration: CLICommandConfiguration
+    cliConfiguration: CLICommandConfiguration,
+    activityHandler: @Sendable @escaping () async -> Void
   ) async throws {
     let executablePath: String?
     switch cliConfiguration.mode {
@@ -153,8 +181,10 @@ final class TweakAgentProcessRunner: TweakAgentCommandRunning, @unchecked Sendab
         process.executableURL = URL(fileURLWithPath: executablePath)
         process.arguments = arguments
         process.currentDirectoryURL = URL(fileURLWithPath: workingDirectory)
-        process.standardOutput = FileHandle.nullDevice
-        process.standardError = FileHandle.nullDevice
+        let outputPipe = Pipe()
+        let errorPipe = Pipe()
+        process.standardOutput = outputPipe
+        process.standardError = errorPipe
 
         var environment = ProcessInfo.processInfo.environment
         let paths = CLIPathResolver.executableSearchPaths(
@@ -166,7 +196,20 @@ final class TweakAgentProcessRunner: TweakAgentCommandRunning, @unchecked Sendab
         environment.merge(CLIEnvironmentOverrides.environment) { _, new in new }
         process.environment = environment
 
+        let handleActivity: @Sendable (FileHandle) -> Void = { handle in
+          let data = handle.availableData
+          if !data.isEmpty {
+            Task {
+              await activityHandler()
+            }
+          }
+        }
+        outputPipe.fileHandleForReading.readabilityHandler = handleActivity
+        errorPipe.fileHandleForReading.readabilityHandler = handleActivity
+
         process.terminationHandler = { [weak self] process in
+          outputPipe.fileHandleForReading.readabilityHandler = nil
+          errorPipe.fileHandleForReading.readabilityHandler = nil
           self?.setRunningProcess(nil)
           if process.terminationReason == .exit, process.terminationStatus == 0 {
             continuation.resume()

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/TweakGenerationBanner.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/TweakGenerationBanner.swift
@@ -1,0 +1,54 @@
+import SwiftUI
+
+struct TweakGenerationBanner: View {
+  static let message = "Tweaks are being generated. This can take a few minutes."
+  let startedAt: Date
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      Label {
+        Text(Self.message)
+          .fixedSize(horizontal: false, vertical: true)
+      } icon: {
+        ProgressView()
+          .controlSize(.small)
+          .accessibilityHidden(true)
+      }
+
+      TimelineView(.periodic(from: startedAt, by: 1)) { context in
+        let elapsedTime = Self.elapsedTime(from: startedAt, to: context.date)
+        Text(elapsedTime)
+          .font(.caption.monospacedDigit())
+          .foregroundStyle(.tertiary)
+          .frame(maxWidth: .infinity, alignment: .trailing)
+          .accessibilityLabel("Elapsed time")
+          .accessibilityValue(elapsedTime)
+      }
+    }
+    .font(.caption)
+    .foregroundStyle(.secondary)
+    .frame(maxWidth: .infinity, alignment: .leading)
+    .padding(10)
+    .background(.quaternary.opacity(0.5), in: RoundedRectangle(cornerRadius: 6))
+    .accessibilityElement(children: .combine)
+  }
+
+  static func elapsedTime(from startDate: Date, to currentDate: Date) -> String {
+    let elapsedSeconds = max(0, Int(currentDate.timeIntervalSince(startDate)))
+    let hours = elapsedSeconds / 3_600
+    let minutes = (elapsedSeconds % 3_600) / 60
+    let seconds = elapsedSeconds % 60
+
+    if hours > 0 {
+      return "\(hours):\(twoDigits(minutes)):\(twoDigits(seconds))"
+    }
+    return "\(minutes):\(twoDigits(seconds))"
+  }
+
+  private static func twoDigits(_ value: Int) -> String {
+    if value < 10 {
+      return "0\(value)"
+    }
+    return "\(value)"
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/TweakGenerationTimer.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/TweakGenerationTimer.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+struct TweakGenerationTimer: Equatable {
+  private(set) var startedAt: Date?
+
+  mutating func start(at date: Date = .now) {
+    startedAt = date
+  }
+
+  mutating func stop() {
+    startedAt = nil
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/TweakPanelStatusArea.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/TweakPanelStatusArea.swift
@@ -1,0 +1,50 @@
+import Canvas
+import SwiftUI
+
+struct TweakPanelStatusArea: View {
+  @Binding var agentState: TweaksAgentState
+  @Binding var defaultsSaveState: TweaksDefaultsSaveState
+  let generationStartedAt: Date?
+
+  var body: some View {
+    VStack(spacing: 8) {
+      switch agentState {
+      case .idle:
+        EmptyView()
+      case .working:
+        TweakGenerationBanner(startedAt: generationStartedAt ?? .now)
+      case .failed(let message):
+        TweakStatusBanner(
+          message: message,
+          systemImage: "exclamationmark.circle",
+          tint: .red,
+          onDismiss: dismissAgentStatus
+        )
+      case .conflict:
+        TweakStatusBanner(
+          message: "The file changed while tweaks were being added. Submit again to use the latest version.",
+          systemImage: "arrow.trianglehead.2.clockwise.rotate.90",
+          tint: .orange,
+          onDismiss: dismissAgentStatus
+        )
+      }
+
+      if case .failed(let message) = defaultsSaveState {
+        TweakStatusBanner(
+          message: message,
+          systemImage: "exclamationmark.circle",
+          tint: .red,
+          onDismiss: dismissDefaultsStatus
+        )
+      }
+    }
+  }
+
+  private func dismissAgentStatus() {
+    agentState = .idle
+  }
+
+  private func dismissDefaultsStatus() {
+    defaultsSaveState = .idle
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/TweakPanelStatusRouting.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/TweakPanelStatusRouting.swift
@@ -1,0 +1,26 @@
+import Canvas
+
+enum TweakPanelStatusRouting {
+  static func canvasAgentState(for state: TweaksAgentState) -> TweaksAgentState {
+    .idle
+  }
+
+  static func canvasDefaultsState(
+    for state: TweaksDefaultsSaveState
+  ) -> TweaksDefaultsSaveState {
+    state == .saving ? .saving : .idle
+  }
+
+  static func showsHostStatus(
+    agentState: TweaksAgentState,
+    defaultsState: TweaksDefaultsSaveState
+  ) -> Bool {
+    if agentState != .idle {
+      true
+    } else if case .failed = defaultsState {
+      true
+    } else {
+      false
+    }
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/TweakStatusBanner.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/TweakStatusBanner.swift
@@ -1,0 +1,30 @@
+import SwiftUI
+
+struct TweakStatusBanner: View {
+  let message: String
+  let systemImage: String
+  let tint: Color
+  let onDismiss: () -> Void
+
+  var body: some View {
+    HStack(alignment: .top, spacing: 8) {
+      Image(systemName: systemImage)
+        .accessibilityHidden(true)
+
+      Text(message)
+        .fixedSize(horizontal: false, vertical: true)
+
+      Spacer(minLength: 4)
+
+      Button("Dismiss", systemImage: "xmark", action: onDismiss)
+        .labelStyle(.iconOnly)
+        .buttonStyle(.plain)
+        .help("Dismiss")
+    }
+    .font(.caption)
+    .foregroundStyle(tint)
+    .frame(maxWidth: .infinity, alignment: .leading)
+    .padding(10)
+    .background(tint.opacity(0.1), in: RoundedRectangle(cornerRadius: 6))
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/WebPreviewTweaksPanel.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/WebPreviewTweaksPanel.swift
@@ -1,0 +1,44 @@
+import Canvas
+import SwiftUI
+
+struct WebPreviewTweaksPanel: View {
+  let state: TweaksState
+  @Binding var agentState: TweaksAgentState
+  @Binding var defaultsSaveState: TweaksDefaultsSaveState
+  let generationStartedAt: Date?
+  let onSubmitDescription: (String) -> Void
+  let onIdeas: () -> Void
+  let onValueChange: (TweakProp, TweakPropValue) -> Void
+  let onReset: () -> Void
+  let onSaveDefaults: () -> Void
+
+  var body: some View {
+    VStack(spacing: 0) {
+      TweaksPanelView(
+        state: state,
+        agentState: TweakPanelStatusRouting.canvasAgentState(for: agentState),
+        defaultsSaveState: TweakPanelStatusRouting.canvasDefaultsState(for: defaultsSaveState),
+        onSubmitDescription: onSubmitDescription,
+        onIdeas: onIdeas,
+        onValueChange: onValueChange,
+        onReset: onReset,
+        onSaveDefaults: onSaveDefaults
+      )
+      .disabled(agentState == .working)
+
+      if TweakPanelStatusRouting.showsHostStatus(
+        agentState: agentState,
+        defaultsState: defaultsSaveState
+      ) {
+        TweakPanelStatusArea(
+          agentState: $agentState,
+          defaultsSaveState: $defaultsSaveState,
+          generationStartedAt: generationStartedAt
+        )
+        .padding(.horizontal, 14)
+        .padding(.bottom, 14)
+      }
+    }
+    .frame(width: 320)
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/WebPreviewView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/WebPreviewView.swift
@@ -159,6 +159,7 @@ public struct WebPreviewView: View {
   @State private var tweaksState = TweaksState()
   @State private var tweaksDefaultsWriteCoordinator = TweaksDefaultsWriteCoordinator()
   @State private var tweaksAgentState: TweaksAgentState = .idle
+  @State private var tweakGenerationTimer = TweakGenerationTimer()
   @State private var tweaksDefaultsSaveState: TweaksDefaultsSaveState = .idle
   @State private var isTweaksPopoverPresented = false
   @State private var launchOptionsStatusOverride: String?
@@ -680,17 +681,17 @@ public struct WebPreviewView: View {
     .accessibilityLabel(presentation.accessibilityLabel)
     .help("Tweak this design with live controls")
     .popover(isPresented: $isTweaksPopoverPresented, arrowEdge: .bottom) {
-      TweaksPanelView(
+      WebPreviewTweaksPanel(
         state: tweaksState,
-        agentState: tweaksAgentState,
-        defaultsSaveState: tweaksDefaultsSaveState,
+        agentState: $tweaksAgentState,
+        defaultsSaveState: $tweaksDefaultsSaveState,
+        generationStartedAt: tweakGenerationTimer.startedAt,
         onSubmitDescription: sendCustomTweaksPrompt,
         onIdeas: sendTweaksIdeasPrompt,
         onValueChange: handleTweakValueChange,
         onReset: resetTweakValues,
         onSaveDefaults: saveTweakDefaults
       )
-      .frame(width: 320)
     }
   }
 
@@ -1568,10 +1569,12 @@ public struct WebPreviewView: View {
       return
     }
 
+    tweakGenerationTimer.start()
     tweaksAgentState = .working
     let cliConfiguration = viewModel?.cliConfiguration(for: providerKind)
       ?? (providerKind == .claude ? .claudeDefault : .codexDefault)
     Task {
+      defer { tweakGenerationTimer.stop() }
       do {
         let result = try await tweakAgentService.runTweakAgent(
           prompt: prompt,

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/WebPreviewTweakAgentServiceTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/WebPreviewTweakAgentServiceTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Testing
+import Canvas
 
 @testable import AgentHubCore
 
@@ -37,10 +38,12 @@ private actor TweakAgentMockCommandRunner: TweakAgentCommandRunning {
     prompt: String,
     systemPrompt: String,
     workingDirectory: String,
-    cliConfiguration: CLICommandConfiguration
+    cliConfiguration: CLICommandConfiguration,
+    activityHandler: @Sendable @escaping () async -> Void
   ) async throws {
     self.prompt = prompt
     self.workingDirectory = workingDirectory
+    await activityHandler()
   }
 }
 
@@ -53,7 +56,7 @@ struct WebPreviewTweakAgentServiceTests {
     let service = WebPreviewTweakAgentService(
       workspaceCoordinator: workspace,
       commandRunner: runner,
-      timeout: .seconds(1)
+      inactivityTimeout: .seconds(1)
     )
 
     let result = try await service.runTweakAgent(
@@ -68,6 +71,43 @@ struct WebPreviewTweakAgentServiceTests {
     #expect(await runner.workingDirectory == "/tmp/tweak-task")
     #expect(await workspace.finishedPolicy == .additive)
     #expect(await workspace.didDiscard == false)
+  }
+}
+
+@Suite("TweakAgentProgressTimeout")
+struct TweakAgentProgressTimeoutTests {
+  @Test("Times out only after the inactivity interval")
+  func timesOutAfterInactivity() {
+    let start = ContinuousClock.now
+    var timeout = TweakAgentProgressTimeout(
+      interval: .seconds(300),
+      initialActivity: 1,
+      now: start
+    )
+
+    let didTimeOutBeforeInterval = timeout.hasTimedOut(activity: 1, now: start.advanced(by: .seconds(299)))
+    let didTimeOutAtInterval = timeout.hasTimedOut(activity: 1, now: start.advanced(by: .seconds(300)))
+
+    #expect(!didTimeOutBeforeInterval)
+    #expect(didTimeOutAtInterval)
+  }
+
+  @Test("Progress resets the inactivity interval")
+  func progressResetsTimeout() {
+    let start = ContinuousClock.now
+    var timeout = TweakAgentProgressTimeout(
+      interval: .seconds(300),
+      initialActivity: 1,
+      now: start
+    )
+
+    let didTimeOutOnProgress = timeout.hasTimedOut(activity: 2, now: start.advanced(by: .seconds(290)))
+    let didTimeOutBeforeResetInterval = timeout.hasTimedOut(activity: 2, now: start.advanced(by: .seconds(589)))
+    let didTimeOutAtResetInterval = timeout.hasTimedOut(activity: 2, now: start.advanced(by: .seconds(590)))
+
+    #expect(!didTimeOutOnProgress)
+    #expect(!didTimeOutBeforeResetInterval)
+    #expect(didTimeOutAtResetInterval)
   }
 }
 
@@ -123,5 +163,66 @@ struct TweaksButtonPresentationTests {
     let presentation = TweaksButtonPresentation.resolve(agentState: .idle)
     #expect(!presentation.isLoading)
     #expect(presentation.accessibilityLabel == "Tweaks")
+  }
+}
+
+@Suite("TweakGenerationBanner")
+struct TweakGenerationBannerTests {
+  @Test("Explains that generation can take a few minutes")
+  func messageSetsTimingExpectation() {
+    #expect(TweakGenerationBanner.message == "Tweaks are being generated. This can take a few minutes.")
+  }
+
+  @Test("Formats elapsed generation time")
+  func formatsElapsedTime() {
+    let start = Date(timeIntervalSinceReferenceDate: 1_000)
+
+    #expect(TweakGenerationBanner.elapsedTime(from: start, to: start.addingTimeInterval(65)) == "1:05")
+    #expect(TweakGenerationBanner.elapsedTime(from: start, to: start.addingTimeInterval(3_661)) == "1:01:01")
+    #expect(TweakGenerationBanner.elapsedTime(from: start, to: start.addingTimeInterval(-1)) == "0:00")
+  }
+}
+
+@Suite("TweakGenerationTimer")
+struct TweakGenerationTimerTests {
+  @Test("Keeps the generation start time until work stops")
+  func lifecycle() {
+    let start = Date(timeIntervalSinceReferenceDate: 1_000)
+    var timer = TweakGenerationTimer()
+
+    timer.start(at: start)
+    #expect(timer.startedAt == start)
+
+    timer.stop()
+    #expect(timer.startedAt == nil)
+  }
+}
+
+@Suite("TweakPanelStatusRouting")
+struct TweakPanelStatusRoutingTests {
+  @Test("Canvas does not duplicate host agent status", arguments: [
+    TweaksAgentState.idle,
+    .working,
+    .failed("Failure"),
+    .conflict,
+  ])
+  func canvasAgentStatusIsIdle(state: TweaksAgentState) {
+    #expect(TweakPanelStatusRouting.canvasAgentState(for: state) == .idle)
+  }
+
+  @Test("Canvas retains only the defaults saving state")
+  func canvasDefaultsStatus() {
+    #expect(TweakPanelStatusRouting.canvasDefaultsState(for: .idle) == .idle)
+    #expect(TweakPanelStatusRouting.canvasDefaultsState(for: .saving) == .saving)
+    #expect(TweakPanelStatusRouting.canvasDefaultsState(for: .failed("Failure")) == .idle)
+  }
+
+  @Test("Host status appears only for visible status content")
+  func hostStatusVisibility() {
+    #expect(!TweakPanelStatusRouting.showsHostStatus(agentState: .idle, defaultsState: .idle))
+    #expect(!TweakPanelStatusRouting.showsHostStatus(agentState: .idle, defaultsState: .saving))
+    #expect(TweakPanelStatusRouting.showsHostStatus(agentState: .working, defaultsState: .idle))
+    #expect(TweakPanelStatusRouting.showsHostStatus(agentState: .failed("Failure"), defaultsState: .idle))
+    #expect(TweakPanelStatusRouting.showsHostStatus(agentState: .idle, defaultsState: .failed("Failure")))
   }
 }


### PR DESCRIPTION
## Summary

- Change web preview tweak generation from a fixed three-minute deadline to a five-minute inactivity timeout.
- Track tweak-agent CLI stdout/stderr activity to reset the inactivity timer without retaining output content.
- Add host-side tweak generation status UI with an elapsed timer, dismissible failure/conflict banners, and Canvas status routing to avoid duplicated status.
- Add focused tests for timeout behavior, status routing, timer lifecycle, elapsed-time formatting, and existing tweak-agent command arguments.

## Validation

- `swift test --filter WebPreviewTweakAgentServiceTests` was attempted but hit the known AgentHubCore `CodeEditSymbols` / `Bundle.module` issue documented in AGENTS.md.
- `xcodebuild test -scheme AgentHubCore-Tests -destination 'platform=macOS' -test-timeouts-enabled YES -skipPackagePluginValidation -only-testing:AgentHubTests/WebPreviewTweakAgentServiceTests -only-testing:AgentHubTests/TweakAgentProgressTimeoutTests -only-testing:AgentHubTests/TweakAgentProcessRunnerTests -only-testing:AgentHubTests/TweaksButtonPresentationTests -only-testing:AgentHubTests/TweakGenerationBannerTests -only-testing:AgentHubTests/TweakGenerationTimerTests -only-testing:AgentHubTests/TweakPanelStatusRoutingTests`

Result: 13 tests in 7 suites passed.