### PR TITLE
Improve GitHub session observation and cleanup guidance

### DIFF
--- a/GitHubMonitor.md
+++ b/GitHubMonitor.md
@@ -7,6 +7,8 @@ AgentHub observes GitHub pull request state and CI checks through a shared servi
 - GitHub monitoring is optional and only works when the GitHub CLI (`gh`) is installed, authenticated, and the session project is a GitHub repository.
 - Session rows show GitHub status only when the current session branch has a pull request. Branches with no PR stay visually quiet.
 - When a PR exists, the side-panel session row shows a compact bottom line with PR state and CI summary, for example `Draft PR #20 - CI passing 1/1`.
+- CI failures, requested changes, and merge conflicts are in-app attention states. They affect compact row styling and idle-session ordering, but do not produce macOS notifications.
+- If a refresh fails after a PR has been observed, the row keeps safe last-known data and marks it unavailable instead of replacing useful state with an empty result.
 - Monitoring cards can expose the current branch PR as quick access.
 - The GitHub panel observes the current branch PR and the selected PR detail/check state.
 - The side panel refresh button forces a refresh for the visible session branch targets.
@@ -18,15 +20,16 @@ The shared service is `GitHubPRObservationService`, an actor that implements `Gi
 Core types:
 
 - `GitHubPRObservationTarget`
-  - `.currentBranch(projectPath:branchName:)`
+  - `.session(projectPath:branchName:linkedPullRequests:)`
   - `.pullRequest(projectPath:number:)`
 - `GitHubPRObservationSnapshot`
   - target
   - optional pull request
   - check runs
   - derived `GitHubCISummary`
+  - derived blockers
   - observation state
-  - last refresh date
+  - last successful full refresh date and stale-state flag
 - `GitHubPRObservationState`
   - `.idle`
   - `.refreshing`
@@ -50,34 +53,41 @@ SwiftUI surface
   -> SwiftUI state update
 ```
 
-For current-branch targets, the service calls:
+For session targets, the service resolves the local repository identity from its GitHub remotes, then:
 
-1. `getCurrentBranchPR(at:)`
-2. `getChecks(prNumber:at:)` only if a PR exists
+1. Uses the newest detected PR link only when its `owner/repository` matches the local repository.
+2. Otherwise asks `gh` for the exact supplied session branch, rather than relying on the worktree's currently checked-out branch.
 
-For explicit PR targets, the service fetches PR metadata and checks concurrently.
+The normal refresh path is one `gh pr view` call. PR metadata includes `statusCheckRollup`, workflow names, timestamps, and the head commit OID. `getChecks(prNumber:at:)` is a compatibility fallback only when GitHub omits the rollup field entirely.
 
-`GitHubCLIService.getCurrentBranchPR(at:)` treats GitHub CLI's "no pull requests found for branch ..." response as a valid no-PR result, not as a UI error.
+Fallback check data is retained only when it belongs to the same non-nil head commit OID. A new head never inherits checks from an older commit. `lastRefreshedAt` advances only after a complete successful refresh, so unavailable/stale UI is truthful.
+
+`GitHubCLIService.getCurrentBranchPR(branchName:at:)` treats GitHub CLI's "no pull requests found for branch ..." response as a valid no-PR result, not as a UI error.
 
 ## Polling And Performance
 
 Default observation configuration:
 
-- Pending checks or no discovered PR: refresh every 30 seconds while active
-- Settled PR checks: refresh every 120 seconds while active
-- Idle timeout: stop automatic polling after 5 minutes without session activity
+- Pending checks: refresh every 30 seconds while active and every 120 seconds while idle, for at most one hour from discovery
+- Settled PR checks: refresh every 120 seconds while active, then stop after 5 minutes without activity
+- Merged or closed PRs: stop automatic observation immediately after the terminal state is observed; retain the cached state and allow manual refresh
+- No discovered PR: retry discovery for up to 10 minutes after activity, then stop
 - Transient error backoff: 60 seconds, 120 seconds, then 300 seconds
+- Global GitHub refresh concurrency: at most two `gh` operations
+- Inactive target cache retention: 15 minutes
 
 Performance rules:
 
 - The service only polls targets with active subscribers.
 - Unsubscribing the last subscriber cancels the scheduled polling task for that target.
 - Multiple subscribers for the same target share one snapshot and one scheduled refresh.
-- If a refresh is already running, additional activity is coalesced and evaluated after the current refresh finishes.
+- Manual refresh is awaited and prioritized over queued automatic refreshes. Concurrent requests for the same target are coalesced.
+- A manual refresh without subscribers performs one fetch and populates the cache without starting a background polling loop.
+- Session activity extends the adaptive polling window but does not force an immediate network refresh for every event.
 - Terminal setup errors (`gh` missing, unauthenticated, not a git repository, no remote) pause automatic polling until new activity or a manual refresh reactivates the target.
 - Session row subscriptions can opt out of immediate fetches with `refreshOnSubscribe: false`; activity timestamps decide whether observation should start.
 - Initial sidebar refresh is delayed until after launch and limited to a small batch so GitHub state does not block app startup.
-- Manual refresh walks the current branch targets sequentially with a short delay between targets to avoid a burst of `gh` processes.
+- Repository remote resolution is a cached local `git remote -v` read; it does not add a GitHub network request.
 
 ## UI Integration
 
@@ -87,7 +97,7 @@ Performance rules:
 - `SessionGitHubQuickAccessCoordinatorProtocol` as a legacy PR-only shared source
 - direct `GitHubCLIServiceProtocol` fallback when no shared source is available
 
-`CollapsibleSessionRow` subscribes to current-branch observation through the shared service. It starts with a small per-session stagger, records session activity, and stops polling on disappear. The GitHub row renders only when `currentBranchPR` is non-nil.
+`CollapsibleSessionRow` subscribes to session observation through the shared service. It starts with a small per-session stagger, records session activity, and stops polling on disappear. The GitHub row renders only when `currentBranchPR` is non-nil. Blockers use warning presentation; stale snapshots keep the last-known PR/check summary and disclose that refresh is unavailable. An inactive worktree session with a merged PR and no pending/failing CI replaces the terminal CI detail with a visible `Cleanup` action that routes through the existing worktree deletion confirmation.
 
 `MonitoringCardView` uses the same quick-access view model for current branch PR access in the full session card.
 
@@ -98,7 +108,9 @@ Performance rules:
 
 The selected PR observation keeps PR metadata and CI checks fresh without reloading slower diff/file/comment payloads on every check update.
 
-`MultiProviderSessionsListView` owns the sidebar refresh behavior. It gathers unique current-branch targets from selected sessions, schedules a delayed initial refresh, and exposes a manual refresh action in the sessions header.
+`MultiProviderSessionsListView` owns the sidebar refresh behavior. It gathers unique session targets from selected sessions, schedules a delayed initial refresh, and exposes a manual refresh action in the sessions header.
+
+The global session panel derives GitHub attention from the same observation snapshots. Idle sessions with CI failure, requested changes, or merge conflicts are raised above ordinary idle work without displacing actively working sessions.
 
 ## Testing
 
@@ -107,9 +119,18 @@ Tests cover:
 - target subscription deduplication
 - deferred initial fetch until recent activity
 - faster cadence for pending checks
+- pending checks continuing after session idle and stopping at the one-hour cap
 - slower cadence for settled checks
+- automatic observation stopping for merged/closed PRs while manual refresh remains available
 - terminal error pause/reactivation
 - cancellation when the last subscriber unsubscribes
+- manual one-shot cache population
+- exact session-branch lookup
+- repository-aware detected PR link selection
+- embedded check-rollup decoding and fallback stale-data safety
+- CI/review/merge blocker derivation
+- safe merged-worktree cleanup eligibility
+- global refresh concurrency limiting
 - view model propagation of observed PR/check snapshots
 - no-PR CLI output parsing
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/Models/WorktreeCleanupEligibility.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Models/WorktreeCleanupEligibility.swift
@@ -1,0 +1,33 @@
+//
+//  WorktreeCleanupEligibility.swift
+//  AgentHub
+//
+
+import AgentHubGitHub
+
+public enum WorktreeCleanupEligibility {
+  public static func shouldSuggestCleanup(
+    isWorktree: Bool,
+    isPendingSession: Bool,
+    isSessionActive: Bool,
+    sessionStatus: SessionStatus?,
+    pullRequestState: GitHubPullRequestState?,
+    ciStatus: CIStatus
+  ) -> Bool {
+    guard isWorktree,
+          !isPendingSession,
+          !isSessionActive,
+          pullRequestState == .merged,
+          ciStatus != .failure,
+          ciStatus != .pending else {
+      return false
+    }
+
+    switch sessionStatus {
+    case .thinking, .executingTool, .awaitingApproval:
+      return false
+    case .waitingForUser, .idle, nil:
+      return true
+    }
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/CollapsibleSelectedSessionsPanel.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/CollapsibleSelectedSessionsPanel.swift
@@ -150,7 +150,7 @@ public struct CollapsibleSelectedSessionsPanel: View {
             isPrimary: item.id == primarySessionId,
             customName: customName(for: item),
             sessionStatus: item.sessionStatus,
-            linkedPullRequestNumber: item.linkedPullRequestNumber,
+            linkedPullRequests: item.linkedPullRequests,
             colorScheme: colorScheme,
             isPinned: {
               switch item.providerKind {
@@ -202,7 +202,7 @@ public struct CollapsibleSelectedSessionsPanel: View {
     let timestamp: Date
     let isPending: Bool
     let sessionStatus: SessionStatus?
-    let linkedPullRequestNumber: Int?
+    let linkedPullRequests: [GitHubPullRequestURLReference]
   }
 
   private var items: [SelectedSessionItem] {
@@ -216,7 +216,7 @@ public struct CollapsibleSelectedSessionsPanel: View {
         timestamp: pending.startedAt,
         isPending: true,
         sessionStatus: nil,
-        linkedPullRequestNumber: nil
+        linkedPullRequests: []
       ))
     }
 
@@ -228,7 +228,7 @@ public struct CollapsibleSelectedSessionsPanel: View {
         timestamp: pending.startedAt,
         isPending: true,
         sessionStatus: nil,
-        linkedPullRequestNumber: nil
+        linkedPullRequests: []
       ))
     }
 
@@ -240,7 +240,7 @@ public struct CollapsibleSelectedSessionsPanel: View {
         timestamp: item.session.lastActivityAt,
         isPending: false,
         sessionStatus: item.state?.status,
-        linkedPullRequestNumber: Self.latestPullRequestNumber(in: item.state?.detectedResourceLinks ?? [])
+        linkedPullRequests: Self.pullRequestReferences(in: item.state?.detectedResourceLinks ?? [])
       ))
     }
 
@@ -252,7 +252,7 @@ public struct CollapsibleSelectedSessionsPanel: View {
         timestamp: item.session.lastActivityAt,
         isPending: false,
         sessionStatus: item.state?.status,
-        linkedPullRequestNumber: Self.latestPullRequestNumber(in: item.state?.detectedResourceLinks ?? [])
+        linkedPullRequests: Self.pullRequestReferences(in: item.state?.detectedResourceLinks ?? [])
       ))
     }
 
@@ -268,8 +268,8 @@ public struct CollapsibleSelectedSessionsPanel: View {
     }
   }
 
-  private static func latestPullRequestNumber(in links: [ResourceLink]) -> Int? {
-    GitHubPullRequestURLReference.latestNumber(in: links.map(\.url))
+  private static func pullRequestReferences(in links: [ResourceLink]) -> [GitHubPullRequestURLReference] {
+    links.compactMap { GitHubPullRequestURLReference(urlString: $0.url) }
   }
 
   private func ensurePrimarySelection() {
@@ -414,7 +414,7 @@ public struct SingleProviderCollapsibleSelectedSessionsPanel: View {
             isPrimary: item.id == primarySessionId,
             customName: viewModel.sessionCustomNames[item.session.id],
             sessionStatus: item.sessionStatus,
-            linkedPullRequestNumber: item.linkedPullRequestNumber,
+            linkedPullRequests: item.linkedPullRequests,
             colorScheme: colorScheme,
             isPinned: viewModel.pinnedSessionIds.contains(item.session.id),
             onPin: {
@@ -450,7 +450,7 @@ public struct SingleProviderCollapsibleSelectedSessionsPanel: View {
     let timestamp: Date
     let isPending: Bool
     let sessionStatus: SessionStatus?
-    let linkedPullRequestNumber: Int?
+    let linkedPullRequests: [GitHubPullRequestURLReference]
   }
 
   private var items: [SelectedSessionItem] {
@@ -463,7 +463,7 @@ public struct SingleProviderCollapsibleSelectedSessionsPanel: View {
         timestamp: pending.startedAt,
         isPending: true,
         sessionStatus: nil,
-        linkedPullRequestNumber: nil
+        linkedPullRequests: []
       ))
     }
 
@@ -474,7 +474,7 @@ public struct SingleProviderCollapsibleSelectedSessionsPanel: View {
         timestamp: item.session.lastActivityAt,
         isPending: false,
         sessionStatus: item.state?.status,
-        linkedPullRequestNumber: Self.latestPullRequestNumber(in: item.state?.detectedResourceLinks ?? [])
+        linkedPullRequests: Self.pullRequestReferences(in: item.state?.detectedResourceLinks ?? [])
       ))
     }
 
@@ -494,7 +494,7 @@ public struct SingleProviderCollapsibleSelectedSessionsPanel: View {
     primarySessionId = items.first?.id
   }
 
-  private static func latestPullRequestNumber(in links: [ResourceLink]) -> Int? {
-    GitHubPullRequestURLReference.latestNumber(in: links.map(\.url))
+  private static func pullRequestReferences(in links: [ResourceLink]) -> [GitHubPullRequestURLReference] {
+    links.compactMap { GitHubPullRequestURLReference(urlString: $0.url) }
   }
 }

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/CollapsibleSessionRow.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/CollapsibleSessionRow.swift
@@ -11,7 +11,7 @@ struct CollapsibleSessionRow: View {
   let isPrimary: Bool
   let customName: String?
   let sessionStatus: SessionStatus?
-  var linkedPullRequestNumber: Int? = nil
+  var linkedPullRequests: [GitHubPullRequestURLReference] = []
   let colorScheme: ColorScheme
   let isPinned: Bool
   let onPin: (() -> Void)?
@@ -74,7 +74,7 @@ struct CollapsibleSessionRow: View {
     let repositoryKey = SessionGitHubQuickAccessViewModel.repositoryKey(
       projectPath: session.projectPath,
       branchName: session.branchName,
-      linkedPullRequestNumber: linkedPullRequestNumber
+      linkedPullRequests: linkedPullRequests
     )
     return "\(repositoryKey)|\(isPending)|\(agentHub != nil)"
   }
@@ -84,6 +84,17 @@ struct CollapsibleSessionRow: View {
       (partialResult + Int(scalar.value)) % 1_500
     }
     return 250 + bucket
+  }
+
+  private var shouldSuggestWorktreeCleanup: Bool {
+    WorktreeCleanupEligibility.shouldSuggestCleanup(
+      isWorktree: session.isWorktree,
+      isPendingSession: isPending,
+      isSessionActive: session.isActive,
+      sessionStatus: sessionStatus,
+      pullRequestState: sessionGitHubQuickAccessViewModel.currentBranchPR?.stateKind,
+      ciStatus: sessionGitHubQuickAccessViewModel.ciSummary.overallStatus
+    )
   }
 
   // MARK: - Body
@@ -153,7 +164,9 @@ struct CollapsibleSessionRow: View {
           GitHubSessionRowStatusLine(
             pullRequest: pullRequest,
             summary: sessionGitHubQuickAccessViewModel.ciSummary,
-            observationState: sessionGitHubQuickAccessViewModel.observationState
+            observationState: sessionGitHubQuickAccessViewModel.observationState,
+            lastRefreshedAt: sessionGitHubQuickAccessViewModel.lastRefreshedAt,
+            cleanupWorktreeAction: shouldSuggestWorktreeCleanup ? onDeleteWorktree : nil
           )
           .transition(.opacity)
         }
@@ -325,7 +338,7 @@ struct CollapsibleSessionRow: View {
       return
     }
 
-    if linkedPullRequestNumber == nil {
+    if linkedPullRequests.isEmpty {
       try? await Task.sleep(for: .milliseconds(observationStartupDelayMilliseconds))
       guard !Task.isCancelled else { return }
     }
@@ -333,11 +346,11 @@ struct CollapsibleSessionRow: View {
     await sessionGitHubQuickAccessViewModel.load(
       projectPath: session.projectPath,
       branchName: session.branchName,
-      linkedPullRequestNumber: linkedPullRequestNumber,
+      linkedPullRequests: linkedPullRequests,
       observationService: observationService,
       refreshOnSubscribe: false,
       recordInitialActivity: false,
-      forceRefreshLinkedPullRequest: linkedPullRequestNumber != nil
+      forceRefreshLinkedPullRequest: !linkedPullRequests.isEmpty
     )
     await sessionGitHubQuickAccessViewModel.notifySessionActivity(at: timestamp)
   }
@@ -349,6 +362,8 @@ private struct GitHubSessionRowStatusLine: View {
   let pullRequest: GitHubPullRequest
   let summary: GitHubCISummary
   let observationState: GitHubPRObservationState
+  let lastRefreshedAt: Date?
+  let cleanupWorktreeAction: (() -> Void)?
 
   var body: some View {
     HStack(spacing: 5) {
@@ -361,7 +376,13 @@ private struct GitHubSessionRowStatusLine: View {
         .font(.geist(size: 10, weight: .medium))
         .foregroundColor(.secondary.opacity(0.95))
 
-      if let secondaryText {
+      if let cleanupWorktreeAction {
+        Text("·")
+          .font(.secondaryCaption)
+          .foregroundColor(.secondary.opacity(0.55))
+
+        WorktreeCleanupSuggestionButton(action: cleanupWorktreeAction)
+      } else if let secondaryText {
         Text("·")
           .font(.secondaryCaption)
           .foregroundColor(.secondary.opacity(0.55))
@@ -401,6 +422,27 @@ private struct GitHubSessionRowStatusLine: View {
       return "Refreshing checks"
     }
 
+    if observationState.isUnavailable {
+      return lastRefreshedAt == nil
+        ? "GitHub unavailable"
+        : "Last known: \(statusText)"
+    }
+
+    return statusText
+  }
+
+  private var statusText: String {
+    let blockers = GitHubPRBlocker.blockers(
+      for: pullRequest,
+      ciSummary: summary
+    ).sorted { $0.rawValue < $1.rawValue }
+    if blockers.count == 1, let blocker = blockers.first {
+      return blocker.displayName
+    }
+    if blockers.count > 1 {
+      return "\(blockers.count) PR blockers"
+    }
+
     guard summary.total > 0 else {
       return "No CI checks"
     }
@@ -428,6 +470,9 @@ private struct GitHubSessionRowStatusLine: View {
     if observationState.isRefreshing && summary.total == 0 {
       return "arrow.clockwise"
     }
+    if observationState.isUnavailable || !blockers.isEmpty {
+      return "exclamationmark.triangle.fill"
+    }
     return summary.overallStatus.icon
   }
 
@@ -448,6 +493,8 @@ private struct GitHubSessionRowStatusLine: View {
     if observationState.isRefreshing && summary.total == 0 {
       return .orange
     }
+    if !blockers.isEmpty { return .red }
+    if observationState.isUnavailable { return .orange }
     switch summary.overallStatus {
     case .success:
       return .green
@@ -483,6 +530,25 @@ private struct GitHubSessionRowStatusLine: View {
       return "CI checks are refreshing."
     }
 
+    if observationState.isUnavailable {
+      let availability = lastRefreshedAt == nil
+        ? "GitHub status is unavailable."
+        : "GitHub status is unavailable; showing the last known result."
+      return "\(availability) \(currentGitHubHelpText)"
+    }
+
+    return currentGitHubHelpText
+  }
+
+  private var currentGitHubHelpText: String {
+    if !blockers.isEmpty {
+      let descriptions = blockers
+        .sorted { $0.rawValue < $1.rawValue }
+        .map(\.displayName)
+        .joined(separator: ", ")
+      return "Pull request blockers: \(descriptions)."
+    }
+
     guard summary.total > 0 else {
       return "No CI checks are reported."
     }
@@ -500,6 +566,10 @@ private struct GitHubSessionRowStatusLine: View {
       }
       return "No CI checks are reported."
     }
+  }
+
+  private var blockers: Set<GitHubPRBlocker> {
+    GitHubPRBlocker.blockers(for: pullRequest, ciSummary: summary)
   }
 }
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringCardView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringCardView.swift
@@ -220,8 +220,8 @@ public struct MonitoringCardView: View {
     mcpAppResourceCount == 1 ? "Open 1 MCP app" : "Open \(mcpAppResourceCount) MCP apps"
   }
 
-  private var linkedPullRequestNumber: Int? {
-    GitHubPullRequestURLReference.latestNumber(in: resourceLinks.map(\.url))
+  private var linkedPullRequests: [GitHubPullRequestURLReference] {
+    resourceLinks.compactMap { GitHubPullRequestURLReference(urlString: $0.url) }
   }
 
   private var localDiffSummary: LocalDiffSummary? {
@@ -316,14 +316,14 @@ public struct MonitoringCardView: View {
       await viewModel?.ensureMCPAppRenderItems(for: session, state: state)
     }
     .task(id: gitHubObservationTaskID) {
-      if linkedPullRequestNumber == nil {
+      if linkedPullRequests.isEmpty {
         try? await Task.sleep(for: .seconds(2))
         guard !Task.isCancelled else { return }
       }
       await sessionGitHubQuickAccessViewModel.load(
         projectPath: session.projectPath,
         branchName: session.branchName,
-        linkedPullRequestNumber: linkedPullRequestNumber,
+        linkedPullRequests: linkedPullRequests,
         coordinator: gitHubQuickAccessCoordinator,
         observationService: gitHubPRObservationService
       )
@@ -620,7 +620,7 @@ public struct MonitoringCardView: View {
     SessionGitHubQuickAccessViewModel.repositoryKey(
       projectPath: session.projectPath,
       branchName: session.branchName,
-      linkedPullRequestNumber: linkedPullRequestNumber
+      linkedPullRequests: linkedPullRequests
     )
   }
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
@@ -807,7 +807,7 @@ public struct MultiProviderSessionsListView: View {
     let timestamp: Date
     let isPending: Bool
     let sessionStatus: SessionStatus?
-    let linkedPullRequestNumber: Int?
+    let linkedPullRequests: [GitHubPullRequestURLReference]
   }
 
   private var selectedSessionItems: [SelectedSessionItem] {
@@ -821,7 +821,7 @@ public struct MultiProviderSessionsListView: View {
         timestamp: pending.startedAt,
         isPending: true,
         sessionStatus: nil,
-        linkedPullRequestNumber: nil
+        linkedPullRequests: []
       ))
     }
 
@@ -833,7 +833,7 @@ public struct MultiProviderSessionsListView: View {
         timestamp: pending.startedAt,
         isPending: true,
         sessionStatus: nil,
-        linkedPullRequestNumber: nil
+        linkedPullRequests: []
       ))
     }
 
@@ -845,7 +845,7 @@ public struct MultiProviderSessionsListView: View {
         timestamp: item.session.lastActivityAt,
         isPending: false,
         sessionStatus: item.state?.status,
-        linkedPullRequestNumber: Self.latestPullRequestNumber(in: item.state?.detectedResourceLinks ?? [])
+        linkedPullRequests: Self.pullRequestReferences(in: item.state?.detectedResourceLinks ?? [])
       ))
     }
 
@@ -857,7 +857,7 @@ public struct MultiProviderSessionsListView: View {
         timestamp: item.session.lastActivityAt,
         isPending: false,
         sessionStatus: item.state?.status,
-        linkedPullRequestNumber: Self.latestPullRequestNumber(in: item.state?.detectedResourceLinks ?? [])
+        linkedPullRequests: Self.pullRequestReferences(in: item.state?.detectedResourceLinks ?? [])
       ))
     }
 
@@ -1251,7 +1251,7 @@ public struct MultiProviderSessionsListView: View {
           isPrimary: item.id == primarySessionId,
           customName: selectedSessionCustomName(for: item),
           sessionStatus: item.sessionStatus,
-          linkedPullRequestNumber: item.linkedPullRequestNumber,
+          linkedPullRequests: item.linkedPullRequests,
           colorScheme: colorScheme,
           isPinned: isPinned(item),
           onPin: item.isPending ? nil : {
@@ -1638,8 +1638,8 @@ public struct MultiProviderSessionsListView: View {
       ?? codexViewModel.agentHubProvider?.gitHubPRObservationService
   }
 
-  private static func latestPullRequestNumber(in links: [ResourceLink]) -> Int? {
-    GitHubPullRequestURLReference.latestNumber(in: links.map(\.url))
+  private static func pullRequestReferences(in links: [ResourceLink]) -> [GitHubPullRequestURLReference] {
+    links.compactMap { GitHubPullRequestURLReference(urlString: $0.url) }
   }
 
   private var gitHubRefreshTargets: [GitHubPRObservationTarget] {
@@ -1647,9 +1647,10 @@ public struct MultiProviderSessionsListView: View {
     var targets: [GitHubPRObservationTarget] = []
 
     for item in selectedSessionItems where !item.isPending {
-      let target = GitHubPRObservationTarget.currentBranch(
+      let target = GitHubPRObservationTarget.session(
         projectPath: item.session.projectPath,
-        branchName: item.session.branchName
+        branchName: item.session.branchName,
+        linkedPullRequests: item.linkedPullRequests
       )
       guard seen.insert(target).inserted else { continue }
       targets.append(target)

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/WorktreeCleanupSuggestionButton.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/WorktreeCleanupSuggestionButton.swift
@@ -1,0 +1,24 @@
+//
+//  WorktreeCleanupSuggestionButton.swift
+//  AgentHub
+//
+
+import SwiftUI
+
+struct WorktreeCleanupSuggestionButton: View {
+  let action: () -> Void
+
+  var body: some View {
+    Button(action: action) {
+      Label("Cleanup", systemImage: "trash")
+        .font(.secondaryCaption)
+        .foregroundStyle(.orange)
+        .padding(.horizontal, 5)
+        .padding(.vertical, 1)
+        .background(.orange.opacity(0.14), in: Capsule())
+    }
+    .buttonStyle(.plain)
+    .help("This worktree's pull request is merged — delete the worktree")
+    .accessibilityLabel("Delete merged worktree")
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHubGlobalSessionPanel/GlobalSessionControlPanelModels.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHubGlobalSessionPanel/GlobalSessionControlPanelModels.swift
@@ -15,6 +15,7 @@ public struct GlobalSessionControlPanelGitHubState: Equatable, Sendable {
   public let pullRequestState: GitHubPullRequestState?
   public let pullRequestMergeability: GitHubMergeability?
   public let ciStatus: CIStatus
+  public let blockers: Set<GitHubPRBlocker>
   public let isRefreshing: Bool
 
   public init(
@@ -23,13 +24,22 @@ public struct GlobalSessionControlPanelGitHubState: Equatable, Sendable {
     isRefreshing: Bool = false,
     pullRequestNumber: Int? = nil,
     pullRequestState: GitHubPullRequestState? = nil,
-    pullRequestMergeability: GitHubMergeability? = nil
+    pullRequestMergeability: GitHubMergeability? = nil,
+    blockers: Set<GitHubPRBlocker> = []
   ) {
     self.hasPullRequest = hasPullRequest
     self.pullRequestNumber = pullRequestNumber
     self.pullRequestState = pullRequestState
     self.pullRequestMergeability = pullRequestMergeability
     self.ciStatus = ciStatus
+    var resolvedBlockers = blockers
+    if ciStatus == .failure {
+      resolvedBlockers.insert(.ciFailure)
+    }
+    if pullRequestMergeability == .conflicting {
+      resolvedBlockers.insert(.mergeConflict)
+    }
+    self.blockers = resolvedBlockers
     self.isRefreshing = isRefreshing
   }
 }
@@ -38,7 +48,7 @@ public struct GlobalSessionControlPanelGitHubState: Equatable, Sendable {
 
 public enum GlobalSessionControlPanelAttention: Int, Equatable, Sendable {
   case awaitingApproval = 0
-  case ciFailure = 1
+  case gitHubBlocked = 1
   case working = 2
   case pending = 3
   case ready = 4
@@ -54,7 +64,7 @@ public struct GlobalSessionControlPanelItem: Identifiable, Equatable, Sendable {
   public let timestamp: Date
   public let isPending: Bool
   public let status: SessionStatus?
-  public let linkedPullRequestNumber: Int?
+  public let linkedPullRequests: [GitHubPullRequestURLReference]
   public let customName: String?
   public let gitHubState: GlobalSessionControlPanelGitHubState?
 
@@ -65,7 +75,7 @@ public struct GlobalSessionControlPanelItem: Identifiable, Equatable, Sendable {
     timestamp: Date,
     isPending: Bool,
     status: SessionStatus?,
-    linkedPullRequestNumber: Int?,
+    linkedPullRequests: [GitHubPullRequestURLReference],
     customName: String?,
     gitHubState: GlobalSessionControlPanelGitHubState? = nil
   ) {
@@ -75,7 +85,7 @@ public struct GlobalSessionControlPanelItem: Identifiable, Equatable, Sendable {
     self.timestamp = timestamp
     self.isPending = isPending
     self.status = status
-    self.linkedPullRequestNumber = linkedPullRequestNumber
+    self.linkedPullRequests = linkedPullRequests
     self.customName = customName
     self.gitHubState = gitHubState
   }
@@ -92,7 +102,7 @@ public struct GlobalSessionControlPanelItem: Identifiable, Equatable, Sendable {
       case .thinking, .executingTool:
         return .working
       case .waitingForUser:
-        if gitHubState?.ciStatus == .failure { return .ciFailure }
+        if gitHubState?.blockers.isEmpty == false { return .gitHubBlocked }
         if gitHubState?.ciStatus == .pending { return .pending }
         return .ready
       case .idle:
@@ -100,7 +110,7 @@ public struct GlobalSessionControlPanelItem: Identifiable, Equatable, Sendable {
       }
     }
 
-    if gitHubState?.ciStatus == .failure { return .ciFailure }
+    if gitHubState?.blockers.isEmpty == false { return .gitHubBlocked }
     if isPending || gitHubState?.ciStatus == .pending { return .pending }
     return .idle
   }
@@ -196,7 +206,7 @@ public enum GlobalSessionControlPanelSnapshotBuilder {
       timestamp: pending.startedAt,
       isPending: true,
       status: nil,
-      linkedPullRequestNumber: nil,
+      linkedPullRequests: [],
       customName: nil,
       gitHubState: gitHubStates[id]
     )
@@ -217,14 +227,14 @@ public enum GlobalSessionControlPanelSnapshotBuilder {
       timestamp: session.lastActivityAt,
       isPending: false,
       status: state?.status,
-      linkedPullRequestNumber: latestPullRequestNumber(in: state?.detectedResourceLinks ?? []),
+      linkedPullRequests: pullRequestReferences(in: state?.detectedResourceLinks ?? []),
       customName: customName,
       gitHubState: gitHubStates[id]
     )
   }
 
-  private static func latestPullRequestNumber(in links: [ResourceLink]) -> Int? {
-    GitHubPullRequestURLReference.latestNumber(in: links.map(\.url))
+  private static func pullRequestReferences(in links: [ResourceLink]) -> [GitHubPullRequestURLReference] {
+    links.compactMap { GitHubPullRequestURLReference(urlString: $0.url) }
   }
 }
 
@@ -291,7 +301,7 @@ public enum GlobalSessionCleanupSuggestionBuilder {
     let mergedPullRequestNumbers: [Int] = sortedUnique(
       items.compactMap { item in
         guard item.gitHubState?.pullRequestState == .merged else { return nil }
-        return item.gitHubState?.pullRequestNumber ?? item.linkedPullRequestNumber
+        return item.gitHubState?.pullRequestNumber ?? item.linkedPullRequests.last?.number
       }
     )
     guard !mergedPullRequestNumbers.isEmpty else { return nil }
@@ -331,10 +341,7 @@ public enum GlobalSessionCleanupSuggestionBuilder {
 
   private static func hasBlockingGitHubState(_ item: GlobalSessionControlPanelItem) -> Bool {
     guard let state = item.gitHubState else { return false }
-    if state.ciStatus == .failure || state.ciStatus == .pending {
-      return true
-    }
-    if state.pullRequestMergeability == .conflicting {
+    if !state.blockers.isEmpty || state.ciStatus == .pending {
       return true
     }
     guard state.hasPullRequest else { return false }

--- a/app/modules/AgentHubCore/Sources/AgentHubGlobalSessionPanel/GlobalSessionControlPanelView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHubGlobalSessionPanel/GlobalSessionControlPanelView.swift
@@ -703,7 +703,7 @@ private struct GlobalSessionControlPanelRow: View {
     let repositoryKey = SessionGitHubQuickAccessViewModel.repositoryKey(
       projectPath: item.session.projectPath,
       branchName: item.session.branchName,
-      linkedPullRequestNumber: item.linkedPullRequestNumber
+      linkedPullRequests: item.linkedPullRequests
     )
     return "\(item.id)|\(repositoryKey)|\(item.isPending)|\(agentHub != nil)"
   }
@@ -716,11 +716,14 @@ private struct GlobalSessionControlPanelRow: View {
       "\(prNumber)",
       pullRequest?.state ?? "",
       pullRequest?.mergeable ?? "",
+      pullRequest?.reviewDecision ?? "",
       "\(summary.overallStatus.rawValue)",
       "\(summary.passed)",
       "\(summary.failed)",
       "\(summary.pending)",
       "\(summary.total)",
+      gitHubViewModel.blockers.map(\.rawValue).sorted().map(String.init).joined(separator: ","),
+      "\(gitHubViewModel.observationState.isUnavailable)",
       "\(gitHubViewModel.observationState.isRefreshing)"
     ].joined(separator: "|")
   }
@@ -842,7 +845,7 @@ private struct GlobalSessionControlPanelRow: View {
   private var gitHubLine: some View {
     if let pullRequest = gitHubViewModel.currentBranchPR {
       HStack(spacing: 5) {
-        Image(systemName: gitHubViewModel.ciSummary.overallStatus.icon)
+        Image(systemName: gitHubStatusIcon)
           .font(.system(size: 10, weight: .semibold))
           .foregroundStyle(ciColor)
           .frame(width: 12, height: 12)
@@ -985,7 +988,7 @@ private struct GlobalSessionControlPanelRow: View {
   private var statusColor: Color {
     switch item.attention {
     case .awaitingApproval: return .yellow
-    case .ciFailure: return .red
+    case .gitHubBlocked: return .red
     case .working: return .blue
     case .pending: return .orange
     case .ready: return .green
@@ -994,6 +997,8 @@ private struct GlobalSessionControlPanelRow: View {
   }
 
   private var ciColor: Color {
+    if !gitHubViewModel.blockers.isEmpty { return .red }
+    if gitHubViewModel.observationState.isUnavailable { return .orange }
     switch gitHubViewModel.ciSummary.overallStatus {
     case .success: return .green
     case .failure: return .red
@@ -1003,6 +1008,23 @@ private struct GlobalSessionControlPanelRow: View {
   }
 
   private var ciText: String {
+    if gitHubViewModel.observationState.isUnavailable {
+      return gitHubViewModel.hasStaleObservation
+        ? "Last known: \(gitHubStatusText)"
+        : "GitHub unavailable"
+    }
+    return gitHubStatusText
+  }
+
+  private var gitHubStatusText: String {
+    let blockers = gitHubViewModel.blockers.sorted { $0.rawValue < $1.rawValue }
+    if blockers.count == 1, let blocker = blockers.first {
+      return blocker.displayName
+    }
+    if blockers.count > 1 {
+      return "\(blockers.count) PR blockers"
+    }
+
     let summary = gitHubViewModel.ciSummary
     switch summary.overallStatus {
     case .success:
@@ -1018,6 +1040,16 @@ private struct GlobalSessionControlPanelRow: View {
     }
   }
 
+  private var gitHubStatusIcon: String {
+    if !gitHubViewModel.blockers.isEmpty {
+      return "exclamationmark.triangle.fill"
+    }
+    if gitHubViewModel.observationState.isUnavailable {
+      return "exclamationmark.triangle.fill"
+    }
+    return gitHubViewModel.ciSummary.overallStatus.icon
+  }
+
   private func observeGitHubIfAvailable() async {
     guard !item.isPending, let observationService = agentHub?.gitHubPRObservationService else {
       gitHubViewModel.stopPolling()
@@ -1028,11 +1060,11 @@ private struct GlobalSessionControlPanelRow: View {
     await gitHubViewModel.load(
       projectPath: item.session.projectPath,
       branchName: item.session.branchName,
-      linkedPullRequestNumber: item.linkedPullRequestNumber,
+      linkedPullRequests: item.linkedPullRequests,
       observationService: observationService,
       refreshOnSubscribe: false,
       recordInitialActivity: false,
-      forceRefreshLinkedPullRequest: item.linkedPullRequestNumber != nil
+      forceRefreshLinkedPullRequest: !item.linkedPullRequests.isEmpty
     )
     await gitHubViewModel.notifySessionActivity(at: item.timestamp)
   }
@@ -1049,7 +1081,8 @@ private struct GlobalSessionControlPanelRow: View {
       isRefreshing: gitHubViewModel.observationState.isRefreshing,
       pullRequestNumber: pullRequest.number,
       pullRequestState: pullRequest.stateKind,
-      pullRequestMergeability: pullRequest.mergeabilityKind
+      pullRequestMergeability: pullRequest.mergeabilityKind,
+      blockers: gitHubViewModel.blockers
     ))
   }
 }

--- a/app/modules/AgentHubCore/Tests/AgentHubGlobalSessionPanelTests/GlobalSessionControlPanelTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubGlobalSessionPanelTests/GlobalSessionControlPanelTests.swift
@@ -225,7 +225,7 @@ struct GlobalSessionControlPanelTests {
         timestamp: base.addingTimeInterval(original.seconds),
         isPending: false,
         status: original.status,
-        linkedPullRequestNumber: nil,
+        linkedPullRequests: [],
         customName: nil,
         gitHubState: original.ciStatus.map {
           GlobalSessionControlPanelGitHubState(hasPullRequest: true, ciStatus: $0)
@@ -243,6 +243,39 @@ struct GlobalSessionControlPanelTests {
       "ready",
       "idle-new",
     ])
+  }
+
+  @Test("Review and merge blockers raise idle sessions without displacing active work")
+  func pullRequestBlockersRaiseIdleSessions() {
+    let changesRequested = GlobalSessionControlPanelGitHubState(
+      hasPullRequest: true,
+      ciStatus: .success,
+      blockers: [.changesRequested]
+    )
+    let mergeConflict = GlobalSessionControlPanelGitHubState(
+      hasPullRequest: true,
+      ciStatus: .success,
+      pullRequestMergeability: .conflicting
+    )
+    let blockedIdle = panelItem(
+      id: "blocked-idle",
+      seconds: 10,
+      status: .idle,
+      gitHubState: changesRequested
+    )
+    let blockedWorking = panelItem(
+      id: "blocked-working",
+      seconds: 20,
+      status: .thinking,
+      gitHubState: mergeConflict
+    )
+
+    #expect(blockedIdle.attention == .gitHubBlocked)
+    #expect(blockedWorking.attention == .working)
+    #expect(GlobalSessionControlPanelSnapshotBuilder.sorted([
+      blockedWorking,
+      blockedIdle,
+    ]).map(\.id) == ["blocked-idle", "blocked-working"])
   }
 
   @Test("Compact selector uses most recent active row")
@@ -457,7 +490,8 @@ struct GlobalSessionControlPanelTests {
     status: SessionStatus?,
     isActive: Bool = false,
     isPending: Bool = false,
-    providerKind: SessionProviderKind = .claude
+    providerKind: SessionProviderKind = .claude,
+    gitHubState: GlobalSessionControlPanelGitHubState? = nil
   ) -> GlobalSessionControlPanelItem {
     let timestamp = Date(timeIntervalSince1970: 1_000 + seconds)
     return GlobalSessionControlPanelItem(
@@ -473,8 +507,9 @@ struct GlobalSessionControlPanelTests {
       timestamp: timestamp,
       isPending: isPending,
       status: status,
-      linkedPullRequestNumber: nil,
-      customName: nil
+      linkedPullRequests: [],
+      customName: nil,
+      gitHubState: gitHubState
     )
   }
 
@@ -503,7 +538,9 @@ struct GlobalSessionControlPanelTests {
       timestamp: Date(timeIntervalSince1970: 1_000),
       isPending: isPending,
       status: status,
-      linkedPullRequestNumber: linkedPullRequestNumber,
+      linkedPullRequests: linkedPullRequestNumber.map {
+        Self.pullRequestReferences(number: $0)
+      } ?? [],
       customName: nil,
       gitHubState: gitHubState
     )
@@ -522,6 +559,12 @@ struct GlobalSessionControlPanelTests {
       pullRequestState: state,
       pullRequestMergeability: mergeability
     )
+  }
+
+  private static func pullRequestReferences(number: Int) -> [GitHubPullRequestURLReference] {
+    [GitHubPullRequestURLReference(
+      urlString: "https://github.com/test/repo/pull/\(number)"
+    )].compactMap { $0 }
   }
 
   private func makeDefaults() -> UserDefaults {

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/WorktreeCleanupEligibilityTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/WorktreeCleanupEligibilityTests.swift
@@ -1,0 +1,96 @@
+import AgentHubGitHub
+import Testing
+
+@testable import AgentHubCore
+
+@Suite("Worktree cleanup eligibility")
+struct WorktreeCleanupEligibilityTests {
+  @Test("Suggests cleanup only for safe merged worktree sessions")
+  func suggestsCleanupForSafeMergedWorktree() {
+    #expect(WorktreeCleanupEligibility.shouldSuggestCleanup(
+      isWorktree: true,
+      isPendingSession: false,
+      isSessionActive: false,
+      sessionStatus: .idle,
+      pullRequestState: .merged,
+      ciStatus: .success
+    ))
+    #expect(WorktreeCleanupEligibility.shouldSuggestCleanup(
+      isWorktree: true,
+      isPendingSession: false,
+      isSessionActive: false,
+      sessionStatus: .waitingForUser,
+      pullRequestState: .merged,
+      ciStatus: .none
+    ))
+  }
+
+  @Test("Suppresses cleanup while the worktree may still be in use")
+  func suppressesUnsafeCleanupSuggestions() {
+    let safeArguments = (
+      isWorktree: true,
+      isPendingSession: false,
+      isSessionActive: false,
+      sessionStatus: SessionStatus?.some(.idle),
+      pullRequestState: GitHubPullRequestState?.some(.merged),
+      ciStatus: CIStatus.success
+    )
+
+    #expect(!WorktreeCleanupEligibility.shouldSuggestCleanup(
+      isWorktree: false,
+      isPendingSession: safeArguments.isPendingSession,
+      isSessionActive: safeArguments.isSessionActive,
+      sessionStatus: safeArguments.sessionStatus,
+      pullRequestState: safeArguments.pullRequestState,
+      ciStatus: safeArguments.ciStatus
+    ))
+    #expect(!WorktreeCleanupEligibility.shouldSuggestCleanup(
+      isWorktree: safeArguments.isWorktree,
+      isPendingSession: true,
+      isSessionActive: safeArguments.isSessionActive,
+      sessionStatus: safeArguments.sessionStatus,
+      pullRequestState: safeArguments.pullRequestState,
+      ciStatus: safeArguments.ciStatus
+    ))
+    #expect(!WorktreeCleanupEligibility.shouldSuggestCleanup(
+      isWorktree: safeArguments.isWorktree,
+      isPendingSession: safeArguments.isPendingSession,
+      isSessionActive: true,
+      sessionStatus: safeArguments.sessionStatus,
+      pullRequestState: safeArguments.pullRequestState,
+      ciStatus: safeArguments.ciStatus
+    ))
+    #expect(!WorktreeCleanupEligibility.shouldSuggestCleanup(
+      isWorktree: safeArguments.isWorktree,
+      isPendingSession: safeArguments.isPendingSession,
+      isSessionActive: safeArguments.isSessionActive,
+      sessionStatus: .awaitingApproval(tool: "Bash"),
+      pullRequestState: safeArguments.pullRequestState,
+      ciStatus: safeArguments.ciStatus
+    ))
+    #expect(!WorktreeCleanupEligibility.shouldSuggestCleanup(
+      isWorktree: safeArguments.isWorktree,
+      isPendingSession: safeArguments.isPendingSession,
+      isSessionActive: safeArguments.isSessionActive,
+      sessionStatus: safeArguments.sessionStatus,
+      pullRequestState: .open,
+      ciStatus: safeArguments.ciStatus
+    ))
+    #expect(!WorktreeCleanupEligibility.shouldSuggestCleanup(
+      isWorktree: safeArguments.isWorktree,
+      isPendingSession: safeArguments.isPendingSession,
+      isSessionActive: safeArguments.isSessionActive,
+      sessionStatus: safeArguments.sessionStatus,
+      pullRequestState: safeArguments.pullRequestState,
+      ciStatus: .failure
+    ))
+    #expect(!WorktreeCleanupEligibility.shouldSuggestCleanup(
+      isWorktree: safeArguments.isWorktree,
+      isPendingSession: safeArguments.isPendingSession,
+      isSessionActive: safeArguments.isSessionActive,
+      sessionStatus: safeArguments.sessionStatus,
+      pullRequestState: safeArguments.pullRequestState,
+      ciStatus: .pending
+    ))
+  }
+}

--- a/app/modules/AgentHubGitHub/Sources/AgentHubGitHub/Models/GitHubModels.swift
+++ b/app/modules/AgentHubGitHub/Sources/AgentHubGitHub/Models/GitHubModels.swift
@@ -32,6 +32,15 @@ public enum GitHubPullRequestState: Equatable, Sendable {
     case .unknown(let value): value
     }
   }
+
+  public var isTerminal: Bool {
+    switch self {
+    case .closed, .merged:
+      true
+    case .open, .unknown:
+      false
+    }
+  }
 }
 
 public enum GitHubIssueState: Equatable, Sendable {
@@ -107,7 +116,10 @@ public enum GitHubCheckStatus: Equatable, Sendable {
   case completed
   case inProgress
   case queued
+  case requested
+  case waiting
   case pending
+  case expected
   case pass
   case fail
   case skipping
@@ -119,7 +131,10 @@ public enum GitHubCheckStatus: Equatable, Sendable {
     case "COMPLETED": self = .completed
     case "IN_PROGRESS": self = .inProgress
     case "QUEUED": self = .queued
+    case "REQUESTED": self = .requested
+    case "WAITING": self = .waiting
     case "PENDING": self = .pending
+    case "EXPECTED": self = .expected
     case "PASS": self = .pass
     case "FAIL": self = .fail
     case "SKIPPING": self = .skipping
@@ -136,7 +151,10 @@ public enum GitHubCheckStatus: Equatable, Sendable {
     case .completed: "Completed"
     case .inProgress: "In Progress"
     case .queued: "Queued"
+    case .requested: "Requested"
+    case .waiting: "Waiting"
     case .pending: "Pending"
+    case .expected: "Expected"
     case .pass: "Pass"
     case .fail: "Fail"
     case .skipping: "Skipping"
@@ -233,6 +251,7 @@ public struct GitHubPullRequest: Identifiable, Equatable, Sendable, Decodable {
   public let state: String
   public let url: String
   public let headRefName: String
+  public let headRefOid: String?
   public let baseRefName: String
   public let author: GitHubAuthor?
   public let createdAt: Date?
@@ -255,6 +274,7 @@ public struct GitHubPullRequest: Identifiable, Equatable, Sendable, Decodable {
     state: String,
     url: String,
     headRefName: String,
+    headRefOid: String? = nil,
     baseRefName: String,
     author: GitHubAuthor?,
     createdAt: Date?,
@@ -276,6 +296,7 @@ public struct GitHubPullRequest: Identifiable, Equatable, Sendable, Decodable {
     self.state = state
     self.url = url
     self.headRefName = headRefName
+    self.headRefOid = headRefOid
     self.baseRefName = baseRefName
     self.author = author
     self.createdAt = createdAt
@@ -333,13 +354,14 @@ public struct GitHubPullRequest: Identifiable, Equatable, Sendable, Decodable {
     guard let checks = statusCheckRollup, !checks.isEmpty else {
       return .none
     }
-    if checks.contains(where: { $0.ciStatus == .pending }) {
-      return .pending
-    }
     if checks.contains(where: { $0.ciStatus == .failure }) {
       return .failure
     }
-    if checks.allSatisfy({ $0.ciStatus == .success || $0.ciStatus == .none }) {
+    if checks.contains(where: { $0.ciStatus == .pending }) {
+      return .pending
+    }
+    if checks.contains(where: { $0.ciStatus == .success })
+        && checks.allSatisfy({ $0.ciStatus == .success || $0.ciStatus == .none }) {
       return .success
     }
     return .none
@@ -347,7 +369,7 @@ public struct GitHubPullRequest: Identifiable, Equatable, Sendable, Decodable {
 
   enum CodingKeys: String, CodingKey {
     case number, title, body, state, url
-    case headRefName, baseRefName
+    case headRefName, headRefOid, baseRefName
     case author, createdAt, updatedAt
     case isDraft, mergeable
     case additions, deletions, changedFiles
@@ -429,8 +451,13 @@ public struct GitHubCheckRun: Identifiable, Equatable, Sendable, Decodable {
   public let conclusion: String?
   public let bucket: String?
   public let detailsUrl: String?
+  public let workflowName: String?
+  public let startedAt: Date?
+  public let completedAt: Date?
 
-  public var id: String { name }
+  public var id: String {
+    [workflowName ?? "", name, detailsUrl ?? ""].joined(separator: "|")
+  }
 
   public init(from decoder: any Decoder) throws {
     let c = try decoder.container(keyedBy: CodingKeys.self)
@@ -447,10 +474,13 @@ public struct GitHubCheckRun: Identifiable, Equatable, Sendable, Decodable {
     // CheckRun uses `detailsUrl`; StatusContext uses `targetUrl`
     detailsUrl = try c.decodeIfPresent(String.self, forKey: .detailsUrl)
       ?? c.decodeIfPresent(String.self, forKey: .targetUrl)
+    workflowName = try c.decodeIfPresent(String.self, forKey: .workflowName)
+    startedAt = try c.decodeIfPresent(Date.self, forKey: .startedAt)
+    completedAt = try c.decodeIfPresent(Date.self, forKey: .completedAt)
   }
 
   private enum CodingKeys: String, CodingKey {
-    case name, status, conclusion, bucket, detailsUrl
+    case name, status, conclusion, bucket, detailsUrl, workflowName, startedAt, completedAt
     case context, state, targetUrl
   }
 
@@ -478,7 +508,8 @@ public struct GitHubCheckRun: Identifiable, Equatable, Sendable, Decodable {
 
     if let conclusionKind {
       switch conclusionKind {
-      case .success, .neutral, .skipped: return .success
+      case .success: return .success
+      case .neutral, .skipped: return .none
       case .failure, .error, .timedOut, .actionRequired, .cancelled, .startupFailure, .stale:
         return .failure
       case .unknown:
@@ -487,7 +518,7 @@ public struct GitHubCheckRun: Identifiable, Equatable, Sendable, Decodable {
     }
 
     switch statusKind {
-    case .inProgress, .queued, .pending: return .pending
+    case .inProgress, .queued, .requested, .waiting, .pending, .expected: return .pending
     case .pass: return .success
     case .fail, .cancel: return .failure
     case .skipping, .completed, .unknown: return .none
@@ -528,7 +559,7 @@ public struct GitHubCheckRun: Identifiable, Equatable, Sendable, Decodable {
     }
 
     switch statusKind {
-    case .inProgress, .queued, .pending: return "clock.fill"
+    case .inProgress, .queued, .requested, .waiting, .pending, .expected: return "clock.fill"
     case .pass: return "checkmark.circle.fill"
     case .fail, .cancel: return "xmark.circle.fill"
     case .skipping: return "minus.circle.fill"
@@ -541,13 +572,19 @@ public struct GitHubCheckRun: Identifiable, Equatable, Sendable, Decodable {
     status: String,
     conclusion: String? = nil,
     bucket: String? = nil,
-    detailsUrl: String? = nil
+    detailsUrl: String? = nil,
+    workflowName: String? = nil,
+    startedAt: Date? = nil,
+    completedAt: Date? = nil
   ) {
     self.name = name
     self.status = status
     self.conclusion = conclusion
     self.bucket = bucket
     self.detailsUrl = detailsUrl
+    self.workflowName = workflowName
+    self.startedAt = startedAt
+    self.completedAt = completedAt
   }
 }
 

--- a/app/modules/AgentHubGitHub/Sources/AgentHubGitHub/Models/GitHubPullRequestURLReference.swift
+++ b/app/modules/AgentHubGitHub/Sources/AgentHubGitHub/Models/GitHubPullRequestURLReference.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct GitHubPullRequestURLReference: Equatable, Sendable {
+public struct GitHubPullRequestURLReference: Equatable, Hashable, Sendable {
   public let owner: String
   public let repository: String
   public let number: Int
@@ -42,5 +42,17 @@ public struct GitHubPullRequestURLReference: Equatable, Sendable {
 
   public static func latestNumber(in urls: [String]) -> Int? {
     latest(in: urls)?.number
+  }
+
+  public func belongs(to identity: GitHubRepositoryIdentity) -> Bool {
+    owner.caseInsensitiveCompare(identity.owner) == .orderedSame
+      && repository.caseInsensitiveCompare(identity.repository) == .orderedSame
+  }
+
+  public static func latest(
+    matching identity: GitHubRepositoryIdentity,
+    in references: [GitHubPullRequestURLReference]
+  ) -> GitHubPullRequestURLReference? {
+    references.last { $0.belongs(to: identity) }
   }
 }

--- a/app/modules/AgentHubGitHub/Sources/AgentHubGitHub/Services/GitHubCLIService.swift
+++ b/app/modules/AgentHubGitHub/Sources/AgentHubGitHub/Services/GitHubCLIService.swift
@@ -44,7 +44,7 @@ public enum GitHubCLIError: LocalizedError, Sendable {
 public actor GitHubCLIService {
 
   private static let commandTimeout: TimeInterval = 30.0
-  static let checksJSONFields = "name,state,link,bucket"
+  static let checksJSONFields = "name,state,link,bucket,workflow,startedAt,completedAt"
   static let noPullRequestsFoundMessageFragment = "no pull requests found"
   static let noChecksReportedMessageFragment = "no checks reported"
 
@@ -154,7 +154,7 @@ public actor GitHubCLIService {
     authoredByMe: Bool = false,
     labels: [String] = []
   ) async throws -> [GitHubPullRequest] {
-    let fields = "number,title,body,state,url,headRefName,baseRefName,author,createdAt,updatedAt,isDraft,mergeable,additions,deletions,changedFiles,reviewDecision,statusCheckRollup,labels,reviewRequests"
+    let fields = "number,title,body,state,url,headRefName,headRefOid,baseRefName,author,createdAt,updatedAt,isDraft,mergeable,additions,deletions,changedFiles,reviewDecision,statusCheckRollup,labels,reviewRequests"
 
     let effectiveLimit = authoredByMe ? 200 : limit
     GitHubLogger.github.debug("[PR list] fetching state=\(state) limit=\(effectiveLimit) authoredByMe=\(authoredByMe) labels=\(labels) repoPath=\(repoPath)")
@@ -200,7 +200,7 @@ public actor GitHubCLIService {
     number: Int,
     at repoPath: String
   ) async throws -> GitHubPullRequest {
-    let fields = "number,title,body,state,url,headRefName,baseRefName,author,createdAt,updatedAt,isDraft,mergeable,additions,deletions,changedFiles,reviewDecision,statusCheckRollup,labels,reviewRequests,comments"
+    let fields = "number,title,body,state,url,headRefName,headRefOid,baseRefName,author,createdAt,updatedAt,isDraft,mergeable,additions,deletions,changedFiles,reviewDecision,statusCheckRollup,labels,reviewRequests"
 
     let json = try await runGH(
       ["pr", "view", "\(number)", "--json", fields],
@@ -211,12 +211,20 @@ public actor GitHubCLIService {
   }
 
   /// Gets the PR for the current branch (if any)
-  public func getCurrentBranchPR(at repoPath: String) async throws -> GitHubPullRequest? {
-    let fields = "number,title,body,state,url,headRefName,baseRefName,author,createdAt,updatedAt,isDraft,mergeable,additions,deletions,changedFiles,reviewDecision,statusCheckRollup,labels,reviewRequests,comments"
+  public func getCurrentBranchPR(
+    branchName: String?,
+    at repoPath: String
+  ) async throws -> GitHubPullRequest? {
+    let fields = "number,title,body,state,url,headRefName,headRefOid,baseRefName,author,createdAt,updatedAt,isDraft,mergeable,additions,deletions,changedFiles,reviewDecision,statusCheckRollup,labels,reviewRequests"
+    var arguments = ["pr", "view"]
+    if let branchName, !branchName.isEmpty {
+      arguments.append(branchName)
+    }
+    arguments.append(contentsOf: ["--json", fields])
 
     do {
       let json = try await runGH(
-        ["pr", "view", "--json", fields],
+        arguments,
         at: repoPath,
         quietFailureMessages: [Self.noPullRequestsFoundMessageFragment]
       )
@@ -703,16 +711,23 @@ public actor GitHubCLIService {
       let state: String
       let bucket: String?
       let link: String?
+      let workflow: String?
+      let startedAt: Date?
+      let completedAt: Date?
     }
 
     do {
+      decoder.dateDecodingStrategy = .iso8601
       let rawChecks = try decoder.decode([RawCheck].self, from: data)
       return rawChecks.map { raw in
         GitHubCheckRun(
           name: raw.name,
           status: raw.state,
           bucket: raw.bucket,
-          detailsUrl: raw.link
+          detailsUrl: raw.link,
+          workflowName: raw.workflow,
+          startedAt: raw.startedAt,
+          completedAt: raw.completedAt
         )
       }
     } catch {

--- a/app/modules/AgentHubGitHub/Sources/AgentHubGitHub/Services/GitHubCLIServiceProtocol.swift
+++ b/app/modules/AgentHubGitHub/Sources/AgentHubGitHub/Services/GitHubCLIServiceProtocol.swift
@@ -40,8 +40,8 @@ public protocol GitHubCLIServiceProtocol: AnyObject, Sendable {
   /// Gets details of a specific pull request
   func getPullRequest(number: Int, at repoPath: String) async throws -> GitHubPullRequest
 
-  /// Gets the PR for the current branch (if any)
-  func getCurrentBranchPR(at repoPath: String) async throws -> GitHubPullRequest?
+  /// Gets the PR for an explicit branch, or the checkout's current branch when nil.
+  func getCurrentBranchPR(branchName: String?, at repoPath: String) async throws -> GitHubPullRequest?
 
   /// Gets the unified diff for a pull request
   func getPullRequestDiff(number: Int, at repoPath: String) async throws -> String
@@ -85,4 +85,10 @@ public protocol GitHubCLIServiceProtocol: AnyObject, Sendable {
 
   /// Lists recent workflow runs
   func listWorkflowRuns(at repoPath: String, limit: Int) async throws -> String
+}
+
+public extension GitHubCLIServiceProtocol {
+  func getCurrentBranchPR(at repoPath: String) async throws -> GitHubPullRequest? {
+    try await getCurrentBranchPR(branchName: nil, at: repoPath)
+  }
 }

--- a/app/modules/AgentHubGitHub/Sources/AgentHubGitHub/Services/GitHubPRObservationService.swift
+++ b/app/modules/AgentHubGitHub/Sources/AgentHubGitHub/Services/GitHubPRObservationService.swift
@@ -2,38 +2,56 @@
 //  GitHubPRObservationService.swift
 //  AgentHub
 //
-//  Shared PR/check observation for GitHub surfaces.
+//  Shared, performance-bounded PR/check observation for GitHub surfaces.
 //
 
 import Foundation
 
 public enum GitHubPRObservationTarget: Hashable, Sendable {
-  case currentBranch(projectPath: String, branchName: String?)
+  case session(
+    projectPath: String,
+    branchName: String?,
+    linkedPullRequests: [GitHubPullRequestURLReference]
+  )
   case pullRequest(projectPath: String, number: Int)
 
   public var projectPath: String {
     switch self {
-    case .currentBranch(let projectPath, _), .pullRequest(let projectPath, _):
-      return projectPath
+    case .session(let projectPath, _, _), .pullRequest(let projectPath, _):
+      projectPath
     }
   }
 
   public var pullRequestNumber: Int? {
     switch self {
-    case .currentBranch:
-      return nil
+    case .session:
+      nil
     case .pullRequest(_, let number):
-      return number
+      number
     }
   }
 
   var key: String {
     switch self {
-    case .currentBranch(let projectPath, let branchName):
-      return "current|\(projectPath)|\(branchName ?? "")"
+    case .session(let projectPath, let branchName, let linkedPullRequests):
+      let links = linkedPullRequests
+        .map { "\($0.owner.lowercased())/\($0.repository.lowercased())#\($0.number)" }
+        .joined(separator: ",")
+      return "session|\(projectPath)|\(branchName ?? "")|\(links)"
     case .pullRequest(let projectPath, let number):
       return "pr|\(projectPath)|\(number)"
     }
+  }
+
+  public static func currentBranch(
+    projectPath: String,
+    branchName: String?
+  ) -> GitHubPRObservationTarget {
+    .session(
+      projectPath: projectPath,
+      branchName: branchName,
+      linkedPullRequests: []
+    )
   }
 }
 
@@ -47,6 +65,47 @@ public enum GitHubPRObservationState: Equatable, Sendable {
   public var isRefreshing: Bool {
     if case .refreshing = self { return true }
     return false
+  }
+
+  public var isUnavailable: Bool {
+    switch self {
+    case .error, .paused:
+      true
+    case .idle, .refreshing, .ready:
+      false
+    }
+  }
+}
+
+public enum GitHubPRBlocker: Int, CaseIterable, Hashable, Sendable {
+  case ciFailure
+  case changesRequested
+  case mergeConflict
+
+  public var displayName: String {
+    switch self {
+    case .ciFailure: "CI failing"
+    case .changesRequested: "Changes requested"
+    case .mergeConflict: "Merge conflict"
+    }
+  }
+
+  public static func blockers(
+    for pullRequest: GitHubPullRequest?,
+    ciSummary: GitHubCISummary
+  ) -> Set<GitHubPRBlocker> {
+    guard let pullRequest, pullRequest.stateKind == .open else { return [] }
+    var blockers: Set<GitHubPRBlocker> = []
+    if ciSummary.failed > 0 {
+      blockers.insert(.ciFailure)
+    }
+    if pullRequest.reviewDecisionKind == .changesRequested {
+      blockers.insert(.changesRequested)
+    }
+    if pullRequest.mergeabilityKind == .conflicting {
+      blockers.insert(.mergeConflict)
+    }
+    return blockers
   }
 }
 
@@ -96,7 +155,9 @@ public struct GitHubPRObservationSnapshot: Equatable, Sendable {
   public let pullRequest: GitHubPullRequest?
   public let checks: [GitHubCheckRun]
   public let ciSummary: GitHubCISummary
+  public let blockers: Set<GitHubPRBlocker>
   public let state: GitHubPRObservationState
+  /// The last time PR metadata and CI checks were both fetched successfully.
   public let lastRefreshedAt: Date?
 
   public init(
@@ -106,12 +167,18 @@ public struct GitHubPRObservationSnapshot: Equatable, Sendable {
     state: GitHubPRObservationState,
     lastRefreshedAt: Date?
   ) {
+    let ciSummary = GitHubCISummary(checks: checks)
     self.target = target
     self.pullRequest = pullRequest
     self.checks = checks
-    self.ciSummary = GitHubCISummary(checks: checks)
+    self.ciSummary = ciSummary
+    self.blockers = GitHubPRBlocker.blockers(for: pullRequest, ciSummary: ciSummary)
     self.state = state
     self.lastRefreshedAt = lastRefreshedAt
+  }
+
+  public var isStale: Bool {
+    state.isUnavailable && lastRefreshedAt != nil
   }
 
   public static func initial(target: GitHubPRObservationTarget) -> GitHubPRObservationSnapshot {
@@ -123,6 +190,7 @@ public struct GitHubPRObservationSnapshot: Equatable, Sendable {
       lastRefreshedAt: nil
     )
   }
+
 }
 
 public struct GitHubPRObservationSubscription: Sendable {
@@ -141,6 +209,7 @@ public protocol GitHubPRObservationServiceProtocol: AnyObject, Sendable {
     refreshOnSubscribe: Bool
   ) async -> GitHubPRObservationSubscription
   func unsubscribe(subscriptionID: UUID) async
+  /// Performs or joins a refresh and returns only after that refresh completes.
   func refresh(_ target: GitHubPRObservationTarget) async
   func recordActivity(for target: GitHubPRObservationTarget, at: Date) async
 }
@@ -153,20 +222,77 @@ public extension GitHubPRObservationServiceProtocol {
 
 public struct GitHubPRObservationConfiguration: Sendable {
   public var pendingPollInterval: TimeInterval
+  public var idlePendingPollInterval: TimeInterval
   public var settledPollInterval: TimeInterval
   public var idleTimeout: TimeInterval
+  public var checksDiscoveryWindow: TimeInterval
+  public var pendingObservationLimit: TimeInterval
+  public var inactiveEntryRetention: TimeInterval
+  public var maximumConcurrentRefreshes: Int
   public var errorBackoff: [TimeInterval]
 
   public init(
     pendingPollInterval: TimeInterval = 30,
+    idlePendingPollInterval: TimeInterval = 120,
     settledPollInterval: TimeInterval = 120,
     idleTimeout: TimeInterval = 5 * 60,
+    checksDiscoveryWindow: TimeInterval = 10 * 60,
+    pendingObservationLimit: TimeInterval = 60 * 60,
+    inactiveEntryRetention: TimeInterval = 15 * 60,
+    maximumConcurrentRefreshes: Int = 2,
     errorBackoff: [TimeInterval] = [60, 120, 300]
   ) {
     self.pendingPollInterval = pendingPollInterval
+    self.idlePendingPollInterval = idlePendingPollInterval
     self.settledPollInterval = settledPollInterval
     self.idleTimeout = idleTimeout
+    self.checksDiscoveryWindow = checksDiscoveryWindow
+    self.pendingObservationLimit = pendingObservationLimit
+    self.inactiveEntryRetention = inactiveEntryRetention
+    self.maximumConcurrentRefreshes = max(1, maximumConcurrentRefreshes)
     self.errorBackoff = errorBackoff
+  }
+}
+
+private enum GitHubObservationRefreshPriority: Sendable {
+  case automatic
+  case manual
+}
+
+private actor GitHubObservationRefreshLimiter {
+  private let limit: Int
+  private var activeCount = 0
+  private var manualWaiters: [CheckedContinuation<Void, Never>] = []
+  private var automaticWaiters: [CheckedContinuation<Void, Never>] = []
+
+  init(limit: Int) {
+    self.limit = max(1, limit)
+  }
+
+  func acquire(priority: GitHubObservationRefreshPriority) async {
+    if activeCount < limit {
+      activeCount += 1
+      return
+    }
+
+    await withCheckedContinuation { continuation in
+      switch priority {
+      case .automatic:
+        automaticWaiters.append(continuation)
+      case .manual:
+        manualWaiters.append(continuation)
+      }
+    }
+  }
+
+  func release() {
+    if !manualWaiters.isEmpty {
+      manualWaiters.removeFirst().resume()
+    } else if !automaticWaiters.isEmpty {
+      automaticWaiters.removeFirst().resume()
+    } else {
+      activeCount = max(0, activeCount - 1)
+    }
   }
 }
 
@@ -175,31 +301,51 @@ public actor GitHubPRObservationService: GitHubPRObservationServiceProtocol {
     let target: GitHubPRObservationTarget
     var snapshot: GitHubPRObservationSnapshot
     var lastActivityAt: Date?
+    var lastUsedAt = Date.now
+    var checksDiscoveryDeadline: Date?
+    var pendingObservationDeadline: Date?
+    var observedHeadOID: String?
     var consecutiveErrorCount = 0
     var isTerminallyPaused = false
     var isRefreshing = false
     var pendingPostRefreshEvaluation = false
     var scheduledRefreshTask: Task<Void, Never>?
+    var refreshWaiters: [CheckedContinuation<Void, Never>] = []
     var subscribers: [UUID: AsyncStream<GitHubPRObservationSnapshot>.Continuation] = [:]
   }
 
+  private enum RefreshResult {
+    case success(GitHubPRObservationSnapshot)
+    case degraded(GitHubPRObservationSnapshot, Error)
+    case failure(Error)
+  }
+
   private let service: any GitHubCLIServiceProtocol
+  private let repositoryIdentityResolver: any GitHubRepositoryIdentityResolverProtocol
   private let configuration: GitHubPRObservationConfiguration
+  private let refreshLimiter: GitHubObservationRefreshLimiter
   private var entries: [String: Entry] = [:]
   private var subscriptionKeys: [UUID: String] = [:]
 
   public init(
     service: any GitHubCLIServiceProtocol = GitHubCLIService(),
+    repositoryIdentityResolver: any GitHubRepositoryIdentityResolverProtocol = GitHubRepositoryIdentityResolver(),
     configuration: GitHubPRObservationConfiguration = GitHubPRObservationConfiguration()
   ) {
     self.service = service
+    self.repositoryIdentityResolver = repositoryIdentityResolver
     self.configuration = configuration
+    self.refreshLimiter = GitHubObservationRefreshLimiter(
+      limit: configuration.maximumConcurrentRefreshes
+    )
   }
 
   public func subscribe(
     to target: GitHubPRObservationTarget,
     refreshOnSubscribe: Bool = true
   ) async -> GitHubPRObservationSubscription {
+    pruneInactiveEntries(now: .now)
+
     let subscriptionID = UUID()
     var continuation: AsyncStream<GitHubPRObservationSnapshot>.Continuation?
     let updates = AsyncStream<GitHubPRObservationSnapshot> { streamContinuation in
@@ -219,9 +365,7 @@ public actor GitHubPRObservationService: GitHubPRObservationServiceProtocol {
     let key = target.key
     var entry = entries[key] ?? Entry(target: target, snapshot: .initial(target: target))
     entry.subscribers[subscriptionID] = continuation
-    if !entry.isTerminallyPaused || entry.consecutiveErrorCount == 0 {
-      entry.isTerminallyPaused = false
-    }
+    entry.lastUsedAt = .now
     entries[key] = entry
     subscriptionKeys[subscriptionID] = key
 
@@ -240,6 +384,7 @@ public actor GitHubPRObservationService: GitHubPRObservationServiceProtocol {
     }
 
     entry.subscribers.removeValue(forKey: subscriptionID)?.finish()
+    entry.lastUsedAt = .now
     if entry.subscribers.isEmpty {
       entry.scheduledRefreshTask?.cancel()
       entry.scheduledRefreshTask = nil
@@ -248,23 +393,55 @@ public actor GitHubPRObservationService: GitHubPRObservationServiceProtocol {
   }
 
   public func refresh(_ target: GitHubPRObservationTarget) async {
+    pruneInactiveEntries(now: .now)
+
     let key = target.key
-    if entries[key] == nil {
-      entries[key] = Entry(target: target, snapshot: .initial(target: target))
+    var entry = entries[key] ?? Entry(target: target, snapshot: .initial(target: target))
+    entry.lastUsedAt = .now
+    entry.isTerminallyPaused = false
+    entry.scheduledRefreshTask?.cancel()
+    entry.scheduledRefreshTask = nil
+    entries[key] = entry
+
+    if entry.isRefreshing {
+      await waitForRefresh(for: key)
+      return
     }
-    scheduleRefreshIfNeeded(for: key, forceImmediate: true)
+
+    await executeRefresh(
+      for: key,
+      allowsWithoutSubscribers: true,
+      priority: .manual
+    )
   }
 
   public func recordActivity(for target: GitHubPRObservationTarget, at date: Date) async {
+    pruneInactiveEntries(now: .now)
+
     let key = target.key
     guard var entry = entries[key] else { return }
 
     if let previousActivity = entry.lastActivityAt, previousActivity >= date {
-      entries[key] = entry
       return
     }
 
     entry.lastActivityAt = date
+    entry.lastUsedAt = .now
+    if entry.snapshot.pullRequest?.stateKind.isTerminal == true {
+      entry.pendingObservationDeadline = nil
+      entry.checksDiscoveryDeadline = nil
+      entries[key] = entry
+      return
+    }
+
+    if entry.snapshot.ciSummary.pending == 0,
+       entry.snapshot.pullRequest == nil || entry.snapshot.checks.isEmpty {
+      entry.checksDiscoveryDeadline = maxDate(
+        entry.checksDiscoveryDeadline,
+        date.addingTimeInterval(configuration.checksDiscoveryWindow)
+      )
+    }
+
     guard !entry.subscribers.isEmpty else {
       entries[key] = entry
       return
@@ -275,15 +452,14 @@ public actor GitHubPRObservationService: GitHubPRObservationServiceProtocol {
     }
 
     let shouldReactivate = entry.isTerminallyPaused
+    entry.isTerminallyPaused = false
     if entry.isRefreshing {
       entry.pendingPostRefreshEvaluation = true
       entries[key] = entry
       return
     }
 
-    entry.isTerminallyPaused = false
     entries[key] = entry
-
     scheduleRefreshIfNeeded(
       for: key,
       forceImmediate: shouldReactivate || needsImmediateRefresh(entry, now: date)
@@ -294,6 +470,7 @@ public actor GitHubPRObservationService: GitHubPRObservationServiceProtocol {
 
   private func scheduleRefreshIfNeeded(for key: String, forceImmediate: Bool) {
     guard var entry = entries[key], !entry.subscribers.isEmpty else { return }
+    guard entry.snapshot.pullRequest?.stateKind.isTerminal != true else { return }
 
     if entry.isRefreshing {
       entry.pendingPostRefreshEvaluation = true
@@ -302,7 +479,6 @@ public actor GitHubPRObservationService: GitHubPRObservationServiceProtocol {
     }
 
     if !forceImmediate, entry.scheduledRefreshTask != nil {
-      entries[key] = entry
       return
     }
 
@@ -313,7 +489,6 @@ public actor GitHubPRObservationService: GitHubPRObservationServiceProtocol {
     } else if canAutoRefresh(entry, now: now) {
       interval = remainingRefreshInterval(for: entry, now: now)
     } else {
-      entries[key] = entry
       return
     }
 
@@ -330,25 +505,33 @@ public actor GitHubPRObservationService: GitHubPRObservationServiceProtocol {
 
   private func executeScheduledRefresh(for key: String) async {
     guard var entry = entries[key] else { return }
+    entry.scheduledRefreshTask = nil
+    entries[key] = entry
 
-    guard !entry.subscribers.isEmpty else {
-      entry.scheduledRefreshTask = nil
-      entry.isRefreshing = false
-      entry.pendingPostRefreshEvaluation = false
-      entries[key] = entry
-      return
-    }
+    guard canAutoRefresh(entry, now: .now) else { return }
+    await executeRefresh(
+      for: key,
+      allowsWithoutSubscribers: false,
+      priority: .automatic
+    )
+  }
 
-    if entry.snapshot.lastRefreshedAt != nil, !canAutoRefresh(entry, now: .now) {
-      entry.scheduledRefreshTask = nil
-      entry.isRefreshing = false
-      entry.pendingPostRefreshEvaluation = false
+  private func executeRefresh(
+    for key: String,
+    allowsWithoutSubscribers: Bool,
+    priority: GitHubObservationRefreshPriority
+  ) async {
+    guard var entry = entries[key] else { return }
+    guard allowsWithoutSubscribers || !entry.subscribers.isEmpty else { return }
+
+    if entry.isRefreshing {
+      entry.pendingPostRefreshEvaluation = true
       entries[key] = entry
       return
     }
 
     entry.isRefreshing = true
-    entry.scheduledRefreshTask = nil
+    entry.lastUsedAt = .now
     entry.snapshot = GitHubPRObservationSnapshot(
       target: entry.target,
       pullRequest: entry.snapshot.pullRequest,
@@ -356,70 +539,112 @@ public actor GitHubPRObservationService: GitHubPRObservationServiceProtocol {
       state: .refreshing,
       lastRefreshedAt: entry.snapshot.lastRefreshedAt
     )
+    let target = entry.target
+    let previousSnapshot = entry.snapshot
     entries[key] = entry
     broadcast(entry.snapshot, for: key)
 
-    let refreshResult = await refreshSnapshot(for: entry.target)
+    await refreshLimiter.acquire(priority: priority)
 
-    guard var refreshedEntry = entries[key] else { return }
-    refreshedEntry.isRefreshing = false
-    refreshedEntry.scheduledRefreshTask = nil
-    let hadCoalescedActivity = refreshedEntry.pendingPostRefreshEvaluation
-    refreshedEntry.pendingPostRefreshEvaluation = false
-
-    guard !Task.isCancelled, !refreshedEntry.subscribers.isEmpty else {
-      entries[key] = refreshedEntry
+    guard let permittedEntry = entries[key],
+          allowsWithoutSubscribers || !permittedEntry.subscribers.isEmpty else {
+      await refreshLimiter.release()
+      finishRefreshWithoutResult(for: key)
       return
     }
 
-    switch refreshResult {
-    case .success(let snapshot):
-      refreshedEntry.snapshot = snapshot
-      refreshedEntry.consecutiveErrorCount = 0
-      refreshedEntry.isTerminallyPaused = false
-      entries[key] = refreshedEntry
-      broadcast(snapshot, for: key)
+    let refreshResult = await refreshSnapshot(
+      for: target,
+      previousSnapshot: previousSnapshot
+    )
+    await refreshLimiter.release()
+    apply(refreshResult, for: key)
+  }
 
-      if canAutoRefresh(refreshedEntry, now: .now) {
-        scheduleRefreshIfNeeded(for: key, forceImmediate: false)
-      }
+  private func apply(_ result: RefreshResult, for key: String) {
+    guard var entry = entries[key] else { return }
+    entry.isRefreshing = false
+    entry.scheduledRefreshTask = nil
+    entry.lastUsedAt = .now
+    let hadCoalescedActivity = entry.pendingPostRefreshEvaluation
+    entry.pendingPostRefreshEvaluation = false
+
+    switch result {
+    case .success(let snapshot):
+      entry.snapshot = snapshot
+      entry.consecutiveErrorCount = 0
+      entry.isTerminallyPaused = false
+      updateObservationWindows(for: &entry, snapshot: snapshot, now: .now)
+
+    case .degraded(let snapshot, let error):
+      entry.snapshot = snapshot
+      apply(error: error, to: &entry)
 
     case .failure(let error):
-      let message = error.localizedDescription
-      if isTerminal(error) {
-        refreshedEntry.isTerminallyPaused = true
-        refreshedEntry.consecutiveErrorCount = 0
-        refreshedEntry.snapshot = GitHubPRObservationSnapshot(
-          target: refreshedEntry.target,
-          pullRequest: refreshedEntry.snapshot.pullRequest,
-          checks: refreshedEntry.snapshot.checks,
-          state: .paused(message),
-          lastRefreshedAt: refreshedEntry.snapshot.lastRefreshedAt
-        )
-        entries[key] = refreshedEntry
-        broadcast(refreshedEntry.snapshot, for: key)
-        return
-      }
-
-      refreshedEntry.consecutiveErrorCount += 1
-      refreshedEntry.isTerminallyPaused = false
-      refreshedEntry.snapshot = GitHubPRObservationSnapshot(
-        target: refreshedEntry.target,
-        pullRequest: refreshedEntry.snapshot.pullRequest,
-        checks: refreshedEntry.snapshot.checks,
-        state: .error(message),
-        lastRefreshedAt: refreshedEntry.snapshot.lastRefreshedAt
+      let state: GitHubPRObservationState = isTerminal(error)
+        ? .paused(error.localizedDescription)
+        : .error(error.localizedDescription)
+      entry.snapshot = GitHubPRObservationSnapshot(
+        target: entry.target,
+        pullRequest: entry.snapshot.pullRequest,
+        checks: entry.snapshot.checks,
+        state: state,
+        lastRefreshedAt: entry.snapshot.lastRefreshedAt
       )
-      entries[key] = refreshedEntry
-      broadcast(refreshedEntry.snapshot, for: key)
+      apply(error: error, to: &entry)
+    }
 
-      if canAutoRefresh(refreshedEntry, now: .now) {
-        scheduleBackoffRefresh(for: key, errorCount: refreshedEntry.consecutiveErrorCount)
+    let snapshot = entry.snapshot
+    let waiters = entry.refreshWaiters
+    entry.refreshWaiters.removeAll()
+    entries[key] = entry
+    broadcast(snapshot, for: key)
+    waiters.forEach { $0.resume() }
+
+    guard !entry.subscribers.isEmpty else { return }
+
+    if entry.isTerminallyPaused {
+      return
+    } else if entry.consecutiveErrorCount > 0 {
+      if canAutoRefresh(entry, now: .now) {
+        scheduleBackoffRefresh(for: key, errorCount: entry.consecutiveErrorCount)
       }
+    } else if canAutoRefresh(entry, now: .now) {
+      scheduleRefreshIfNeeded(for: key, forceImmediate: false)
     }
 
     if hadCoalescedActivity {
       scheduleRefreshIfNeeded(for: key, forceImmediate: false)
+    }
+  }
+
+  private func apply(error: Error, to entry: inout Entry) {
+    if isTerminal(error) {
+      entry.isTerminallyPaused = true
+      entry.consecutiveErrorCount = 0
+    } else {
+      entry.isTerminallyPaused = false
+      entry.consecutiveErrorCount += 1
+    }
+  }
+
+  private func finishRefreshWithoutResult(for key: String) {
+    guard var entry = entries[key] else { return }
+    entry.isRefreshing = false
+    let waiters = entry.refreshWaiters
+    entry.refreshWaiters.removeAll()
+    entries[key] = entry
+    waiters.forEach { $0.resume() }
+  }
+
+  private func waitForRefresh(for key: String) async {
+    await withCheckedContinuation { continuation in
+      guard var entry = entries[key], entry.isRefreshing else {
+        continuation.resume()
+        return
+      }
+      entry.refreshWaiters.append(continuation)
+      entries[key] = entry
     }
   }
 
@@ -451,80 +676,166 @@ public actor GitHubPRObservationService: GitHubPRObservationServiceProtocol {
   // MARK: - Fetching
 
   private func refreshSnapshot(
-    for target: GitHubPRObservationTarget
-  ) async -> Result<GitHubPRObservationSnapshot, Error> {
+    for target: GitHubPRObservationTarget,
+    previousSnapshot: GitHubPRObservationSnapshot
+  ) async -> RefreshResult {
     do {
+      let pullRequest: GitHubPullRequest?
       switch target {
-      case .currentBranch(let projectPath, _):
-        guard let pullRequest = try await service.getCurrentBranchPR(at: projectPath) else {
-          return .success(GitHubPRObservationSnapshot(
-            target: target,
-            pullRequest: nil,
-            checks: [],
-            state: .ready,
-            lastRefreshedAt: .now
-          ))
+      case .session(let projectPath, let branchName, let linkedPullRequests):
+        let identity = await repositoryIdentityResolver.resolveIdentity(at: projectPath)
+        if let identity,
+           let linkedPullRequest = GitHubPullRequestURLReference.latest(
+             matching: identity,
+             in: linkedPullRequests
+           ) {
+          pullRequest = try await service.getPullRequest(
+            number: linkedPullRequest.number,
+            at: projectPath
+          )
+        } else {
+          pullRequest = try await service.getCurrentBranchPR(
+            branchName: branchName,
+            at: projectPath
+          )
         }
-        let checksResult = await fetchChecks(prNumber: pullRequest.number, at: projectPath)
+
+      case .pullRequest(let projectPath, let number):
+        pullRequest = try await service.getPullRequest(number: number, at: projectPath)
+      }
+
+      guard let pullRequest else {
+        return .success(GitHubPRObservationSnapshot(
+          target: target,
+          pullRequest: nil,
+          checks: [],
+          state: .ready,
+          lastRefreshedAt: .now
+        ))
+      }
+
+      if let checks = pullRequest.statusCheckRollup {
         return .success(GitHubPRObservationSnapshot(
           target: target,
           pullRequest: pullRequest,
-          checks: checksResult.checks,
-          state: checksResult.state,
+          checks: checks,
+          state: .ready,
           lastRefreshedAt: .now
         ))
+      }
 
-      case .pullRequest(let projectPath, let number):
-        let resolvedPullRequest = try await service.getPullRequest(number: number, at: projectPath)
-        let checksResult = await fetchChecks(prNumber: number, at: projectPath)
-        let snapshot = GitHubPRObservationSnapshot(
-          target: target,
-          pullRequest: resolvedPullRequest,
-          checks: checksResult.checks,
-          state: checksResult.state,
-          lastRefreshedAt: .now
+      do {
+        let checks = try await service.getChecks(
+          prNumber: pullRequest.number,
+          at: target.projectPath
         )
-        return .success(snapshot)
+        return .success(GitHubPRObservationSnapshot(
+          target: target,
+          pullRequest: pullRequest,
+          checks: checks,
+          state: .ready,
+          lastRefreshedAt: .now
+        ))
+      } catch {
+        let isSameHead = previousSnapshot.pullRequest?.headRefOid == pullRequest.headRefOid
+          && pullRequest.headRefOid != nil
+        return .degraded(GitHubPRObservationSnapshot(
+          target: target,
+          pullRequest: pullRequest,
+          checks: isSameHead ? previousSnapshot.checks : [],
+          state: isTerminal(error)
+            ? .paused(error.localizedDescription)
+            : .error(error.localizedDescription),
+          lastRefreshedAt: isSameHead ? previousSnapshot.lastRefreshedAt : nil
+        ), error)
       }
     } catch {
       return .failure(error)
     }
   }
 
-  private func fetchChecks(
-    prNumber: Int,
-    at projectPath: String
-  ) async -> (checks: [GitHubCheckRun], state: GitHubPRObservationState) {
-    do {
-      let checks = try await service.getChecks(prNumber: prNumber, at: projectPath)
-      return (checks, .ready)
-    } catch {
-      return ([], .error(error.localizedDescription))
+  // MARK: - Helpers
+
+  private func updateObservationWindows(
+    for entry: inout Entry,
+    snapshot: GitHubPRObservationSnapshot,
+    now: Date
+  ) {
+    if snapshot.pullRequest?.stateKind.isTerminal == true {
+      entry.observedHeadOID = snapshot.pullRequest?.headRefOid
+      entry.pendingObservationDeadline = nil
+      entry.checksDiscoveryDeadline = nil
+      return
+    }
+
+    let headOID = snapshot.pullRequest?.headRefOid
+    let isNewHead = headOID != entry.observedHeadOID
+    entry.observedHeadOID = headOID
+
+    if snapshot.ciSummary.pending > 0 {
+      if isNewHead || entry.pendingObservationDeadline == nil {
+        entry.pendingObservationDeadline = now.addingTimeInterval(
+          configuration.pendingObservationLimit
+        )
+      }
+      entry.checksDiscoveryDeadline = nil
+    } else if snapshot.pullRequest == nil || snapshot.checks.isEmpty {
+      entry.pendingObservationDeadline = nil
+      if isNewHead || entry.checksDiscoveryDeadline == nil {
+        entry.checksDiscoveryDeadline = now.addingTimeInterval(
+          configuration.checksDiscoveryWindow
+        )
+      }
+    } else {
+      entry.pendingObservationDeadline = nil
+      entry.checksDiscoveryDeadline = nil
     }
   }
 
-  // MARK: - Helpers
-
   private func canAutoRefresh(_ entry: Entry, now: Date) -> Bool {
     guard !entry.isTerminallyPaused, !entry.subscribers.isEmpty else { return false }
-    guard let lastActivityAt = entry.lastActivityAt else { return entry.snapshot.lastRefreshedAt == nil }
+    guard entry.snapshot.pullRequest?.stateKind.isTerminal != true else { return false }
+
+    if entry.snapshot.ciSummary.pending > 0 {
+      return entry.pendingObservationDeadline.map { now <= $0 } ?? false
+    }
+
+    if (entry.snapshot.pullRequest == nil || entry.snapshot.checks.isEmpty),
+       let deadline = entry.checksDiscoveryDeadline {
+      return now <= deadline
+    }
+
+    guard let lastActivityAt = entry.lastActivityAt else {
+      return entry.snapshot.lastRefreshedAt == nil
+    }
     return now.timeIntervalSince(lastActivityAt) <= configuration.idleTimeout
   }
 
   private func needsImmediateRefresh(_ entry: Entry, now: Date) -> Bool {
+    guard entry.snapshot.pullRequest?.stateKind.isTerminal != true else { return false }
     guard let lastRefreshedAt = entry.snapshot.lastRefreshedAt else { return true }
-    return now.timeIntervalSince(lastRefreshedAt) >= pollingInterval(for: entry.snapshot)
+    return now.timeIntervalSince(lastRefreshedAt) >= pollingInterval(for: entry, now: now)
   }
 
   private func remainingRefreshInterval(for entry: Entry, now: Date) -> TimeInterval {
     guard let lastRefreshedAt = entry.snapshot.lastRefreshedAt else { return 0 }
-    return max(0, pollingInterval(for: entry.snapshot) - now.timeIntervalSince(lastRefreshedAt))
+    return max(
+      0,
+      pollingInterval(for: entry, now: now) - now.timeIntervalSince(lastRefreshedAt)
+    )
   }
 
-  private func pollingInterval(for snapshot: GitHubPRObservationSnapshot) -> TimeInterval {
-    if snapshot.pullRequest == nil || snapshot.ciSummary.pending > 0 {
-      return configuration.pendingPollInterval
+  private func pollingInterval(for entry: Entry, now: Date) -> TimeInterval {
+    let isRecentlyActive = entry.lastActivityAt.map {
+      now.timeIntervalSince($0) <= configuration.idleTimeout
+    } ?? false
+
+    if entry.snapshot.ciSummary.pending > 0 || entry.snapshot.checks.isEmpty {
+      return isRecentlyActive
+        ? configuration.pendingPollInterval
+        : configuration.idlePendingPollInterval
     }
+
     return configuration.settledPollInterval
   }
 
@@ -537,6 +848,26 @@ public actor GitHubPRObservationService: GitHubPRObservationServiceProtocol {
     case .commandFailed, .parseError, .timeout:
       return false
     }
+  }
+
+  private func pruneInactiveEntries(now: Date) {
+    let staleKeys = entries.compactMap { key, entry -> String? in
+      guard entry.subscribers.isEmpty,
+            !entry.isRefreshing,
+            now.timeIntervalSince(entry.lastUsedAt) >= configuration.inactiveEntryRetention else {
+        return nil
+      }
+      return key
+    }
+    for key in staleKeys {
+      entries[key]?.scheduledRefreshTask?.cancel()
+      entries.removeValue(forKey: key)
+    }
+  }
+
+  private func maxDate(_ lhs: Date?, _ rhs: Date) -> Date {
+    guard let lhs else { return rhs }
+    return max(lhs, rhs)
   }
 
   private static func duration(for interval: TimeInterval) -> Duration {

--- a/app/modules/AgentHubGitHub/Sources/AgentHubGitHub/Services/GitHubRepositoryIdentityResolver.swift
+++ b/app/modules/AgentHubGitHub/Sources/AgentHubGitHub/Services/GitHubRepositoryIdentityResolver.swift
@@ -1,0 +1,123 @@
+//
+//  GitHubRepositoryIdentityResolver.swift
+//  AgentHub
+//
+//  Resolves a local checkout to its GitHub owner/repository without network I/O.
+//
+
+import Foundation
+
+public struct GitHubRepositoryIdentity: Equatable, Hashable, Sendable {
+  public let owner: String
+  public let repository: String
+
+  public init(owner: String, repository: String) {
+    self.owner = owner
+    self.repository = repository
+  }
+
+  public init?(remoteURL: String) {
+    let trimmed = remoteURL.trimmingCharacters(in: .whitespacesAndNewlines)
+    let path: String
+
+    if let components = URLComponents(string: trimmed),
+              components.scheme != nil,
+              let host = components.host?.lowercased(),
+              host == "github.com" || host == "www.github.com" {
+      path = components.path
+    } else if let separator = trimmed.firstIndex(of: ":") {
+      let host = trimmed[..<separator]
+        .split(separator: "@", omittingEmptySubsequences: false)
+        .last?
+        .lowercased()
+      guard host == "github.com" || host == "www.github.com" else { return nil }
+      path = String(trimmed[trimmed.index(after: separator)...])
+    } else {
+      return nil
+    }
+
+    let parts = path
+      .split(separator: "/", omittingEmptySubsequences: true)
+      .map(String.init)
+    guard parts.count >= 2 else { return nil }
+
+    let repository = parts[1].hasSuffix(".git")
+      ? String(parts[1].dropLast(4))
+      : parts[1]
+    guard !parts[0].isEmpty, !repository.isEmpty else { return nil }
+
+    self.owner = parts[0]
+    self.repository = repository
+  }
+}
+
+public protocol GitHubRepositoryIdentityResolverProtocol: AnyObject, Sendable {
+  func resolveIdentity(at projectPath: String) async -> GitHubRepositoryIdentity?
+}
+
+public actor GitHubRepositoryIdentityResolver: GitHubRepositoryIdentityResolverProtocol {
+  private var cache: [String: GitHubRepositoryIdentity] = [:]
+  private var attemptedPaths: Set<String> = []
+
+  public init() {}
+
+  public func resolveIdentity(at projectPath: String) async -> GitHubRepositoryIdentity? {
+    let normalizedPath = URL(fileURLWithPath: projectPath).standardizedFileURL.path
+    if attemptedPaths.contains(normalizedPath) {
+      return cache[normalizedPath]
+    }
+
+    attemptedPaths.insert(normalizedPath)
+    var isDirectory: ObjCBool = false
+    guard FileManager.default.fileExists(atPath: normalizedPath, isDirectory: &isDirectory),
+          isDirectory.boolValue else {
+      return nil
+    }
+    guard let output = Self.gitRemoteOutput(at: normalizedPath) else { return nil }
+
+    let candidates = output
+      .split(whereSeparator: \.isNewline)
+      .compactMap(Self.remoteCandidate(from:))
+
+    let identity = candidates
+      .first(where: { $0.name == "origin" })?.identity
+      ?? candidates.first?.identity
+
+    if let identity {
+      cache[normalizedPath] = identity
+    }
+    return identity
+  }
+
+  private nonisolated static func gitRemoteOutput(at projectPath: String) -> String? {
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "/usr/bin/git")
+    process.arguments = ["-C", projectPath, "remote", "-v"]
+
+    let outputPipe = Pipe()
+    process.standardOutput = outputPipe
+    process.standardError = FileHandle.nullDevice
+
+    do {
+      try process.run()
+    } catch {
+      return nil
+    }
+
+    let data = outputPipe.fileHandleForReading.readDataToEndOfFile()
+    process.waitUntilExit()
+    guard process.terminationStatus == 0 else { return nil }
+    return String(data: data, encoding: .utf8)
+  }
+
+  private nonisolated static func remoteCandidate(
+    from line: Substring
+  ) -> (name: String, identity: GitHubRepositoryIdentity)? {
+    let fields = line.split(whereSeparator: \.isWhitespace)
+    guard fields.count >= 2,
+          let identity = GitHubRepositoryIdentity(remoteURL: String(fields[1])) else {
+      return nil
+    }
+    return (String(fields[0]), identity)
+  }
+}

--- a/app/modules/AgentHubGitHub/Sources/AgentHubGitHub/Services/SessionGitHubQuickAccessCoordinator.swift
+++ b/app/modules/AgentHubGitHub/Sources/AgentHubGitHub/Services/SessionGitHubQuickAccessCoordinator.swift
@@ -147,6 +147,11 @@ public actor SessionGitHubQuickAccessCoordinator: SessionGitHubQuickAccessCoordi
     }
 
     entry.lastActivityAt = at
+    if entry.currentBranchPR?.stateKind.isTerminal == true {
+      entries[repositoryKey] = entry
+      return
+    }
+
     guard !entry.subscribers.isEmpty else {
       entries[repositoryKey] = entry
       return
@@ -173,6 +178,7 @@ public actor SessionGitHubQuickAccessCoordinator: SessionGitHubQuickAccessCoordi
 
   private func scheduleRefreshIfNeeded(for repositoryKey: String, forceImmediate: Bool) {
     guard var entry = entries[repositoryKey], !entry.subscribers.isEmpty else { return }
+    guard entry.currentBranchPR?.stateKind.isTerminal != true else { return }
 
     if entry.isRefreshing {
       entry.pendingPostRefreshEvaluation = true
@@ -243,7 +249,10 @@ public actor SessionGitHubQuickAccessCoordinator: SessionGitHubQuickAccessCoordi
     entries[repositoryKey] = entry
     GitHubLogger.github.debug("[QuickAccess] refresh start key=\(repositoryKey, privacy: .public)")
 
-    let refreshResult = await refreshCurrentBranchPR(at: entry.projectPath)
+    let refreshResult = await refreshCurrentBranchPR(
+      branchName: entry.branchName,
+      at: entry.projectPath
+    )
 
     guard var refreshedEntry = entries[repositoryKey] else { return }
     refreshedEntry.isRefreshing = false
@@ -345,9 +354,15 @@ public actor SessionGitHubQuickAccessCoordinator: SessionGitHubQuickAccessCoordi
 
   // MARK: - Refresh Helpers
 
-  private func refreshCurrentBranchPR(at projectPath: String) async -> Result<GitHubPullRequest?, Error> {
+  private func refreshCurrentBranchPR(
+    branchName: String?,
+    at projectPath: String
+  ) async -> Result<GitHubPullRequest?, Error> {
     do {
-      return .success(try await service.getCurrentBranchPR(at: projectPath))
+      return .success(try await service.getCurrentBranchPR(
+        branchName: branchName,
+        at: projectPath
+      ))
     } catch {
       return .failure(error)
     }
@@ -355,11 +370,13 @@ public actor SessionGitHubQuickAccessCoordinator: SessionGitHubQuickAccessCoordi
 
   private func canAutoRefresh(_ entry: Entry, now: Date) -> Bool {
     guard !entry.isTerminallyPaused, !entry.subscribers.isEmpty else { return false }
+    guard entry.currentBranchPR?.stateKind.isTerminal != true else { return false }
     guard let lastActivityAt = entry.lastActivityAt else { return false }
     return now.timeIntervalSince(lastActivityAt) <= configuration.idleTimeout
   }
 
   private func needsImmediateRefresh(_ entry: Entry, now: Date) -> Bool {
+    guard entry.currentBranchPR?.stateKind.isTerminal != true else { return false }
     guard let lastRefreshAt = entry.lastRefreshAt else { return true }
     return now.timeIntervalSince(lastRefreshAt) >= pollingInterval(for: entry)
   }

--- a/app/modules/AgentHubGitHub/Sources/AgentHubGitHub/ViewModels/GitHubViewModel.swift
+++ b/app/modules/AgentHubGitHub/Sources/AgentHubGitHub/ViewModels/GitHubViewModel.swift
@@ -439,7 +439,10 @@ public final class GitHubViewModel {
     }
 
     do {
-      currentBranchPR = try await service.getCurrentBranchPR(at: repoPath)
+      currentBranchPR = try await service.getCurrentBranchPR(
+        branchName: currentBranchName,
+        at: repoPath
+      )
     } catch {
       GitHubLogger.github.info("No PR for current branch: \(error.localizedDescription)")
     }
@@ -696,9 +699,10 @@ public final class GitHubViewModel {
 
   private func startCurrentBranchObservationIfAvailable() async {
     guard let observationService, let repoPath = currentRepoPath else { return }
-    let target = GitHubPRObservationTarget.currentBranch(
+    let target = GitHubPRObservationTarget.session(
       projectPath: repoPath,
-      branchName: currentBranchName
+      branchName: currentBranchName,
+      linkedPullRequests: []
     )
     let subscription = await observationService.subscribe(to: target)
     currentBranchSubscriptionID = subscription.id
@@ -713,9 +717,10 @@ public final class GitHubViewModel {
 
   private func refreshCurrentBranchObservation() async {
     guard let observationService, let repoPath = currentRepoPath else { return }
-    let target = GitHubPRObservationTarget.currentBranch(
+    let target = GitHubPRObservationTarget.session(
       projectPath: repoPath,
-      branchName: currentBranchName
+      branchName: currentBranchName,
+      linkedPullRequests: []
     )
     await observationService.recordActivity(for: target, at: .now)
     await observationService.refresh(target)

--- a/app/modules/AgentHubGitHub/Sources/AgentHubGitHub/ViewModels/SessionGitHubQuickAccessViewModel.swift
+++ b/app/modules/AgentHubGitHub/Sources/AgentHubGitHub/ViewModels/SessionGitHubQuickAccessViewModel.swift
@@ -20,6 +20,14 @@ public final class SessionGitHubQuickAccessViewModel {
     GitHubCISummary(checks: currentBranchChecks)
   }
 
+  public var blockers: Set<GitHubPRBlocker> {
+    GitHubPRBlocker.blockers(for: currentBranchPR, ciSummary: ciSummary)
+  }
+
+  public var hasStaleObservation: Bool {
+    observationState.isUnavailable && lastRefreshedAt != nil
+  }
+
   private var coordinator: (any SessionGitHubQuickAccessCoordinatorProtocol)?
   private var observationService: (any GitHubPRObservationServiceProtocol)?
   private let service: any GitHubCLIServiceProtocol
@@ -44,7 +52,7 @@ public final class SessionGitHubQuickAccessViewModel {
   public func load(
     projectPath: String,
     branchName: String?,
-    linkedPullRequestNumber: Int? = nil,
+    linkedPullRequests: [GitHubPullRequestURLReference] = [],
     coordinator: (any SessionGitHubQuickAccessCoordinatorProtocol)? = nil,
     observationService: (any GitHubPRObservationServiceProtocol)? = nil,
     refreshOnSubscribe: Bool = true,
@@ -54,7 +62,7 @@ public final class SessionGitHubQuickAccessViewModel {
     let repositoryKey = Self.repositoryKey(
       projectPath: projectPath,
       branchName: branchName,
-      linkedPullRequestNumber: linkedPullRequestNumber
+      linkedPullRequests: linkedPullRequests
     )
     if let coordinator {
       self.coordinator = coordinator
@@ -80,7 +88,7 @@ public final class SessionGitHubQuickAccessViewModel {
       let target = observationTarget(
         projectPath: projectPath,
         branchName: branchName,
-        linkedPullRequestNumber: linkedPullRequestNumber
+        linkedPullRequests: linkedPullRequests
       )
       currentObservationTarget = target
       let subscription = await observationService.subscribe(to: target, refreshOnSubscribe: refreshOnSubscribe)
@@ -94,7 +102,7 @@ public final class SessionGitHubQuickAccessViewModel {
       if recordInitialActivity {
         await observationService.recordActivity(for: target, at: .now)
       }
-      if linkedPullRequestNumber != nil, forceRefreshLinkedPullRequest {
+      if !linkedPullRequests.isEmpty, forceRefreshLinkedPullRequest {
         await observationService.refresh(target)
       }
       return
@@ -114,10 +122,18 @@ public final class SessionGitHubQuickAccessViewModel {
 
     do {
       let pullRequest: GitHubPullRequest?
-      if let linkedPullRequestNumber {
-        pullRequest = try await service.getPullRequest(number: linkedPullRequestNumber, at: projectPath)
+      if let linkedPullRequest = linkedPullRequests.last {
+        let candidate = try await service.getPullRequest(
+          number: linkedPullRequest.number,
+          at: projectPath
+        )
+        let resolvedReference = GitHubPullRequestURLReference(urlString: candidate.url)
+        pullRequest = resolvedReference?.owner.caseInsensitiveCompare(linkedPullRequest.owner) == .orderedSame
+          && resolvedReference?.repository.caseInsensitiveCompare(linkedPullRequest.repository) == .orderedSame
+          ? candidate
+          : try await service.getCurrentBranchPR(branchName: branchName, at: projectPath)
       } else {
-        pullRequest = try await service.getCurrentBranchPR(at: projectPath)
+        pullRequest = try await service.getCurrentBranchPR(branchName: branchName, at: projectPath)
       }
       guard !Task.isCancelled, loadedRepositoryKey == repositoryKey else { return }
       currentBranchPR = pullRequest
@@ -139,9 +155,6 @@ public final class SessionGitHubQuickAccessViewModel {
         for: target,
         at: activityDate
       )
-      if target.pullRequestNumber != nil {
-        await observationService.refresh(target)
-      }
     } else if let coordinator {
       await coordinator.recordActivity(
         projectPath: projectPath,
@@ -226,22 +239,24 @@ public final class SessionGitHubQuickAccessViewModel {
   private nonisolated func observationTarget(
     projectPath: String,
     branchName: String?,
-    linkedPullRequestNumber: Int?
+    linkedPullRequests: [GitHubPullRequestURLReference]
   ) -> GitHubPRObservationTarget {
-    if let linkedPullRequestNumber {
-      return .pullRequest(projectPath: projectPath, number: linkedPullRequestNumber)
-    }
-    return .currentBranch(projectPath: projectPath, branchName: branchName)
+    .session(
+      projectPath: projectPath,
+      branchName: branchName,
+      linkedPullRequests: linkedPullRequests
+    )
   }
 
   public nonisolated static func repositoryKey(
     projectPath: String,
     branchName: String?,
-    linkedPullRequestNumber: Int? = nil
+    linkedPullRequests: [GitHubPullRequestURLReference] = []
   ) -> String {
-    if let linkedPullRequestNumber {
-      return "\(projectPath)|\(branchName ?? "")|pr:\(linkedPullRequestNumber)"
+    guard !linkedPullRequests.isEmpty else {
+      return "\(projectPath)|\(branchName ?? "")"
     }
-    return "\(projectPath)|\(branchName ?? "")"
+    let links = linkedPullRequests.map(\.url).joined(separator: ",")
+    return "\(projectPath)|\(branchName ?? "")|\(links)"
   }
 }

--- a/app/modules/AgentHubGitHub/Tests/AgentHubGitHubTests/GitHubCLIServiceTests.swift
+++ b/app/modules/AgentHubGitHub/Tests/AgentHubGitHubTests/GitHubCLIServiceTests.swift
@@ -36,6 +36,51 @@ struct GitHubCLIServiceParsingTests {
     #expect(checks[0].statusDisplayName == "Pending")
   }
 
+  @Test("maps unfinished and non-failing terminal check states accurately")
+  func mapsExpandedCheckStates() {
+    #expect(GitHubCheckRun(name: "Waiting", status: "WAITING").ciStatus == .pending)
+    #expect(GitHubCheckRun(name: "Requested", status: "REQUESTED").ciStatus == .pending)
+    #expect(GitHubCheckRun(name: "Expected", status: "EXPECTED").ciStatus == .pending)
+    #expect(GitHubCheckRun(
+      name: "Neutral",
+      status: "COMPLETED",
+      conclusion: "NEUTRAL"
+    ).ciStatus == .none)
+    #expect(GitHubCheckRun(
+      name: "Skipped",
+      status: "COMPLETED",
+      conclusion: "SKIPPED"
+    ).ciStatus == .none)
+    #expect(GitHubCheckRun(
+      name: "Action",
+      status: "COMPLETED",
+      conclusion: "ACTION_REQUIRED"
+    ).ciStatus == .failure)
+  }
+
+  @Test("decodes workflow rollup metadata with stable check identity")
+  func decodesWorkflowRollupMetadata() throws {
+    let json = """
+    {
+      "name": "test",
+      "status": "COMPLETED",
+      "conclusion": "SUCCESS",
+      "detailsUrl": "https://github.com/test/repo/actions/runs/1/job/2",
+      "workflowName": "Tests",
+      "startedAt": "2026-07-12T05:38:49Z",
+      "completedAt": "2026-07-12T05:40:03Z"
+    }
+    """
+    let decoder = JSONDecoder()
+    decoder.dateDecodingStrategy = .iso8601
+    let check = try decoder.decode(GitHubCheckRun.self, from: Data(json.utf8))
+
+    #expect(check.workflowName == "Tests")
+    #expect(check.startedAt != nil)
+    #expect(check.completedAt != nil)
+    #expect(check.id == "Tests|test|https://github.com/test/repo/actions/runs/1/job/2")
+  }
+
   @Test("current branch no-PR message is recognized")
   func currentBranchNoPRMessageIsRecognized() {
     #expect(GitHubCLIService.isNoCurrentBranchPRMessage(

--- a/app/modules/AgentHubGitHub/Tests/AgentHubGitHubTests/GitHubPRObservationServiceTests.swift
+++ b/app/modules/AgentHubGitHub/Tests/AgentHubGitHubTests/GitHubPRObservationServiceTests.swift
@@ -10,25 +10,34 @@ import Testing
 
 @testable import AgentHubGitHub
 
-private func makeObservedPR(number: Int = 1, title: String = "Observed PR") -> GitHubPullRequest {
+private func makeObservedPR(
+  number: Int = 1,
+  title: String = "Observed PR",
+  state: String = "OPEN",
+  headRefOid: String? = nil,
+  checks: [GitHubCheckRun]? = nil,
+  reviewDecision: String? = nil,
+  mergeable: String? = "MERGEABLE"
+) -> GitHubPullRequest {
   GitHubPullRequest(
     number: number,
     title: title,
     body: nil,
-    state: "OPEN",
+    state: state,
     url: "https://github.com/test/repo/pull/\(number)",
     headRefName: "feature",
+    headRefOid: headRefOid,
     baseRefName: "main",
     author: GitHubAuthor(login: "testuser", name: nil),
     createdAt: .now,
     updatedAt: .now,
     isDraft: false,
-    mergeable: "MERGEABLE",
+    mergeable: mergeable,
     additions: 10,
     deletions: 2,
     changedFiles: 3,
-    reviewDecision: nil,
-    statusCheckRollup: nil,
+    reviewDecision: reviewDecision,
+    statusCheckRollup: checks,
     labels: nil,
     reviewRequests: nil,
     comments: nil
@@ -70,8 +79,378 @@ private actor ObservationSnapshotCollector {
   }
 }
 
+private actor FixedGitHubRepositoryIdentityResolver: GitHubRepositoryIdentityResolverProtocol {
+  let identity: GitHubRepositoryIdentity?
+
+  init(identity: GitHubRepositoryIdentity?) {
+    self.identity = identity
+  }
+
+  func resolveIdentity(at projectPath: String) async -> GitHubRepositoryIdentity? {
+    identity
+  }
+}
+
 @Suite("GitHubPRObservationService")
 struct GitHubPRObservationServiceTests {
+
+  @Test("uses the exact session branch and embedded check rollup in one fetch")
+  func usesExactBranchAndEmbeddedChecks() async {
+    let service = MockGitHubCLIService()
+    service.currentBranchPRResult = makeObservedPR(
+      number: 5,
+      headRefOid: "abc123",
+      checks: [makeObservedCheck(name: "Build", conclusion: "FAILURE")]
+    )
+    let observer = GitHubPRObservationService(
+      service: service,
+      repositoryIdentityResolver: FixedGitHubRepositoryIdentityResolver(identity: nil),
+      configuration: makeObservationConfiguration()
+    )
+    let target = GitHubPRObservationTarget.currentBranch(
+      projectPath: "/tmp/repo",
+      branchName: "feature/exact"
+    )
+
+    await observer.refresh(target)
+
+    #expect(service.getCurrentBranchPRCallCount == 1)
+    #expect(service.getCurrentBranchPRBranchName == "feature/exact")
+    #expect(service.getChecksCallCount == 0)
+  }
+
+  @Test("uses only linked pull requests that match the session repository")
+  func verifiesLinkedPullRequestRepository() async throws {
+    let service = MockGitHubCLIService()
+    service.pullRequestResult = makeObservedPR(number: 41, checks: [])
+    service.currentBranchPRResult = makeObservedPR(number: 42, checks: [])
+    let identity = GitHubRepositoryIdentity(owner: "test", repository: "repo")
+    let observer = GitHubPRObservationService(
+      service: service,
+      repositoryIdentityResolver: FixedGitHubRepositoryIdentityResolver(identity: identity),
+      configuration: makeObservationConfiguration()
+    )
+    let unrelated = try #require(GitHubPullRequestURLReference(
+      urlString: "https://github.com/other/project/pull/40"
+    ))
+    let matching = try #require(GitHubPullRequestURLReference(
+      urlString: "https://github.com/test/repo/pull/41"
+    ))
+    let linkedTarget = GitHubPRObservationTarget.session(
+      projectPath: "/tmp/repo",
+      branchName: "feature/exact",
+      linkedPullRequests: [unrelated, matching]
+    )
+
+    await observer.refresh(linkedTarget)
+
+    #expect(service.getPullRequestCallCount == 1)
+    #expect(service.getPullRequestNumber == 41)
+    #expect(service.getCurrentBranchPRCallCount == 0)
+
+    let branchTarget = GitHubPRObservationTarget.session(
+      projectPath: "/tmp/other-copy",
+      branchName: "feature/fallback",
+      linkedPullRequests: [unrelated]
+    )
+    await observer.refresh(branchTarget)
+
+    #expect(service.getCurrentBranchPRCallCount == 1)
+    #expect(service.getCurrentBranchPRBranchName == "feature/fallback")
+  }
+
+  @Test("preserves same-head checks and freshness when a fallback check fetch fails")
+  func preservesSameHeadChecksOnTransientFailure() async {
+    let service = MockGitHubCLIService()
+    let pullRequest = makeObservedPR(number: 51, headRefOid: "same-head", checks: nil)
+    service.currentBranchPRResults = [.success(pullRequest), .success(pullRequest)]
+    service.checksResults = [
+      .success([makeObservedCheck(name: "Build", conclusion: "FAILURE")]),
+      .failure(GitHubCLIError.timeout),
+    ]
+    let observer = GitHubPRObservationService(
+      service: service,
+      repositoryIdentityResolver: FixedGitHubRepositoryIdentityResolver(identity: nil),
+      configuration: makeObservationConfiguration()
+    )
+    let target = GitHubPRObservationTarget.currentBranch(
+      projectPath: "/tmp/repo",
+      branchName: "feature"
+    )
+    let collector = ObservationSnapshotCollector()
+    let subscription = await observer.subscribe(to: target, refreshOnSubscribe: false)
+    let collectionTask = Task {
+      for await snapshot in subscription.updates {
+        await collector.append(snapshot)
+      }
+    }
+
+    await observer.refresh(target)
+    try? await Task.sleep(for: .milliseconds(5))
+    let successfulRefreshDate = await collector.snapshots().last {
+      $0.state == .ready
+    }?.lastRefreshedAt
+    await observer.refresh(target)
+    try? await Task.sleep(for: .milliseconds(5))
+
+    let degraded = await collector.snapshots().last
+    #expect(degraded?.checks.map(\.name) == ["Build"])
+    #expect(degraded?.ciSummary.overallStatus == .failure)
+    #expect(degraded?.lastRefreshedAt == successfulRefreshDate)
+    #expect(degraded?.isStale == true)
+
+    collectionTask.cancel()
+    await observer.unsubscribe(subscriptionID: subscription.id)
+  }
+
+  @Test("does not carry fallback checks across pull request head commits")
+  func clearsFallbackChecksForNewHead() async {
+    let service = MockGitHubCLIService()
+    service.currentBranchPRResults = [
+      .success(makeObservedPR(number: 52, headRefOid: "old-head", checks: nil)),
+      .success(makeObservedPR(number: 52, headRefOid: "new-head", checks: nil)),
+    ]
+    service.checksResults = [
+      .success([makeObservedCheck(name: "Old build", conclusion: "FAILURE")]),
+      .failure(GitHubCLIError.timeout),
+    ]
+    let observer = GitHubPRObservationService(
+      service: service,
+      repositoryIdentityResolver: FixedGitHubRepositoryIdentityResolver(identity: nil),
+      configuration: makeObservationConfiguration(errorBackoff: [1])
+    )
+    let target = GitHubPRObservationTarget.currentBranch(
+      projectPath: "/tmp/repo",
+      branchName: "feature"
+    )
+    let collector = ObservationSnapshotCollector()
+    let subscription = await observer.subscribe(to: target, refreshOnSubscribe: false)
+    let collectionTask = Task {
+      for await snapshot in subscription.updates {
+        await collector.append(snapshot)
+      }
+    }
+
+    await observer.refresh(target)
+    await observer.refresh(target)
+    try? await Task.sleep(for: .milliseconds(5))
+
+    let degraded = await collector.snapshots().last
+    #expect(degraded?.pullRequest?.headRefOid == "new-head")
+    #expect(degraded?.checks.isEmpty == true)
+    #expect(degraded?.lastRefreshedAt == nil)
+    #expect(degraded?.isStale == false)
+
+    collectionTask.cancel()
+    await observer.unsubscribe(subscriptionID: subscription.id)
+  }
+
+  @Test("continues pending checks after idle and stops at the pending deadline")
+  func pendingChecksOutliveIdleButRespectDeadline() async {
+    let service = MockGitHubCLIService()
+    service.currentBranchPRResult = makeObservedPR(
+      number: 61,
+      headRefOid: "pending-head",
+      checks: [makeObservedCheck(
+        name: "Build",
+        status: "WAITING",
+        conclusion: nil
+      )]
+    )
+    let observer = GitHubPRObservationService(
+      service: service,
+      repositoryIdentityResolver: FixedGitHubRepositoryIdentityResolver(identity: nil),
+      configuration: GitHubPRObservationConfiguration(
+        pendingPollInterval: 0.01,
+        idlePendingPollInterval: 0.02,
+        settledPollInterval: 0.2,
+        idleTimeout: 0.005,
+        checksDiscoveryWindow: 0.05,
+        pendingObservationLimit: 0.07,
+        inactiveEntryRetention: 1,
+        maximumConcurrentRefreshes: 2,
+        errorBackoff: [0.02]
+      )
+    )
+    let target = GitHubPRObservationTarget.currentBranch(
+      projectPath: "/tmp/repo",
+      branchName: "feature"
+    )
+    let subscription = await observer.subscribe(to: target, refreshOnSubscribe: false)
+
+    await observer.recordActivity(for: target, at: .now)
+    try? await Task.sleep(for: .milliseconds(40))
+    await observer.recordActivity(for: target, at: .now)
+    try? await Task.sleep(for: .milliseconds(60))
+    let callsAtDeadline = service.getCurrentBranchPRCallCount
+    try? await Task.sleep(for: .milliseconds(60))
+
+    #expect(callsAtDeadline >= 3)
+    #expect(service.getCurrentBranchPRCallCount == callsAtDeadline)
+
+    await observer.unsubscribe(subscriptionID: subscription.id)
+  }
+
+  @Test("bounds pull request discovery after session activity")
+  func boundsPullRequestDiscovery() async {
+    let service = MockGitHubCLIService()
+    service.currentBranchPRResult = nil
+    let observer = GitHubPRObservationService(
+      service: service,
+      repositoryIdentityResolver: FixedGitHubRepositoryIdentityResolver(identity: nil),
+      configuration: GitHubPRObservationConfiguration(
+        pendingPollInterval: 0.01,
+        idlePendingPollInterval: 0.02,
+        settledPollInterval: 0.2,
+        idleTimeout: 0.005,
+        checksDiscoveryWindow: 0.06,
+        pendingObservationLimit: 1,
+        inactiveEntryRetention: 1,
+        maximumConcurrentRefreshes: 2,
+        errorBackoff: [0.02]
+      )
+    )
+    let target = GitHubPRObservationTarget.currentBranch(
+      projectPath: "/tmp/repo",
+      branchName: "feature"
+    )
+    let subscription = await observer.subscribe(to: target, refreshOnSubscribe: false)
+
+    await observer.recordActivity(for: target, at: .now)
+    try? await Task.sleep(for: .milliseconds(90))
+    let callsAfterDiscovery = service.getCurrentBranchPRCallCount
+    try? await Task.sleep(for: .milliseconds(50))
+
+    #expect(callsAfterDiscovery >= 2)
+    #expect(service.getCurrentBranchPRCallCount == callsAfterDiscovery)
+
+    await observer.unsubscribe(subscriptionID: subscription.id)
+  }
+
+  @Test("manual refresh populates cache without a subscriber")
+  func manualRefreshWithoutSubscriberPopulatesCache() async {
+    let service = MockGitHubCLIService()
+    service.currentBranchPRResult = makeObservedPR(number: 71, checks: [])
+    let observer = GitHubPRObservationService(
+      service: service,
+      repositoryIdentityResolver: FixedGitHubRepositoryIdentityResolver(identity: nil),
+      configuration: makeObservationConfiguration()
+    )
+    let target = GitHubPRObservationTarget.currentBranch(
+      projectPath: "/tmp/repo",
+      branchName: "feature"
+    )
+
+    await observer.refresh(target)
+    let subscription = await observer.subscribe(to: target, refreshOnSubscribe: false)
+    var iterator = subscription.updates.makeAsyncIterator()
+    let cachedSnapshot = await iterator.next()
+
+    #expect(cachedSnapshot?.pullRequest?.number == 71)
+    #expect(cachedSnapshot?.state == .ready)
+    #expect(service.getCurrentBranchPRCallCount == 1)
+
+    await observer.unsubscribe(subscriptionID: subscription.id)
+  }
+
+  @Test("terminal pull requests stop automatic observation but remain manually refreshable")
+  func terminalPullRequestsStopAutomaticObservation() async {
+    for state in ["MERGED", "CLOSED"] {
+      let service = MockGitHubCLIService()
+      service.currentBranchPRResult = makeObservedPR(
+        number: 73,
+        state: state,
+        headRefOid: "terminal-head",
+        checks: []
+      )
+      let observer = GitHubPRObservationService(
+        service: service,
+        repositoryIdentityResolver: FixedGitHubRepositoryIdentityResolver(identity: nil),
+        configuration: GitHubPRObservationConfiguration(
+          pendingPollInterval: 0.01,
+          idlePendingPollInterval: 0.01,
+          settledPollInterval: 0.01,
+          idleTimeout: 1,
+          checksDiscoveryWindow: 1,
+          pendingObservationLimit: 1,
+          inactiveEntryRetention: 1,
+          maximumConcurrentRefreshes: 2,
+          errorBackoff: [0.01]
+        )
+      )
+      let target = GitHubPRObservationTarget.currentBranch(
+        projectPath: "/tmp/repo-\(state.lowercased())",
+        branchName: "feature"
+      )
+      let subscription = await observer.subscribe(to: target, refreshOnSubscribe: false)
+
+      await observer.recordActivity(for: target, at: .now)
+      try? await Task.sleep(for: .milliseconds(50))
+
+      #expect(service.getCurrentBranchPRCallCount == 1)
+
+      await observer.recordActivity(for: target, at: .now)
+      try? await Task.sleep(for: .milliseconds(30))
+
+      #expect(service.getCurrentBranchPRCallCount == 1)
+
+      await observer.refresh(target)
+      try? await Task.sleep(for: .milliseconds(30))
+
+      #expect(service.getCurrentBranchPRCallCount == 2)
+
+      await observer.unsubscribe(subscriptionID: subscription.id)
+    }
+  }
+
+  @Test("caps concurrent refresh work across targets")
+  func capsConcurrentRefreshes() async {
+    let service = MockGitHubCLIService()
+    service.currentBranchPRDelay = 0.04
+    service.currentBranchPRResult = makeObservedPR(number: 72, checks: [])
+    let observer = GitHubPRObservationService(
+      service: service,
+      repositoryIdentityResolver: FixedGitHubRepositoryIdentityResolver(identity: nil),
+      configuration: GitHubPRObservationConfiguration(
+        maximumConcurrentRefreshes: 2
+      )
+    )
+    let targets = (0..<4).map { index in
+      GitHubPRObservationTarget.currentBranch(
+        projectPath: "/tmp/repo-\(index)",
+        branchName: "feature-\(index)"
+      )
+    }
+
+    await withTaskGroup(of: Void.self) { group in
+      for target in targets {
+        group.addTask {
+          await observer.refresh(target)
+        }
+      }
+    }
+
+    #expect(await service.peakCurrentBranchPRCallCount() == 2)
+  }
+
+  @Test("derives CI, review, and merge blockers without extra fetches")
+  func derivesAllBlockers() {
+    let pullRequest = makeObservedPR(
+      number: 81,
+      checks: [makeObservedCheck(name: "Build", conclusion: "FAILURE")],
+      reviewDecision: "CHANGES_REQUESTED",
+      mergeable: "CONFLICTING"
+    )
+    let snapshot = GitHubPRObservationSnapshot(
+      target: .pullRequest(projectPath: "/tmp/repo", number: 81),
+      pullRequest: pullRequest,
+      checks: pullRequest.statusCheckRollup ?? [],
+      state: .ready,
+      lastRefreshedAt: .now
+    )
+
+    #expect(snapshot.blockers == [.ciFailure, .changesRequested, .mergeConflict])
+  }
 
   @Test("deduplicates subscribers for the same current-branch target")
   func deduplicatesSubscribers() async {
@@ -147,8 +526,8 @@ struct GitHubPRObservationServiceTests {
     #expect(readySnapshot?.pullRequest?.number == 88)
     #expect(readySnapshot?.checks.isEmpty == true)
     #expect(readySnapshot?.ciSummary.total == 0)
-    #expect(service.getCurrentBranchPRCallCount == 1)
-    #expect(service.getChecksCallCount == 1)
+    #expect(service.getCurrentBranchPRCallCount >= 1)
+    #expect(service.getChecksCallCount >= 1)
 
     collectionTask.cancel()
     await observer.unsubscribe(subscriptionID: subscription.id)
@@ -181,8 +560,8 @@ struct GitHubPRObservationServiceTests {
     }
     #expect(degradedSnapshot?.pullRequest?.number == 89)
     #expect(degradedSnapshot?.checks.isEmpty == true)
-    #expect(service.getCurrentBranchPRCallCount == 1)
-    #expect(service.getChecksCallCount == 1)
+    #expect(service.getCurrentBranchPRCallCount >= 1)
+    #expect(service.getChecksCallCount >= 1)
 
     collectionTask.cancel()
     await observer.unsubscribe(subscriptionID: subscription.id)
@@ -195,7 +574,7 @@ struct GitHubPRObservationServiceTests {
     service.checksResults = [.failure(GitHubCLIError.timeout)]
     let observer = GitHubPRObservationService(
       service: service,
-      configuration: makeObservationConfiguration()
+      configuration: makeObservationConfiguration(errorBackoff: [0.2])
     )
     let target = GitHubPRObservationTarget.pullRequest(projectPath: "/tmp/repo", number: 90)
     let collector = ObservationSnapshotCollector()

--- a/app/modules/AgentHubGitHub/Tests/AgentHubGitHubTests/GitHubPullRequestURLReferenceTests.swift
+++ b/app/modules/AgentHubGitHub/Tests/AgentHubGitHubTests/GitHubPullRequestURLReferenceTests.swift
@@ -32,4 +32,40 @@ struct GitHubPullRequestURLReferenceTests {
     #expect(GitHubPullRequestURLReference(urlString: "https://github.com/jamesrochabrun/AgentHub/issues/322") == nil)
     #expect(GitHubPullRequestURLReference(urlString: "https://avatars.githubusercontent.com/u/5378604") == nil)
   }
+
+  @Test("Normalizes HTTPS and SSH GitHub remotes")
+  func normalizesGitHubRemoteURLs() throws {
+    let https = try #require(GitHubRepositoryIdentity(
+      remoteURL: "https://github.com/JamesRochabrun/AgentHub.git"
+    ))
+    let scp = try #require(GitHubRepositoryIdentity(
+      remoteURL: "git@github.com:jamesrochabrun/AgentHub.git"
+    ))
+    let ssh = try #require(GitHubRepositoryIdentity(
+      remoteURL: "ssh://git@github.com/jamesrochabrun/AgentHub.git"
+    ))
+
+    #expect(https.owner == "JamesRochabrun")
+    #expect(https.repository == "AgentHub")
+    #expect(scp == GitHubRepositoryIdentity(owner: "jamesrochabrun", repository: "AgentHub"))
+    #expect(ssh == scp)
+    #expect(GitHubRepositoryIdentity(remoteURL: "https://gitlab.com/test/repo.git") == nil)
+    #expect(GitHubRepositoryIdentity(remoteURL: "git@evilgithub.com:test/repo.git") == nil)
+  }
+
+  @Test("Selects the latest pull request for the resolved repository")
+  func selectsLatestMatchingRepositoryReference() throws {
+    let references = [
+      "https://github.com/test/repo/pull/10",
+      "https://github.com/other/repo/pull/99",
+      "https://github.com/TEST/REPO/pull/11",
+    ].compactMap(GitHubPullRequestURLReference.init(urlString:))
+
+    let result = GitHubPullRequestURLReference.latest(
+      matching: GitHubRepositoryIdentity(owner: "test", repository: "repo"),
+      in: references
+    )
+
+    #expect(result?.number == 11)
+  }
 }

--- a/app/modules/AgentHubGitHub/Tests/AgentHubGitHubTests/MockGitHubCLIService.swift
+++ b/app/modules/AgentHubGitHub/Tests/AgentHubGitHubTests/MockGitHubCLIService.swift
@@ -8,6 +8,24 @@
 import Foundation
 @testable import AgentHubGitHub
 
+private actor MockGitHubCallConcurrencyTracker {
+  private var activeCount = 0
+  private var peakCount = 0
+
+  func begin() {
+    activeCount += 1
+    peakCount = max(peakCount, activeCount)
+  }
+
+  func end() {
+    activeCount = max(0, activeCount - 1)
+  }
+
+  func peak() -> Int {
+    peakCount
+  }
+}
+
 /// Mock GitHub CLI service for testing ViewModels and other consumers.
 ///
 /// Configure return values and errors before each test, then assert on
@@ -21,6 +39,7 @@ import Foundation
 /// #expect(mock.listPullRequestsCalled)
 /// ```
 final class MockGitHubCLIService: GitHubCLIServiceProtocol, @unchecked Sendable {
+  private let currentBranchConcurrency = MockGitHubCallConcurrencyTracker()
 
   // MARK: - Configuration
 
@@ -126,25 +145,31 @@ final class MockGitHubCLIService: GitHubCLIServiceProtocol, @unchecked Sendable 
   var getCurrentBranchPRCalled = false
   var getCurrentBranchPRCallCount = 0
   var getCurrentBranchPRRepoPath: String?
+  var getCurrentBranchPRBranchName: String?
 
-  func getCurrentBranchPR(at repoPath: String) async throws -> GitHubPullRequest? {
+  func getCurrentBranchPR(branchName: String?, at repoPath: String) async throws -> GitHubPullRequest? {
+    await currentBranchConcurrency.begin()
     getCurrentBranchPRCalled = true
     getCurrentBranchPRCallCount += 1
     getCurrentBranchPRRepoPath = repoPath
+    getCurrentBranchPRBranchName = branchName
     if currentBranchPRDelay > 0 {
       try? await Task.sleep(for: .milliseconds(Int(currentBranchPRDelay * 1_000)))
     }
+    let result: Result<GitHubPullRequest?, Error>
     if !currentBranchPRResults.isEmpty {
-      let nextResult = currentBranchPRResults.removeFirst()
-      switch nextResult {
-      case .success(let result):
-        return result
-      case .failure(let error):
-        throw error
-      }
+      result = currentBranchPRResults.removeFirst()
+    } else if let error = errorToThrow {
+      result = .failure(error)
+    } else {
+      result = .success(currentBranchPRResult)
     }
-    if let error = errorToThrow { throw error }
-    return currentBranchPRResult
+    await currentBranchConcurrency.end()
+    return try result.get()
+  }
+
+  func peakCurrentBranchPRCallCount() async -> Int {
+    await currentBranchConcurrency.peak()
   }
 
   var pullRequestDiffResult = ""
@@ -331,6 +356,7 @@ final class MockGitHubCLIService: GitHubCLIServiceProtocol, @unchecked Sendable 
     getCurrentBranchPRCalled = false
     getCurrentBranchPRCallCount = 0
     getCurrentBranchPRRepoPath = nil
+    getCurrentBranchPRBranchName = nil
     getPullRequestDiffCalled = false
     getPullRequestFilesCalled = false
     getPullRequestReviewCommentsCalled = false

--- a/app/modules/AgentHubGitHub/Tests/AgentHubGitHubTests/SessionGitHubQuickAccessViewModelTests.swift
+++ b/app/modules/AgentHubGitHub/Tests/AgentHubGitHubTests/SessionGitHubQuickAccessViewModelTests.swift
@@ -250,15 +250,22 @@ struct SessionGitHubQuickAccessViewModelTests {
 
   @Test("linked pull request subscribes to explicit PR observation")
   @MainActor
-  func linkedPullRequestSubscribesToExplicitPRObservation() async {
+  func linkedPullRequestSubscribesToExplicitPRObservation() async throws {
     let observer = MockSessionGitHubPRObservationService()
     let viewModel = SessionGitHubQuickAccessViewModel(observationService: observer)
-    let target = GitHubPRObservationTarget.pullRequest(projectPath: "/tmp/repo", number: 322)
+    let reference = try #require(GitHubPullRequestURLReference(
+      urlString: "https://github.com/test/repo/pull/322"
+    ))
+    let target = GitHubPRObservationTarget.session(
+      projectPath: "/tmp/repo",
+      branchName: "feature/github",
+      linkedPullRequests: [reference]
+    )
 
     await viewModel.load(
       projectPath: "/tmp/repo",
       branchName: "feature/github",
-      linkedPullRequestNumber: 322
+      linkedPullRequests: [reference]
     )
     await observer.publish(GitHubPRObservationSnapshot(
       target: target,
@@ -276,17 +283,24 @@ struct SessionGitHubQuickAccessViewModelTests {
     #expect(await observer.refreshedTargets == [target])
   }
 
-  @Test("linked pull request activity force refreshes and applies state changes")
+  @Test("linked pull request activity is coalesced by the observation service")
   @MainActor
-  func linkedPullRequestActivityForceRefreshesAndAppliesStateChanges() async {
+  func linkedPullRequestActivityForceRefreshesAndAppliesStateChanges() async throws {
     let observer = MockSessionGitHubPRObservationService()
     let viewModel = SessionGitHubQuickAccessViewModel(observationService: observer)
-    let target = GitHubPRObservationTarget.pullRequest(projectPath: "/tmp/repo", number: 322)
+    let reference = try #require(GitHubPullRequestURLReference(
+      urlString: "https://github.com/test/repo/pull/322"
+    ))
+    let target = GitHubPRObservationTarget.session(
+      projectPath: "/tmp/repo",
+      branchName: "feature/github",
+      linkedPullRequests: [reference]
+    )
 
     await viewModel.load(
       projectPath: "/tmp/repo",
       branchName: "feature/github",
-      linkedPullRequestNumber: 322
+      linkedPullRequests: [reference]
     )
     await observer.publish(GitHubPRObservationSnapshot(
       target: target,
@@ -306,20 +320,28 @@ struct SessionGitHubQuickAccessViewModelTests {
     try? await Task.sleep(for: .milliseconds(10))
 
     #expect(viewModel.currentBranchPR?.isDraft == false)
-    #expect(await observer.refreshedTargets == [target, target])
+    #expect(await observer.refreshedTargets == [target])
+    #expect(await observer.recordedActivityTargets == [target, target])
   }
 
   @Test("linked merged pull request remains visible")
   @MainActor
-  func linkedMergedPullRequestRemainsVisible() async {
+  func linkedMergedPullRequestRemainsVisible() async throws {
     let observer = MockSessionGitHubPRObservationService()
     let viewModel = SessionGitHubQuickAccessViewModel(observationService: observer)
-    let target = GitHubPRObservationTarget.pullRequest(projectPath: "/tmp/repo", number: 322)
+    let reference = try #require(GitHubPullRequestURLReference(
+      urlString: "https://github.com/test/repo/pull/322"
+    ))
+    let target = GitHubPRObservationTarget.session(
+      projectPath: "/tmp/repo",
+      branchName: "feature/github",
+      linkedPullRequests: [reference]
+    )
 
     await viewModel.load(
       projectPath: "/tmp/repo",
       branchName: "feature/github",
-      linkedPullRequestNumber: 322
+      linkedPullRequests: [reference]
     )
     await observer.publish(GitHubPRObservationSnapshot(
       target: target,


### PR DESCRIPTION
## Summary

- make session PR selection repository-aware and query the exact current branch
- observe embedded CI rollups, review state, merge blockers, and head-SHA staleness with bounded adaptive polling
- stop automatic observation after a PR is merged or closed while preserving cached state and manual refresh
- show a compact cleanup action for safe, inactive worktrees whose PR is merged

## Why

Session GitHub state could select the wrong PR, miss CI failures, continue polling terminal PRs, and leave completed worktrees without a clear cleanup signal. This makes the state more accurate while keeping launch work delayed and observation deduplicated.

## Impact

GitHub state is shared across panel and session-row consumers, terminal PRs become quiet, and worktree cleanup is only suggested when session and CI state make deletion safe.

## Validation

- `swift test` in `AgentHubGitHub`: 91 tests passed; the existing headless-quarantined coordinator suite remained skipped
- focused Core suites: `WorktreeCleanupEligibilityTests` (2 passed) and `GlobalSessionControlPanelTests` (18 passed)
- `git diff --check`: passed
- `./scripts/test.sh`: package tests passed, but the Core scheme exited nonzero because the existing SwiftLint build commands for `CodeEditSourceEditor` and `CodeEditTextView` reported missing output folders