### PR TITLE
Update Canvas to 1.3.3 and wire delete-all tweaks

### DIFF
--- a/app/AgentHub.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/app/AgentHub.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/jamesrochabrun/Canvas",
       "state" : {
-        "revision" : "7c489d3ef4910c32a4cecb33a0c91cc5e20e58e9",
-        "version" : "1.3.2"
+        "revision" : "1c246e294b615bdd2cea822366facbfc579dd03c",
+        "version" : "1.3.3"
       }
     },
     {

--- a/app/modules/AgentHubCore/Package.resolved
+++ b/app/modules/AgentHubCore/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "993ac3fcefff89226a13257843eff29d8ae108579c8fc43ad4fe64965c1abc62",
+  "originHash" : "ae4d1cd8af21cfde40faedeea8f57209c03c4258f9d6dab63ab3e6b94bb932c2",
   "pins" : [
     {
       "identity" : "beautiful-mermaid-swift",
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/jamesrochabrun/Canvas",
       "state" : {
-        "revision" : "7c489d3ef4910c32a4cecb33a0c91cc5e20e58e9",
-        "version" : "1.3.2"
+        "revision" : "1c246e294b615bdd2cea822366facbfc579dd03c",
+        "version" : "1.3.3"
       }
     },
     {

--- a/app/modules/AgentHubCore/Package.swift
+++ b/app/modules/AgentHubCore/Package.swift
@@ -46,7 +46,7 @@ let package = Package(
     .package(path: "../AgentHubGitHub"),
     .package(path: "../Storybook"),
     .package(path: "../SimulatorPreview"),
-    .package(url: "https://github.com/jamesrochabrun/Canvas", exact: "1.3.2"),
+    .package(url: "https://github.com/jamesrochabrun/Canvas", exact: "1.3.3"),
     .package(url: "https://github.com/jamesrochabrun/PierreDiffsSwift", exact: "1.2.2"),
     .package(url: "https://github.com/jamesrochabrun/SwiftTerm", exact: "1.13.0-agenthub.8"),
     .package(url: "https://github.com/gonzalezreal/swift-markdown-ui", from: "2.0.0"),

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/WebPreviewTweaksPanel.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/WebPreviewTweaksPanel.swift
@@ -9,6 +9,7 @@ struct WebPreviewTweaksPanel: View {
   let onSubmitDescription: (String) -> Void
   let onIdeas: () -> Void
   let onValueChange: (TweakProp, TweakPropValue) -> Void
+  let onDeleteAll: () -> Void
   let onReset: () -> Void
   let onSaveDefaults: () -> Void
 
@@ -21,6 +22,7 @@ struct WebPreviewTweaksPanel: View {
         onSubmitDescription: onSubmitDescription,
         onIdeas: onIdeas,
         onValueChange: onValueChange,
+        onDeleteAll: onDeleteAll,
         onReset: onReset,
         onSaveDefaults: onSaveDefaults
       )

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/WebPreviewView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/WebPreviewView.swift
@@ -685,6 +685,7 @@ public struct WebPreviewView: View {
         onSubmitDescription: sendCustomTweaksPrompt,
         onIdeas: sendTweaksIdeasPrompt,
         onValueChange: handleTweakValueChange,
+        onDeleteAll: sendDeleteAllTweaksPrompt,
         onReset: resetTweakValues,
         onSaveDefaults: saveTweakDefaults
       )
@@ -1526,6 +1527,13 @@ public struct WebPreviewView: View {
         fileName: tweakPromptTargetName,
         instruction: instruction
       ),
+      policy: .flexible
+    )
+  }
+
+  private func sendDeleteAllTweaksPrompt() {
+    runTweakAgent(
+      TweaksPromptBuilder.deleteAllPrompt(fileName: tweakPromptTargetName),
       policy: .flexible
     )
   }


### PR DESCRIPTION
## Summary
- Bump the Canvas pin from 1.3.2 to 1.3.3 (`Package.swift` + both `Package.resolved` files).
- Adopt the source-breaking API change: `TweaksPanelView` now requires an `onDeleteAll` callback. The tweaks panel footer gains a destructive **Delete All Tweaks** button (confirmation-gated, rendered by Canvas).
- Wire delete-all to the existing tweak-agent pipeline via the new `TweaksPromptBuilder.deleteAllPrompt(fileName:)`, using the `.flexible` policy — `.additive` validates that all base props are preserved, which would reject a removal.
- No app changes needed for the rest of 1.3.3: the content-frame selector removal only affected another host's dev shell (AgentHub loads previews directly in the WKWebView), and the new branded `TweakSlider` is internal to the panel and tints from `Color.accentColor`.

After a successful delete-all, the file reload re-probes the declared schema and the existing `handleTweakSchemaAvailabilityChange` clears the panel state, so no extra state handling was required.

## Test plan
- Targeted suites pass on 1.3.3: `WebPreviewTweakAgentService`, `TweakWorkspaceCoordinator`, `TweaksDefaultsWriteCoordinator` (10 tests, 3 suites, TEST SUCCEEDED).

🤖 Generated with [Claude Code](https://claude.com/claude-code)