### PR TITLE
Add Sierra AgentHub defaults and transcript mode

### DIFF
--- a/app/AgentHub/AgentHubApp.swift
+++ b/app/AgentHub/AgentHubApp.swift
@@ -21,6 +21,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
   /// Wires the Ghostty-aware terminal surface factory; `AgentHubCore` falls back
   /// to the regular SwiftTerm surface when no provider is supplied.
   let provider = AgentHubProvider(
+    configuration: .sierraLocal,
     terminalSurfaceFactory: DefaultEmbeddedTerminalSurfaceFactory(
       ghosttyProvider: { AgentHubGhosttyTerminalSurface() }
     ),

--- a/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubConfiguration.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubConfiguration.swift
@@ -46,6 +46,9 @@ public struct AgentHubConfiguration: Sendable {
   /// Session provider to use (Claude or Codex)
   public var sessionProvider: SessionProviderKind
 
+  /// Enables Sierra-specific first-run defaults for the app target.
+  public var sierraDefaultsEnabled: Bool
+
   /// Creates a configuration with custom values
   public init(
     claudeDataPath: String = "~/.claude",
@@ -55,7 +58,8 @@ public struct AgentHubConfiguration: Sendable {
     statsDisplayMode: StatsDisplayMode = .menuBar,
     cliCommand: String = "claude",
     codexCommand: String = "codex",
-    sessionProvider: SessionProviderKind = .claude
+    sessionProvider: SessionProviderKind = .claude,
+    sierraDefaultsEnabled: Bool = false
   ) {
     let expanded = NSString(string: claudeDataPath).expandingTildeInPath
     self.claudeDataPath = expanded
@@ -66,6 +70,7 @@ public struct AgentHubConfiguration: Sendable {
     self.cliCommand = cliCommand
     self.codexCommand = codexCommand
     self.sessionProvider = sessionProvider
+    self.sierraDefaultsEnabled = sierraDefaultsEnabled
   }
 
   /// Default configuration with sensible defaults
@@ -87,6 +92,25 @@ public struct AgentHubConfiguration: Sendable {
         "\(homeDir)/.cargo/bin",
         "\(homeDir)/.local/bin"
       ]
+    )
+  }
+
+  /// Sierra-oriented local fork configuration.
+  public static var sierraLocal: AgentHubConfiguration {
+    let homeDir = NSHomeDirectory()
+    return AgentHubConfiguration(
+      additionalCLIPaths: [
+        "\(homeDir)/Library/Application Support/AgentHub/bin",
+        "\(homeDir)/.claude/local",
+        "\(homeDir)/.local/bin",
+        "/opt/homebrew/bin",
+        "/usr/local/bin",
+        "/usr/bin",
+        "\(homeDir)/.bun/bin",
+        "\(homeDir)/.deno/bin",
+        "\(homeDir)/.cargo/bin"
+      ],
+      sierraDefaultsEnabled: true
     )
   }
 }

--- a/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubDefaults.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubDefaults.swift
@@ -218,6 +218,12 @@ public enum AgentHubDefaults {
   /// Type: String (default: "")
   public static let worktreeBranchPrefix = "\(keyPrefix)worktree.generatedBranchPrefix"
 
+  // MARK: - Sierra Defaults
+
+  /// Whether Sierra first-run defaults have completed.
+  /// Type: Bool (default: false)
+  public static let sierraDefaultsBootstrapped = "\(keyPrefix)sierra.defaultsBootstrapped"
+
   /// How worktree sessions are grouped in module-oriented UI.
   /// Type: String (default: WorktreeDisplayMode.parent.rawValue)
   public static let worktreeDisplayMode = "\(keyPrefix)worktree.displayMode"

--- a/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubProvider.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubProvider.swift
@@ -276,6 +276,10 @@ public final class AgentHubProvider {
       AgentHubDefaults.globalSessionPanelDisplayMode: 0,
     ])
 
+    if configuration.sierraDefaultsEnabled {
+      seedSierraUserDefaults(defaults)
+    }
+
     // Claude command: if developer provided non-default, lock it
     if configuration.cliCommand != "claude" {
       defaults.set(configuration.cliCommand, forKey: AgentHubDefaults.claudeCommand)
@@ -291,6 +295,28 @@ public final class AgentHubProvider {
       defaults.set(true, forKey: AgentHubDefaults.codexCommandLockedByDeveloper)
     } else if defaults.string(forKey: AgentHubDefaults.codexCommand) == nil {
       defaults.set("codex", forKey: AgentHubDefaults.codexCommand)
+    }
+
+    if configuration.sierraDefaultsEnabled {
+      Task { @MainActor [weak self] in
+        guard let self, let store = self.metadataStore else { return }
+        await SierraDefaultsBootstrap(metadataStore: store).bootstrap()
+      }
+    }
+  }
+
+  private func seedSierraUserDefaults(_ defaults: UserDefaults) {
+    if defaults.string(forKey: AgentHubDefaults.claudeCommand) == nil {
+      defaults.set("agenthub-claude", forKey: AgentHubDefaults.claudeCommand)
+    }
+    if defaults.string(forKey: AgentHubDefaults.codexCommand) == nil {
+      defaults.set("codex", forKey: AgentHubDefaults.codexCommand)
+    }
+    defaults.set(true, forKey: AgentHubDefaults.enabledProviders + ".claude")
+    defaults.set(true, forKey: AgentHubDefaults.enabledProviders + ".codex")
+    if defaults.string(forKey: AgentHubDefaults.worktreeBranchPrefix) == nil {
+      let prefix = NSUserName().lowercased().filter { $0.isLetter || $0.isNumber }
+      defaults.set(prefix, forKey: AgentHubDefaults.worktreeBranchPrefix)
     }
   }
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/Models/SessionMonitorState.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Models/SessionMonitorState.swift
@@ -36,6 +36,9 @@ public struct SessionMonitorState: Equatable, Sendable {
   // Recent activity log
   public var recentActivities: [ActivityEntry]
 
+  // Renderable user/assistant transcript extracted from provider JSONL.
+  public var transcriptEntries: [TranscriptEntry]
+
   // Mermaid diagram detection
   public var hasMermaidContent: Bool
 
@@ -67,6 +70,7 @@ public struct SessionMonitorState: Equatable, Sendable {
     gitBranch: String? = nil,
     pendingToolUse: PendingToolUse? = nil,
     recentActivities: [ActivityEntry] = [],
+    transcriptEntries: [TranscriptEntry] = [],
     hasMermaidContent: Bool = false,
     detectedResourceLinks: [ResourceLink] = [],
     detectedMCPAppResources: [MCPAppResourceDescriptor] = [],
@@ -87,6 +91,7 @@ public struct SessionMonitorState: Equatable, Sendable {
     self.gitBranch = gitBranch
     self.pendingToolUse = pendingToolUse
     self.recentActivities = recentActivities
+    self.transcriptEntries = transcriptEntries
     self.hasMermaidContent = hasMermaidContent
     self.detectedResourceLinks = detectedResourceLinks
     self.detectedMCPAppResources = detectedMCPAppResources

--- a/app/modules/AgentHubCore/Sources/AgentHub/Models/TranscriptEntry.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Models/TranscriptEntry.swift
@@ -1,0 +1,33 @@
+//
+//  TranscriptEntry.swift
+//  AgentHub
+//
+
+import Foundation
+
+public struct TranscriptEntry: Identifiable, Equatable, Sendable {
+  public let id: UUID
+  public let timestamp: Date?
+  public let role: TranscriptRole
+  public let content: String
+  public let provider: SessionProviderKind
+
+  public init(
+    id: UUID = UUID(),
+    timestamp: Date?,
+    role: TranscriptRole,
+    content: String,
+    provider: SessionProviderKind
+  ) {
+    self.id = id
+    self.timestamp = timestamp
+    self.role = role
+    self.content = content
+    self.provider = provider
+  }
+}
+
+public enum TranscriptRole: String, Equatable, Sendable {
+  case user
+  case assistant
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/CodexSessionFileWatcher.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/CodexSessionFileWatcher.swift
@@ -289,6 +289,7 @@ public actor CodexSessionFileWatcher {
       // way to surface approval-window state. See plans/parsed-weaving-nebula.md.
       pendingToolUse: nil,
       recentActivities: result.recentActivities,
+      transcriptEntries: result.transcriptEntries,
       hasMermaidContent: result.hasMermaidContent,
       detectedResourceLinks: result.detectedResourceLinks,
       detectedMCPAppResources: result.detectedMCPAppResources,

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/CodexSessionJSONLParser.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/CodexSessionJSONLParser.swift
@@ -54,6 +54,7 @@ public struct CodexSessionJSONLParser {
     public var messageCount: Int = 0
     public var pendingToolUses: [String: PendingToolInfo] = [:]
     public var recentActivities: [ActivityEntry] = []
+    public var transcriptEntries: [TranscriptEntry] = []
     public var lastActivityAt: Date?
     public var sessionStartedAt: Date?
     public var currentStatus: SessionStatus = .idle
@@ -263,12 +264,14 @@ public struct CodexSessionJSONLParser {
     case "user_message":
       result.messageCount += 1
       if let message = payload["message"] as? String, !message.isEmpty {
+        appendTranscriptEntry(role: .user, content: message, timestamp: timestamp, to: &result)
         addActivity(type: .userMessage, description: String(message.prefix(80)), timestamp: timestamp, to: &result)
       }
 
     case "agent_message":
       result.messageCount += 1
       if let message = payload["message"] as? String, !message.isEmpty {
+        appendTranscriptEntry(role: .assistant, content: message, timestamp: timestamp, to: &result)
         if message.contains("```mermaid") { result.hasMermaidContent = true }
         appendResourceLinks(extractResourceLinks(from: message, timestamp: timestamp), to: &result)
         appendMCPAppResources(MCPAppResourceExtractor.extract(from: message), to: &result)
@@ -310,6 +313,22 @@ public struct CodexSessionJSONLParser {
     default:
       break
     }
+  }
+
+  private static func appendTranscriptEntry(
+    role: TranscriptRole,
+    content: String,
+    timestamp: Date?,
+    to result: inout ParseResult
+  ) {
+    let trimmed = content.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else { return }
+    result.transcriptEntries.append(TranscriptEntry(
+      timestamp: timestamp,
+      role: role,
+      content: trimmed,
+      provider: .codex
+    ))
   }
 
   /// Codex reports an MCP tool call as a single `mcp_tool_call_end` event carrying

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/SessionFileWatcher.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/SessionFileWatcher.swift
@@ -580,6 +580,7 @@ public actor SessionFileWatcher {
       gitBranch: result.gitBranch,
       pendingToolUse: pendingToolUse,
       recentActivities: result.recentActivities,
+      transcriptEntries: result.transcriptEntries,
       hasMermaidContent: result.hasMermaidContent,
       detectedResourceLinks: result.detectedResourceLinks,
       detectedMCPAppResources: result.detectedMCPAppResources,

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/SessionJSONLParser.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/SessionJSONLParser.swift
@@ -87,6 +87,7 @@ public struct SessionJSONLParser {
     public var messageCount: Int = 0
     public var pendingToolUses: [String: PendingToolInfo] = [:]  // toolUseId -> info
     public var recentActivities: [ActivityEntry] = []
+    public var transcriptEntries: [TranscriptEntry] = []
     public var lastActivityAt: Date?
     public var sessionStartedAt: Date?
     public var currentStatus: SessionStatus = .idle
@@ -205,6 +206,13 @@ public struct SessionJSONLParser {
       // Only add user message activity if there's actual text (not just tool results)
       let textPreview = extractTextPreview(from: entry.message?.content)
       if !textPreview.isEmpty {
+        appendTranscriptEntries(
+          from: entry.message?.content,
+          role: .user,
+          timestamp: timestamp,
+          provider: .claude,
+          to: &result
+        )
         addActivity(
           type: .userMessage,
           description: textPreview,
@@ -238,7 +246,12 @@ public struct SessionJSONLParser {
 
       // Process content blocks
       if let blocks = entry.message?.content {
-        processContentBlocks(blocks, timestamp: timestamp, into: &result)
+        processContentBlocks(
+          blocks,
+          timestamp: timestamp,
+          transcriptRole: .assistant,
+          into: &result
+        )
       }
 
     case "summary":
@@ -260,6 +273,7 @@ public struct SessionJSONLParser {
   private static func processContentBlocks(
     _ blocks: [ContentBlock],
     timestamp: Date?,
+    transcriptRole: TranscriptRole? = nil,
     into result: inout ParseResult
   ) {
     for block in blocks {
@@ -360,6 +374,15 @@ public struct SessionJSONLParser {
 
       case "text":
         if let text = block.text {
+          if let transcriptRole {
+            appendTranscriptEntry(
+              role: transcriptRole,
+              content: text,
+              timestamp: timestamp,
+              provider: .claude,
+              to: &result
+            )
+          }
           if text.contains("```mermaid") {
             result.hasMermaidContent = true
           }
@@ -382,6 +405,44 @@ public struct SessionJSONLParser {
         break
       }
     }
+  }
+
+  private static func appendTranscriptEntries(
+    from blocks: [ContentBlock]?,
+    role: TranscriptRole,
+    timestamp: Date?,
+    provider: SessionProviderKind,
+    to result: inout ParseResult
+  ) {
+    guard let blocks else { return }
+    for block in blocks where block.type == "text" {
+      if let text = block.text {
+        appendTranscriptEntry(
+          role: role,
+          content: text,
+          timestamp: timestamp,
+          provider: provider,
+          to: &result
+        )
+      }
+    }
+  }
+
+  private static func appendTranscriptEntry(
+    role: TranscriptRole,
+    content: String,
+    timestamp: Date?,
+    provider: SessionProviderKind,
+    to result: inout ParseResult
+  ) {
+    let trimmed = content.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else { return }
+    result.transcriptEntries.append(TranscriptEntry(
+      timestamp: timestamp,
+      role: role,
+      content: trimmed,
+      provider: provider
+    ))
   }
 
   /// Re-evaluate current status based on time elapsed since last activity

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/SierraDefaultsBootstrap.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/SierraDefaultsBootstrap.swift
@@ -1,0 +1,376 @@
+//
+//  SierraDefaultsBootstrap.swift
+//  AgentHub
+//
+
+import Foundation
+
+public protocol SierraDefaultsBootstrapProtocol: Sendable {
+  func bootstrap() async
+}
+
+public final class SierraDefaultsBootstrap: SierraDefaultsBootstrapProtocol, @unchecked Sendable {
+  private let metadataStore: SessionMetadataStore
+  private let defaults: UserDefaults
+  private let fileManager: FileManager
+  private let homeDirectory: URL
+  private let applicationSupportDirectory: URL
+
+  public init(
+    metadataStore: SessionMetadataStore,
+    defaults: UserDefaults = .standard,
+    fileManager: FileManager = .default,
+    homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser,
+    applicationSupportDirectory: URL? = nil
+  ) {
+    self.metadataStore = metadataStore
+    self.defaults = defaults
+    self.fileManager = fileManager
+    self.homeDirectory = homeDirectory
+    self.applicationSupportDirectory = applicationSupportDirectory
+      ?? homeDirectory
+        .appendingPathComponent("Library/Application Support/AgentHub", isDirectory: true)
+  }
+
+  public func bootstrap() async {
+    installClaudeWrapper()
+    seedUserDefaults()
+    await seedAIConfig()
+    await seedWorkspaceState()
+    defaults.set(true, forKey: AgentHubDefaults.sierraDefaultsBootstrapped)
+  }
+
+  private func seedUserDefaults() {
+    if defaults.string(forKey: AgentHubDefaults.claudeCommand) == nil {
+      defaults.set("agenthub-claude", forKey: AgentHubDefaults.claudeCommand)
+    }
+
+    if defaults.string(forKey: AgentHubDefaults.codexCommand) == nil {
+      defaults.set("codex", forKey: AgentHubDefaults.codexCommand)
+    }
+
+    defaults.set(true, forKey: AgentHubDefaults.enabledProviders + ".claude")
+    defaults.set(true, forKey: AgentHubDefaults.enabledProviders + ".codex")
+
+    if defaults.string(forKey: AgentHubDefaults.worktreeBranchPrefix) == nil {
+      defaults.set(usernameBranchPrefix(), forKey: AgentHubDefaults.worktreeBranchPrefix)
+    }
+  }
+
+  private func seedAIConfig() async {
+    await seedAIConfig(
+      provider: "claude",
+      defaultModel: "us.anthropic.claude-opus-4-8[1m]",
+      effortLevel: "high"
+    )
+    await seedAIConfig(provider: "codex", defaultModel: "gpt-5.5", effortLevel: "high")
+  }
+
+  private func seedAIConfig(provider: String, defaultModel: String, effortLevel: String) async {
+    do {
+      if let existing = try await metadataStore.getAIConfig(for: provider),
+         !existing.defaultModel.isEmpty || !existing.effortLevel.isEmpty {
+        return
+      }
+      try await metadataStore.saveAIConfig(AIConfigRecord(
+        provider: provider,
+        defaultModel: defaultModel,
+        effortLevel: effortLevel
+      ))
+    } catch {
+      AppLogger.session.error("[SierraDefaults] Failed to seed AI config for \(provider): \(error.localizedDescription)")
+    }
+  }
+
+  private func seedWorkspaceState() async {
+    let paths = discoverRepositoryPaths()
+    guard !paths.isEmpty else { return }
+
+    for provider in [SessionProviderKind.claude, .codex] {
+      let existing = metadataStore.getWorkspaceStateSync(for: provider)
+      guard existing.selectedRepositoryPaths.isEmpty else { continue }
+      let state = SessionWorkspaceState(
+        selectedRepositoryPaths: paths,
+        monitoredSessionIds: existing.monitoredSessionIds,
+        ownedWorktreePaths: existing.ownedWorktreePaths,
+        expansionState: Dictionary(uniqueKeysWithValues: paths.map { ("repo:" + $0, true) })
+      )
+      do {
+        try await metadataStore.saveWorkspaceState(state, for: provider)
+      } catch {
+        AppLogger.session.error("[SierraDefaults] Failed to seed workspace state for \(provider.rawValue): \(error.localizedDescription)")
+      }
+    }
+  }
+
+  private func installClaudeWrapper() {
+    let binDirectory = applicationSupportDirectory.appendingPathComponent("bin", isDirectory: true)
+    let configDirectory = applicationSupportDirectory.appendingPathComponent("claude-config", isDirectory: true)
+    let wrapperURL = binDirectory.appendingPathComponent("agenthub-claude")
+    let settingsURL = configDirectory.appendingPathComponent("settings.json")
+    let mcpConfigURL = configDirectory.appendingPathComponent("mcp-config.json")
+
+    do {
+      try fileManager.createDirectory(at: binDirectory, withIntermediateDirectories: true)
+      try fileManager.createDirectory(at: configDirectory, withIntermediateDirectories: true)
+      try wrapperScript(settingsPath: settingsURL.path, mcpConfigPath: mcpConfigURL.path)
+        .write(to: wrapperURL, atomically: true, encoding: .utf8)
+      try settingsJSON().write(to: settingsURL, atomically: true, encoding: .utf8)
+      try mcpConfigJSON().write(to: mcpConfigURL, atomically: true, encoding: .utf8)
+      try fileManager.setAttributes([.posixPermissions: 0o755], ofItemAtPath: wrapperURL.path)
+    } catch {
+      AppLogger.session.error("[SierraDefaults] Failed to install Claude wrapper: \(error.localizedDescription)")
+    }
+  }
+
+  private func wrapperScript(settingsPath: String, mcpConfigPath: String) -> String {
+    let localClaude = homeDirectory.appendingPathComponent(".local/bin/claude").path
+    return """
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    export PATH="\(homeDirectory.path)/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:${PATH:-}"
+    export AWS_PROFILE="${AWS_PROFILE:-claudecode}"
+    export AWS_REGION="${AWS_REGION:-us-west-2}"
+    export CLAUDE_CODE_USE_BEDROCK="${CLAUDE_CODE_USE_BEDROCK:-1}"
+    export ANTHROPIC_DEFAULT_FABLE_MODEL="${ANTHROPIC_DEFAULT_FABLE_MODEL:-us.anthropic.claude-fable-5}"
+    export ANTHROPIC_DEFAULT_OPUS_MODEL="${ANTHROPIC_DEFAULT_OPUS_MODEL:-us.anthropic.claude-opus-4-8[1m]}"
+    export ANTHROPIC_DEFAULT_SONNET_MODEL="${ANTHROPIC_DEFAULT_SONNET_MODEL:-us.anthropic.claude-sonnet-4-6}"
+    export ANTHROPIC_MODEL="${ANTHROPIC_MODEL:-us.anthropic.claude-opus-4-8[1m]}"
+    export CLAUDE_CODE_SUBAGENT_MODEL="${CLAUDE_CODE_SUBAGENT_MODEL:-us.anthropic.claude-opus-4-8[1m]}"
+    export TERM="${TERM:-xterm-256color}"
+    export COLORTERM="${COLORTERM:-truecolor}"
+    export CLICOLOR="${CLICOLOR:-1}"
+    export CLICOLOR_FORCE="${CLICOLOR_FORCE:-1}"
+    export FORCE_COLOR="${FORCE_COLOR:-1}"
+
+    if [[ "${1:-}" == "claude" ]]; then
+      shift
+    fi
+    if [[ "${1:-}" == "--" ]]; then
+      shift
+    fi
+
+    permission_args=()
+    has_permission_mode=0
+    for arg in "$@"; do
+      if [[ "$arg" == "--permission-mode" || "$arg" == "--dangerously-skip-permissions" ]]; then
+        has_permission_mode=1
+        break
+      fi
+    done
+    if [[ "$has_permission_mode" == "0" ]]; then
+      permission_args=(--permission-mode bypassPermissions)
+    fi
+
+    mcp_args=()
+    if [[ -s "\(mcpConfigPath)" ]]; then
+      mcp_args=(--mcp-config="\(mcpConfigPath)")
+    fi
+
+    if [[ -x "\(localClaude)" ]]; then
+      exec "\(localClaude)" --setting-sources project,local --settings "\(settingsPath)" "${mcp_args[@]}" "${permission_args[@]}" "$@"
+    fi
+
+    exec claude --setting-sources project,local --settings "\(settingsPath)" "${mcp_args[@]}" "${permission_args[@]}" "$@"
+    """
+  }
+
+  private func mcpConfigJSON() -> String {
+    let claudeConfigURL = homeDirectory.appendingPathComponent(".claude.json")
+    guard
+      let data = try? Data(contentsOf: claudeConfigURL),
+      let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+      let mcpServers = object["mcpServers"] as? [String: Any]
+    else {
+      return "{\n  \"mcpServers\": {}\n}\n"
+    }
+
+    do {
+      let mcpConfigData = try JSONSerialization.data(
+        withJSONObject: ["mcpServers": mcpServers],
+        options: [.prettyPrinted, .sortedKeys]
+      )
+      return String(data: mcpConfigData, encoding: .utf8).map { $0 + "\n" }
+        ?? "{\n  \"mcpServers\": {}\n}\n"
+    } catch {
+      return "{\n  \"mcpServers\": {}\n}\n"
+    }
+  }
+
+  private func settingsJSON() -> String {
+    """
+    {
+      "awsAuthRefresh": "aws sso login --profile claudecode",
+      "env": {
+        "ENABLE_TOOL_SEARCH": "auto:0",
+        "CLAUDE_CODE_AUTO_COMPACT_WINDOW": "300000"
+      },
+      "model": "opus",
+      "effortLevel": "high",
+      "enabledPlugins": {
+        "figma@claude-plugins-official": true,
+        "github@claude-plugins-official": true,
+        "linear@claude-plugins-official": true,
+        "claude-video-vision@claude-video-vision": true
+      },
+      "extraKnownMarketplaces": {
+        "claude-video-vision": {
+          "source": {
+            "source": "git",
+            "url": "https://github.com/jordanrendric/claude-video-vision.git"
+          }
+        }
+      },
+      "enableAllProjectMcpServers": true,
+      "skipDangerousModePermissionPrompt": true,
+      "permissions": {
+        "defaultMode": "bypassPermissions",
+        "allow": [
+          "Bash(*)",
+          "Read",
+          "Write",
+          "Edit",
+          "MultiEdit",
+          "Glob",
+          "Grep",
+          "WebFetch",
+          "WebSearch",
+          "Task",
+          "Skill",
+          "mcp__chrome-devtools__*",
+          "mcp__cloudwatch-eu__*",
+          "mcp__cloudwatch-sg__*",
+          "mcp__cloudwatch-us__*",
+          "mcp__dataresearch__*",
+          "mcp__ffmpeg-comprehensive__*",
+          "mcp__ffmpeg-lite__*",
+          "mcp__ffmpeg-micro__*",
+          "mcp__grafana-eu__*",
+          "mcp__grafana-jp__*",
+          "mcp__grafana-sg__*",
+          "mcp__grafana-us__*",
+          "mcp__linear__*",
+          "mcp__linear-server__*",
+          "mcp__ml-training__*",
+          "mcp__pinewood__*",
+          "mcp__plugin_claude-video-vision_claude-video-vision__*",
+          "mcp__plugin_figma_figma__*",
+          "mcp__plugin_github_github__*",
+          "mcp__plugin_linear_linear__*",
+          "mcp__playwright__*",
+          "mcp__sierra__*",
+          "mcp__sierra-dev__*",
+          "mcp__sierra-tools__*",
+          "mcp__video-analyzer__*"
+        ]
+      }
+    }
+    """
+  }
+
+  private func usernameBranchPrefix() -> String {
+    NSUserName()
+      .lowercased()
+      .filter { $0.isLetter || $0.isNumber }
+  }
+
+  private func discoverRepositoryPaths() -> [String] {
+    var paths: Set<String> = []
+    addKnownRepositoryPaths(to: &paths)
+    addConductorWorkspacePaths(to: &paths)
+    addHomeChildGitRepositories(to: &paths)
+    return paths.sorted()
+  }
+
+  private func addKnownRepositoryPaths(to paths: inout Set<String>) {
+    let knownRelativePaths = [
+      "sierra",
+      "shopping-prototypes",
+      "ticketmaster",
+      "cityfurniture",
+      "ulta",
+      "modern-animal",
+      "sonos",
+      "shipt",
+      "vivid-seats",
+      "directv",
+      "nordstrom"
+    ]
+
+    for relativePath in knownRelativePaths {
+      insertGitRepository(homeDirectory.appendingPathComponent(relativePath).path, into: &paths)
+    }
+
+    let agentsDirectory = homeDirectory.appendingPathComponent("dev/agents-customer", isDirectory: true)
+    addImmediateGitChildren(of: agentsDirectory, to: &paths)
+  }
+
+  private func addConductorWorkspacePaths(to paths: inout Set<String>) {
+    let root = homeDirectory.appendingPathComponent("conductor/workspaces", isDirectory: true)
+    guard let customers = try? fileManager.contentsOfDirectory(
+      at: root,
+      includingPropertiesForKeys: [.isDirectoryKey],
+      options: [.skipsHiddenFiles]
+    ) else {
+      return
+    }
+
+    for customer in customers {
+      addImmediateGitChildren(of: customer, to: &paths)
+    }
+  }
+
+  private func addHomeChildGitRepositories(to paths: inout Set<String>) {
+    guard let children = try? fileManager.contentsOfDirectory(
+      at: homeDirectory,
+      includingPropertiesForKeys: [.isDirectoryKey],
+      options: [.skipsHiddenFiles]
+    ) else {
+      return
+    }
+
+    let excluded = Set([
+      "Applications",
+      "Desktop",
+      "Documents",
+      "Downloads",
+      "Library",
+      "Movies",
+      "Music",
+      "Pictures",
+      "Public",
+      "node_modules",
+      ".cache"
+    ])
+
+    for child in children where !excluded.contains(child.lastPathComponent) {
+      insertGitRepository(child.path, into: &paths)
+    }
+  }
+
+  private func addImmediateGitChildren(of directory: URL, to paths: inout Set<String>) {
+    guard let children = try? fileManager.contentsOfDirectory(
+      at: directory,
+      includingPropertiesForKeys: [.isDirectoryKey],
+      options: [.skipsHiddenFiles]
+    ) else {
+      return
+    }
+
+    for child in children {
+      insertGitRepository(child.path, into: &paths)
+    }
+  }
+
+  private func insertGitRepository(_ path: String, into paths: inout Set<String>) {
+    var isDirectory: ObjCBool = false
+    guard fileManager.fileExists(atPath: path, isDirectory: &isDirectory), isDirectory.boolValue else {
+      return
+    }
+    guard fileManager.fileExists(atPath: URL(fileURLWithPath: path).appendingPathComponent(".git").path) else {
+      return
+    }
+    paths.insert(WorktreeModuleResolver.normalizedDirectoryPath(path))
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/TerminalLauncher.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/TerminalLauncher.swift
@@ -392,6 +392,10 @@ public struct TerminalLauncher {
     additionalPaths: [String]?
   ) -> String? {
     let fileManager = FileManager.default
+    if command.contains("/"), fileManager.isExecutableFile(atPath: command) {
+      return command
+    }
+
     let allPaths = CLIPathResolver.executableSearchPaths(additionalPaths: additionalPaths ?? [])
 
     // Search for the command in all paths

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/EmbeddedTerminalLaunchBuilder.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/EmbeddedTerminalLaunchBuilder.swift
@@ -188,6 +188,9 @@ public enum EmbeddedTerminalLaunchBuilder {
     var environment = ProcessInfo.processInfo.environment
     environment["TERM"] = "xterm-256color"
     environment["COLORTERM"] = "truecolor"
+    environment["CLICOLOR"] = "1"
+    environment["CLICOLOR_FORCE"] = "1"
+    environment["FORCE_COLOR"] = "1"
     environment["LANG"] = "en_US.UTF-8"
     environment.removeValue(forKey: "TERM_PROGRAM")
     environment.removeValue(forKey: "AGENTHUB_CLI")

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringCardView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringCardView.swift
@@ -75,7 +75,7 @@ public struct MonitoringCardView: View {
     initialInputText: String? = nil,
     terminalKey: String? = nil,
     viewModel: CLISessionsViewModel? = nil,
-    contentMode: Binding<MonitoringCardContentMode> = .constant(.terminal),
+    contentMode: Binding<MonitoringCardContentMode> = .constant(.transcript),
     selectedEditorFilePath: Binding<String?> = .constant(nil),
     editorProjectPath: String? = nil,
     editorNavigationRequest: FileExplorerNavigationRequest? = nil,
@@ -879,12 +879,32 @@ public struct MonitoringCardView: View {
   @ViewBuilder
   private var monitorContent: some View {
     switch effectiveContentMode {
+    case .transcript:
+      transcriptContent
     case .terminal:
       terminalContent
     case .editor:
       editorContent
     case .diffs:
       diffContent
+    }
+  }
+
+  @ViewBuilder
+  private var transcriptContent: some View {
+    if let state, !state.transcriptEntries.isEmpty {
+      TranscriptView(entries: state.transcriptEntries)
+    } else {
+      terminalContent
+        .overlay(alignment: .topLeading) {
+          Text("Transcript will appear after the first parsed message.")
+            .font(.primaryCaption)
+            .foregroundStyle(.secondary)
+            .padding(DesignTokens.Spacing.sm)
+            .background(.thinMaterial)
+            .clipShape(RoundedRectangle(cornerRadius: DesignTokens.Radius.sm, style: .continuous))
+            .padding(DesignTokens.Spacing.sm)
+        }
     }
   }
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringEditorState.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringEditorState.swift
@@ -26,6 +26,7 @@ public enum DiffDisplayMode: String, CaseIterable, Identifiable, Sendable {
 }
 
 public enum MonitoringCardContentMode: String, CaseIterable, Identifiable {
+  case transcript
   case terminal
   case editor
   case diffs
@@ -34,6 +35,7 @@ public enum MonitoringCardContentMode: String, CaseIterable, Identifiable {
 
   var label: String {
     switch self {
+    case .transcript: "Transcript"
     case .terminal: "Terminal"
     case .editor: "Files"
     case .diffs: "Diffs"
@@ -42,6 +44,7 @@ public enum MonitoringCardContentMode: String, CaseIterable, Identifiable {
 
   var systemImage: String {
     switch self {
+    case .transcript: "text.bubble"
     case .terminal: "terminal"
     case .editor: "doc.text"
     case .diffs: "arrow.left.arrow.right"
@@ -66,7 +69,7 @@ public struct FileExplorerNavigationRequest: Equatable {
 }
 
 struct MonitoringEditorState: Equatable {
-  var contentMode: MonitoringCardContentMode = .terminal
+  var contentMode: MonitoringCardContentMode = .transcript
   var projectPath: String
   var selectedFilePath: String?
   var navigationRequest: FileExplorerNavigationRequest?
@@ -82,7 +85,7 @@ enum MonitoringEditorStateStore {
     diffDisplayMode: DiffDisplayMode,
     diffAvailabilityStatus: DiffAvailabilityStatus?
   ) -> [MonitoringCardContentMode] {
-    var modes: [MonitoringCardContentMode] = [.terminal, .editor]
+    var modes: [MonitoringCardContentMode] = [.transcript, .terminal, .editor]
     if diffDisplayMode == .inline,
        diffAvailabilityStatus?.canShowDiffViewer == true {
       modes.append(.diffs)
@@ -94,7 +97,7 @@ enum MonitoringEditorStateStore {
     _ contentMode: MonitoringCardContentMode,
     availableModes: [MonitoringCardContentMode]
   ) -> MonitoringCardContentMode {
-    availableModes.contains(contentMode) ? contentMode : .terminal
+    availableModes.contains(contentMode) ? contentMode : (availableModes.first ?? .terminal)
   }
 
   static func nextContentMode(

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/TranscriptView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/TranscriptView.swift
@@ -1,0 +1,49 @@
+//
+//  TranscriptView.swift
+//  AgentHub
+//
+
+import SwiftUI
+
+struct TranscriptView: View {
+  let entries: [TranscriptEntry]
+
+  var body: some View {
+    ScrollView {
+      LazyVStack(alignment: .leading, spacing: DesignTokens.Spacing.md) {
+        ForEach(entries) { entry in
+          TranscriptEntryView(entry: entry)
+        }
+      }
+      .padding(DesignTokens.Spacing.md)
+      .frame(maxWidth: .infinity, alignment: .leading)
+    }
+    .background(Color.surfaceCanvas)
+  }
+}
+
+private struct TranscriptEntryView: View {
+  let entry: TranscriptEntry
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: DesignTokens.Spacing.xs) {
+      Text(entry.role == .user ? "You" : entry.provider.rawValue)
+        .font(.primaryCaption)
+        .foregroundStyle(.secondary)
+
+      switch entry.role {
+      case .user:
+        Text(entry.content)
+          .font(.primaryBody)
+          .textSelection(.enabled)
+          .padding(DesignTokens.Spacing.sm)
+          .frame(maxWidth: .infinity, alignment: .leading)
+          .background(Color.surfaceCard)
+          .clipShape(RoundedRectangle(cornerRadius: DesignTokens.Radius.sm, style: .continuous))
+      case .assistant:
+        MarkdownView(content: entry.content, includeScrollView: false)
+          .background(Color.clear)
+      }
+    }
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/CLISessionsViewModel.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/CLISessionsViewModel.swift
@@ -2939,7 +2939,7 @@ public final class CLISessionsViewModel {
   ///   - skipCheckout: If true, skips git checkout even for non-worktrees (already on correct branch)
   ///   - dangerouslySkipPermissions: If true, adds --dangerously-skip-permissions flag
   /// - Returns: An error if launching failed, nil on success
-  public func openTerminalInWorktree(_ worktree: WorktreeBranch, skipCheckout: Bool = false, dangerouslySkipPermissions: Bool = false) -> Error? {
+  public func openTerminalInWorktree(_ worktree: WorktreeBranch, skipCheckout: Bool = false, dangerouslySkipPermissions: Bool = true) -> Error? {
     guard providerKind == .claude else {
       return NSError(
         domain: "CLISessionsViewModel",
@@ -3108,6 +3108,9 @@ public final class CLISessionsViewModel {
     permissionModePlan: Bool = false,
     worktreeName: String? = nil
   ) {
+    let effectiveDangerouslySkipPermissions = providerKind == .claude
+      ? (dangerouslySkipPermissions || !permissionModePlan)
+      : false
     let promptForTerminalSubmission = providerKind == .claude ? nonEmpty(initialPrompt) : nil
     let promptForProcessLaunch = providerKind == .claude ? nil : initialPrompt
 
@@ -3118,7 +3121,7 @@ public final class CLISessionsViewModel {
       launchPath: launchPath,
       initialPrompt: promptForProcessLaunch,
       initialInputText: initialInputText,
-      dangerouslySkipPermissions: dangerouslySkipPermissions,
+      dangerouslySkipPermissions: effectiveDangerouslySkipPermissions,
       permissionModePlan: permissionModePlan,
       worktreeName: worktreeName
     )

--- a/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/MultiSessionLaunchViewModel.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/MultiSessionLaunchViewModel.swift
@@ -39,7 +39,7 @@ public enum ClaudeMode: CaseIterable, Sendable {
 
   var next: ClaudeMode {
     switch self {
-    case .disabled: return .enabled
+    case .disabled: return .enabledDangerously
     case .enabled: return .enabledDangerously
     case .enabledDangerously: return .disabled
     }
@@ -380,7 +380,7 @@ public final class MultiSessionLaunchViewModel {
 
     switch targetProvider {
     case .claude:
-      claudeMode = .enabled
+      claudeMode = .enabledDangerously
       isCodexSelected = false
     case .codex:
       claudeMode = .disabled

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/MonitoringEditorStateTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/MonitoringEditorStateTests.swift
@@ -6,7 +6,7 @@ import Testing
 
 @Suite("MonitoringEditorState")
 struct MonitoringEditorStateTests {
-  @Test("Missing editor state defaults to terminal mode and the item project path")
+  @Test("Missing editor state defaults to transcript mode and the item project path")
   func defaultStateUsesItemProjectPath() {
     let state = MonitoringEditorStateStore.state(
       for: "claude-session-1",
@@ -14,7 +14,7 @@ struct MonitoringEditorStateTests {
       in: [:]
     )
 
-    #expect(state.contentMode == .terminal)
+    #expect(state.contentMode == .transcript)
     #expect(state.projectPath == "/tmp/repo")
     #expect(state.selectedFilePath == nil)
     #expect(state.navigationRequest == nil)
@@ -115,8 +115,8 @@ struct MonitoringEditorStateTests {
     #expect(state.contentMode == .diffs)
   }
 
-  @Test("Unavailable diff mode falls back to terminal")
-  func unavailableDiffModeFallsBackToTerminal() {
+  @Test("Unavailable diff mode falls back to first available mode")
+  func unavailableDiffModeFallsBackToFirstAvailableMode() {
     let mode = MonitoringEditorStateStore.coercedContentMode(
       .diffs,
       availableModes: [.terminal, .editor]
@@ -127,19 +127,20 @@ struct MonitoringEditorStateTests {
 
   @Test("Content shortcut cycles visible modes by index")
   func contentShortcutCyclesVisibleModesByIndex() {
-    let modes: [MonitoringCardContentMode] = [.terminal, .editor, .diffs]
+    let modes: [MonitoringCardContentMode] = [.transcript, .terminal, .editor, .diffs]
 
+    #expect(MonitoringEditorStateStore.nextContentMode(after: .transcript, availableModes: modes) == .terminal)
     #expect(MonitoringEditorStateStore.nextContentMode(after: .terminal, availableModes: modes) == .editor)
     #expect(MonitoringEditorStateStore.nextContentMode(after: .editor, availableModes: modes) == .diffs)
-    #expect(MonitoringEditorStateStore.nextContentMode(after: .diffs, availableModes: modes) == .terminal)
+    #expect(MonitoringEditorStateStore.nextContentMode(after: .diffs, availableModes: modes) == .transcript)
   }
 
   @Test("Content shortcut falls back to first visible mode when current mode disappears")
   func contentShortcutFallsBackToFirstVisibleMode() {
     #expect(MonitoringEditorStateStore.nextContentMode(
       after: .diffs,
-      availableModes: [.terminal, .editor]
-    ) == .terminal)
+      availableModes: [.transcript, .terminal, .editor]
+    ) == .transcript)
     #expect(MonitoringEditorStateStore.nextContentMode(
       after: .terminal,
       availableModes: []
@@ -165,9 +166,9 @@ struct MonitoringEditorStateTests {
       diffAvailabilityStatus: .available
     )
 
-    #expect(availableItems.map(\.value) == [.terminal, .editor, .diffs])
-    #expect(checkingItems.map(\.value) == [.terminal, .editor, .diffs])
-    #expect(unavailableItems.map(\.value) == [.terminal, .editor])
-    #expect(sidePanelItems.map(\.value) == [.terminal, .editor])
+    #expect(availableItems.map(\.value) == [.transcript, .terminal, .editor, .diffs])
+    #expect(checkingItems.map(\.value) == [.transcript, .terminal, .editor, .diffs])
+    #expect(unavailableItems.map(\.value) == [.transcript, .terminal, .editor])
+    #expect(sidePanelItems.map(\.value) == [.transcript, .terminal, .editor])
   }
 }

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/SierraDefaultsBootstrapTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/SierraDefaultsBootstrapTests.swift
@@ -1,0 +1,134 @@
+import Foundation
+import Testing
+
+@testable import AgentHubCore
+
+@Suite("Sierra defaults bootstrap", .serialized)
+struct SierraDefaultsBootstrapTests {
+  @Test("Seeds commands, AI config, workspace state, and wrapper without overwriting user edits")
+  func seedsDefaultsWithoutOverwritingUserEdits() async throws {
+    let root = FileManager.default.temporaryDirectory
+      .appendingPathComponent("sierra_bootstrap_\(UUID().uuidString)", isDirectory: true)
+    let home = root.appendingPathComponent("home", isDirectory: true)
+    let appSupport = root.appendingPathComponent("app-support", isDirectory: true)
+    let repo = home.appendingPathComponent("sierra", isDirectory: true)
+    try FileManager.default.createDirectory(
+      at: repo.appendingPathComponent(".git", isDirectory: true),
+      withIntermediateDirectories: true
+    )
+    try FileManager.default.createDirectory(
+      at: home.appendingPathComponent("conductor/workspaces/ticketmaster/run-1/.git", isDirectory: true),
+      withIntermediateDirectories: true
+    )
+    try """
+    {
+      "mcpServers": {
+        "sierra-tools": {
+          "type": "http",
+          "url": "https://sierra.tools/-/api/mcp"
+        }
+      },
+      "projects": {
+        "\(home.path)/sierra": {
+          "mcpServers": {
+            "linear-server": {
+              "type": "sse",
+              "url": "https://mcp.linear.app/sse"
+            }
+          }
+        }
+      }
+    }
+    """.write(to: home.appendingPathComponent(".claude.json"), atomically: true, encoding: .utf8)
+
+    let defaults = try #require(UserDefaults(suiteName: "SierraDefaultsBootstrapTests-\(UUID().uuidString)"))
+    defaults.set("custom-claude", forKey: AgentHubDefaults.claudeCommand)
+    let store = try SessionMetadataStore(path: root.appendingPathComponent("metadata.sqlite").path)
+
+    let bootstrap = SierraDefaultsBootstrap(
+      metadataStore: store,
+      defaults: defaults,
+      homeDirectory: home,
+      applicationSupportDirectory: appSupport
+    )
+    await bootstrap.bootstrap()
+
+    #expect(defaults.string(forKey: AgentHubDefaults.claudeCommand) == "custom-claude")
+    #expect(defaults.string(forKey: AgentHubDefaults.codexCommand) == "codex")
+    #expect(defaults.bool(forKey: AgentHubDefaults.enabledProviders + ".claude"))
+    #expect(defaults.bool(forKey: AgentHubDefaults.enabledProviders + ".codex"))
+    #expect(defaults.bool(forKey: AgentHubDefaults.sierraDefaultsBootstrapped))
+
+    let claudeConfig = try #require(try await store.getAIConfig(for: "claude"))
+    let codexConfig = try #require(try await store.getAIConfig(for: "codex"))
+    #expect(claudeConfig.defaultModel == "us.anthropic.claude-opus-4-8[1m]")
+    #expect(claudeConfig.effortLevel == "high")
+    #expect(codexConfig.defaultModel == "gpt-5.5")
+    #expect(codexConfig.effortLevel == "high")
+
+    let claudeWorkspace = store.getWorkspaceStateSync(for: .claude)
+    let codexWorkspace = store.getWorkspaceStateSync(for: .codex)
+    #expect(claudeWorkspace.selectedRepositoryPaths == codexWorkspace.selectedRepositoryPaths)
+    #expect(claudeWorkspace.selectedRepositoryPaths.contains(repo.path))
+    #expect(claudeWorkspace.selectedRepositoryPaths.contains(
+      home.appendingPathComponent("conductor/workspaces/ticketmaster/run-1").path
+    ))
+
+    let wrapperURL = appSupport.appendingPathComponent("bin/agenthub-claude")
+    let settingsURL = appSupport.appendingPathComponent("claude-config/settings.json")
+    let mcpConfigURL = appSupport.appendingPathComponent("claude-config/mcp-config.json")
+    #expect(FileManager.default.isExecutableFile(atPath: wrapperURL.path))
+    #expect(FileManager.default.fileExists(atPath: settingsURL.path))
+    #expect(FileManager.default.fileExists(atPath: mcpConfigURL.path))
+    let wrapperScript = try String(contentsOf: wrapperURL, encoding: .utf8)
+    #expect(wrapperScript.contains("--mcp-config=\"\(mcpConfigURL.path)\""))
+    let settingsData = try Data(contentsOf: settingsURL)
+    let settings = try #require(JSONSerialization.jsonObject(with: settingsData) as? [String: Any])
+    #expect(settings["enableAllProjectMcpServers"] as? Bool == true)
+    let permissions = try #require(settings["permissions"] as? [String: Any])
+    let allow = try #require(permissions["allow"] as? [String])
+    #expect(allow.contains("mcp__sierra__*"))
+    #expect(allow.contains("mcp__sierra-tools__*"))
+    #expect(allow.contains("mcp__plugin_figma_figma__*"))
+    #expect(!allow.contains("mcp__*"))
+    let mcpConfigData = try Data(contentsOf: mcpConfigURL)
+    let mcpConfig = try #require(JSONSerialization.jsonObject(with: mcpConfigData) as? [String: Any])
+    let mcpServers = try #require(mcpConfig["mcpServers"] as? [String: Any])
+    #expect(mcpServers["sierra-tools"] != nil)
+    #expect(mcpServers["linear-server"] == nil)
+  }
+
+  @Test("Does not overwrite existing AI config or workspace state")
+  func preservesExistingConfigAndWorkspaceState() async throws {
+    let root = FileManager.default.temporaryDirectory
+      .appendingPathComponent("sierra_bootstrap_preserve_\(UUID().uuidString)", isDirectory: true)
+    let home = root.appendingPathComponent("home", isDirectory: true)
+    try FileManager.default.createDirectory(
+      at: home.appendingPathComponent("sierra/.git", isDirectory: true),
+      withIntermediateDirectories: true
+    )
+    let store = try SessionMetadataStore(path: root.appendingPathComponent("metadata.sqlite").path)
+    try await store.saveWorkspaceState(
+      SessionWorkspaceState(selectedRepositoryPaths: ["/existing"]),
+      for: .claude
+    )
+    try await store.saveAIConfig(AIConfigRecord(
+      provider: "claude",
+      defaultModel: "custom-model",
+      effortLevel: "medium"
+    ))
+
+    let defaults = try #require(UserDefaults(suiteName: "SierraDefaultsBootstrapTests-\(UUID().uuidString)"))
+    await SierraDefaultsBootstrap(
+      metadataStore: store,
+      defaults: defaults,
+      homeDirectory: home,
+      applicationSupportDirectory: root.appendingPathComponent("app-support", isDirectory: true)
+    ).bootstrap()
+
+    let claudeConfig = try #require(try await store.getAIConfig(for: "claude"))
+    #expect(claudeConfig.defaultModel == "custom-model")
+    #expect(claudeConfig.effortLevel == "medium")
+    #expect(store.getWorkspaceStateSync(for: .claude).selectedRepositoryPaths == ["/existing"])
+  }
+}

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/TerminalLauncherExecutableResolutionTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/TerminalLauncherExecutableResolutionTests.swift
@@ -1,0 +1,17 @@
+import Foundation
+import Testing
+
+@testable import AgentHubCore
+
+@Suite("TerminalLauncher executable resolution")
+struct TerminalLauncherExecutableResolutionTests {
+  @Test("Accepts executable absolute command paths")
+  func acceptsExecutableAbsoluteCommandPaths() throws {
+    let executable = FileManager.default.temporaryDirectory
+      .appendingPathComponent("agenthub-executable-\(UUID().uuidString)")
+    try "#!/bin/sh\nexit 0\n".write(to: executable, atomically: true, encoding: .utf8)
+    try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: executable.path)
+
+    #expect(TerminalLauncher.findExecutable(command: executable.path, additionalPaths: []) == executable.path)
+  }
+}

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/TranscriptParserTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/TranscriptParserTests.swift
@@ -1,0 +1,44 @@
+import Testing
+
+@testable import AgentHubCore
+
+@Suite("Transcript parser extraction")
+struct TranscriptParserTests {
+  @Test("Claude transcript captures user and assistant text")
+  func claudeTranscriptCapturesUserAndAssistantText() {
+    let lines = [
+      """
+      {"type":"user","timestamp":"2026-01-01T00:00:00Z","message":{"role":"user","content":[{"type":"text","text":"Please summarize this."}]}}
+      """,
+      """
+      {"type":"assistant","timestamp":"2026-01-01T00:00:01Z","message":{"role":"assistant","content":[{"type":"text","text":"## Summary\\n\\nDone."}]}}
+      """
+    ]
+
+    var result = SessionJSONLParser.ParseResult()
+    SessionJSONLParser.parseNewLines(lines, into: &result)
+
+    #expect(result.transcriptEntries.map(\.role) == [.user, .assistant])
+    #expect(result.transcriptEntries.map(\.provider) == [.claude, .claude])
+    #expect(result.transcriptEntries.map(\.content) == ["Please summarize this.", "## Summary\n\nDone."])
+  }
+
+  @Test("Codex transcript captures user and agent messages")
+  func codexTranscriptCapturesUserAndAgentMessages() {
+    let lines = [
+      """
+      {"type":"event_msg","timestamp":"2026-01-01T00:00:00Z","payload":{"type":"user_message","message":"Write tests."}}
+      """,
+      """
+      {"type":"event_msg","timestamp":"2026-01-01T00:00:01Z","payload":{"type":"agent_message","message":"### Tests\\n\\nAdded."}}
+      """
+    ]
+
+    var result = CodexSessionJSONLParser.ParseResult()
+    CodexSessionJSONLParser.parseNewLines(lines, into: &result)
+
+    #expect(result.transcriptEntries.map(\.role) == [.user, .assistant])
+    #expect(result.transcriptEntries.map(\.provider) == [.codex, .codex])
+    #expect(result.transcriptEntries.map(\.content) == ["Write tests.", "### Tests\n\nAdded."])
+  }
+}


### PR DESCRIPTION
## Summary
- Add an opt-in Sierra bootstrap path for AgentHub defaults, including Bedrock Claude wrapper setup, Codex/Claude defaults, repo discovery, color env, and valid MCP permissions.
- Add transcript parsing/rendering for Claude and Codex sessions, with Transcript as the default monitoring card mode and Terminal preserved as an explicit mode.
- Add focused tests for Sierra bootstrap, transcript parsing, terminal executable resolution, and monitoring mode defaults.

## Notes
- Sierra defaults are seeded only when local AgentHub settings are unset or provider workspace state is empty.
- Claude MCP permissions use explicit server-scoped allow rules such as `mcp__sierra-tools__*`; the invalid broad `mcp__*` rule is intentionally avoided.
- The AgentHub-owned Claude wrapper keeps settings isolated while enabling project MCP servers and loading an AgentHub-owned MCP config derived from user Claude config.

## Validation
- Ran `git diff --check`.
- Live wrapper syntax checked with `bash -n` while iterating locally.
- Full Xcode test execution was not available in this environment because `xcodebuild` requires the full Xcode app, not just Command Line Tools.
