### PR TITLE
Persist workspace agent sessions and nest them in the sidebar

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubProvider.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubProvider.swift
@@ -224,6 +224,24 @@ public final class AgentHubProvider {
   /// Codex sessions view model - created lazily and cached
   public private(set) lazy var codexSessionsViewModel: CLISessionsViewModel = makeSessionsViewModel(providerKind: .codex)
 
+  /// Bridges provider-neutral workspaces to Claude and Codex monitoring.
+  public private(set) lazy var agentWorkspaceSessionCoordinator: any AgentWorkspaceSessionCoordinating = AgentWorkspaceSessionCoordinator(
+    claudeViewModel: claudeSessionsViewModel,
+    codexViewModel: codexSessionsViewModel
+  )
+
+  /// Provider-neutral, lazily mounted Ghostty workspaces.
+  public private(set) lazy var agentWorkspacesViewModel: AgentWorkspacesViewModel = AgentWorkspacesViewModel(
+    store: metadataStore,
+    metadataStore: metadataStore,
+    terminalSurfaceFactory: terminalSurfaceFactory,
+    sessionCoordinator: agentWorkspaceSessionCoordinator,
+    detectionService: AccessorySessionDetectionService(
+      claudeDataPath: configuration.claudeDataPath,
+      codexDataPath: configuration.codexDataPath
+    )
+  )
+
   /// Backwards-compatible default sessions view model (Claude)
   public private(set) lazy var sessionsViewModel: CLISessionsViewModel = claudeSessionsViewModel
 
@@ -558,6 +576,7 @@ public final class AgentHubProvider {
       AppLogger.session.info("Terminating terminal for key: \(key)")
       terminal.terminateProcess()
     }
+    agentWorkspacesViewModel.terminateAllTerminals()
   }
 
   public func recreateEmbeddedTerminalsForSelectedBackend() {

--- a/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubViews.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubViews.swift
@@ -53,6 +53,7 @@ public struct AgentHubSessionsView: View {
     MultiProviderSessionsListView(
       claudeViewModel: provider.claudeSessionsViewModel,
       codexViewModel: provider.codexSessionsViewModel,
+      workspaceViewModel: provider.agentWorkspacesViewModel,
       columnVisibility: $columnVisibility,
       intelligenceViewModel: provider.intelligenceViewModel,
       worktreeBranchNamingService: provider.worktreeBranchNamingService,

--- a/app/modules/AgentHubCore/Sources/AgentHub/Models/AgentWorkspaceActivity.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Models/AgentWorkspaceActivity.swift
@@ -1,0 +1,33 @@
+//
+//  AgentWorkspaceActivity.swift
+//  AgentHub
+//
+
+public enum AgentWorkspaceActivity: Int, Comparable, Equatable, Sendable {
+  case idle
+  case ready
+  case working
+  case needsAttention
+
+  public var label: String {
+    switch self {
+    case .idle: "Idle"
+    case .ready: "Ready"
+    case .working: "Working"
+    case .needsAttention: "Needs attention"
+    }
+  }
+
+  public var systemImage: String {
+    switch self {
+    case .idle: "circle"
+    case .ready: "checkmark.circle"
+    case .working: "gearshape"
+    case .needsAttention: "exclamationmark.circle"
+    }
+  }
+
+  public static func < (lhs: AgentWorkspaceActivity, rhs: AgentWorkspaceActivity) -> Bool {
+    lhs.rawValue < rhs.rawValue
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/Models/AgentWorkspaceRecord.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Models/AgentWorkspaceRecord.swift
@@ -1,0 +1,52 @@
+//
+//  AgentWorkspaceRecord.swift
+//  AgentHub
+//
+//  SQLite record for a provider-neutral terminal workspace.
+//
+
+import Foundation
+import GRDB
+
+public struct AgentWorkspaceRecord: Codable, Equatable, Identifiable, Sendable, FetchableRecord, PersistableRecord {
+  public var id: String
+  public var projectPath: String
+  public var customName: String?
+  public var backend: Int
+  public var snapshotData: Data
+  public var createdAt: Date
+  public var updatedAt: Date
+
+  public static var databaseTableName: String { "agent_workspaces" }
+
+  public init(
+    id: String = UUID().uuidString,
+    projectPath: String,
+    customName: String? = nil,
+    backend: EmbeddedTerminalBackend = .ghostty,
+    snapshot: TerminalWorkspaceSnapshot,
+    createdAt: Date = .now,
+    updatedAt: Date = .now
+  ) throws {
+    self.id = id
+    self.projectPath = projectPath
+    self.customName = customName
+    self.backend = backend.rawValue
+    snapshotData = try JSONEncoder().encode(snapshot)
+    self.createdAt = createdAt
+    self.updatedAt = updatedAt
+  }
+
+  public var terminalBackend: EmbeddedTerminalBackend {
+    EmbeddedTerminalBackend(rawValue: backend) ?? .ghostty
+  }
+
+  public func decodedSnapshot() throws -> TerminalWorkspaceSnapshot {
+    try JSONDecoder().decode(TerminalWorkspaceSnapshot.self, from: snapshotData)
+  }
+
+  public mutating func updateSnapshot(_ snapshot: TerminalWorkspaceSnapshot) throws {
+    snapshotData = try JSONEncoder().encode(snapshot)
+    updatedAt = .now
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/Models/AgentWorkspaceSessionLink.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Models/AgentWorkspaceSessionLink.swift
@@ -1,0 +1,44 @@
+//
+//  AgentWorkspaceSessionLink.swift
+//  AgentHub
+//
+//  Persisted ownership link between a neutral workspace and a CLI session.
+//
+
+import Foundation
+import GRDB
+
+public struct AgentWorkspaceSessionLink: Codable, Equatable, Sendable, FetchableRecord, PersistableRecord {
+  public var workspaceId: String
+  public var provider: String
+  public var sessionId: String
+  public var origin: String
+  public var createdAt: Date
+  public var updatedAt: Date
+
+  public static var databaseTableName: String { "workspace_session_links" }
+
+  public init(
+    workspaceId: String,
+    provider: SessionProviderKind,
+    sessionId: String,
+    origin: SessionRelationshipOrigin,
+    createdAt: Date = .now,
+    updatedAt: Date = .now
+  ) {
+    self.workspaceId = workspaceId
+    self.provider = provider.rawValue
+    self.sessionId = sessionId
+    self.origin = origin.rawValue
+    self.createdAt = createdAt
+    self.updatedAt = updatedAt
+  }
+
+  public var providerKind: SessionProviderKind? {
+    SessionProviderKind(rawValue: provider)
+  }
+
+  public var relationshipOrigin: SessionRelationshipOrigin? {
+    SessionRelationshipOrigin(rawValue: origin)
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/Models/AgentWorkspaceSessionReference.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Models/AgentWorkspaceSessionReference.swift
@@ -1,0 +1,25 @@
+//
+//  AgentWorkspaceSessionReference.swift
+//  AgentHub
+//
+//  Provider-neutral identity used to reconcile workspace-owned sessions with
+//  the normal monitored-session restoration flow.
+//
+
+import Foundation
+
+public struct AgentWorkspaceSessionReference: Equatable, Hashable, Sendable {
+  public let provider: SessionProviderKind
+  public let sessionId: String
+  public let projectPath: String
+
+  public init(
+    provider: SessionProviderKind,
+    sessionId: String,
+    projectPath: String
+  ) {
+    self.provider = provider
+    self.sessionId = sessionId
+    self.projectPath = projectPath
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/Models/TerminalWorkspaceSnapshot.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Models/TerminalWorkspaceSnapshot.swift
@@ -5,6 +5,7 @@
 //  Persisted structure for restoring embedded terminal workspaces.
 //
 
+import AgentHubSessionGraph
 import Foundation
 
 public struct TerminalWorkspaceSnapshot: Codable, Equatable, Sendable {
@@ -12,17 +13,64 @@ public struct TerminalWorkspaceSnapshot: Codable, Equatable, Sendable {
   public var panels: [TerminalWorkspacePanelSnapshot]
   public var activePanelIndex: Int
   public var splitLayout: TerminalWorkspaceSplitNode?
+  public var splitRatiosByPath: [String: [Double]]
 
   public init(
-    schemaVersion: Int = 3,
+    schemaVersion: Int = 4,
     panels: [TerminalWorkspacePanelSnapshot],
     activePanelIndex: Int = 0,
-    splitLayout: TerminalWorkspaceSplitNode? = nil
+    splitLayout: TerminalWorkspaceSplitNode? = nil,
+    splitRatiosByPath: [String: [Double]] = [:]
   ) {
     self.schemaVersion = schemaVersion
     self.panels = panels
     self.activePanelIndex = activePanelIndex
     self.splitLayout = splitLayout
+    self.splitRatiosByPath = splitRatiosByPath
+  }
+
+  private enum CodingKeys: String, CodingKey {
+    case schemaVersion
+    case panels
+    case activePanelIndex
+    case splitLayout
+    case splitRatiosByPath
+  }
+
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    schemaVersion = try container.decodeIfPresent(Int.self, forKey: .schemaVersion) ?? 1
+    panels = try container.decode([TerminalWorkspacePanelSnapshot].self, forKey: .panels)
+    activePanelIndex = try container.decodeIfPresent(Int.self, forKey: .activePanelIndex) ?? 0
+    splitLayout = try container.decodeIfPresent(TerminalWorkspaceSplitNode.self, forKey: .splitLayout)
+    splitRatiosByPath = try container.decodeIfPresent(
+      [String: [Double]].self,
+      forKey: .splitRatiosByPath
+    ) ?? [:]
+  }
+
+  public func normalizedSplitRatios() -> [String: [Double]] {
+    guard let splitLayout else { return [:] }
+    var childCounts: [String: Int] = [:]
+    splitLayout.collectSplitChildCounts(path: "root", into: &childCounts)
+
+    return Dictionary(uniqueKeysWithValues: childCounts.compactMap { path, childCount in
+      guard let ratios = splitRatiosByPath[path] else { return nil }
+      return (path, Self.normalized(ratios: ratios, childCount: childCount))
+    })
+  }
+
+  private static func normalized(ratios: [Double], childCount: Int) -> [Double] {
+    guard childCount > 0 else { return [] }
+    guard ratios.count == childCount,
+          ratios.allSatisfy({ $0.isFinite && $0 >= 0 }) else {
+      return Array(repeating: 1 / Double(childCount), count: childCount)
+    }
+    let total = ratios.reduce(0, +)
+    guard total > 0 else {
+      return Array(repeating: 1 / Double(childCount), count: childCount)
+    }
+    return ratios.map { $0 / total }
   }
 }
 
@@ -60,6 +108,21 @@ public indirect enum TerminalWorkspaceSplitNode: Equatable, Sendable {
       }
       guard !remappedChildren.isEmpty else { return nil }
       return .split(axis: axis, children: remappedChildren)
+    }
+  }
+
+  fileprivate func collectSplitChildCounts(
+    path: String,
+    into result: inout [String: Int]
+  ) {
+    switch self {
+    case .panel:
+      return
+    case .split(_, let children):
+      result[path] = children.count
+      for (index, child) in children.enumerated() {
+        child.collectSplitChildCounts(path: "\(path).\(index)", into: &result)
+      }
     }
   }
 }

--- a/app/modules/AgentHubCore/Sources/AgentHub/Models/WorkspaceSessionDetectionContext.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Models/WorkspaceSessionDetectionContext.swift
@@ -1,0 +1,30 @@
+//
+//  WorkspaceSessionDetectionContext.swift
+//  AgentHub
+//
+
+import Foundation
+
+/// Runtime identity for an unlinked terminal tab that may start a CLI session.
+///
+/// The identifier is scoped to the mounted terminal surface. It intentionally
+/// does not become part of the persisted workspace snapshot; persisted identity
+/// comes from the linked Claude or Codex session once detection succeeds.
+public struct WorkspaceSessionDetectionContext: Equatable, Sendable {
+  public let id: String
+  public let provider: SessionProviderKind?
+  public let projectPath: String
+  public let foregroundProcessID: Int32?
+
+  public init(
+    id: String,
+    provider: SessionProviderKind?,
+    projectPath: String,
+    foregroundProcessID: Int32?
+  ) {
+    self.id = id
+    self.provider = provider
+    self.projectPath = projectPath
+    self.foregroundProcessID = foregroundProcessID
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/Models/WorkspaceSurfaceLaunchContext.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Models/WorkspaceSurfaceLaunchContext.swift
@@ -9,10 +9,17 @@ public struct WorkspaceSurfaceLaunchContext: Equatable, Sendable {
   public let provider: SessionProviderKind?
   public let projectPath: String
   public let startedAt: Date
+  public let detectionContextID: String?
 
-  public init(provider: SessionProviderKind?, projectPath: String, startedAt: Date) {
+  public init(
+    provider: SessionProviderKind?,
+    projectPath: String,
+    startedAt: Date,
+    detectionContextID: String? = nil
+  ) {
     self.provider = provider
     self.projectPath = projectPath
     self.startedAt = startedAt
+    self.detectionContextID = detectionContextID
   }
 }

--- a/app/modules/AgentHubCore/Sources/AgentHub/Models/WorkspaceSurfaceLaunchContext.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Models/WorkspaceSurfaceLaunchContext.swift
@@ -1,0 +1,18 @@
+//
+//  WorkspaceSurfaceLaunchContext.swift
+//  AgentHub
+//
+
+import Foundation
+
+public struct WorkspaceSurfaceLaunchContext: Equatable, Sendable {
+  public let provider: SessionProviderKind?
+  public let projectPath: String
+  public let startedAt: Date
+
+  public init(provider: SessionProviderKind?, projectPath: String, startedAt: Date) {
+    self.provider = provider
+    self.projectPath = projectPath
+    self.startedAt = startedAt
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/Models/WorkspaceSurfacePlacement.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Models/WorkspaceSurfacePlacement.swift
@@ -1,0 +1,10 @@
+//
+//  WorkspaceSurfacePlacement.swift
+//  AgentHub
+//
+
+public enum WorkspaceSurfacePlacement: String, CaseIterable, Equatable, Sendable {
+  case tab
+  case splitRight
+  case splitDown
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/Models/WorkspaceTerminalLaunchKind.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Models/WorkspaceTerminalLaunchKind.swift
@@ -1,0 +1,9 @@
+//
+//  WorkspaceTerminalLaunchKind.swift
+//  AgentHub
+//
+
+public enum WorkspaceTerminalLaunchKind: Equatable, Sendable {
+  case shell
+  case agent(SessionProviderKind)
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/AgentWorkspaceSessionCoordinating.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/AgentWorkspaceSessionCoordinating.swift
@@ -1,0 +1,13 @@
+//
+//  AgentWorkspaceSessionCoordinating.swift
+//  AgentHub
+//
+//  Bridges neutral workspaces to the existing provider session view models.
+//
+
+@MainActor
+public protocol AgentWorkspaceSessionCoordinating: AnyObject {
+  func cliConfiguration(for provider: SessionProviderKind) -> CLICommandConfiguration
+  func monitorDetectedSession(_ result: AccessorySessionDetectionResult)
+  func activity(for links: [AgentWorkspaceSessionLink]) -> AgentWorkspaceActivity
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/AgentWorkspaceSessionCoordinating.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/AgentWorkspaceSessionCoordinating.swift
@@ -8,6 +8,7 @@
 @MainActor
 public protocol AgentWorkspaceSessionCoordinating: AnyObject {
   func cliConfiguration(for provider: SessionProviderKind) -> CLICommandConfiguration
-  func monitorDetectedSession(_ result: AccessorySessionDetectionResult)
+  func monitorDetectedSession(_ result: AccessorySessionDetectionResult) async
+  func restorePersistedSessions(_ references: [AgentWorkspaceSessionReference]) async
   func activity(for links: [AgentWorkspaceSessionLink]) -> AgentWorkspaceActivity
 }

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/AgentWorkspaceSessionCoordinator.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/AgentWorkspaceSessionCoordinator.swift
@@ -1,0 +1,61 @@
+//
+//  AgentWorkspaceSessionCoordinator.swift
+//  AgentHub
+//
+
+import Foundation
+
+@MainActor
+public final class AgentWorkspaceSessionCoordinator: AgentWorkspaceSessionCoordinating {
+  private let claudeViewModel: CLISessionsViewModel
+  private let codexViewModel: CLISessionsViewModel
+
+  public init(
+    claudeViewModel: CLISessionsViewModel,
+    codexViewModel: CLISessionsViewModel
+  ) {
+    self.claudeViewModel = claudeViewModel
+    self.codexViewModel = codexViewModel
+  }
+
+  public func cliConfiguration(for provider: SessionProviderKind) -> CLICommandConfiguration {
+    viewModel(for: provider).cliConfiguration(for: provider)
+  }
+
+  public func monitorDetectedSession(_ result: AccessorySessionDetectionResult) {
+    let viewModel = viewModel(for: result.provider)
+    let session = CLISession(
+      id: result.sessionId,
+      projectPath: result.projectPath,
+      branchName: result.branchName,
+      lastActivityAt: .now,
+      isActive: true,
+      sessionFilePath: result.sessionFilePath
+    )
+    viewModel.startMonitoring(session: session)
+    viewModel.refresh()
+  }
+
+  public func activity(for links: [AgentWorkspaceSessionLink]) -> AgentWorkspaceActivity {
+    links.reduce(.idle) { activity, link in
+      guard let provider = link.providerKind,
+            let status = viewModel(for: provider).monitorStates[link.sessionId]?.status else {
+        return activity
+      }
+      return max(activity, Self.activity(for: status))
+    }
+  }
+
+  private func viewModel(for provider: SessionProviderKind) -> CLISessionsViewModel {
+    provider == .claude ? claudeViewModel : codexViewModel
+  }
+
+  private static func activity(for status: SessionStatus) -> AgentWorkspaceActivity {
+    switch status {
+    case .awaitingApproval: .needsAttention
+    case .thinking, .executingTool: .working
+    case .waitingForUser: .ready
+    case .idle: .idle
+    }
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/AgentWorkspaceSessionCoordinator.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/AgentWorkspaceSessionCoordinator.swift
@@ -22,7 +22,7 @@ public final class AgentWorkspaceSessionCoordinator: AgentWorkspaceSessionCoordi
     viewModel(for: provider).cliConfiguration(for: provider)
   }
 
-  public func monitorDetectedSession(_ result: AccessorySessionDetectionResult) {
+  public func monitorDetectedSession(_ result: AccessorySessionDetectionResult) async {
     let viewModel = viewModel(for: result.provider)
     let session = CLISession(
       id: result.sessionId,
@@ -32,8 +32,15 @@ public final class AgentWorkspaceSessionCoordinator: AgentWorkspaceSessionCoordi
       isActive: true,
       sessionFilePath: result.sessionFilePath
     )
-    viewModel.startMonitoring(session: session)
-    viewModel.refresh()
+    await viewModel.registerWorkspaceSession(session)
+  }
+
+  public func restorePersistedSessions(_ references: [AgentWorkspaceSessionReference]) async {
+    for provider in SessionProviderKind.allCases {
+      let providerReferences = references.filter { $0.provider == provider }
+      guard !providerReferences.isEmpty else { continue }
+      await viewModel(for: provider).restoreWorkspaceSessions(providerReferences)
+    }
   }
 
   public func activity(for links: [AgentWorkspaceSessionLink]) -> AgentWorkspaceActivity {

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/AgentWorkspaceStoreProtocol.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/AgentWorkspaceStoreProtocol.swift
@@ -1,0 +1,20 @@
+//
+//  AgentWorkspaceStoreProtocol.swift
+//  AgentHub
+//
+//  Persistence abstraction for provider-neutral terminal workspaces.
+//
+
+import Foundation
+
+public protocol AgentWorkspaceStoreProtocol: Sendable {
+  func loadAgentWorkspaces() async throws -> [AgentWorkspaceRecord]
+  func loadAgentWorkspaceSessionLinks() async throws -> [AgentWorkspaceSessionLink]
+
+  func saveAgentWorkspace(
+    _ workspace: AgentWorkspaceRecord,
+    links: [AgentWorkspaceSessionLink]
+  ) async throws
+
+  func deleteAgentWorkspace(id: String) async throws
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/SessionMetadataStore.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/SessionMetadataStore.swift
@@ -10,7 +10,7 @@ import GRDB
 
 /// Actor-based service for persisting session metadata to SQLite
 /// Uses GRDB for database operations with async/await support
-public actor SessionMetadataStore: TerminalWorkspaceStoreProtocol {
+public actor SessionMetadataStore: TerminalWorkspaceStoreProtocol, AgentWorkspaceStoreProtocol {
 
   // MARK: - Properties
 
@@ -26,6 +26,7 @@ public actor SessionMetadataStore: TerminalWorkspaceStoreProtocol {
     static let addOwnedWorktreePaths = "v9_add_owned_worktree_paths"
     static let createSessionRelationships = "v10_create_session_relationships"
     static let createProjectSimulatorPreferences = "v11_create_project_simulator_preferences"
+    static let createAgentWorkspaces = "v12_create_agent_workspaces"
   }
 
   static let migrationIdentifiers = [
@@ -39,7 +40,8 @@ public actor SessionMetadataStore: TerminalWorkspaceStoreProtocol {
     MigrationID.createClaudeHookInstallations,
     MigrationID.addOwnedWorktreePaths,
     MigrationID.createSessionRelationships,
-    MigrationID.createProjectSimulatorPreferences
+    MigrationID.createProjectSimulatorPreferences,
+    MigrationID.createAgentWorkspaces
   ]
 
   private let dbQueue: DatabaseQueue
@@ -202,6 +204,36 @@ public actor SessionMetadataStore: TerminalWorkspaceStoreProtocol {
       }
     }
 
+    migrator.registerMigration(MigrationID.createAgentWorkspaces) { db in
+      try db.create(table: "agent_workspaces") { t in
+        t.column("id", .text).primaryKey()
+        t.column("projectPath", .text).notNull().indexed()
+        t.column("customName", .text)
+        t.column("backend", .integer).notNull()
+        t.column("snapshotData", .blob).notNull()
+        t.column("createdAt", .datetime).notNull()
+        t.column("updatedAt", .datetime).notNull()
+      }
+
+      try db.create(table: "workspace_session_links") { t in
+        t.column("workspaceId", .text)
+          .notNull()
+          .references("agent_workspaces", onDelete: .cascade)
+        t.column("provider", .text).notNull()
+        t.column("sessionId", .text).notNull()
+        t.column("origin", .text).notNull()
+        t.column("createdAt", .datetime).notNull()
+        t.column("updatedAt", .datetime).notNull()
+        t.primaryKey(["workspaceId", "provider", "sessionId"], onConflict: .replace)
+        t.uniqueKey(["provider", "sessionId"])
+      }
+      try db.create(
+        index: "idx_workspace_session_links_workspace",
+        on: "workspace_session_links",
+        columns: ["workspaceId"]
+      )
+    }
+
     return migrator
   }
 
@@ -297,6 +329,8 @@ public actor SessionMetadataStore: TerminalWorkspaceStoreProtocol {
   /// Clears all metadata (for testing/reset)
   public func clearAll() throws {
     try dbQueue.write { db in
+      _ = try AgentWorkspaceSessionLink.deleteAll(db)
+      _ = try AgentWorkspaceRecord.deleteAll(db)
       _ = try TerminalWorkspaceRecord.deleteAll(db)
       _ = try SessionWorkspaceStateRecord.deleteAll(db)
       _ = try ClaudeHookInstallationRecord.deleteAll(db)
@@ -447,6 +481,48 @@ public actor SessionMetadataStore: TerminalWorkspaceStoreProtocol {
         .deleteAll(db)
     }
   }
+
+  // MARK: - Agent Workspaces
+
+  public func loadAgentWorkspaces() async throws -> [AgentWorkspaceRecord] {
+    try await dbQueue.read { db in
+      try AgentWorkspaceRecord
+        .order(Column("createdAt").desc)
+        .fetchAll(db)
+    }
+  }
+
+  public func loadAgentWorkspaceSessionLinks() async throws -> [AgentWorkspaceSessionLink] {
+    try await dbQueue.read { db in
+      try AgentWorkspaceSessionLink
+        .order(Column("createdAt"))
+        .fetchAll(db)
+    }
+  }
+
+  public func saveAgentWorkspace(
+    _ workspace: AgentWorkspaceRecord,
+    links: [AgentWorkspaceSessionLink]
+  ) async throws {
+    try await dbQueue.write { db in
+      try workspace.save(db)
+      _ = try AgentWorkspaceSessionLink
+        .filter(Column("workspaceId") == workspace.id)
+        .deleteAll(db)
+      for link in links {
+        try link.save(db)
+      }
+    }
+  }
+
+  public func deleteAgentWorkspace(id: String) async throws {
+    try await dbQueue.write { db in
+      _ = try AgentWorkspaceSessionLink
+        .filter(Column("workspaceId") == id)
+        .deleteAll(db)
+      _ = try AgentWorkspaceRecord.deleteOne(db, key: id)
+    }
+  }
 }
 
 extension SessionMetadataStore: ManagedProcessStoreProtocol {
@@ -480,11 +556,12 @@ extension SessionMetadataStore: ManagedProcessStoreProtocol {
 
 extension SessionMetadataStore: SessionRelationshipStoreProtocol {
   public func saveSessionRelationship(_ relationship: SessionRelationshipRecord) async throws {
-    var record = relationship
+    var updatedRecord = relationship
     let now = Date()
-    record.updatedAt = now
+    updatedRecord.updatedAt = now
 
     try await dbQueue.write { db in
+      var record = updatedRecord
       if let existing = try SessionRelationshipRecord
         .filter(Column("sourceProvider") == record.sourceProvider)
         .filter(Column("sourceSessionId") == record.sourceSessionId)

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/WorkspaceSessionProcessProviderResolver.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/WorkspaceSessionProcessProviderResolver.swift
@@ -1,0 +1,80 @@
+//
+//  WorkspaceSessionProcessProviderResolver.swift
+//  AgentHub
+//
+
+import Foundation
+
+public protocol WorkspaceSessionProcessProviderResolving: Sendable {
+  func provider(
+    for processID: Int32,
+    executableNames: [SessionProviderKind: String]
+  ) async -> SessionProviderKind?
+}
+
+/// Identifies the CLI currently running in a terminal from its foreground PID.
+/// Results are cached by PID because a process cannot change its executable.
+public actor WorkspaceSessionProcessProviderResolver: WorkspaceSessionProcessProviderResolving {
+  private enum CachedProvider: Sendable {
+    case provider(SessionProviderKind)
+    case unsupported
+
+    var resolvedProvider: SessionProviderKind? {
+      switch self {
+      case .provider(let provider): provider
+      case .unsupported: nil
+      }
+    }
+  }
+
+  private let processInspector: any ProcessInspecting
+  private var cache: [Int32: CachedProvider] = [:]
+
+  public init() {
+    processInspector = DarwinProcessInspector()
+  }
+
+  init(processInspector: any ProcessInspecting) {
+    self.processInspector = processInspector
+  }
+
+  public func provider(
+    for processID: Int32,
+    executableNames: [SessionProviderKind: String]
+  ) async -> SessionProviderKind? {
+    guard processID > 0 else { return nil }
+    if let cached = cache[processID] {
+      return cached.resolvedProvider
+    }
+
+    let commandLine = await processInspector.identity(for: processID)?.commandLine
+    let provider = commandLine.flatMap {
+      Self.provider(from: $0, executableNames: executableNames)
+    }
+    cache[processID] = provider.map(CachedProvider.provider) ?? .unsupported
+    if cache.count > 512 {
+      cache.removeAll(keepingCapacity: true)
+    }
+    return provider
+  }
+
+  static func provider(
+    from commandLine: String,
+    executableNames: [SessionProviderKind: String]
+  ) -> SessionProviderKind? {
+    let normalizedCommand = commandLine.lowercased()
+    let matches = SessionProviderKind.allCases.filter { provider in
+      let configuredExecutable = executableNames[provider]
+        .map { URL(fileURLWithPath: $0).lastPathComponent.lowercased() }
+      let signatures = [configuredExecutable, provider == .claude ? "claude" : "codex"]
+        .compactMap { $0 }
+      return signatures.contains { signature in
+        normalizedCommand.range(
+          of: "(^|[/[:space:]])\(NSRegularExpression.escapedPattern(for: signature))([[:space:]]|$)",
+          options: .regularExpression
+        ) != nil
+      }
+    }
+    return matches.count == 1 ? matches[0] : nil
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/AgentWorkspaceCloseConfirmationModifier.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/AgentWorkspaceCloseConfirmationModifier.swift
@@ -1,0 +1,28 @@
+//
+//  AgentWorkspaceCloseConfirmationModifier.swift
+//  AgentHub
+//
+
+import SwiftUI
+
+struct AgentWorkspaceCloseConfirmationModifier: ViewModifier {
+  @Binding var workspaceID: String?
+  let onConfirm: () -> Void
+
+  func body(content: Content) -> some View {
+    content.confirmationDialog(
+      "Close Workspace?",
+      isPresented: Binding(
+        get: { workspaceID != nil },
+        set: { if !$0 { workspaceID = nil } }
+      )
+    ) {
+      Button("Close Workspace", role: .destructive, action: onConfirm)
+      Button("Cancel", role: .cancel) {
+        workspaceID = nil
+      }
+    } message: {
+      Text("Running terminal processes will stop. Linked Claude and Codex session history will remain available.")
+    }
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/AgentWorkspaceDetailView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/AgentWorkspaceDetailView.swift
@@ -1,0 +1,81 @@
+//
+//  AgentWorkspaceDetailView.swift
+//  AgentHub
+//
+
+import SwiftUI
+
+struct AgentWorkspaceDetailView: View {
+  let workspace: AgentWorkspaceRecord
+  let viewModel: AgentWorkspacesViewModel
+  let onRename: (String?) -> Void
+  let onClose: () -> Void
+
+  @Environment(\.colorScheme) private var colorScheme
+  @Environment(\.runtimeTheme) private var runtimeTheme
+  @AppStorage(AgentHubDefaults.terminalFontSize) private var terminalFontSize = 12.0
+  @AppStorage(AgentHubDefaults.terminalFontFamily) private var terminalFontFamily = "SF Mono"
+  @State private var isRenaming = false
+  @State private var renameText = ""
+
+  var body: some View {
+    VStack(spacing: 0) {
+      HStack(spacing: 10) {
+        VStack(alignment: .leading, spacing: 2) {
+          Text(viewModel.displayName(for: workspace))
+            .font(.headline)
+          Text(workspace.projectPath)
+            .font(.caption)
+            .foregroundStyle(.secondary)
+            .lineLimit(1)
+            .truncationMode(.middle)
+        }
+
+        Spacer()
+
+        AgentWorkspaceSurfaceMenu { kind, placement in
+          viewModel.launchSurface(
+            workspaceID: workspace.id,
+            kind: kind,
+            placement: placement,
+            isDark: colorScheme == .dark
+          )
+        }
+
+        Menu("Workspace Actions", systemImage: "ellipsis.circle") {
+          Button("Rename", systemImage: "pencil", action: beginRename)
+          Button("Close Workspace", systemImage: "xmark", role: .destructive, action: onClose)
+        }
+        .menuStyle(.borderlessButton)
+      }
+      .padding(.horizontal, 12)
+      .padding(.vertical, 10)
+
+      Divider()
+
+      AgentWorkspaceTerminalView(
+        workspaceID: workspace.id,
+        viewModel: viewModel,
+        isDark: colorScheme == .dark,
+        fontSize: terminalFontSize,
+        fontFamily: terminalFontFamily,
+        theme: runtimeTheme
+      )
+      .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+    .alert("Rename Workspace", isPresented: $isRenaming) {
+      TextField("Workspace name", text: $renameText)
+      Button("Cancel", role: .cancel) {}
+      Button("Rename", action: commitRename)
+    }
+  }
+
+  private func beginRename() {
+    renameText = viewModel.displayName(for: workspace)
+    isRenaming = true
+  }
+
+  private func commitRename() {
+    onRename(renameText)
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/AgentWorkspaceErrorAlertModifier.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/AgentWorkspaceErrorAlertModifier.swift
@@ -1,0 +1,24 @@
+//
+//  AgentWorkspaceErrorAlertModifier.swift
+//  AgentHub
+//
+
+import SwiftUI
+
+struct AgentWorkspaceErrorAlertModifier: ViewModifier {
+  @Bindable var viewModel: AgentWorkspacesViewModel
+
+  func body(content: Content) -> some View {
+    content.alert(
+      "Workspace Error",
+      isPresented: Binding(
+        get: { viewModel.errorMessage != nil },
+        set: { if !$0 { viewModel.clearError() } }
+      )
+    ) {
+      Button("OK", action: viewModel.clearError)
+    } message: {
+      Text(viewModel.errorMessage ?? "")
+    }
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/AgentWorkspaceRow.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/AgentWorkspaceRow.swift
@@ -9,6 +9,8 @@ struct AgentWorkspaceRow: View {
   let workspace: AgentWorkspaceRecord
   let viewModel: AgentWorkspacesViewModel
   let isSelected: Bool
+  var isSessionsExpanded = false
+  var onToggleSessions: (() -> Void)?
   let onSelect: () -> Void
   let onRename: (String?) -> Void
   let onClose: () -> Void
@@ -18,7 +20,7 @@ struct AgentWorkspaceRow: View {
   @State private var renameText = ""
 
   var body: some View {
-    Button(action: onSelect) {
+    HStack(spacing: 0) {
       HStack(spacing: 8) {
         Image(systemName: "rectangle.3.group")
           .foregroundStyle(isSelected ? .primary : .secondary)
@@ -35,20 +37,41 @@ struct AgentWorkspaceRow: View {
 
         Spacer(minLength: 4)
 
+        actionsView
+          .fixedSize(horizontal: true, vertical: false)
+          .opacity(isHovered ? 1 : 0)
+          .animation(.easeInOut(duration: 0.25), value: isHovered)
+
         Image(systemName: activity.systemImage)
           .foregroundStyle(activityColor)
           .help(activity.label)
           .accessibilityLabel(activity.label)
       }
-      .padding(.horizontal, 8)
+      .padding(.leading, 8)
+      .padding(.trailing, onToggleSessions == nil ? 8 : 4)
       .padding(.vertical, 6)
       .contentShape(.rect)
-      .background(
-        isSelected ? Color.accentColor.opacity(0.16) : Color.primary.opacity(isHovered ? 0.05 : 0),
-        in: .rect(cornerRadius: 6)
-      )
+      .onTapGesture(perform: onSelect)
+
+      if let onToggleSessions {
+        Button(action: onToggleSessions) {
+          Image(systemName: "chevron.right")
+            .font(.caption2.weight(.semibold))
+            .foregroundStyle(.secondary)
+            .rotationEffect(.degrees(isSessionsExpanded ? 90 : 0))
+            .frame(width: 16, height: 16)
+            .contentShape(.rect)
+        }
+        .buttonStyle(.plain)
+        .padding(.trailing, 6)
+        .help(isSessionsExpanded ? "Hide agent sessions" : "Show agent sessions")
+        .accessibilityLabel(isSessionsExpanded ? "Hide agent sessions" : "Show agent sessions")
+      }
     }
-    .buttonStyle(.plain)
+    .background(
+      isSelected ? Color.accentColor.opacity(0.16) : Color.primary.opacity(isHovered ? 0.05 : 0),
+      in: .rect(cornerRadius: 6)
+    )
     .onHover { isHovered = $0 }
     .contextMenu {
       Button("Rename", systemImage: "pencil", action: beginRename)
@@ -60,6 +83,24 @@ struct AgentWorkspaceRow: View {
       Button("Cancel", role: .cancel) {}
       Button("Rename", action: commitRename)
     }
+  }
+
+  private var actionsView: some View {
+    Menu {
+      Button("Rename", systemImage: "pencil", action: beginRename)
+      Divider()
+      Button("Close Workspace", systemImage: "xmark", role: .destructive, action: onClose)
+    } label: {
+      Image(systemName: "ellipsis")
+        .font(.system(size: 11))
+        .foregroundColor(.secondary)
+        .frame(width: 20, height: 20)
+        .contentShape(.rect)
+    }
+    .menuStyle(.borderlessButton)
+    .menuIndicator(.hidden)
+    .fixedSize()
+    .help("Workspace actions")
   }
 
   private var activity: AgentWorkspaceActivity {

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/AgentWorkspaceRow.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/AgentWorkspaceRow.swift
@@ -1,0 +1,95 @@
+//
+//  AgentWorkspaceRow.swift
+//  AgentHub
+//
+
+import SwiftUI
+
+struct AgentWorkspaceRow: View {
+  let workspace: AgentWorkspaceRecord
+  let viewModel: AgentWorkspacesViewModel
+  let isSelected: Bool
+  let onSelect: () -> Void
+  let onRename: (String?) -> Void
+  let onClose: () -> Void
+
+  @State private var isHovered = false
+  @State private var isRenaming = false
+  @State private var renameText = ""
+
+  var body: some View {
+    Button(action: onSelect) {
+      HStack(spacing: 8) {
+        Image(systemName: "rectangle.3.group")
+          .foregroundStyle(isSelected ? .primary : .secondary)
+          .accessibilityHidden(true)
+
+        VStack(alignment: .leading, spacing: 2) {
+          Text(viewModel.displayName(for: workspace))
+            .font(.callout.weight(.medium))
+            .lineLimit(1)
+          Text(metadataText)
+            .font(.caption)
+            .foregroundStyle(.secondary)
+        }
+
+        Spacer(minLength: 4)
+
+        Image(systemName: activity.systemImage)
+          .foregroundStyle(activityColor)
+          .help(activity.label)
+          .accessibilityLabel(activity.label)
+      }
+      .padding(.horizontal, 8)
+      .padding(.vertical, 6)
+      .contentShape(.rect)
+      .background(
+        isSelected ? Color.accentColor.opacity(0.16) : Color.primary.opacity(isHovered ? 0.05 : 0),
+        in: .rect(cornerRadius: 6)
+      )
+    }
+    .buttonStyle(.plain)
+    .onHover { isHovered = $0 }
+    .contextMenu {
+      Button("Rename", systemImage: "pencil", action: beginRename)
+      Divider()
+      Button("Close Workspace", systemImage: "xmark", role: .destructive, action: onClose)
+    }
+    .alert("Rename Workspace", isPresented: $isRenaming) {
+      TextField("Workspace name", text: $renameText)
+      Button("Cancel", role: .cancel) {}
+      Button("Rename", action: commitRename)
+    }
+  }
+
+  private var activity: AgentWorkspaceActivity {
+    viewModel.activity(for: workspace.id)
+  }
+
+  private var metadataText: String {
+    let panes = viewModel.paneCount(for: workspace)
+    let agents = viewModel.linkedAgentCount(for: workspace.id)
+    let paneLabel = panes == 1 ? "1 pane" : "\(panes) panes"
+    guard agents > 0 else { return paneLabel }
+    let agentLabel = agents == 1 ? "1 agent" : "\(agents) agents"
+    return "\(paneLabel) · \(agentLabel)"
+  }
+
+  private var activityColor: Color {
+    switch activity {
+    case .idle: .secondary
+    case .ready: .green
+    case .working: .blue
+    case .needsAttention: .yellow
+    }
+  }
+
+  private func beginRename() {
+    renameText = viewModel.displayName(for: workspace)
+    isRenaming = true
+  }
+
+  private func commitRename() {
+    onRename(renameText)
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/AgentWorkspaceSurfaceMenu.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/AgentWorkspaceSurfaceMenu.swift
@@ -1,0 +1,38 @@
+//
+//  AgentWorkspaceSurfaceMenu.swift
+//  AgentHub
+//
+
+import SwiftUI
+
+struct AgentWorkspaceSurfaceMenu: View {
+  let onLaunch: (WorkspaceTerminalLaunchKind, WorkspaceSurfacePlacement) -> Void
+
+  var body: some View {
+    Menu("Add Surface", systemImage: "plus") {
+      placementMenu(title: "New Tab", systemImage: "rectangle.stack", placement: .tab)
+      placementMenu(title: "Split Right", systemImage: "rectangle.split.2x1", placement: .splitRight)
+      placementMenu(title: "Split Down", systemImage: "rectangle.split.1x2", placement: .splitDown)
+    }
+    .menuStyle(.borderlessButton)
+    .help("Add a shell or agent surface")
+  }
+
+  private func placementMenu(
+    title: String,
+    systemImage: String,
+    placement: WorkspaceSurfacePlacement
+  ) -> some View {
+    Menu(title, systemImage: systemImage) {
+      Button("Shell", systemImage: "terminal") {
+        onLaunch(.shell, placement)
+      }
+      Button("Claude", systemImage: "sparkles") {
+        onLaunch(.agent(.claude), placement)
+      }
+      Button("Codex", systemImage: "chevron.left.forwardslash.chevron.right") {
+        onLaunch(.agent(.codex), placement)
+      }
+    }
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/AgentWorkspaceTerminalView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/AgentWorkspaceTerminalView.swift
@@ -1,0 +1,60 @@
+//
+//  AgentWorkspaceTerminalView.swift
+//  AgentHub
+//
+
+import AppKit
+import SwiftUI
+
+public struct AgentWorkspaceTerminalView: NSViewRepresentable {
+  let workspaceID: String
+  let viewModel: AgentWorkspacesViewModel
+  let isDark: Bool
+  let fontSize: Double
+  let fontFamily: String
+  let theme: RuntimeTheme?
+
+  public init(
+    workspaceID: String,
+    viewModel: AgentWorkspacesViewModel,
+    isDark: Bool,
+    fontSize: Double,
+    fontFamily: String,
+    theme: RuntimeTheme?
+  ) {
+    self.workspaceID = workspaceID
+    self.viewModel = viewModel
+    self.isDark = isDark
+    self.fontSize = fontSize
+    self.fontFamily = fontFamily
+    self.theme = theme
+  }
+
+  public func makeNSView(context: Context) -> NSView {
+    guard let surface = viewModel.terminalSurface(
+      for: workspaceID,
+      isDark: isDark
+    ) else {
+      let label = NSTextField(labelWithString: "Workspace unavailable")
+      label.alignment = .center
+      label.textColor = .secondaryLabelColor
+      return label
+    }
+    surface.syncAppearance(
+      isDark: isDark,
+      fontSize: fontSize,
+      fontFamily: fontFamily,
+      theme: theme
+    )
+    return surface.view
+  }
+
+  public func updateNSView(_ nsView: NSView, context: Context) {
+    viewModel.terminalSurface(for: workspaceID, isDark: isDark)?.syncAppearance(
+      isDark: isDark,
+      fontSize: fontSize,
+      fontFamily: fontFamily,
+      theme: theme
+    )
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/CommandPaletteView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/CommandPaletteView.swift
@@ -11,6 +11,7 @@ import SwiftUI
 
 public enum CommandPaletteAction: Identifiable {
   case newSession
+  case newWorkspace
   case switchToSession(id: String, name: String, provider: SessionProviderKind, firstMessage: String?)
   case selectRepository(path: String, name: String)
   case openSettings
@@ -20,6 +21,7 @@ public enum CommandPaletteAction: Identifiable {
   public var id: String {
     switch self {
     case .newSession: return "new-session"
+    case .newWorkspace: return "new-workspace"
     case .switchToSession(let id, _, _, _): return "session-\(id)"
     case .selectRepository(let path, _): return "repo-\(path)"
     case .openSettings: return "settings"
@@ -31,6 +33,7 @@ public enum CommandPaletteAction: Identifiable {
   var title: String {
     switch self {
     case .newSession: return "New Session"
+    case .newWorkspace: return "New Workspace"
     case .switchToSession(_, let name, _, _): return name
     case .selectRepository(_, let name): return name
     case .openSettings: return "Open Settings"
@@ -42,6 +45,7 @@ public enum CommandPaletteAction: Identifiable {
   var subtitle: String? {
     switch self {
     case .newSession: return "Start from the focused session's worktree"
+    case .newWorkspace: return "Open a multi-panel terminal in the focused project"
     case .switchToSession(_, _, let provider, let firstMessage):
       if let firstMessage {
         let trimmed = firstMessage.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -60,6 +64,7 @@ public enum CommandPaletteAction: Identifiable {
   var icon: String {
     switch self {
     case .newSession: return "plus.circle.fill"
+    case .newWorkspace: return "rectangle.3.group"
     case .switchToSession: return "arrow.right.circle"
     case .selectRepository: return "folder"
     case .openSettings: return "gear"
@@ -71,6 +76,7 @@ public enum CommandPaletteAction: Identifiable {
   var shortcut: String? {
     switch self {
     case .newSession: return "⌘N"
+    case .newWorkspace: return "⌘⇧N"
     case .toggleSidebar: return "⌘B"
     case .openSettings: return "⌘,"
     case .toggleTerminalEditor: return "⌥`"
@@ -137,6 +143,7 @@ public struct CommandPaletteView: View {
   private var quickActions: [CommandPaletteAction] {
     [
       .newSession,
+      .newWorkspace,
       .toggleTerminalEditor,
       .openSettings,
       .toggleSidebar,

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/EmbeddedTerminalSurface.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/EmbeddedTerminalSurface.swift
@@ -64,6 +64,14 @@ public protocol EmbeddedTerminalSurface: AnyObject {
     projectPath: String,
     origin: SessionRelationshipOrigin
   ) -> Bool
+  func workspaceSessionDetectionContexts() -> [WorkspaceSessionDetectionContext]
+  func markWorkspaceSession(
+    contextID: String,
+    provider: SessionProviderKind,
+    sessionId: String,
+    projectPath: String,
+    origin: SessionRelationshipOrigin
+  ) -> Bool
   func openWorkspaceSurface(
     kind: WorkspaceTerminalLaunchKind,
     placement: WorkspaceSurfacePlacement,
@@ -71,6 +79,11 @@ public protocol EmbeddedTerminalSurface: AnyObject {
     projectPath: String,
     metadataStore: SessionMetadataStore?
   ) -> WorkspaceSurfaceLaunchContext?
+  @discardableResult
+  func focusWorkspaceSession(
+    provider: SessionProviderKind,
+    sessionId: String
+  ) -> Bool
   func captureWorkspaceSnapshot() -> TerminalWorkspaceSnapshot?
   func restoreWorkspaceSnapshot(_ snapshot: TerminalWorkspaceSnapshot)
 }
@@ -114,6 +127,25 @@ public extension EmbeddedTerminalSurface {
     false
   }
 
+  func workspaceSessionDetectionContexts() -> [WorkspaceSessionDetectionContext] {
+    []
+  }
+
+  func markWorkspaceSession(
+    contextID: String,
+    provider: SessionProviderKind,
+    sessionId: String,
+    projectPath: String,
+    origin: SessionRelationshipOrigin
+  ) -> Bool {
+    markAccessorySession(
+      provider: provider,
+      sessionId: sessionId,
+      projectPath: projectPath,
+      origin: origin
+    )
+  }
+
   func openWorkspaceSurface(
     kind: WorkspaceTerminalLaunchKind,
     placement: WorkspaceSurfacePlacement,
@@ -122,6 +154,14 @@ public extension EmbeddedTerminalSurface {
     metadataStore: SessionMetadataStore?
   ) -> WorkspaceSurfaceLaunchContext? {
     nil
+  }
+
+  @discardableResult
+  func focusWorkspaceSession(
+    provider: SessionProviderKind,
+    sessionId: String
+  ) -> Bool {
+    false
   }
 }
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/EmbeddedTerminalSurface.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/EmbeddedTerminalSurface.swift
@@ -26,6 +26,7 @@ public protocol EmbeddedTerminalSurface: AnyObject {
   var onRequestShowEditor: (() -> Void)? { get set }
   var consumeQueuedWebPreviewContextOnSubmit: (() -> String?)? { get set }
   var onWorkspaceChanged: ((TerminalWorkspaceSnapshot) -> Void)? { get set }
+  var workspaceCLIConfigurationProvider: ((SessionProviderKind) -> CLICommandConfiguration)? { get set }
 
   func updateContext(terminalSessionKey: String?, sessionViewModel: CLISessionsViewModel?)
   func configure(
@@ -63,12 +64,24 @@ public protocol EmbeddedTerminalSurface: AnyObject {
     projectPath: String,
     origin: SessionRelationshipOrigin
   ) -> Bool
+  func openWorkspaceSurface(
+    kind: WorkspaceTerminalLaunchKind,
+    placement: WorkspaceSurfacePlacement,
+    cliConfiguration: CLICommandConfiguration?,
+    projectPath: String,
+    metadataStore: SessionMetadataStore?
+  ) -> WorkspaceSurfaceLaunchContext?
   func captureWorkspaceSnapshot() -> TerminalWorkspaceSnapshot?
   func restoreWorkspaceSnapshot(_ snapshot: TerminalWorkspaceSnapshot)
 }
 
 public extension EmbeddedTerminalSurface {
   var onWorkspaceChanged: ((TerminalWorkspaceSnapshot) -> Void)? {
+    get { nil }
+    set {}
+  }
+
+  var workspaceCLIConfigurationProvider: ((SessionProviderKind) -> CLICommandConfiguration)? {
     get { nil }
     set {}
   }
@@ -99,6 +112,16 @@ public extension EmbeddedTerminalSurface {
     origin: SessionRelationshipOrigin
   ) -> Bool {
     false
+  }
+
+  func openWorkspaceSurface(
+    kind: WorkspaceTerminalLaunchKind,
+    placement: WorkspaceSurfacePlacement,
+    cliConfiguration: CLICommandConfiguration?,
+    projectPath: String,
+    metadataStore: SessionMetadataStore?
+  ) -> WorkspaceSurfaceLaunchContext? {
+    nil
   }
 }
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/EmbeddedTerminalView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/EmbeddedTerminalView.swift
@@ -1198,6 +1198,45 @@ public class TerminalContainerView: NSView, ManagedLocalProcessTerminalViewDeleg
     return true
   }
 
+  public func workspaceSessionDetectionContexts() -> [WorkspaceSessionDetectionContext] {
+    allTabs.compactMap { tab in
+      guard !isProtectedAgentTab(tab), tab.linkedSession == nil else { return nil }
+      return WorkspaceSessionDetectionContext(
+        id: workspaceDetectionContextID(for: tab),
+        provider: inferredProvider(for: tab),
+        projectPath: resolvedExistingDirectory(tab.workingDirectory),
+        foregroundProcessID: tab.terminalView.currentProcessId
+      )
+    }
+  }
+
+  public func markWorkspaceSession(
+    contextID: String,
+    provider: SessionProviderKind,
+    sessionId: String,
+    projectPath: String,
+    origin: SessionRelationshipOrigin
+  ) -> Bool {
+    guard let tab = allTabs.first(where: {
+      workspaceDetectionContextID(for: $0) == contextID
+    }) else {
+      return false
+    }
+    guard !isProtectedAgentTab(tab), tab.linkedSession == nil else { return false }
+
+    tab.role = .agent
+    tab.name = provider.rawValue
+    tab.linkedSession = TerminalWorkspaceLinkedSessionSnapshot(
+      provider: provider,
+      sessionId: sessionId,
+      relationshipKind: .accessoryChild
+    )
+    tab.workingDirectory = resolvedExistingDirectory(projectPath)
+    refreshWorkspaceRootView()
+    notifyWorkspaceChanged()
+    return true
+  }
+
   private func candidateAccessoryTab(for workingDirectory: String) -> RegularTerminalTab? {
     let candidates = allTabs.filter { tab in
       !isProtectedAgentTab(tab)
@@ -1205,6 +1244,24 @@ public class TerminalContainerView: NSView, ManagedLocalProcessTerminalViewDeleg
         && resolvedExistingDirectory(tab.workingDirectory) == workingDirectory
     }
     return candidates.first { $0.role == .agent } ?? candidates.first { $0.role == .shell }
+  }
+
+  private func workspaceDetectionContextID(for tab: RegularTerminalTab) -> String {
+    "regular-\(tab.id.rawValue.uuidString)"
+  }
+
+  private func inferredProvider(for tab: RegularTerminalTab) -> SessionProviderKind? {
+    let label = [tab.name, tab.title]
+      .compactMap(Self.nonEmpty)
+      .joined(separator: " ")
+      .lowercased()
+    if label.contains("claude") {
+      return .claude
+    }
+    if label.contains("codex") {
+      return .codex
+    }
+    return nil
   }
 
   private func canCloseRegularPanel(_ panel: RegularTerminalPanel) -> Bool {

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderMonitoringPanelView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderMonitoringPanelView.swift
@@ -173,6 +173,7 @@ public struct MultiProviderMonitoringPanelView: View {
   let onEmbeddedSidePanelVisibilityChange: (Bool) -> Void
   let onAddFolder: () -> Void
   let onRequestStartSession: (String?) -> Void
+  let onRequestCreateWorkspace: (String) -> Void
   let onRequestForkSession: (CLISession, SessionProviderKind) -> Void
 
   @State private var sessionFileSheetItem: SessionFileSheetItem?
@@ -235,6 +236,7 @@ public struct MultiProviderMonitoringPanelView: View {
     onEmbeddedSidePanelVisibilityChange: @escaping (Bool) -> Void = { _ in },
     onAddFolder: @escaping () -> Void,
     onRequestStartSession: @escaping (String?) -> Void,
+    onRequestCreateWorkspace: @escaping (String) -> Void = { _ in },
     onRequestForkSession: @escaping (CLISession, SessionProviderKind) -> Void = { _, _ in }
   ) {
     self.claudeViewModel = claudeViewModel
@@ -244,6 +246,7 @@ public struct MultiProviderMonitoringPanelView: View {
     self.onEmbeddedSidePanelVisibilityChange = onEmbeddedSidePanelVisibilityChange
     self.onAddFolder = onAddFolder
     self.onRequestStartSession = onRequestStartSession
+    self.onRequestCreateWorkspace = onRequestCreateWorkspace
     self.onRequestForkSession = onRequestForkSession
   }
 
@@ -456,7 +459,8 @@ public struct MultiProviderMonitoringPanelView: View {
       ModuleLandingView(
         modulePath: modulePath,
         rootRepositoryPath: rootRepositoryPath(for: modulePath),
-        onStartSession: { onRequestStartSession(modulePath) }
+        onStartSession: { onRequestStartSession(modulePath) },
+        onCreateWorkspace: { onRequestCreateWorkspace(modulePath) }
       )
     } else if !snapshot.allItems.isEmpty {
       monitoredSessionsList(snapshot: snapshot)
@@ -1514,6 +1518,7 @@ private struct ModuleLandingView: View {
   let modulePath: String
   let rootRepositoryPath: String
   let onStartSession: () -> Void
+  let onCreateWorkspace: () -> Void
 
   @Environment(\.colorScheme) private var colorScheme
 
@@ -1538,23 +1543,30 @@ private struct ModuleLandingView: View {
         .truncationMode(.middle)
         .frame(maxWidth: .infinity)
 
-      Button(action: onStartSession) {
-        HStack(spacing: 8) {
-          Image(systemName: "plus.circle.fill")
-            .font(.system(size: 13))
-          Text("Start Session")
-            .font(.system(size: 13, weight: .semibold))
+      HStack(spacing: 10) {
+        Button(action: onStartSession) {
+          HStack(spacing: 8) {
+            Image(systemName: "plus.circle.fill")
+              .font(.system(size: 13))
+            Text("Start Session")
+              .font(.system(size: 13, weight: .semibold))
+          }
+          .foregroundStyle(colorScheme == .dark ? .black : .white)
+          .frame(height: 36)
+          .padding(.horizontal, 18)
+          .background(
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+              .fill(Color.primary)
+          )
         }
-        .foregroundStyle(colorScheme == .dark ? .black : .white)
-        .frame(height: 36)
-        .padding(.horizontal, 18)
-        .background(
-          RoundedRectangle(cornerRadius: 10, style: .continuous)
-            .fill(Color.primary)
-        )
+        .buttonStyle(.plain)
+        .help("Start a session in \(moduleName)")
+
+        Button("New Workspace", systemImage: "rectangle.3.group", action: onCreateWorkspace)
+          .buttonStyle(.bordered)
+          .controlSize(.large)
+          .help("Open a multi-panel terminal in \(moduleName)")
       }
-      .buttonStyle(.plain)
-      .help("Start a session in \(moduleName)")
     }
     .frame(maxWidth: .infinity, maxHeight: .infinity)
     .padding(.horizontal, 48)

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
@@ -131,6 +131,7 @@ private struct StartSessionSheetContext: Identifiable {
 public struct MultiProviderSessionsListView: View {
   @Bindable var claudeViewModel: CLISessionsViewModel
   @Bindable var codexViewModel: CLISessionsViewModel
+  @Bindable var workspaceViewModel: AgentWorkspacesViewModel
   @Binding var columnVisibility: NavigationSplitViewVisibility
 
   @State private var sessionFileSheetItem: SessionFileSheetItem?
@@ -154,6 +155,8 @@ public struct MultiProviderSessionsListView: View {
   @State private var removeConfirmation: RemoveConfirmation?
   @State private var worktreeModuleDeleteConfirmation: WorktreeModuleDeleteConfirmation?
   @State private var selectedModuleLandingPath: String?
+  @State private var selectedWorkspaceID: String?
+  @State private var workspacePendingCloseID: String?
   @State private var pendingAddedModulePaths: [String] = []
   @State private var isRefreshingGitHubStates = false
   @State private var didScheduleInitialGitHubStateRefresh = false
@@ -187,6 +190,7 @@ public struct MultiProviderSessionsListView: View {
   public init(
     claudeViewModel: CLISessionsViewModel,
     codexViewModel: CLISessionsViewModel,
+    workspaceViewModel: AgentWorkspacesViewModel,
     columnVisibility: Binding<NavigationSplitViewVisibility>,
     intelligenceViewModel: IntelligenceViewModel? = nil,
     worktreeBranchNamingService: (any WorktreeBranchNamingServiceProtocol)? = nil,
@@ -194,6 +198,7 @@ public struct MultiProviderSessionsListView: View {
   ) {
     self.claudeViewModel = claudeViewModel
     self.codexViewModel = codexViewModel
+    self.workspaceViewModel = workspaceViewModel
     self._columnVisibility = columnVisibility
     self.intelligenceViewModel = intelligenceViewModel
     self.worktreeBranchNamingService = worktreeBranchNamingService
@@ -231,6 +236,9 @@ public struct MultiProviderSessionsListView: View {
       scheduleInitialGitHubStateRefreshIfNeeded()
       consumeGlobalSessionSelectionIfNeeded()
     }
+    .task {
+      await workspaceViewModel.load()
+    }
     .onChange(of: agentHub?.globalSessionSelectionRouter.selectionRequest?.id) { _, _ in
       consumeGlobalSessionSelectionIfNeeded()
     }
@@ -242,11 +250,13 @@ public struct MultiProviderSessionsListView: View {
     }
     .onChange(of: claudeViewModel.lastCreatedPendingId) { _, newId in
       guard let newId else { return }
+      selectedWorkspaceID = nil
       primarySessionId = "pending-claude-\(newId.uuidString)"
       claudeViewModel.lastCreatedPendingId = nil
     }
     .onChange(of: codexViewModel.lastCreatedPendingId) { _, newId in
       guard let newId else { return }
+      selectedWorkspaceID = nil
       primarySessionId = "pending-codex-\(newId.uuidString)"
       codexViewModel.lastCreatedPendingId = nil
     }
@@ -428,6 +438,13 @@ public struct MultiProviderSessionsListView: View {
     }
     .modifier(ArchiveConfirmationAlert(confirmation: $archiveConfirmation))
     .modifier(RemoveConfirmationAlert(confirmation: $removeConfirmation))
+    .modifier(
+      AgentWorkspaceCloseConfirmationModifier(
+        workspaceID: $workspacePendingCloseID,
+        onConfirm: closePendingWorkspace
+      )
+    )
+    .modifier(AgentWorkspaceErrorAlertModifier(viewModel: workspaceViewModel))
   }
 
   // MARK: - UI Helpers
@@ -441,20 +458,39 @@ public struct MultiProviderSessionsListView: View {
       // Progress bar lives above the detail pane only (not over the sidebar).
       WorktreeGenerationProgressBar()
 
-      MultiProviderMonitoringPanelView(
-        claudeViewModel: claudeViewModel,
-        codexViewModel: codexViewModel,
-        primarySessionId: $primarySessionId,
-        selectedModuleLandingPath: $selectedModuleLandingPath,
-        onEmbeddedSidePanelVisibilityChange: handleEmbeddedSidePanelVisibilityChange,
-        onAddFolder: { showAddRepositoryPicker() },
-        onRequestStartSession: { preferredRepositoryPath in
-          triggerNewSessionFlow(preferredRepositoryPath: preferredRepositoryPath)
-        },
-        onRequestForkSession: { session, targetProvider in
-          triggerForkSessionFlow(session: session, targetProvider: targetProvider)
+      Group {
+        if let selectedWorkspaceID,
+           let workspace = workspaceViewModel.workspace(id: selectedWorkspaceID) {
+          AgentWorkspaceDetailView(
+            workspace: workspace,
+            viewModel: workspaceViewModel,
+            onRename: { name in
+              Task {
+                await workspaceViewModel.renameWorkspace(id: workspace.id, name: name)
+              }
+            },
+            onClose: {
+              requestCloseWorkspace(workspace.id)
+            }
+          )
+        } else {
+          MultiProviderMonitoringPanelView(
+            claudeViewModel: claudeViewModel,
+            codexViewModel: codexViewModel,
+            primarySessionId: $primarySessionId,
+            selectedModuleLandingPath: $selectedModuleLandingPath,
+            onEmbeddedSidePanelVisibilityChange: handleEmbeddedSidePanelVisibilityChange,
+            onAddFolder: { showAddRepositoryPicker() },
+            onRequestStartSession: { preferredRepositoryPath in
+              triggerNewSessionFlow(preferredRepositoryPath: preferredRepositoryPath)
+            },
+            onRequestCreateWorkspace: createWorkspace,
+            onRequestForkSession: { session, targetProvider in
+              triggerForkSessionFlow(session: session, targetProvider: targetProvider)
+            }
+          )
         }
-      )
+      }
       .padding(12)
       .agentHubPanel()
       .frame(minWidth: 300)
@@ -476,6 +512,10 @@ public struct MultiProviderSessionsListView: View {
 
       Button("") { triggerFocusedNewSessionFlow() }
         .keyboardShortcut("n", modifiers: .command)
+        .hidden()
+
+      Button("") { createWorkspaceInFocusedProject() }
+        .keyboardShortcut("n", modifiers: [.command, .shift])
         .hidden()
 
       Button("") { handleCommandPaletteAction(.toggleSidebar) }
@@ -950,31 +990,51 @@ public struct MultiProviderSessionsListView: View {
     }
 
     guard isTrackedRepositoryModule(group.id) else { return nil }
+    let projectWorkspaces = workspaceViewModel.workspaces(for: group.id)
     return {
       removeConfirmation = RemoveConfirmation(
         title: "Remove \(group.displayName)?",
-        message: repositoryRemovalMessage(name: group.displayName, sessionCount: group.items.count)
+        message: repositoryRemovalMessage(
+          name: group.displayName,
+          sessionCount: group.items.count,
+          workspaceCount: projectWorkspaces.count
+        )
       ) {
-        if selectedModuleLandingPath == group.id {
-          selectedModuleLandingPath = nil
-        }
-        if let repo = selectedRepository(in: claudeViewModel.selectedRepositories, matching: group.id) {
-          claudeViewModel.removeRepository(repo)
-        }
-        if let repo = selectedRepository(in: codexViewModel.selectedRepositories, matching: group.id) {
-          codexViewModel.removeRepository(repo)
+        Task {
+          for workspace in projectWorkspaces {
+            await workspaceViewModel.closeWorkspace(id: workspace.id)
+          }
+          if projectWorkspaces.contains(where: { $0.id == selectedWorkspaceID }) {
+            selectedWorkspaceID = nil
+          }
+          if selectedModuleLandingPath == group.id {
+            selectedModuleLandingPath = nil
+          }
+          if let repo = selectedRepository(in: claudeViewModel.selectedRepositories, matching: group.id) {
+            claudeViewModel.removeRepository(repo)
+          }
+          if let repo = selectedRepository(in: codexViewModel.selectedRepositories, matching: group.id) {
+            codexViewModel.removeRepository(repo)
+          }
         }
       }
     }
   }
 
-  private func repositoryRemovalMessage(name: String, sessionCount: Int) -> String {
+  private func repositoryRemovalMessage(
+    name: String,
+    sessionCount: Int,
+    workspaceCount: Int
+  ) -> String {
+    var effects: [String] = []
     if sessionCount > 0 {
-      let threadLabel = sessionCount == 1 ? "thread" : "threads"
-      return "This will archive \(sessionCount) active \(threadLabel) "
-        + "and remove \(name) from your list."
+      effects.append("archive \(sessionCount) active \(sessionCount == 1 ? "thread" : "threads")")
     }
-    return "This will remove \(name) from your list."
+    if workspaceCount > 0 {
+      effects.append("close \(workspaceCount) \(workspaceCount == 1 ? "workspace" : "workspaces")")
+    }
+    guard !effects.isEmpty else { return "This will remove \(name) from your list." }
+    return "This will \(effects.joined(separator: " and ")) and remove \(name) from your list."
   }
 
   private func worktreeRemovalMessage(name: String, sessionCount: Int) -> String {
@@ -1030,6 +1090,15 @@ public struct MultiProviderSessionsListView: View {
 
   private func removeWorktreeModuleFocus(_ worktree: WorktreeBranch) {
     let path = WorktreeModuleResolver.normalizedDirectoryPath(worktree.path)
+    let workspaces = workspaceViewModel.workspaces(for: path)
+    if workspaces.contains(where: { $0.id == selectedWorkspaceID }) {
+      selectedWorkspaceID = nil
+    }
+    Task {
+      for workspace in workspaces {
+        await workspaceViewModel.closeWorkspace(id: workspace.id)
+      }
+    }
     if selectedModuleLandingPath == path {
       selectedModuleLandingPath = nil
     }
@@ -1128,6 +1197,7 @@ public struct MultiProviderSessionsListView: View {
           ForEach(sections) { section in
             ForEach(section.groups) { group in
               let isExpanded = !collapsedProjectGroups.contains(group.id)
+              let groupWorkspaces = workspaceViewModel.workspaces(for: group.id)
               let worktreeModule = worktreeModule(for: group.id)
               let worktreeSessionCount = worktreeModule == nil
                 ? 0
@@ -1136,8 +1206,8 @@ public struct MultiProviderSessionsListView: View {
               ProjectGroupHeader(
                 name: group.displayName,
                 isExpanded: isExpanded,
-                canToggle: !group.items.isEmpty,
-                isSelected: selectedModuleLandingPath == group.id && group.items.isEmpty,
+                canToggle: !group.items.isEmpty || !groupWorkspaces.isEmpty,
+                isSelected: selectedModuleLandingPath == group.id && group.items.isEmpty && groupWorkspaces.isEmpty,
                 onToggle: {
                   withAnimation(.easeInOut(duration: 0.25)) {
                     if isExpanded {
@@ -1153,6 +1223,9 @@ public struct MultiProviderSessionsListView: View {
                 repoPath: group.id,
                 onStartSession: {
                   triggerNewSessionFlow(preferredRepositoryPath: group.id)
+                },
+                onCreateWorkspace: {
+                  createWorkspace(projectPath: group.id)
                 },
                 onOpenInFinder: {
                   NSWorkspace.shared.selectFile(nil, inFileViewerRootedAtPath: group.id)
@@ -1195,6 +1268,7 @@ public struct MultiProviderSessionsListView: View {
               )
 
               if isExpanded {
+                workspaceRows(for: groupWorkspaces)
                 sessionRows(for: group.items)
               }
             }
@@ -1206,6 +1280,15 @@ public struct MultiProviderSessionsListView: View {
         }
 
       case .status:
+        if !workspaceViewModel.workspaces.isEmpty {
+          VStack(alignment: .leading, spacing: 4) {
+            Text("Workspaces")
+              .font(.caption.weight(.semibold))
+              .foregroundStyle(.secondary)
+              .padding(.top, 6)
+            workspaceRows(for: workspaceViewModel.workspaces)
+          }
+        }
         let grouped = statusGroupedSessions
         ForEach(StatusGroupCategory.allCases) { category in
           let items = grouped[category] ?? []
@@ -1238,6 +1321,35 @@ public struct MultiProviderSessionsListView: View {
   }
 
   // MARK: - Per-Provider Content
+
+  @ViewBuilder
+  private func workspaceRows(for workspaces: [AgentWorkspaceRecord]) -> some View {
+    VStack(spacing: 2) {
+      ForEach(workspaces) { workspace in
+        AgentWorkspaceRow(
+          workspace: workspace,
+          viewModel: workspaceViewModel,
+          isSelected: workspace.id == selectedWorkspaceID,
+          onSelect: {
+            selectedModuleLandingPath = nil
+            primarySessionId = nil
+            selectedWorkspaceID = workspace.id
+            setAuxiliaryShellVisible(false)
+          },
+          onRename: { name in
+            Task {
+              await workspaceViewModel.renameWorkspace(id: workspace.id, name: name)
+            }
+          },
+          onClose: {
+            requestCloseWorkspace(workspace.id)
+          }
+        )
+        .id("workspace-\(workspace.id)")
+      }
+    }
+    .padding(.top, 2)
+  }
 
   @ViewBuilder
   private func sessionRows(for items: [SelectedSessionItem]) -> some View {
@@ -1281,6 +1393,7 @@ public struct MultiProviderSessionsListView: View {
             }
           }(),
           onSelect: {
+            selectedWorkspaceID = nil
             selectedModuleLandingPath = nil
             primarySessionId = item.id
           }
@@ -1731,7 +1844,7 @@ public struct MultiProviderSessionsListView: View {
   }
 
   private func ensurePrimarySelection() {
-    guard selectedModuleLandingPath == nil else {
+    guard selectedModuleLandingPath == nil, selectedWorkspaceID == nil else {
       primarySessionId = nil
       return
     }
@@ -1758,6 +1871,7 @@ public struct MultiProviderSessionsListView: View {
     }
 
     selectedModuleLandingPath = nil
+    selectedWorkspaceID = nil
     selectedProviderRaw = request.providerKind.rawValue
     primarySessionId = request.itemId
     scrollToSessionId = request.itemId
@@ -1765,6 +1879,7 @@ public struct MultiProviderSessionsListView: View {
   }
 
   private func selectEmptyModule(_ path: String) {
+    selectedWorkspaceID = nil
     selectedModuleLandingPath = path
     primarySessionId = nil
     setAuxiliaryShellVisible(false)
@@ -1867,8 +1982,12 @@ public struct MultiProviderSessionsListView: View {
     case .newSession:
       triggerFocusedNewSessionFlow()
 
+    case .newWorkspace:
+      createWorkspaceInFocusedProject()
+
     case .switchToSession(let id, _, _, _):
       if let item = selectedSessionItems.first(where: { $0.id == id }) {
+        selectedWorkspaceID = nil
         selectedModuleLandingPath = nil
         primarySessionId = item.id
         scrollToSessionId = item.id
@@ -1932,6 +2051,50 @@ public struct MultiProviderSessionsListView: View {
       preferredRepositoryPath: focusedSessionLaunchPath,
       fallsBackToRepositoryPicker: false
     )
+  }
+
+  private func createWorkspaceInFocusedProject() {
+    let selectedWorkspacePath = selectedWorkspaceID
+      .flatMap { workspaceViewModel.workspace(id: $0) }?
+      .projectPath
+    guard let projectPath = selectedWorkspacePath ?? focusedSessionLaunchPath else { return }
+    createWorkspace(projectPath: projectPath)
+  }
+
+  private func createWorkspace(projectPath: String) {
+    Task {
+      guard let workspaceID = await workspaceViewModel.createWorkspace(projectPath: projectPath) else {
+        return
+      }
+      selectedModuleLandingPath = nil
+      primarySessionId = nil
+      selectedWorkspaceID = workspaceID
+      setAuxiliaryShellVisible(false)
+    }
+  }
+
+  private func requestCloseWorkspace(_ workspaceID: String) {
+    if workspaceViewModel.requiresCloseConfirmation(id: workspaceID) {
+      workspacePendingCloseID = workspaceID
+    } else {
+      closeWorkspace(workspaceID)
+    }
+  }
+
+  private func closePendingWorkspace() {
+    guard let workspaceID = workspacePendingCloseID else { return }
+    workspacePendingCloseID = nil
+    closeWorkspace(workspaceID)
+  }
+
+  private func closeWorkspace(_ workspaceID: String) {
+    if selectedWorkspaceID == workspaceID {
+      selectedWorkspaceID = nil
+      ensurePrimarySelection()
+    }
+    Task {
+      await workspaceViewModel.closeWorkspace(id: workspaceID)
+    }
   }
 
   private func triggerNewSessionFlow(
@@ -2096,6 +2259,7 @@ private struct ProjectGroupHeader: View {
   let onSelectEmptyModule: () -> Void
   let repoPath: String
   let onStartSession: () -> Void
+  let onCreateWorkspace: () -> Void
   let onOpenInFinder: () -> Void
   let onOpenGitHub: () -> Void
   let onArchiveSessions: (() -> Void)?
@@ -2133,6 +2297,10 @@ private struct ProjectGroupHeader: View {
       .help(canToggle ? "Expand or collapse sessions" : "Show module landing page")
 
       HeaderIconMenu(systemName: "ellipsis", size: 14, help: "More actions") {
+        Button(action: onCreateWorkspace) {
+          Label("New Workspace", systemImage: "rectangle.3.group")
+        }
+        Divider()
         Button(action: onOpenInFinder) {
           Label("Open in Finder", systemImage: "folder")
         }

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
@@ -143,6 +143,7 @@ public struct MultiProviderSessionsListView: View {
   @State private var sessionToDeleteWorktree: CLISession? = nil
   @State private var showCommandPalette = false
   @State private var collapsedProjectGroups: Set<String> = []
+  @State private var expandedWorkspaceSessionGroups: Set<String> = []
   @State private var sidebarGroupMode: SidebarGroupMode = .repo
   @State private var collapsedStatusGroups: Set<StatusGroupCategory> = []
   @State private var isPinnedSectionCollapsed: Bool = false
@@ -614,8 +615,9 @@ public struct MultiProviderSessionsListView: View {
         }
         .onChange(of: scrollToSessionId) { _, newId in
           guard let newId else { return }
+          let targetId = resolvedScrollTargetID(for: newId)
           withAnimation(.easeInOut(duration: 0.25)) {
-            proxy.scrollTo(newId, anchor: .top)
+            proxy.scrollTo(targetId, anchor: .top)
           }
           scrollToSessionId = nil
         }
@@ -943,7 +945,7 @@ public struct MultiProviderSessionsListView: View {
 
   private var pinnedSessionItems: [SelectedSessionItem] {
     SidebarSessionOrdering.pinnedItems(
-      from: selectedSessionItems,
+      from: selectedSessionItems.filter { !isWorkspaceOwned($0) },
       isPinned: isPinned,
       timestamp: { $0.timestamp },
       id: { $0.id }
@@ -1130,7 +1132,7 @@ public struct MultiProviderSessionsListView: View {
 
   private var navigableSessionItems: [SelectedSessionItem] {
     SidebarSessionOrdering.flattenedItems(
-      from: selectedSessionItems,
+      from: selectedSessionItems.filter { !isWorkspaceOwned($0) },
       repositories: Array(orderedTrackedRepos),
       groupMode: sidebarGroupMode,
       worktreeDisplayMode: worktreeDisplayMode,
@@ -1269,7 +1271,7 @@ public struct MultiProviderSessionsListView: View {
 
               if isExpanded {
                 workspaceRows(for: groupWorkspaces)
-                sessionRows(for: group.items)
+                sessionRows(for: group.items.filter { !isWorkspaceOwned($0) })
               }
             }
 
@@ -1291,7 +1293,7 @@ public struct MultiProviderSessionsListView: View {
         }
         let grouped = statusGroupedSessions
         ForEach(StatusGroupCategory.allCases) { category in
-          let items = grouped[category] ?? []
+          let items = (grouped[category] ?? []).filter { !isWorkspaceOwned($0) }
           if !items.isEmpty {
             let isExpanded = !collapsedStatusGroups.contains(category)
 
@@ -1322,14 +1324,65 @@ public struct MultiProviderSessionsListView: View {
 
   // MARK: - Per-Provider Content
 
+  /// Sessions owned by a workspace render nested under its row instead of as
+  /// top-level siblings; they stay registered for monitoring (approvals,
+  /// notifications, activity rollups) — only the presentation is grouped.
+  private var workspaceOwnedItemsByWorkspaceID: [String: [SelectedSessionItem]] {
+    var owned: [String: [SelectedSessionItem]] = [:]
+    for item in selectedSessionItems where !item.isPending {
+      if let workspaceID = workspaceViewModel.workspaceID(
+        owningSession: item.session.id,
+        provider: item.providerKind
+      ) {
+        owned[workspaceID, default: []].append(item)
+      }
+    }
+    return owned
+  }
+
+  private func isWorkspaceOwned(_ item: SelectedSessionItem) -> Bool {
+    !item.isPending && workspaceViewModel.workspaceID(
+      owningSession: item.session.id,
+      provider: item.providerKind
+    ) != nil
+  }
+
+  /// Workspace-owned sessions render as nested rows with a prefixed scroll ID;
+  /// expand their group so the scroll target exists.
+  private func resolvedScrollTargetID(for itemID: String) -> String {
+    guard let item = selectedSessionItems.first(where: { $0.id == itemID }),
+          !item.isPending,
+          let workspaceID = workspaceViewModel.workspaceID(
+            owningSession: item.session.id,
+            provider: item.providerKind
+          )
+    else { return itemID }
+    expandedWorkspaceSessionGroups.insert(workspaceID)
+    return "workspace-session-\(itemID)"
+  }
+
   @ViewBuilder
   private func workspaceRows(for workspaces: [AgentWorkspaceRecord]) -> some View {
+    let ownedItems = workspaceOwnedItemsByWorkspaceID
     VStack(spacing: 2) {
       ForEach(workspaces) { workspace in
+        let sessionItems = ownedItems[workspace.id] ?? []
+        let isSessionsExpanded = expandedWorkspaceSessionGroups.contains(workspace.id)
+
         AgentWorkspaceRow(
           workspace: workspace,
           viewModel: workspaceViewModel,
           isSelected: workspace.id == selectedWorkspaceID,
+          isSessionsExpanded: isSessionsExpanded,
+          onToggleSessions: sessionItems.isEmpty ? nil : {
+            withAnimation(.easeInOut(duration: 0.25)) {
+              if isSessionsExpanded {
+                expandedWorkspaceSessionGroups.remove(workspace.id)
+              } else {
+                expandedWorkspaceSessionGroups.insert(workspace.id)
+              }
+            }
+          },
           onSelect: {
             selectedModuleLandingPath = nil
             primarySessionId = nil
@@ -1346,9 +1399,55 @@ public struct MultiProviderSessionsListView: View {
           }
         )
         .id("workspace-\(workspace.id)")
+
+        if isSessionsExpanded, !sessionItems.isEmpty {
+          workspaceSessionRows(for: sessionItems)
+        }
       }
     }
     .padding(.top, 2)
+  }
+
+  /// Nested rows for workspace-owned sessions. Selecting one focuses the pane
+  /// that hosts the session inside the workspace — never a standalone card,
+  /// which could attach a second PTY to the same session.
+  @ViewBuilder
+  private func workspaceSessionRows(for items: [SelectedSessionItem]) -> some View {
+    VStack(spacing: 2) {
+      ForEach(items) { item in
+        CollapsibleSessionRow(
+          session: item.session,
+          providerKind: item.providerKind,
+          timestamp: item.timestamp,
+          isPending: item.isPending,
+          isPrimary: false,
+          customName: selectedSessionCustomName(for: item),
+          sessionStatus: item.sessionStatus,
+          linkedPullRequests: item.linkedPullRequests,
+          colorScheme: colorScheme,
+          isPinned: isPinned(item),
+          onPin: nil,
+          onArchive: nil,
+          onDeleteWorktree: nil,
+          onSelect: {
+            selectedModuleLandingPath = nil
+            primarySessionId = nil
+            let workspaceID = workspaceViewModel.focusWorkspaceSession(
+              provider: item.providerKind,
+              sessionId: item.session.id,
+              isDark: colorScheme == .dark
+            )
+            if let workspaceID {
+              selectedWorkspaceID = workspaceID
+              setAuxiliaryShellVisible(false)
+            }
+          }
+        )
+        .padding(.leading, 16)
+        .transition(.opacity)
+        .id("workspace-session-\(item.id)")
+      }
+    }
   }
 
   @ViewBuilder
@@ -1849,7 +1948,9 @@ public struct MultiProviderSessionsListView: View {
       return
     }
 
-    let items = selectedSessionItems
+    // Workspace-owned sessions never auto-select as the primary standalone
+    // card; their PTY lives inside the workspace surface.
+    let items = selectedSessionItems.filter { !isWorkspaceOwned($0) }
     guard !items.isEmpty else {
       primarySessionId = nil
       return
@@ -1866,14 +1967,26 @@ public struct MultiProviderSessionsListView: View {
       return
     }
 
-    guard selectedSessionItems.contains(where: { $0.id == request.itemId }) else {
+    guard let item = selectedSessionItems.first(where: { $0.id == request.itemId }) else {
       return
     }
 
     selectedModuleLandingPath = nil
-    selectedWorkspaceID = nil
     selectedProviderRaw = request.providerKind.rawValue
-    primarySessionId = request.itemId
+    if !item.isPending,
+       let workspaceID = workspaceViewModel.focusWorkspaceSession(
+         provider: item.providerKind,
+         sessionId: item.session.id,
+         isDark: colorScheme == .dark
+       ) {
+      // Workspace-owned sessions open inside their workspace pane.
+      primarySessionId = nil
+      selectedWorkspaceID = workspaceID
+      setAuxiliaryShellVisible(false)
+    } else {
+      selectedWorkspaceID = nil
+      primarySessionId = request.itemId
+    }
     scrollToSessionId = request.itemId
     router.markConsumed(request)
   }
@@ -1987,9 +2100,21 @@ public struct MultiProviderSessionsListView: View {
 
     case .switchToSession(let id, _, _, _):
       if let item = selectedSessionItems.first(where: { $0.id == id }) {
-        selectedWorkspaceID = nil
         selectedModuleLandingPath = nil
-        primarySessionId = item.id
+        if !item.isPending,
+           let workspaceID = workspaceViewModel.focusWorkspaceSession(
+             provider: item.providerKind,
+             sessionId: item.session.id,
+             isDark: colorScheme == .dark
+           ) {
+          // Workspace-owned sessions open inside their workspace pane.
+          primarySessionId = nil
+          selectedWorkspaceID = workspaceID
+          setAuxiliaryShellVisible(false)
+        } else {
+          selectedWorkspaceID = nil
+          primarySessionId = item.id
+        }
         scrollToSessionId = item.id
       }
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/TerminalDirectionalFocusResolver.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/TerminalDirectionalFocusResolver.swift
@@ -1,0 +1,93 @@
+//
+//  TerminalDirectionalFocusResolver.swift
+//  AgentHub
+//
+
+import CoreGraphics
+
+public enum TerminalFocusDirection: Sendable {
+  case left
+  case right
+  case up
+  case down
+}
+
+public enum TerminalDirectionalFocusResolver {
+  public static func target<ID: Hashable>(
+    from currentID: ID,
+    frames: [ID: CGRect],
+    direction: TerminalFocusDirection
+  ) -> ID? {
+    guard let currentFrame = frames[currentID] else { return nil }
+    let currentCenter = CGPoint(x: currentFrame.midX, y: currentFrame.midY)
+
+    let candidates = frames.compactMap { id, frame -> Candidate<ID>? in
+      guard id != currentID else { return nil }
+      let center = CGPoint(x: frame.midX, y: frame.midY)
+      let primaryDistance: Double
+      let perpendicularDistance: Double
+      let overlaps: Bool
+
+      switch direction {
+      case .left:
+        guard center.x < currentCenter.x else { return nil }
+        primaryDistance = currentCenter.x - center.x
+        perpendicularDistance = abs(currentCenter.y - center.y)
+        overlaps = frame.intersectsVertically(with: currentFrame)
+      case .right:
+        guard center.x > currentCenter.x else { return nil }
+        primaryDistance = center.x - currentCenter.x
+        perpendicularDistance = abs(currentCenter.y - center.y)
+        overlaps = frame.intersectsVertically(with: currentFrame)
+      case .up:
+        guard center.y < currentCenter.y else { return nil }
+        primaryDistance = currentCenter.y - center.y
+        perpendicularDistance = abs(currentCenter.x - center.x)
+        overlaps = frame.intersectsHorizontally(with: currentFrame)
+      case .down:
+        guard center.y > currentCenter.y else { return nil }
+        primaryDistance = center.y - currentCenter.y
+        perpendicularDistance = abs(currentCenter.x - center.x)
+        overlaps = frame.intersectsHorizontally(with: currentFrame)
+      }
+
+      let score = primaryDistance + perpendicularDistance * (overlaps ? 0.1 : 1)
+      return Candidate(
+        id: id,
+        score: score,
+        primaryDistance: primaryDistance,
+        x: frame.minX,
+        y: frame.minY
+      )
+    }
+
+    return candidates.min(by: Candidate.isOrderedBefore)?.id
+  }
+}
+
+private struct Candidate<ID> {
+  let id: ID
+  let score: Double
+  let primaryDistance: Double
+  let x: Double
+  let y: Double
+
+  static func isOrderedBefore(_ lhs: Candidate, _ rhs: Candidate) -> Bool {
+    if lhs.score != rhs.score { return lhs.score < rhs.score }
+    if lhs.primaryDistance != rhs.primaryDistance {
+      return lhs.primaryDistance < rhs.primaryDistance
+    }
+    if lhs.y != rhs.y { return lhs.y < rhs.y }
+    return lhs.x < rhs.x
+  }
+}
+
+private extension CGRect {
+  func intersectsVertically(with other: CGRect) -> Bool {
+    minY < other.maxY && maxY > other.minY
+  }
+
+  func intersectsHorizontally(with other: CGRect) -> Bool {
+    minX < other.maxX && maxX > other.minX
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/AgentWorkspacesViewModel.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/AgentWorkspacesViewModel.swift
@@ -1,0 +1,502 @@
+//
+//  AgentWorkspacesViewModel.swift
+//  AgentHub
+//
+//  Main-actor orchestration for provider-neutral terminal workspaces.
+//
+
+import AgentHubSessionGraph
+import Foundation
+
+@MainActor
+@Observable
+public final class AgentWorkspacesViewModel {
+  private struct DetectionKey: Hashable {
+    let workspaceID: String
+    let provider: SessionProviderKind
+    let contextID: String
+  }
+
+  private struct PendingDetection: Sendable {
+    let workspaceID: String
+    let provider: SessionProviderKind
+    let projectPath: String
+    let startedAt: Date
+    let baseline: AccessorySessionDetectionBaseline
+    let origin: SessionRelationshipOrigin
+  }
+
+  private struct SessionIdentity: Hashable {
+    let provider: SessionProviderKind
+    let sessionID: String
+  }
+
+  private let store: (any AgentWorkspaceStoreProtocol)?
+  private let metadataStore: SessionMetadataStore?
+  private let terminalSurfaceFactory: any EmbeddedTerminalSurfaceFactory
+  private let sessionCoordinator: any AgentWorkspaceSessionCoordinating
+  private let detectionService: any AccessorySessionDetectionServiceProtocol
+  private let detectionPollInterval: Duration
+
+  @ObservationIgnored private var activeSurfaces: [String: any EmbeddedTerminalSurface] = [:]
+  @ObservationIgnored private var saveTasks: [String: Task<Void, Never>] = [:]
+  @ObservationIgnored private var detectionTasks: [DetectionKey: Task<Void, Never>] = [:]
+  @ObservationIgnored private var activeDetectionKeysByWorkspace: [String: Set<DetectionKey>] = [:]
+  @ObservationIgnored private var didLoad = false
+
+  public private(set) var workspaces: [AgentWorkspaceRecord] = []
+  public private(set) var linksByWorkspaceID: [String: [AgentWorkspaceSessionLink]] = [:]
+  public private(set) var errorMessage: String?
+
+  public init(
+    store: (any AgentWorkspaceStoreProtocol)?,
+    metadataStore: SessionMetadataStore?,
+    terminalSurfaceFactory: any EmbeddedTerminalSurfaceFactory,
+    sessionCoordinator: any AgentWorkspaceSessionCoordinating,
+    detectionService: any AccessorySessionDetectionServiceProtocol = AccessorySessionDetectionService(),
+    detectionPollInterval: Duration = .seconds(1)
+  ) {
+    self.store = store
+    self.metadataStore = metadataStore
+    self.terminalSurfaceFactory = terminalSurfaceFactory
+    self.sessionCoordinator = sessionCoordinator
+    self.detectionService = detectionService
+    self.detectionPollInterval = detectionPollInterval
+  }
+
+  deinit {
+    for task in saveTasks.values {
+      task.cancel()
+    }
+    for task in detectionTasks.values {
+      task.cancel()
+    }
+  }
+
+  public func load() async {
+    guard !didLoad else { return }
+    didLoad = true
+    guard let store else { return }
+
+    do {
+      async let loadedWorkspaces = store.loadAgentWorkspaces()
+      async let loadedLinks = store.loadAgentWorkspaceSessionLinks()
+      workspaces = try await loadedWorkspaces
+      linksByWorkspaceID = Dictionary(grouping: try await loadedLinks, by: \.workspaceId)
+      for workspace in workspaces where linksByWorkspaceID[workspace.id] == nil {
+        linksByWorkspaceID[workspace.id] = []
+      }
+    } catch {
+      errorMessage = "Could not restore workspaces: \(error.localizedDescription)"
+    }
+  }
+
+  @discardableResult
+  public func createWorkspace(projectPath: String) async -> String? {
+    let path = Self.normalizedPath(projectPath)
+    let snapshot = Self.initialSnapshot(projectPath: path)
+
+    do {
+      let workspace = try AgentWorkspaceRecord(projectPath: path, snapshot: snapshot)
+      if let store {
+        try await store.saveAgentWorkspace(workspace, links: [])
+      }
+      workspaces.insert(workspace, at: 0)
+      linksByWorkspaceID[workspace.id] = []
+      errorMessage = nil
+      return workspace.id
+    } catch {
+      errorMessage = "Could not create workspace: \(error.localizedDescription)"
+      return nil
+    }
+  }
+
+  public func renameWorkspace(id: String, name: String?) async {
+    guard let index = workspaces.firstIndex(where: { $0.id == id }) else { return }
+    let trimmed = name?.trimmingCharacters(in: .whitespacesAndNewlines)
+    workspaces[index].customName = trimmed?.isEmpty == false ? trimmed : nil
+    workspaces[index].updatedAt = .now
+    await persistWorkspace(id: id)
+  }
+
+  public func closeWorkspace(id: String) async {
+    saveTasks[id]?.cancel()
+    saveTasks[id] = nil
+    cancelDetection(for: id)
+    activeSurfaces.removeValue(forKey: id)?.terminateProcess()
+
+    do {
+      try await store?.deleteAgentWorkspace(id: id)
+      workspaces.removeAll { $0.id == id }
+      linksByWorkspaceID.removeValue(forKey: id)
+      errorMessage = nil
+    } catch {
+      errorMessage = "Could not close workspace: \(error.localizedDescription)"
+    }
+  }
+
+  public func terminateAllTerminals() {
+    for surface in activeSurfaces.values {
+      surface.terminateProcess()
+    }
+    activeSurfaces.removeAll()
+  }
+
+  public func workspaces(for projectPath: String) -> [AgentWorkspaceRecord] {
+    let path = Self.normalizedPath(projectPath)
+    return workspaces
+      .filter { Self.normalizedPath($0.projectPath) == path }
+      .sorted { $0.createdAt < $1.createdAt }
+  }
+
+  public func workspace(id: String) -> AgentWorkspaceRecord? {
+    workspaces.first { $0.id == id }
+  }
+
+  public func displayName(for workspace: AgentWorkspaceRecord) -> String {
+    if let customName = workspace.customName?.trimmingCharacters(in: .whitespacesAndNewlines),
+       !customName.isEmpty {
+      return customName
+    }
+    let projectWorkspaces = workspaces(for: workspace.projectPath)
+    guard let index = projectWorkspaces.firstIndex(where: { $0.id == workspace.id }), index > 0 else {
+      return "Workspace"
+    }
+    return "Workspace \(index + 1)"
+  }
+
+  public func linkedAgentCount(for workspaceID: String) -> Int {
+    linksByWorkspaceID[workspaceID]?.count ?? 0
+  }
+
+  public func paneCount(for workspace: AgentWorkspaceRecord) -> Int {
+    (try? workspace.decodedSnapshot().panels.count) ?? 0
+  }
+
+  public func activity(for workspaceID: String) -> AgentWorkspaceActivity {
+    sessionCoordinator.activity(for: linksByWorkspaceID[workspaceID] ?? [])
+  }
+
+  public func requiresCloseConfirmation(id: String) -> Bool {
+    activeSurfaces[id] != nil || !(linksByWorkspaceID[id]?.isEmpty ?? true)
+  }
+
+  public func terminalSurface(
+    for workspaceID: String,
+    isDark: Bool
+  ) -> (any EmbeddedTerminalSurface)? {
+    if let existing = activeSurfaces[workspaceID] {
+      return existing
+    }
+    guard let workspace = workspace(id: workspaceID),
+          let snapshot = try? workspace.decodedSnapshot() else {
+      return nil
+    }
+
+    let surface = terminalSurfaceFactory.makeSurface(for: .ghostty)
+    surface.updateContext(
+      terminalSessionKey: "workspace-\(workspace.id)",
+      sessionViewModel: nil
+    )
+    surface.onWorkspaceChanged = { [weak self] snapshot in
+      self?.handleWorkspaceChanged(snapshot, workspaceID: workspaceID)
+    }
+    surface.workspaceCLIConfigurationProvider = { [weak self] provider in
+      self?.sessionCoordinator.cliConfiguration(for: provider)
+        ?? (provider == .claude ? .claudeDefault : .codexDefault)
+    }
+    let initialWorkingDirectory = snapshot.panels
+      .first(where: { $0.role == .primary })?
+      .tabs.first?
+      .workingDirectory ?? workspace.projectPath
+    surface.configureShell(projectPath: initialWorkingDirectory, isDark: isDark, shellPath: nil)
+    surface.restoreWorkspaceSnapshot(snapshot)
+    activeSurfaces[workspaceID] = surface
+    syncPassiveDetectionContexts(snapshot, workspaceID: workspaceID)
+    return surface
+  }
+
+  public func launchSurface(
+    workspaceID: String,
+    kind: WorkspaceTerminalLaunchKind,
+    placement: WorkspaceSurfacePlacement,
+    isDark: Bool
+  ) {
+    guard let workspace = workspace(id: workspaceID),
+          let surface = terminalSurface(for: workspaceID, isDark: isDark) else {
+      return
+    }
+
+    let provider: SessionProviderKind? = if case .agent(let provider) = kind {
+      provider
+    } else {
+      nil
+    }
+    let startedAt = Date.now
+    let baseline = provider.map {
+      detectionService.makeBaseline(
+        provider: $0,
+        projectPath: surface.activeWorkingDirectory() ?? workspace.projectPath,
+        startedAt: startedAt
+      )
+    }
+    let configuration = provider.map(sessionCoordinator.cliConfiguration(for:))
+
+    guard let context = surface.openWorkspaceSurface(
+      kind: kind,
+      placement: placement,
+      cliConfiguration: configuration,
+      projectPath: workspace.projectPath,
+      metadataStore: metadataStore
+    ) else {
+      errorMessage = "The terminal is still starting. Try again in a moment."
+      return
+    }
+
+    errorMessage = nil
+    guard let provider, let baseline else { return }
+    cancelPassiveDetection(workspaceID: workspaceID, provider: provider)
+    startDetection(
+      PendingDetection(
+        workspaceID: workspaceID,
+        provider: provider,
+        projectPath: context.projectPath,
+        startedAt: context.startedAt,
+        baseline: baseline,
+        origin: .explicit
+      ),
+      contextID: "explicit-\(UUID().uuidString)"
+    )
+  }
+
+  public func clearError() {
+    errorMessage = nil
+  }
+
+  private func handleWorkspaceChanged(
+    _ snapshot: TerminalWorkspaceSnapshot,
+    workspaceID: String
+  ) {
+    guard let index = workspaces.firstIndex(where: { $0.id == workspaceID }) else { return }
+    do {
+      try workspaces[index].updateSnapshot(snapshot)
+      reconcileLinks(from: snapshot, workspaceID: workspaceID)
+      syncPassiveDetectionContexts(snapshot, workspaceID: workspaceID)
+      scheduleSave(workspaceID: workspaceID)
+    } catch {
+      errorMessage = "Could not save workspace layout: \(error.localizedDescription)"
+    }
+  }
+
+  private func reconcileLinks(
+    from snapshot: TerminalWorkspaceSnapshot,
+    workspaceID: String
+  ) {
+    let linkedSessions = snapshot.panels.flatMap(\.tabs).compactMap(\.linkedSession)
+    let identities = Set(linkedSessions.map {
+      SessionIdentity(provider: $0.provider, sessionID: $0.sessionId)
+    })
+    let existing = linksByWorkspaceID[workspaceID] ?? []
+    let existingByIdentity: [SessionIdentity: AgentWorkspaceSessionLink] = Dictionary(
+      uniqueKeysWithValues: existing.compactMap { link -> (SessionIdentity, AgentWorkspaceSessionLink)? in
+      guard let provider = link.providerKind else { return nil }
+      return (SessionIdentity(provider: provider, sessionID: link.sessionId), link)
+      }
+    )
+
+    linksByWorkspaceID[workspaceID] = identities.map { identity in
+      existingByIdentity[identity] ?? AgentWorkspaceSessionLink(
+        workspaceId: workspaceID,
+        provider: identity.provider,
+        sessionId: identity.sessionID,
+        origin: .detected
+      )
+    }
+  }
+
+  private func syncPassiveDetectionContexts(
+    _ snapshot: TerminalWorkspaceSnapshot,
+    workspaceID: String
+  ) {
+    let shells = snapshot.panels.enumerated().flatMap { panelIndex, panel in
+      panel.tabs.enumerated().compactMap { tabIndex, tab -> (Int, Int, String)? in
+        guard tab.role == .shell, tab.linkedSession == nil,
+              let path = tab.workingDirectory else { return nil }
+        return (panelIndex, tabIndex, Self.normalizedPath(path))
+      }
+    }
+    let countsByPath = Dictionary(grouping: shells, by: { $0.2 }).mapValues(\.count)
+    var currentKeys: Set<DetectionKey> = []
+
+    for (panelIndex, tabIndex, path) in shells where countsByPath[path] == 1 {
+      for provider in SessionProviderKind.allCases {
+        let contextID = "passive-\(panelIndex)-\(tabIndex)-\(path)"
+        let key = DetectionKey(
+          workspaceID: workspaceID,
+          provider: provider,
+          contextID: contextID
+        )
+        currentKeys.insert(key)
+        guard detectionTasks[key] == nil else { continue }
+        let startedAt = Date.now
+        startDetection(
+          PendingDetection(
+            workspaceID: workspaceID,
+            provider: provider,
+            projectPath: path,
+            startedAt: startedAt,
+            baseline: detectionService.makeBaseline(
+              provider: provider,
+              projectPath: path,
+              startedAt: startedAt
+            ),
+            origin: .detected
+          ),
+          contextID: contextID
+        )
+      }
+    }
+
+    let previousKeys = activeDetectionKeysByWorkspace[workspaceID] ?? []
+    for key in previousKeys.subtracting(currentKeys) {
+      detectionTasks[key]?.cancel()
+      detectionTasks[key] = nil
+    }
+    activeDetectionKeysByWorkspace[workspaceID] = currentKeys
+  }
+
+  private func startDetection(
+    _ pending: PendingDetection,
+    contextID: String
+  ) {
+    let key = DetectionKey(
+      workspaceID: pending.workspaceID,
+      provider: pending.provider,
+      contextID: contextID
+    )
+    detectionTasks[key]?.cancel()
+    detectionTasks[key] = Task { [weak self, pending, key] in
+      while !Task.isCancelled {
+        try? await Task.sleep(for: detectionPollInterval)
+        guard !Task.isCancelled, let self else { return }
+        guard let result = detectionService.detectNewSession(
+          provider: pending.provider,
+          projectPath: pending.projectPath,
+          startedAt: pending.startedAt,
+          baseline: pending.baseline
+        ) else {
+          continue
+        }
+        detectionTasks[key] = nil
+        resolveDetection(pending, result: result)
+        return
+      }
+    }
+  }
+
+  private func resolveDetection(
+    _ pending: PendingDetection,
+    result: AccessorySessionDetectionResult
+  ) {
+    guard let surface = activeSurfaces[pending.workspaceID] else { return }
+    guard surface.markAccessorySession(
+      provider: result.provider,
+      sessionId: result.sessionId,
+      projectPath: result.projectPath,
+      origin: pending.origin
+    ) else {
+      return
+    }
+
+    var links = linksByWorkspaceID[pending.workspaceID] ?? []
+    links.removeAll {
+      $0.providerKind == result.provider && $0.sessionId == result.sessionId
+    }
+    links.append(
+      AgentWorkspaceSessionLink(
+        workspaceId: pending.workspaceID,
+        provider: result.provider,
+        sessionId: result.sessionId,
+        origin: pending.origin
+      )
+    )
+    linksByWorkspaceID[pending.workspaceID] = links
+    sessionCoordinator.monitorDetectedSession(result)
+
+    if let snapshot = surface.captureWorkspaceSnapshot() {
+      handleWorkspaceChanged(snapshot, workspaceID: pending.workspaceID)
+    }
+  }
+
+  private func scheduleSave(workspaceID: String) {
+    saveTasks[workspaceID]?.cancel()
+    saveTasks[workspaceID] = Task { [weak self] in
+      try? await Task.sleep(for: .milliseconds(250))
+      guard !Task.isCancelled, let self else { return }
+      await persistWorkspace(id: workspaceID)
+      saveTasks[workspaceID] = nil
+    }
+  }
+
+  private func persistWorkspace(id: String) async {
+    guard let workspace = workspace(id: id), let store else { return }
+    do {
+      try await store.saveAgentWorkspace(
+        workspace,
+        links: linksByWorkspaceID[id] ?? []
+      )
+      errorMessage = nil
+    } catch {
+      errorMessage = "Could not save workspace: \(error.localizedDescription)"
+    }
+  }
+
+  private func cancelDetection(for workspaceID: String) {
+    let keys = detectionTasks.keys.filter { $0.workspaceID == workspaceID }
+    for key in keys {
+      detectionTasks[key]?.cancel()
+      detectionTasks[key] = nil
+    }
+    activeDetectionKeysByWorkspace[workspaceID] = nil
+  }
+
+  private func cancelPassiveDetection(
+    workspaceID: String,
+    provider: SessionProviderKind
+  ) {
+    let keys = detectionTasks.keys.filter {
+      $0.workspaceID == workspaceID
+        && $0.provider == provider
+        && $0.contextID.hasPrefix("passive-")
+    }
+    for key in keys {
+      detectionTasks[key]?.cancel()
+      detectionTasks[key] = nil
+      activeDetectionKeysByWorkspace[workspaceID]?.remove(key)
+    }
+  }
+
+  private static func initialSnapshot(projectPath: String) -> TerminalWorkspaceSnapshot {
+    TerminalWorkspaceSnapshot(
+      panels: [
+        TerminalWorkspacePanelSnapshot(
+          role: .primary,
+          tabs: [
+            TerminalWorkspaceTabSnapshot(
+              role: .shell,
+              name: "Shell",
+              title: "Shell",
+              workingDirectory: projectPath
+            )
+          ]
+        )
+      ]
+    )
+  }
+
+  private static func normalizedPath(_ path: String) -> String {
+    URL(fileURLWithPath: (path as NSString).expandingTildeInPath)
+      .standardizedFileURL
+      .path
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/AgentWorkspacesViewModel.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/AgentWorkspacesViewModel.swift
@@ -20,6 +20,7 @@ public final class AgentWorkspacesViewModel {
   private struct PendingDetection: Sendable {
     let workspaceID: String
     let provider: SessionProviderKind
+    let surfaceContextID: String?
     let projectPath: String
     let startedAt: Date
     let baseline: AccessorySessionDetectionBaseline
@@ -36,6 +37,7 @@ public final class AgentWorkspacesViewModel {
   private let terminalSurfaceFactory: any EmbeddedTerminalSurfaceFactory
   private let sessionCoordinator: any AgentWorkspaceSessionCoordinating
   private let detectionService: any AccessorySessionDetectionServiceProtocol
+  private let processProviderResolver: any WorkspaceSessionProcessProviderResolving
   private let detectionPollInterval: Duration
 
   @ObservationIgnored private var activeSurfaces: [String: any EmbeddedTerminalSurface] = [:]
@@ -54,6 +56,7 @@ public final class AgentWorkspacesViewModel {
     terminalSurfaceFactory: any EmbeddedTerminalSurfaceFactory,
     sessionCoordinator: any AgentWorkspaceSessionCoordinating,
     detectionService: any AccessorySessionDetectionServiceProtocol = AccessorySessionDetectionService(),
+    processProviderResolver: any WorkspaceSessionProcessProviderResolving = WorkspaceSessionProcessProviderResolver(),
     detectionPollInterval: Duration = .seconds(1)
   ) {
     self.store = store
@@ -61,6 +64,7 @@ public final class AgentWorkspacesViewModel {
     self.terminalSurfaceFactory = terminalSurfaceFactory
     self.sessionCoordinator = sessionCoordinator
     self.detectionService = detectionService
+    self.processProviderResolver = processProviderResolver
     self.detectionPollInterval = detectionPollInterval
   }
 
@@ -86,6 +90,7 @@ public final class AgentWorkspacesViewModel {
       for workspace in workspaces where linksByWorkspaceID[workspace.id] == nil {
         linksByWorkspaceID[workspace.id] = []
       }
+      await sessionCoordinator.restorePersistedSessions(persistedSessionReferences())
     } catch {
       errorMessage = "Could not restore workspaces: \(error.localizedDescription)"
     }
@@ -167,6 +172,32 @@ public final class AgentWorkspacesViewModel {
 
   public func linkedAgentCount(for workspaceID: String) -> Int {
     linksByWorkspaceID[workspaceID]?.count ?? 0
+  }
+
+  public func workspaceID(
+    owningSession sessionId: String,
+    provider: SessionProviderKind
+  ) -> String? {
+    linksByWorkspaceID.first { _, links in
+      links.contains { $0.providerKind == provider && $0.sessionId == sessionId }
+    }?.key
+  }
+
+  /// Routes a sidebar selection of a workspace-owned session to the pane that
+  /// hosts it. Returns the owning workspace ID so the caller can select the
+  /// workspace, or nil when no workspace owns the session.
+  @discardableResult
+  public func focusWorkspaceSession(
+    provider: SessionProviderKind,
+    sessionId: String,
+    isDark: Bool
+  ) -> String? {
+    guard let workspaceID = workspaceID(owningSession: sessionId, provider: provider) else {
+      return nil
+    }
+    terminalSurface(for: workspaceID, isDark: isDark)?
+      .focusWorkspaceSession(provider: provider, sessionId: sessionId)
+    return workspaceID
   }
 
   public func paneCount(for workspace: AgentWorkspaceRecord) -> Int {
@@ -255,17 +286,24 @@ public final class AgentWorkspacesViewModel {
 
     errorMessage = nil
     guard let provider, let baseline else { return }
-    cancelPassiveDetection(workspaceID: workspaceID, provider: provider)
+    if let detectionContextID = context.detectionContextID {
+      cancelDetection(
+        workspaceID: workspaceID,
+        surfaceContextID: detectionContextID
+      )
+    }
     startDetection(
       PendingDetection(
         workspaceID: workspaceID,
         provider: provider,
+        surfaceContextID: context.detectionContextID,
         projectPath: context.projectPath,
         startedAt: context.startedAt,
         baseline: baseline,
         origin: .explicit
       ),
-      contextID: "explicit-\(UUID().uuidString)"
+      contextID: context.detectionContextID.map { "explicit-\($0)" }
+        ?? "explicit-\(UUID().uuidString)"
     )
   }
 
@@ -315,22 +353,17 @@ public final class AgentWorkspacesViewModel {
   }
 
   private func syncPassiveDetectionContexts(
-    _ snapshot: TerminalWorkspaceSnapshot,
+    _: TerminalWorkspaceSnapshot,
     workspaceID: String
   ) {
-    let shells = snapshot.panels.enumerated().flatMap { panelIndex, panel in
-      panel.tabs.enumerated().compactMap { tabIndex, tab -> (Int, Int, String)? in
-        guard tab.role == .shell, tab.linkedSession == nil,
-              let path = tab.workingDirectory else { return nil }
-        return (panelIndex, tabIndex, Self.normalizedPath(path))
-      }
-    }
-    let countsByPath = Dictionary(grouping: shells, by: { $0.2 }).mapValues(\.count)
+    guard let surface = activeSurfaces[workspaceID] else { return }
+    let contexts = surface.workspaceSessionDetectionContexts()
     var currentKeys: Set<DetectionKey> = []
 
-    for (panelIndex, tabIndex, path) in shells where countsByPath[path] == 1 {
+    for context in contexts {
+      let path = Self.normalizedPath(context.projectPath)
       for provider in SessionProviderKind.allCases {
-        let contextID = "passive-\(panelIndex)-\(tabIndex)-\(path)"
+        let contextID = "passive-\(context.id)"
         let key = DetectionKey(
           workspaceID: workspaceID,
           provider: provider,
@@ -343,6 +376,7 @@ public final class AgentWorkspacesViewModel {
           PendingDetection(
             workspaceID: workspaceID,
             provider: provider,
+            surfaceContextID: context.id,
             projectPath: path,
             startedAt: startedAt,
             baseline: detectionService.makeBaseline(
@@ -374,12 +408,34 @@ public final class AgentWorkspacesViewModel {
       provider: pending.provider,
       contextID: contextID
     )
+    let pollInterval = detectionPollInterval
+    let processProviderResolver = processProviderResolver
+    let executableNames = executableNamesByProvider()
     detectionTasks[key]?.cancel()
     detectionTasks[key] = Task { [weak self, pending, key] in
       while !Task.isCancelled {
-        try? await Task.sleep(for: detectionPollInterval)
+        try? await Task.sleep(for: pollInterval)
         guard !Task.isCancelled, let self else { return }
-        guard let result = detectionService.detectNewSession(
+        if let surfaceContextID = pending.surfaceContextID {
+          guard let context = self.activeSurfaces[pending.workspaceID]?
+            .workspaceSessionDetectionContexts()
+            .first(where: { $0.id == surfaceContextID }) else {
+            self.detectionTasks[key] = nil
+            return
+          }
+          let provider: SessionProviderKind? = if let provider = context.provider {
+            provider
+          } else if let processID = context.foregroundProcessID {
+            await processProviderResolver.provider(
+              for: processID,
+              executableNames: executableNames
+            )
+          } else {
+            nil
+          }
+          guard provider == pending.provider else { continue }
+        }
+        guard let result = self.detectionService.detectNewSession(
           provider: pending.provider,
           projectPath: pending.projectPath,
           startedAt: pending.startedAt,
@@ -387,8 +443,8 @@ public final class AgentWorkspacesViewModel {
         ) else {
           continue
         }
-        detectionTasks[key] = nil
-        resolveDetection(pending, result: result)
+        self.detectionTasks[key] = nil
+        await self.resolveDetection(pending, result: result)
         return
       }
     }
@@ -397,14 +453,32 @@ public final class AgentWorkspacesViewModel {
   private func resolveDetection(
     _ pending: PendingDetection,
     result: AccessorySessionDetectionResult
-  ) {
+  ) async {
+    let isAlreadyLinked = (linksByWorkspaceID[pending.workspaceID] ?? []).contains {
+      $0.providerKind == result.provider && $0.sessionId == result.sessionId
+    }
+    guard !isAlreadyLinked else {
+      rebaselineDetection(pending)
+      return
+    }
     guard let surface = activeSurfaces[pending.workspaceID] else { return }
-    guard surface.markAccessorySession(
-      provider: result.provider,
-      sessionId: result.sessionId,
-      projectPath: result.projectPath,
-      origin: pending.origin
-    ) else {
+    let didMarkSession = if let surfaceContextID = pending.surfaceContextID {
+      surface.markWorkspaceSession(
+        contextID: surfaceContextID,
+        provider: result.provider,
+        sessionId: result.sessionId,
+        projectPath: result.projectPath,
+        origin: pending.origin
+      )
+    } else {
+      surface.markAccessorySession(
+        provider: result.provider,
+        sessionId: result.sessionId,
+        projectPath: result.projectPath,
+        origin: pending.origin
+      )
+    }
+    guard didMarkSession else {
       return
     }
 
@@ -421,11 +495,17 @@ public final class AgentWorkspacesViewModel {
       )
     )
     linksByWorkspaceID[pending.workspaceID] = links
-    sessionCoordinator.monitorDetectedSession(result)
 
     if let snapshot = surface.captureWorkspaceSnapshot() {
       handleWorkspaceChanged(snapshot, workspaceID: pending.workspaceID)
     }
+    await persistWorkspaceImmediately(id: pending.workspaceID)
+    refreshPassiveDetectionBaselines(
+      workspaceID: pending.workspaceID,
+      provider: pending.provider,
+      excludingSurfaceContextID: pending.surfaceContextID
+    )
+    await sessionCoordinator.monitorDetectedSession(result)
   }
 
   private func scheduleSave(workspaceID: String) {
@@ -451,6 +531,57 @@ public final class AgentWorkspacesViewModel {
     }
   }
 
+  private func persistWorkspaceImmediately(id: String) async {
+    saveTasks[id]?.cancel()
+    saveTasks[id] = nil
+    await persistWorkspace(id: id)
+  }
+
+  private func persistedSessionReferences() -> [AgentWorkspaceSessionReference] {
+    var referencesByIdentity: [SessionIdentity: AgentWorkspaceSessionReference] = [:]
+
+    for workspace in workspaces {
+      var projectPathByIdentity: [SessionIdentity: String] = [:]
+      if let snapshot = try? workspace.decodedSnapshot() {
+        for tab in snapshot.panels.flatMap(\.tabs) {
+          guard let linkedSession = tab.linkedSession else { continue }
+          let identity = SessionIdentity(
+            provider: linkedSession.provider,
+            sessionID: linkedSession.sessionId
+          )
+          let projectPath = tab.workingDirectory
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .flatMap { $0.isEmpty ? nil : Self.normalizedPath($0) }
+            ?? Self.normalizedPath(workspace.projectPath)
+          projectPathByIdentity[identity] = projectPath
+          referencesByIdentity[identity] = AgentWorkspaceSessionReference(
+            provider: identity.provider,
+            sessionId: identity.sessionID,
+            projectPath: projectPath
+          )
+        }
+      }
+
+      for link in linksByWorkspaceID[workspace.id] ?? [] {
+        guard let provider = link.providerKind else { continue }
+        let identity = SessionIdentity(provider: provider, sessionID: link.sessionId)
+        referencesByIdentity[identity] = AgentWorkspaceSessionReference(
+          provider: provider,
+          sessionId: link.sessionId,
+          projectPath: projectPathByIdentity[identity]
+            ?? Self.normalizedPath(workspace.projectPath)
+        )
+      }
+    }
+
+    return referencesByIdentity.values.sorted {
+      if $0.provider != $1.provider {
+        return $0.provider.rawValue < $1.provider.rawValue
+      }
+      return $0.sessionId < $1.sessionId
+    }
+  }
+
   private func cancelDetection(for workspaceID: String) {
     let keys = detectionTasks.keys.filter { $0.workspaceID == workspaceID }
     for key in keys {
@@ -460,20 +591,86 @@ public final class AgentWorkspacesViewModel {
     activeDetectionKeysByWorkspace[workspaceID] = nil
   }
 
-  private func cancelPassiveDetection(
+  private func cancelDetection(
     workspaceID: String,
-    provider: SessionProviderKind
+    surfaceContextID: String
   ) {
     let keys = detectionTasks.keys.filter {
       $0.workspaceID == workspaceID
-        && $0.provider == provider
-        && $0.contextID.hasPrefix("passive-")
+        && ($0.contextID == "passive-\(surfaceContextID)"
+          || $0.contextID == "explicit-\(surfaceContextID)")
     }
     for key in keys {
       detectionTasks[key]?.cancel()
       detectionTasks[key] = nil
       activeDetectionKeysByWorkspace[workspaceID]?.remove(key)
     }
+  }
+
+  private func refreshPassiveDetectionBaselines(
+    workspaceID: String,
+    provider: SessionProviderKind,
+    excludingSurfaceContextID: String?
+  ) {
+    let excludedKey = excludingSurfaceContextID.map { "passive-\($0)" }
+    let keys = detectionTasks.keys.filter {
+      $0.workspaceID == workspaceID
+        && $0.provider == provider
+        && $0.contextID.hasPrefix("passive-")
+        && $0.contextID != excludedKey
+    }
+    for key in keys {
+      detectionTasks[key]?.cancel()
+      detectionTasks[key] = nil
+      activeDetectionKeysByWorkspace[workspaceID]?.remove(key)
+    }
+    guard let surface = activeSurfaces[workspaceID],
+          let snapshot = surface.captureWorkspaceSnapshot() else { return }
+    syncPassiveDetectionContexts(snapshot, workspaceID: workspaceID)
+  }
+
+  private func rebaselineDetection(_ pending: PendingDetection) {
+    guard let surfaceContextID = pending.surfaceContextID,
+          let context = activeSurfaces[pending.workspaceID]?
+            .workspaceSessionDetectionContexts()
+            .first(where: { $0.id == surfaceContextID }) else {
+      return
+    }
+    let startedAt = Date.now
+    let projectPath = Self.normalizedPath(context.projectPath)
+    let contextID = "\(pending.origin == .explicit ? "explicit" : "passive")-\(surfaceContextID)"
+    let key = DetectionKey(
+      workspaceID: pending.workspaceID,
+      provider: pending.provider,
+      contextID: contextID
+    )
+    if pending.origin == .detected {
+      activeDetectionKeysByWorkspace[pending.workspaceID, default: []].insert(key)
+    }
+    startDetection(
+      PendingDetection(
+        workspaceID: pending.workspaceID,
+        provider: pending.provider,
+        surfaceContextID: surfaceContextID,
+        projectPath: projectPath,
+        startedAt: startedAt,
+        baseline: detectionService.makeBaseline(
+          provider: pending.provider,
+          projectPath: projectPath,
+          startedAt: startedAt
+        ),
+        origin: pending.origin
+      ),
+      contextID: contextID
+    )
+  }
+
+  private func executableNamesByProvider() -> [SessionProviderKind: String] {
+    Dictionary(
+      uniqueKeysWithValues: SessionProviderKind.allCases.map { provider in
+        (provider, sessionCoordinator.cliConfiguration(for: provider).executableName)
+      }
+    )
   }
 
   private static func initialSnapshot(projectPath: String) -> TerminalWorkspaceSnapshot {

--- a/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/CLISessionsViewModel.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/CLISessionsViewModel.swift
@@ -2317,6 +2317,116 @@ public final class CLISessionsViewModel {
     persistWorkspaceState()
   }
 
+  /// Adopts a newly detected session launched from a provider-neutral workspace.
+  /// The repository must be part of this provider's persisted workspace state
+  /// before the monitored ID is saved, otherwise launch restoration has no
+  /// project root from which to rebuild the session.
+  func registerWorkspaceSession(_ session: CLISession) async {
+    unrestoredSessionIds.insert(session.id)
+    syncFocusedSessionIdsToMonitor(extraSessionIds: [session.id])
+
+    await ensureWorkspaceSessionRepository(at: session.projectPath)
+
+    pendingRestorationSessionIds.remove(session.id)
+    unrestoredSessionIds.remove(session.id)
+    monitoredSessionBackup[session.id] = session
+
+    if monitoredSessionIds.contains(session.id) {
+      ensureLiveMonitoring(sessionId: session.id)
+      persistMonitoredSessions()
+    } else {
+      startMonitoring(session: session)
+    }
+
+    refresh()
+  }
+
+  /// Reconciles workspace-owned session IDs with the normal provider launch
+  /// restoration flow without mounting any terminal surfaces.
+  func restoreWorkspaceSessions(_ references: [AgentWorkspaceSessionReference]) async {
+    let references = Array(Set(references.filter { $0.provider == providerKind }))
+    guard !references.isEmpty else { return }
+
+    let sessionIds = Set(references.map(\.sessionId))
+    pendingRestorationSessionIds.formUnion(sessionIds)
+    unrestoredSessionIds.formUnion(sessionIds)
+    syncFocusedSessionIdsToMonitor(extraSessionIds: sessionIds)
+
+    let projectPaths = Set(references.map {
+      WorktreeModuleResolver.normalizedDirectoryPath($0.projectPath)
+    })
+    for projectPath in projectPaths.sorted() {
+      await ensureWorkspaceSessionRepository(at: projectPath)
+    }
+
+    materializeWorkspaceSessionReferences(references)
+
+    let sessions = await monitorService.loadSessions(ids: sessionIds)
+    restoreLoadedMonitoredSessions(
+      sessions,
+      allowedProjectRoots: projectRoots(from: selectedRepositories)
+    )
+
+    let unresolvedIds = sessionIds.intersection(pendingRestorationSessionIds)
+    pendingRestorationSessionIds.formUnion(unresolvedIds)
+    unrestoredSessionIds.formUnion(unresolvedIds)
+    persistMonitoredSessions()
+  }
+
+  /// Workspace links are durable session identities, so they must appear in the
+  /// normal Sessions list even while their JSONL file is still being located.
+  /// The targeted load below replaces these lightweight entries with parsed
+  /// session metadata as soon as it succeeds.
+  private func materializeWorkspaceSessionReferences(
+    _ references: [AgentWorkspaceSessionReference]
+  ) {
+    var materializedSessions: [CLISession] = []
+
+    for reference in references {
+      monitoredSessionIds.insert(reference.sessionId)
+
+      if let session = findSession(byId: reference.sessionId) {
+        monitoredSessionBackup[reference.sessionId] = session
+        materializedSessions.append(session)
+        continue
+      }
+
+      if let session = monitoredSessionBackup[reference.sessionId] {
+        materializedSessions.append(session)
+        continue
+      }
+
+      let session = CLISession(
+        id: reference.sessionId,
+        projectPath: WorktreeModuleResolver.normalizedDirectoryPath(reference.projectPath),
+        lastActivityAt: .now,
+        isActive: false
+      )
+      monitoredSessionBackup[reference.sessionId] = session
+      materializedSessions.append(session)
+    }
+
+    expandItemsContainingLoadedSessions(materializedSessions)
+    loadCustomNames()
+    loadPinnedSessions()
+  }
+
+  private func ensureWorkspaceSessionRepository(at projectPath: String) async {
+    await focusWorktreeIfNeeded(at: projectPath)
+    let addedRepository = await monitorService.addRepository(projectPath)
+    if addedRepository != nil {
+      browseSessionsLoadState = .loaded
+    }
+
+    let repositories = await monitorService.getSelectedRepositories()
+    selectedRepositories = mergePreservingExpandedState(
+      current: selectedRepositories,
+      updated: repositories
+    )
+    persistSelectedRepositories()
+    syncClaudeHookInstalls()
+  }
+
   /// Syncs the backup store with latest session data from allSessions.
   /// Called after repositories are updated to keep backup fresh for monitored sessions.
   /// Also cleans up any orphaned entries not in monitoredSessionIds.

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/AgentWorkspacePersistenceTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/AgentWorkspacePersistenceTests.swift
@@ -1,0 +1,222 @@
+import Foundation
+import GRDB
+import Testing
+
+@testable import AgentHubCore
+
+@Suite("Agent workspace persistence")
+struct AgentWorkspacePersistenceTests {
+  @Test("Workspace, snapshot, and links round-trip transactionally")
+  func workspaceRoundTrip() async throws {
+    let store = try SessionMetadataStore(path: temporaryAgentWorkspaceDatabasePath())
+    let snapshot = workspaceSnapshot(path: "/tmp/project")
+    var workspace = try AgentWorkspaceRecord(
+      id: "workspace-1",
+      projectPath: "/tmp/project",
+      snapshot: snapshot
+    )
+    let link = AgentWorkspaceSessionLink(
+      workspaceId: workspace.id,
+      provider: .claude,
+      sessionId: "session-1",
+      origin: .explicit
+    )
+
+    try await store.saveAgentWorkspace(workspace, links: [link])
+
+    let loaded = try await store.loadAgentWorkspaces()
+    #expect(loaded.count == 1)
+    #expect(try loaded[0].decodedSnapshot() == snapshot)
+    let loadedLinks = try await store.loadAgentWorkspaceSessionLinks()
+    #expect(loadedLinks.count == 1)
+    #expect(loadedLinks.first?.workspaceId == link.workspaceId)
+    #expect(loadedLinks.first?.provider == link.provider)
+    #expect(loadedLinks.first?.sessionId == link.sessionId)
+    #expect(loadedLinks.first?.origin == link.origin)
+
+    let updatedSnapshot = TerminalWorkspaceSnapshot(
+      panels: snapshot.panels + [
+        TerminalWorkspacePanelSnapshot(
+          role: .auxiliary,
+          tabs: [TerminalWorkspaceTabSnapshot(role: .shell, workingDirectory: "/tmp/project")]
+        )
+      ]
+    )
+    try workspace.updateSnapshot(updatedSnapshot)
+    try await store.saveAgentWorkspace(workspace, links: [])
+
+    #expect(try await store.loadAgentWorkspaceSessionLinks().isEmpty)
+    #expect(try await store.loadAgentWorkspaces().first?.decodedSnapshot() == updatedSnapshot)
+  }
+
+  @Test("A provider session can belong to only one workspace")
+  func sessionLinkHasSingleWorkspaceOwner() async throws {
+    let store = try SessionMetadataStore(path: temporaryAgentWorkspaceDatabasePath())
+    let first = try AgentWorkspaceRecord(
+      id: "workspace-1",
+      projectPath: "/tmp/project",
+      snapshot: workspaceSnapshot(path: "/tmp/project")
+    )
+    let second = try AgentWorkspaceRecord(
+      id: "workspace-2",
+      projectPath: "/tmp/project",
+      snapshot: workspaceSnapshot(path: "/tmp/project")
+    )
+    try await store.saveAgentWorkspace(
+      first,
+      links: [
+        AgentWorkspaceSessionLink(
+          workspaceId: first.id,
+          provider: .codex,
+          sessionId: "session-1",
+          origin: .detected
+        )
+      ]
+    )
+
+    var didThrow = false
+    do {
+      try await store.saveAgentWorkspace(
+        second,
+        links: [
+          AgentWorkspaceSessionLink(
+            workspaceId: second.id,
+            provider: .codex,
+            sessionId: "session-1",
+            origin: .explicit
+          )
+        ]
+      )
+    } catch {
+      didThrow = true
+    }
+    #expect(didThrow)
+  }
+
+  @Test("Deleting a workspace removes links but not session metadata")
+  func workspaceDeletePreservesSessionMetadata() async throws {
+    let store = try SessionMetadataStore(path: temporaryAgentWorkspaceDatabasePath())
+    try await store.setCustomName("Historical Session", for: "session-1")
+    let workspace = try AgentWorkspaceRecord(
+      id: "workspace-1",
+      projectPath: "/tmp/project",
+      snapshot: workspaceSnapshot(path: "/tmp/project")
+    )
+    try await store.saveAgentWorkspace(
+      workspace,
+      links: [
+        AgentWorkspaceSessionLink(
+          workspaceId: workspace.id,
+          provider: .claude,
+          sessionId: "session-1",
+          origin: .explicit
+        )
+      ]
+    )
+
+    try await store.deleteAgentWorkspace(id: workspace.id)
+
+    #expect(try await store.loadAgentWorkspaces().isEmpty)
+    #expect(try await store.loadAgentWorkspaceSessionLinks().isEmpty)
+    #expect(try await store.getCustomName(for: "session-1") == "Historical Session")
+  }
+
+  @Test("v12 migration preserves every v11 table")
+  func migrationPreservesV11Tables() async throws {
+    let path = temporaryAgentWorkspaceDatabasePath()
+    do {
+      _ = try SessionMetadataStore(path: path)
+    }
+
+    let dbQueue = try DatabaseQueue(path: path)
+    try await dbQueue.write { db in
+      let now = Date(timeIntervalSince1970: 1_000)
+      let snapshotData = try JSONEncoder().encode(workspaceSnapshot(path: "/tmp/project"))
+      let emptyStrings = try JSONEncoder().encode([String]())
+      let emptyExpansion = try JSONEncoder().encode([String: Bool]())
+
+      try db.execute(
+        sql: "INSERT INTO session_metadata VALUES (?, ?, ?, ?, ?)",
+        arguments: ["session-1", "Session", now, now, true]
+      )
+      try db.execute(
+        sql: "INSERT INTO session_repo_mapping VALUES (?, ?, ?, ?)",
+        arguments: ["session-1", "/tmp/project", "/tmp/project", now]
+      )
+      try db.execute(
+        sql: "INSERT INTO ai_config VALUES (?, ?, ?, ?, ?, ?, ?)",
+        arguments: ["claude", "", "", "", "", "", now]
+      )
+      try db.execute(
+        sql: "INSERT INTO terminal_workspaces VALUES (?, ?, ?, ?, ?)",
+        arguments: ["claude", "session-1", EmbeddedTerminalBackend.ghostty.rawValue, snapshotData, now]
+      )
+      try db.execute(
+        sql: "INSERT INTO session_workspace_state VALUES (?, ?, ?, ?, ?, ?)",
+        arguments: ["claude", emptyStrings, emptyStrings, emptyExpansion, now, emptyStrings]
+      )
+      try db.execute(
+        sql: "INSERT INTO managed_processes (pid, kind, terminalKey, registeredAt, updatedAt) VALUES (?, ?, ?, ?, ?)",
+        arguments: [42, ManagedProcessKind.auxiliaryShell.rawValue, "terminal-1", now, now]
+      )
+      try db.execute(
+        sql: "INSERT INTO claude_hook_installations VALUES (?, ?, ?)",
+        arguments: ["/tmp/project", now, now]
+      )
+      try db.execute(
+        sql: "INSERT INTO session_relationships VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        arguments: ["claude", "session-1", "codex", "session-2", "accessoryChild", "explicit", now, now]
+      )
+      try db.execute(
+        sql: "INSERT INTO project_simulator_preferences VALUES (?, ?, ?, ?)",
+        arguments: ["/tmp/project", "SIM-1", "simulator", now]
+      )
+
+      try db.execute(sql: "DROP TABLE workspace_session_links")
+      try db.execute(sql: "DROP TABLE agent_workspaces")
+      try db.execute(
+        sql: "DELETE FROM grdb_migrations WHERE identifier = ?",
+        arguments: ["v12_create_agent_workspaces"]
+      )
+    }
+
+    _ = try SessionMetadataStore(path: path)
+
+    try await dbQueue.read { db in
+      let preservedTables = [
+        "session_metadata",
+        "session_repo_mapping",
+        "ai_config",
+        "terminal_workspaces",
+        "session_workspace_state",
+        "managed_processes",
+        "claude_hook_installations",
+        "session_relationships",
+        "project_simulator_preferences"
+      ]
+      for table in preservedTables {
+        let count = try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM \(table)")
+        #expect(count == 1)
+      }
+      #expect(try db.tableExists("agent_workspaces"))
+      #expect(try db.tableExists("workspace_session_links"))
+    }
+  }
+}
+
+private func workspaceSnapshot(path: String) -> TerminalWorkspaceSnapshot {
+  TerminalWorkspaceSnapshot(
+    panels: [
+      TerminalWorkspacePanelSnapshot(
+        role: .primary,
+        tabs: [TerminalWorkspaceTabSnapshot(role: .shell, workingDirectory: path)]
+      )
+    ]
+  )
+}
+
+private func temporaryAgentWorkspaceDatabasePath() -> String {
+  FileManager.default.temporaryDirectory
+    .appending(path: "test_agent_workspaces_\(UUID().uuidString).sqlite")
+    .path
+}

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/AgentWorkspaceSessionCoordinatorTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/AgentWorkspaceSessionCoordinatorTests.swift
@@ -1,0 +1,338 @@
+import Combine
+import Foundation
+import Testing
+
+@testable import AgentHubCore
+
+@MainActor
+@Suite("Agent workspace session coordinator")
+struct AgentWorkspaceSessionCoordinatorTests {
+  @Test(
+    "Detected workspace sessions persist through the normal provider restore flow",
+    arguments: SessionProviderKind.allCases
+  )
+  func detectedSessionPersistsForRelaunch(provider: SessionProviderKind) async throws {
+    let store = try SessionMetadataStore(path: temporaryCoordinatorDatabasePath())
+    let session = workspaceSession(provider: provider)
+    let claudeMonitor = WorkspaceCoordinatorMonitorSpy(
+      sessionsByID: provider == .claude ? [session.id: session] : [:]
+    )
+    let codexMonitor = WorkspaceCoordinatorMonitorSpy(
+      sessionsByID: provider == .codex ? [session.id: session] : [:]
+    )
+    let claudeWatcher = WorkspaceCoordinatorWatcherSpy()
+    let codexWatcher = WorkspaceCoordinatorWatcherSpy()
+    let claudeViewModel = makeCoordinatorViewModel(
+      provider: .claude,
+      monitor: claudeMonitor,
+      watcher: claudeWatcher,
+      store: store
+    )
+    let codexViewModel = makeCoordinatorViewModel(
+      provider: .codex,
+      monitor: codexMonitor,
+      watcher: codexWatcher,
+      store: store
+    )
+    let coordinator = AgentWorkspaceSessionCoordinator(
+      claudeViewModel: claudeViewModel,
+      codexViewModel: codexViewModel
+    )
+
+    await coordinator.monitorDetectedSession(
+      AccessorySessionDetectionResult(
+        provider: provider,
+        sessionId: session.id,
+        projectPath: session.projectPath,
+        branchName: session.branchName,
+        sessionFilePath: try #require(session.sessionFilePath)
+      )
+    )
+
+    await waitForCoordinatorCondition {
+      let state = store.getWorkspaceStateSync(for: provider)
+      return state.selectedRepositoryPaths == [session.projectPath]
+        && state.monitoredSessionIds == [session.id]
+    }
+
+    let relaunchMonitor = WorkspaceCoordinatorMonitorSpy(sessionsByID: [session.id: session])
+    let relaunchWatcher = WorkspaceCoordinatorWatcherSpy()
+    let relaunchedViewModel = makeCoordinatorViewModel(
+      provider: provider,
+      monitor: relaunchMonitor,
+      watcher: relaunchWatcher,
+      store: store
+    )
+
+    await waitForCoordinatorCondition {
+      relaunchedViewModel.selectedRepositories.map(\.path) == [session.projectPath]
+        && relaunchedViewModel.monitoredSessionIds == [session.id]
+        && relaunchedViewModel.monitoredSessions.map(\.session.id) == [session.id]
+    }
+  }
+
+  @Test("Persisted workspace references restore idempotently without mounting terminals")
+  func persistedReferencesRestoreIdempotently() async throws {
+    let store = try SessionMetadataStore(path: temporaryCoordinatorDatabasePath())
+    let session = workspaceSession(provider: .claude)
+    let claudeMonitor = WorkspaceCoordinatorMonitorSpy(sessionsByID: [session.id: session])
+    let claudeWatcher = WorkspaceCoordinatorWatcherSpy()
+    let claudeViewModel = makeCoordinatorViewModel(
+      provider: .claude,
+      monitor: claudeMonitor,
+      watcher: claudeWatcher,
+      store: store
+    )
+    let coordinator = AgentWorkspaceSessionCoordinator(
+      claudeViewModel: claudeViewModel,
+      codexViewModel: makeCoordinatorViewModel(
+        provider: .codex,
+        monitor: WorkspaceCoordinatorMonitorSpy(),
+        watcher: WorkspaceCoordinatorWatcherSpy(),
+        store: store
+      )
+    )
+    let reference = AgentWorkspaceSessionReference(
+      provider: .claude,
+      sessionId: session.id,
+      projectPath: session.projectPath
+    )
+
+    await coordinator.restorePersistedSessions([reference, reference])
+    await coordinator.restorePersistedSessions([reference])
+
+    await waitForCoordinatorCondition {
+      claudeViewModel.monitoredSessionIds == [session.id]
+        && store.getWorkspaceStateSync(for: .claude).monitoredSessionIds == [session.id]
+    }
+    #expect(claudeViewModel.monitoredSessions.map(\.session.id) == [session.id])
+    #expect(await claudeWatcher.startedSessionIDs() == [session.id])
+    #expect(store.getWorkspaceStateSync(for: .claude).monitoredSessionIds == [session.id])
+  }
+
+  @Test("Persisted workspace references are visible while session files are loading")
+  func persistedReferenceIsVisibleDuringTargetedLoad() async throws {
+    let store = try SessionMetadataStore(path: temporaryCoordinatorDatabasePath())
+    let monitor = WorkspaceCoordinatorMonitorSpy(loadDelay: .seconds(5))
+    let viewModel = makeCoordinatorViewModel(
+      provider: .claude,
+      monitor: monitor,
+      watcher: WorkspaceCoordinatorWatcherSpy(),
+      store: store
+    )
+    let coordinator = AgentWorkspaceSessionCoordinator(
+      claudeViewModel: viewModel,
+      codexViewModel: makeCoordinatorViewModel(
+        provider: .codex,
+        monitor: WorkspaceCoordinatorMonitorSpy(),
+        watcher: WorkspaceCoordinatorWatcherSpy(),
+        store: store
+      )
+    )
+    let reference = AgentWorkspaceSessionReference(
+      provider: .claude,
+      sessionId: "loading-session",
+      projectPath: "/tmp/project"
+    )
+
+    let restoreTask = Task {
+      await coordinator.restorePersistedSessions([reference])
+    }
+
+    for _ in 0..<200 where await monitor.loadedSessionRequests().isEmpty {
+      try await Task.sleep(for: .milliseconds(10))
+    }
+
+    #expect(await monitor.loadedSessionRequests() == [Set(["loading-session"])])
+    #expect(viewModel.monitoredSessions.map(\.session.id) == ["loading-session"])
+    #expect(viewModel.monitoredSessions.first?.session.projectPath == "/tmp/project")
+
+    restoreTask.cancel()
+    await restoreTask.value
+  }
+
+  @Test("Missing session files remain visible and retained for a later workspace reconciliation")
+  func missingSessionRemainsRetained() async throws {
+    let store = try SessionMetadataStore(path: temporaryCoordinatorDatabasePath())
+    let monitor = WorkspaceCoordinatorMonitorSpy()
+    let viewModel = makeCoordinatorViewModel(
+      provider: .codex,
+      monitor: monitor,
+      watcher: WorkspaceCoordinatorWatcherSpy(),
+      store: store
+    )
+    let coordinator = AgentWorkspaceSessionCoordinator(
+      claudeViewModel: makeCoordinatorViewModel(
+        provider: .claude,
+        monitor: WorkspaceCoordinatorMonitorSpy(),
+        watcher: WorkspaceCoordinatorWatcherSpy(),
+        store: store
+      ),
+      codexViewModel: viewModel
+    )
+
+    await coordinator.restorePersistedSessions([
+      AgentWorkspaceSessionReference(
+        provider: .codex,
+        sessionId: "missing-session",
+        projectPath: "/tmp/project"
+      )
+    ])
+
+    await waitForCoordinatorCondition {
+      let state = store.getWorkspaceStateSync(for: .codex)
+      return state.selectedRepositoryPaths == ["/tmp/project"]
+        && state.monitoredSessionIds == ["missing-session"]
+    }
+    #expect(viewModel.isMonitoring(sessionId: "missing-session"))
+    #expect(viewModel.monitoredSessions.map(\.session.id) == ["missing-session"])
+    #expect(viewModel.monitoredSessions.first?.session.projectPath == "/tmp/project")
+    #expect(viewModel.monitoredSessions.first?.session.sessionFilePath == nil)
+    #expect(await monitor.loadedSessionRequests() == [Set(["missing-session"])])
+  }
+}
+
+@MainActor
+private func makeCoordinatorViewModel(
+  provider: SessionProviderKind,
+  monitor: WorkspaceCoordinatorMonitorSpy,
+  watcher: WorkspaceCoordinatorWatcherSpy,
+  store: SessionMetadataStore
+) -> CLISessionsViewModel {
+  CLISessionsViewModel(
+    monitorService: monitor,
+    fileWatcher: watcher,
+    searchService: nil,
+    cliConfiguration: CLICommandConfiguration(
+      command: provider == .claude ? "claude" : "codex",
+      mode: provider == .claude ? .claude : .codex
+    ),
+    providerKind: provider,
+    metadataStore: store,
+    approvalNotificationService: NoOpApprovalNotificationService()
+  )
+}
+
+private func workspaceSession(provider: SessionProviderKind) -> CLISession {
+  CLISession(
+    id: "\(provider.rawValue.lowercased())-session",
+    projectPath: "/tmp/project",
+    branchName: "main",
+    lastActivityAt: .now,
+    isActive: true,
+    sessionFilePath: "/tmp/\(provider.rawValue.lowercased())-session.jsonl"
+  )
+}
+
+private actor WorkspaceCoordinatorMonitorSpy: SessionMonitorServiceProtocol {
+  nonisolated(unsafe) private let subject = CurrentValueSubject<[SelectedRepository], Never>([])
+
+  nonisolated var repositoriesPublisher: AnyPublisher<[SelectedRepository], Never> {
+    subject.eraseToAnyPublisher()
+  }
+
+  private let sessionsByID: [String: CLISession]
+  private let loadDelay: Duration?
+  private var repositories: [SelectedRepository] = []
+  private var loadRequests: [Set<String>] = []
+
+  init(
+    sessionsByID: [String: CLISession] = [:],
+    loadDelay: Duration? = nil
+  ) {
+    self.sessionsByID = sessionsByID
+    self.loadDelay = loadDelay
+  }
+
+  func addRepository(_ path: String) async -> SelectedRepository? {
+    guard !repositories.contains(where: { $0.path == path }) else { return nil }
+    let sessions = sessionsByID.values.filter {
+      $0.projectPath == path || $0.projectPath.hasPrefix(path + "/")
+    }
+    let repository = SelectedRepository(
+      path: path,
+      worktrees: [
+        WorktreeBranch(
+          name: "main",
+          path: path,
+          isWorktree: false,
+          sessions: sessions
+        )
+      ]
+    )
+    repositories.append(repository)
+    subject.send(repositories)
+    return repository
+  }
+
+  func loadSessions(ids: Set<String>) async -> [CLISession] {
+    loadRequests.append(ids)
+    if let loadDelay {
+      try? await Task.sleep(for: loadDelay)
+    }
+    return ids.compactMap { sessionsByID[$0] }
+  }
+
+  func removeRepository(_ path: String) async {
+    repositories.removeAll { $0.path == path }
+    subject.send(repositories)
+  }
+
+  func getSelectedRepositories() async -> [SelectedRepository] {
+    repositories
+  }
+
+  func setSelectedRepositories(_ repositories: [SelectedRepository]) async {
+    self.repositories = repositories
+    subject.send(repositories)
+  }
+
+  func refreshSessions(skipWorktreeRedetection: Bool) async {
+    subject.send(repositories)
+  }
+
+  func loadedSessionRequests() -> [Set<String>] {
+    loadRequests
+  }
+}
+
+private actor WorkspaceCoordinatorWatcherSpy: SessionFileWatcherProtocol {
+  nonisolated(unsafe) private let subject = PassthroughSubject<SessionFileWatcher.StateUpdate, Never>()
+
+  nonisolated var statePublisher: AnyPublisher<SessionFileWatcher.StateUpdate, Never> {
+    subject.eraseToAnyPublisher()
+  }
+
+  private var started: [String] = []
+
+  func startMonitoring(sessionId: String, projectPath: String, sessionFilePath: String?) async {
+    started.append(sessionId)
+  }
+
+  func stopMonitoring(sessionId: String) async {}
+  func getState(sessionId: String) async -> SessionMonitorState? { nil }
+  func refreshState(sessionId: String) async {}
+  func setApprovalTimeout(_ seconds: Int) async {}
+
+  func startedSessionIDs() -> [String] {
+    started
+  }
+}
+
+@MainActor
+private func waitForCoordinatorCondition(
+  timeout: Duration = .seconds(2),
+  condition: @escaping @MainActor () -> Bool
+) async {
+  let start = ContinuousClock.now
+  while !condition(), ContinuousClock.now - start < timeout {
+    try? await Task.sleep(for: .milliseconds(20))
+  }
+  #expect(condition())
+}
+
+private func temporaryCoordinatorDatabasePath() -> String {
+  FileManager.default.temporaryDirectory
+    .appending(path: "agent_workspace_coordinator_\(UUID().uuidString).sqlite")
+    .path
+}

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/AgentWorkspacesViewModelTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/AgentWorkspacesViewModelTests.swift
@@ -1,0 +1,397 @@
+import AppKit
+import Foundation
+import Testing
+
+@testable import AgentHubCore
+
+@MainActor
+@Suite("Agent workspaces view model")
+struct AgentWorkspacesViewModelTests {
+  @Test("Loading records does not mount terminals until selected")
+  func lazyTerminalMount() async throws {
+    let workspace = try makeWorkspace(id: "workspace-1")
+    let store = WorkspaceStoreSpy(workspaces: [workspace])
+    let surface = WorkspaceTerminalSurfaceSpy()
+    let viewModel = makeViewModel(store: store, surface: surface)
+
+    await viewModel.load()
+
+    #expect(viewModel.workspaces == [workspace])
+    #expect(surface.configureShellCallCount == 0)
+
+    let mounted = viewModel.terminalSurface(for: workspace.id, isDark: true)
+    let expectedSnapshot = try workspace.decodedSnapshot()
+
+    #expect(mounted != nil)
+    #expect(surface.configureShellCallCount == 1)
+    #expect(surface.restoredSnapshot == expectedSnapshot)
+    #expect(surface.terminalSessionKey == "workspace-workspace-1")
+  }
+
+  @Test("Create, default names, rename, and close persist")
+  func workspaceLifecycle() async throws {
+    let store = WorkspaceStoreSpy()
+    let surface = WorkspaceTerminalSurfaceSpy()
+    let viewModel = makeViewModel(store: store, surface: surface)
+
+    let firstID = try #require(await viewModel.createWorkspace(projectPath: "/tmp/project"))
+    let secondID = try #require(await viewModel.createWorkspace(projectPath: "/tmp/project"))
+    let first = try #require(viewModel.workspace(id: firstID))
+    let second = try #require(viewModel.workspace(id: secondID))
+    #expect(viewModel.displayName(for: first) == "Workspace")
+    #expect(viewModel.displayName(for: second) == "Workspace 2")
+
+    await viewModel.renameWorkspace(id: secondID, name: "Build Lab")
+    #expect(viewModel.workspace(id: secondID)?.customName == "Build Lab")
+
+    _ = viewModel.terminalSurface(for: secondID, isDark: false)
+    #expect(viewModel.requiresCloseConfirmation(id: secondID))
+    await viewModel.closeWorkspace(id: secondID)
+
+    #expect(surface.terminateCallCount == 1)
+    #expect(viewModel.workspace(id: secondID) == nil)
+    #expect(await store.deletedIDs() == [secondID])
+  }
+
+  @Test("Explicit agent launch attaches the detected session")
+  func explicitAgentLaunch() async throws {
+    let result = AccessorySessionDetectionResult(
+      provider: .codex,
+      sessionId: "codex-session",
+      projectPath: "/tmp/project",
+      branchName: "main",
+      sessionFilePath: "/tmp/codex-session.jsonl"
+    )
+    let detection = WorkspaceDetectionServiceSpy(results: [.codex: result])
+    let coordinator = WorkspaceSessionCoordinatorSpy()
+    let store = WorkspaceStoreSpy()
+    let surface = WorkspaceTerminalSurfaceSpy()
+    let viewModel = makeViewModel(
+      store: store,
+      surface: surface,
+      coordinator: coordinator,
+      detection: detection
+    )
+    let workspaceID = try #require(await viewModel.createWorkspace(projectPath: "/tmp/project"))
+    _ = viewModel.terminalSurface(for: workspaceID, isDark: true)
+
+    viewModel.launchSurface(
+      workspaceID: workspaceID,
+      kind: .agent(.codex),
+      placement: .splitDown,
+      isDark: true
+    )
+    try await Task.sleep(for: .milliseconds(80))
+
+    #expect(surface.launches.count == 1)
+    #expect(surface.launches.first?.kind == .agent(.codex))
+    #expect(surface.launches.first?.placement == .splitDown)
+    #expect(surface.launches.first?.configuration?.mode == .codex)
+    #expect(surface.markedSessions == ["codex:codex-session"])
+    #expect(viewModel.linksByWorkspaceID[workspaceID]?.first?.relationshipOrigin == .explicit)
+    #expect(coordinator.monitoredSessionIDs == ["codex-session"])
+  }
+
+  @Test("A unique shell passively attaches a manually started agent")
+  func passiveDetection() async throws {
+    let result = AccessorySessionDetectionResult(
+      provider: .claude,
+      sessionId: "claude-session",
+      projectPath: "/tmp/project",
+      branchName: "main",
+      sessionFilePath: "/tmp/claude-session.jsonl"
+    )
+    let detection = WorkspaceDetectionServiceSpy(results: [.claude: result])
+    let coordinator = WorkspaceSessionCoordinatorSpy()
+    let workspace = try makeWorkspace(id: "workspace-1")
+    let store = WorkspaceStoreSpy(workspaces: [workspace])
+    let surface = WorkspaceTerminalSurfaceSpy()
+    let viewModel = makeViewModel(
+      store: store,
+      surface: surface,
+      coordinator: coordinator,
+      detection: detection
+    )
+    await viewModel.load()
+
+    _ = viewModel.terminalSurface(for: workspace.id, isDark: true)
+    try await Task.sleep(for: .milliseconds(80))
+
+    #expect(viewModel.linksByWorkspaceID[workspace.id]?.first?.relationshipOrigin == .detected)
+    #expect(coordinator.monitoredSessionIDs == ["claude-session"])
+  }
+
+  @Test("Same-directory shell ambiguity does not guess a pane")
+  func ambiguousPassiveDetection() async throws {
+    let snapshot = TerminalWorkspaceSnapshot(
+      panels: [
+        TerminalWorkspacePanelSnapshot(
+          role: .primary,
+          tabs: [TerminalWorkspaceTabSnapshot(role: .shell, workingDirectory: "/tmp/project")]
+        ),
+        TerminalWorkspacePanelSnapshot(
+          role: .auxiliary,
+          tabs: [TerminalWorkspaceTabSnapshot(role: .shell, workingDirectory: "/tmp/project")]
+        )
+      ]
+    )
+    let workspace = try AgentWorkspaceRecord(
+      id: "workspace-1",
+      projectPath: "/tmp/project",
+      snapshot: snapshot
+    )
+    let detection = WorkspaceDetectionServiceSpy(results: [:])
+    let store = WorkspaceStoreSpy(workspaces: [workspace])
+    let surface = WorkspaceTerminalSurfaceSpy()
+    let viewModel = makeViewModel(store: store, surface: surface, detection: detection)
+    await viewModel.load()
+
+    _ = viewModel.terminalSurface(for: workspace.id, isDark: true)
+    try await Task.sleep(for: .milliseconds(50))
+
+    #expect(detection.detectCallCount == 0)
+    #expect(viewModel.linksByWorkspaceID[workspace.id]?.isEmpty == true)
+  }
+}
+
+@MainActor
+private func makeViewModel(
+  store: WorkspaceStoreSpy,
+  surface: WorkspaceTerminalSurfaceSpy,
+  coordinator: WorkspaceSessionCoordinatorSpy? = nil,
+  detection: WorkspaceDetectionServiceSpy? = nil
+) -> AgentWorkspacesViewModel {
+  AgentWorkspacesViewModel(
+    store: store,
+    metadataStore: nil,
+    terminalSurfaceFactory: WorkspaceTerminalSurfaceFactorySpy(surface: surface),
+    sessionCoordinator: coordinator ?? WorkspaceSessionCoordinatorSpy(),
+    detectionService: detection ?? WorkspaceDetectionServiceSpy(results: [:]),
+    detectionPollInterval: .milliseconds(10)
+  )
+}
+
+private func makeWorkspace(id: String) throws -> AgentWorkspaceRecord {
+  try AgentWorkspaceRecord(
+    id: id,
+    projectPath: "/tmp/project",
+    snapshot: TerminalWorkspaceSnapshot(
+      panels: [
+        TerminalWorkspacePanelSnapshot(
+          role: .primary,
+          tabs: [TerminalWorkspaceTabSnapshot(role: .shell, workingDirectory: "/tmp/project")]
+        )
+      ]
+    )
+  )
+}
+
+private actor WorkspaceStoreSpy: AgentWorkspaceStoreProtocol {
+  private var workspaces: [AgentWorkspaceRecord]
+  private var links: [AgentWorkspaceSessionLink]
+  private var deletedWorkspaceIDs: [String] = []
+
+  init(
+    workspaces: [AgentWorkspaceRecord] = [],
+    links: [AgentWorkspaceSessionLink] = []
+  ) {
+    self.workspaces = workspaces
+    self.links = links
+  }
+
+  func loadAgentWorkspaces() async throws -> [AgentWorkspaceRecord] { workspaces }
+  func loadAgentWorkspaceSessionLinks() async throws -> [AgentWorkspaceSessionLink] { links }
+
+  func saveAgentWorkspace(
+    _ workspace: AgentWorkspaceRecord,
+    links: [AgentWorkspaceSessionLink]
+  ) async throws {
+    workspaces.removeAll { $0.id == workspace.id }
+    workspaces.append(workspace)
+    self.links.removeAll { $0.workspaceId == workspace.id }
+    self.links.append(contentsOf: links)
+  }
+
+  func deleteAgentWorkspace(id: String) async throws {
+    workspaces.removeAll { $0.id == id }
+    links.removeAll { $0.workspaceId == id }
+    deletedWorkspaceIDs.append(id)
+  }
+
+  func deletedIDs() -> [String] { deletedWorkspaceIDs }
+}
+
+@MainActor
+private final class WorkspaceSessionCoordinatorSpy: AgentWorkspaceSessionCoordinating {
+  var monitoredSessionIDs: [String] = []
+
+  func cliConfiguration(for provider: SessionProviderKind) -> CLICommandConfiguration {
+    provider == .claude ? .claudeDefault : .codexDefault
+  }
+
+  func monitorDetectedSession(_ result: AccessorySessionDetectionResult) {
+    monitoredSessionIDs.append(result.sessionId)
+  }
+
+  func activity(for links: [AgentWorkspaceSessionLink]) -> AgentWorkspaceActivity {
+    links.isEmpty ? .idle : .working
+  }
+}
+
+private final class WorkspaceDetectionServiceSpy: AccessorySessionDetectionServiceProtocol, @unchecked Sendable {
+  private let lock = NSLock()
+  private let results: [SessionProviderKind: AccessorySessionDetectionResult]
+  private var deliveredProviders: Set<SessionProviderKind> = []
+  private(set) var detectCallCount = 0
+
+  init(results: [SessionProviderKind: AccessorySessionDetectionResult]) {
+    self.results = results
+  }
+
+  func makeBaseline(
+    provider: SessionProviderKind,
+    projectPath: String,
+    startedAt: Date
+  ) -> AccessorySessionDetectionBaseline {
+    AccessorySessionDetectionBaseline(
+      provider: provider,
+      projectPath: projectPath,
+      startedAt: startedAt,
+      knownSessionFiles: []
+    )
+  }
+
+  func detectNewSession(
+    provider: SessionProviderKind,
+    projectPath: String,
+    startedAt: Date,
+    baseline: AccessorySessionDetectionBaseline
+  ) -> AccessorySessionDetectionResult? {
+    lock.lock()
+    detectCallCount += 1
+    let wasInserted = deliveredProviders.insert(provider).inserted
+    lock.unlock()
+    return wasInserted ? results[provider] : nil
+  }
+}
+
+@MainActor
+private final class WorkspaceTerminalSurfaceFactorySpy: EmbeddedTerminalSurfaceFactory {
+  let surface: WorkspaceTerminalSurfaceSpy
+
+  init(surface: WorkspaceTerminalSurfaceSpy) {
+    self.surface = surface
+  }
+
+  func makeSurface(for backend: EmbeddedTerminalBackend) -> any EmbeddedTerminalSurface {
+    surface
+  }
+}
+
+@MainActor
+private final class WorkspaceTerminalSurfaceSpy: NSView, EmbeddedTerminalSurface {
+  struct Launch {
+    let kind: WorkspaceTerminalLaunchKind
+    let placement: WorkspaceSurfacePlacement
+    let configuration: CLICommandConfiguration?
+  }
+
+  var view: NSView { self }
+  var currentProcessPID: Int32?
+  var onUserInteraction: (() -> Void)?
+  var onRequestShowEditor: (() -> Void)?
+  var consumeQueuedWebPreviewContextOnSubmit: (() -> String?)?
+  var onWorkspaceChanged: ((TerminalWorkspaceSnapshot) -> Void)?
+  var workspaceCLIConfigurationProvider: ((SessionProviderKind) -> CLICommandConfiguration)?
+  private(set) var configureShellCallCount = 0
+  private(set) var terminateCallCount = 0
+  private(set) var terminalSessionKey: String?
+  private(set) var restoredSnapshot: TerminalWorkspaceSnapshot?
+  private(set) var launches: [Launch] = []
+  private(set) var markedSessions: [String] = []
+
+  func updateContext(terminalSessionKey: String?, sessionViewModel: CLISessionsViewModel?) {
+    self.terminalSessionKey = terminalSessionKey
+  }
+
+  func configure(
+    sessionId: String?,
+    projectPath: String,
+    cliConfiguration: CLICommandConfiguration,
+    initialPrompt: String?,
+    initialInputText: String?,
+    isDark: Bool,
+    dangerouslySkipPermissions: Bool,
+    permissionModePlan: Bool,
+    worktreeName: String?,
+    metadataStore: SessionMetadataStore?
+  ) {}
+
+  func configureShell(projectPath: String, isDark: Bool, shellPath: String?) {
+    configureShellCallCount += 1
+  }
+
+  func restart(sessionId: String?, projectPath: String, cliConfiguration: CLICommandConfiguration) {}
+  func terminateProcess() { terminateCallCount += 1 }
+  func resetPromptDeliveryFlag() {}
+  func sendPromptIfNeeded(_ prompt: String) {}
+  func submitPromptImmediately(_ prompt: String) -> Bool { false }
+  func typeText(_ text: String) {}
+  func typeInitialTextIfNeeded(_ text: String) {}
+  func syncAppearance(isDark: Bool, fontSize: CGFloat, fontFamily: String, theme: RuntimeTheme?) {}
+  func focus() {}
+  func activeWorkingDirectory() -> String? { "/tmp/project" }
+
+  func openWorkspaceSurface(
+    kind: WorkspaceTerminalLaunchKind,
+    placement: WorkspaceSurfacePlacement,
+    cliConfiguration: CLICommandConfiguration?,
+    projectPath: String,
+    metadataStore: SessionMetadataStore?
+  ) -> WorkspaceSurfaceLaunchContext? {
+    launches.append(Launch(kind: kind, placement: placement, configuration: cliConfiguration))
+    guard var snapshot = restoredSnapshot else { return nil }
+    let role: TerminalWorkspaceTabRole = if case .agent = kind { .agent } else { .shell }
+    let tab = TerminalWorkspaceTabSnapshot(role: role, workingDirectory: projectPath)
+    switch placement {
+    case .tab:
+      snapshot.panels[0].tabs.append(tab)
+    case .splitRight, .splitDown:
+      snapshot.panels.append(TerminalWorkspacePanelSnapshot(role: .auxiliary, tabs: [tab]))
+    }
+    restoredSnapshot = snapshot
+    onWorkspaceChanged?(snapshot)
+    let provider: SessionProviderKind? = if case .agent(let provider) = kind { provider } else { nil }
+    return WorkspaceSurfaceLaunchContext(provider: provider, projectPath: projectPath, startedAt: .now)
+  }
+
+  func markAccessorySession(
+    provider: SessionProviderKind,
+    sessionId: String,
+    projectPath: String,
+    origin: SessionRelationshipOrigin
+  ) -> Bool {
+    guard var snapshot = restoredSnapshot else { return false }
+    for panelIndex in snapshot.panels.indices {
+      for tabIndex in snapshot.panels[panelIndex].tabs.indices {
+        guard snapshot.panels[panelIndex].tabs[tabIndex].linkedSession == nil,
+              snapshot.panels[panelIndex].tabs[tabIndex].workingDirectory == projectPath else {
+          continue
+        }
+        snapshot.panels[panelIndex].tabs[tabIndex].role = .agent
+        snapshot.panels[panelIndex].tabs[tabIndex].linkedSession = TerminalWorkspaceLinkedSessionSnapshot(
+          provider: provider,
+          sessionId: sessionId
+        )
+        restoredSnapshot = snapshot
+        markedSessions.append("\(provider.rawValue.lowercased()):\(sessionId)")
+        onWorkspaceChanged?(snapshot)
+        return true
+      }
+    }
+    return false
+  }
+
+  func captureWorkspaceSnapshot() -> TerminalWorkspaceSnapshot? { restoredSnapshot }
+  func restoreWorkspaceSnapshot(_ snapshot: TerminalWorkspaceSnapshot) { restoredSnapshot = snapshot }
+}

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/AgentWorkspacesViewModelTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/AgentWorkspacesViewModelTests.swift
@@ -28,6 +28,128 @@ struct AgentWorkspacesViewModelTests {
     #expect(surface.terminalSessionKey == "workspace-workspace-1")
   }
 
+  @Test("Loading linked sessions reconciles normal monitoring without mounting terminals")
+  func loadReconcilesPersistedSessionsLazily() async throws {
+    let snapshot = TerminalWorkspaceSnapshot(
+      panels: [
+        TerminalWorkspacePanelSnapshot(
+          role: .primary,
+          tabs: [TerminalWorkspaceTabSnapshot(role: .shell, workingDirectory: "/tmp/project")]
+        ),
+        TerminalWorkspacePanelSnapshot(
+          role: .auxiliary,
+          tabs: [
+            TerminalWorkspaceTabSnapshot(
+              role: .agent,
+              workingDirectory: "/tmp/project/feature",
+              linkedSession: TerminalWorkspaceLinkedSessionSnapshot(
+                provider: .codex,
+                sessionId: "codex-session"
+              )
+            )
+          ]
+        )
+      ]
+    )
+    let workspace = try AgentWorkspaceRecord(
+      id: "workspace-1",
+      projectPath: "/tmp/project",
+      snapshot: snapshot
+    )
+    let store = WorkspaceStoreSpy(
+      workspaces: [workspace],
+      links: [
+        AgentWorkspaceSessionLink(
+          workspaceId: workspace.id,
+          provider: .codex,
+          sessionId: "codex-session",
+          origin: .explicit
+        )
+      ]
+    )
+    let coordinator = WorkspaceSessionCoordinatorSpy()
+    let surface = WorkspaceTerminalSurfaceSpy()
+    let viewModel = makeViewModel(
+      store: store,
+      surface: surface,
+      coordinator: coordinator
+    )
+
+    await viewModel.load()
+
+    #expect(coordinator.restoredReferences == [
+      AgentWorkspaceSessionReference(
+        provider: .codex,
+        sessionId: "codex-session",
+        projectPath: "/tmp/project/feature"
+      )
+    ])
+    #expect(surface.configureShellCallCount == 0)
+  }
+
+  @Test("Session ownership lookup resolves the linking workspace")
+  func sessionOwnershipLookup() async throws {
+    let workspace = try makeWorkspace(id: "workspace-1")
+    let store = WorkspaceStoreSpy(
+      workspaces: [workspace],
+      links: [
+        AgentWorkspaceSessionLink(
+          workspaceId: workspace.id,
+          provider: .claude,
+          sessionId: "claude-session",
+          origin: .detected
+        )
+      ]
+    )
+    let surface = WorkspaceTerminalSurfaceSpy()
+    let viewModel = makeViewModel(store: store, surface: surface)
+
+    await viewModel.load()
+
+    #expect(viewModel.workspaceID(owningSession: "claude-session", provider: .claude) == workspace.id)
+    #expect(viewModel.workspaceID(owningSession: "claude-session", provider: .codex) == nil)
+    #expect(viewModel.workspaceID(owningSession: "other-session", provider: .claude) == nil)
+  }
+
+  @Test("Focusing an owned session mounts the workspace surface and routes focus to its pane")
+  func focusOwnedSessionRoutesToSurface() async throws {
+    let workspace = try makeWorkspace(id: "workspace-1")
+    let store = WorkspaceStoreSpy(
+      workspaces: [workspace],
+      links: [
+        AgentWorkspaceSessionLink(
+          workspaceId: workspace.id,
+          provider: .claude,
+          sessionId: "claude-session",
+          origin: .detected
+        )
+      ]
+    )
+    let surface = WorkspaceTerminalSurfaceSpy()
+    let viewModel = makeViewModel(store: store, surface: surface)
+
+    await viewModel.load()
+
+    let focusedWorkspaceID = viewModel.focusWorkspaceSession(
+      provider: .claude,
+      sessionId: "claude-session",
+      isDark: true
+    )
+
+    #expect(focusedWorkspaceID == workspace.id)
+    #expect(surface.configureShellCallCount == 1)
+    #expect(surface.focusedSessions == ["claude:claude-session"])
+
+    let unownedWorkspaceID = viewModel.focusWorkspaceSession(
+      provider: .codex,
+      sessionId: "claude-session",
+      isDark: true
+    )
+
+    #expect(unownedWorkspaceID == nil)
+    #expect(surface.focusedSessions == ["claude:claude-session"])
+  }
+
   @Test("Create, default names, rename, and close persist")
   func workspaceLifecycle() async throws {
     let store = WorkspaceStoreSpy()
@@ -53,8 +175,11 @@ struct AgentWorkspacesViewModelTests {
     #expect(await store.deletedIDs() == [secondID])
   }
 
-  @Test("Explicit agent launch attaches the detected session")
-  func explicitAgentLaunch() async throws {
+  @Test(
+    "Explicit agent tabs and splits attach and persist the detected session",
+    arguments: [WorkspaceSurfacePlacement.tab, .splitDown]
+  )
+  func explicitAgentLaunch(placement: WorkspaceSurfacePlacement) async throws {
     let result = AccessorySessionDetectionResult(
       provider: .codex,
       sessionId: "codex-session",
@@ -78,18 +203,25 @@ struct AgentWorkspacesViewModelTests {
     viewModel.launchSurface(
       workspaceID: workspaceID,
       kind: .agent(.codex),
-      placement: .splitDown,
+      placement: placement,
       isDark: true
     )
     try await Task.sleep(for: .milliseconds(80))
 
     #expect(surface.launches.count == 1)
     #expect(surface.launches.first?.kind == .agent(.codex))
-    #expect(surface.launches.first?.placement == .splitDown)
+    #expect(surface.launches.first?.placement == placement)
     #expect(surface.launches.first?.configuration?.mode == .codex)
     #expect(surface.markedSessions == ["codex:codex-session"])
     #expect(viewModel.linksByWorkspaceID[workspaceID]?.first?.relationshipOrigin == .explicit)
     #expect(coordinator.monitoredSessionIDs == ["codex-session"])
+
+    let savedWorkspace = try #require(await store.workspace(id: workspaceID))
+    let savedSnapshot = try savedWorkspace.decodedSnapshot()
+    let linkedSessions = savedSnapshot.panels.flatMap(\.tabs).compactMap(\.linkedSession)
+    #expect(linkedSessions.map(\.sessionId) == ["codex-session"])
+    #expect(savedSnapshot.panels.count == (placement == .tab ? 1 : 2))
+    #expect(await store.links(for: workspaceID).map(\.sessionId) == ["codex-session"])
   }
 
   @Test("A unique shell passively attaches a manually started agent")
@@ -103,7 +235,10 @@ struct AgentWorkspacesViewModelTests {
     )
     let detection = WorkspaceDetectionServiceSpy(results: [.claude: result])
     let coordinator = WorkspaceSessionCoordinatorSpy()
-    let workspace = try makeWorkspace(id: "workspace-1")
+    let workspace = try makeWorkspace(
+      id: "workspace-1",
+      title: "✳ Claude Code"
+    )
     let store = WorkspaceStoreSpy(workspaces: [workspace])
     let surface = WorkspaceTerminalSurfaceSpy()
     let viewModel = makeViewModel(
@@ -121,17 +256,29 @@ struct AgentWorkspacesViewModelTests {
     #expect(coordinator.monitoredSessionIDs == ["claude-session"])
   }
 
-  @Test("Same-directory shell ambiguity does not guess a pane")
-  func ambiguousPassiveDetection() async throws {
+  @Test("Same-directory Claude and Codex shells attach to their exact surfaces")
+  func sameDirectoryPassiveDetectionUsesSurfaceIdentity() async throws {
     let snapshot = TerminalWorkspaceSnapshot(
       panels: [
         TerminalWorkspacePanelSnapshot(
           role: .primary,
-          tabs: [TerminalWorkspaceTabSnapshot(role: .shell, workingDirectory: "/tmp/project")]
+          tabs: [
+            TerminalWorkspaceTabSnapshot(
+              role: .shell,
+              title: "✳ Claude Code",
+              workingDirectory: "/tmp/project"
+            )
+          ]
         ),
         TerminalWorkspacePanelSnapshot(
           role: .auxiliary,
-          tabs: [TerminalWorkspaceTabSnapshot(role: .shell, workingDirectory: "/tmp/project")]
+          tabs: [
+            TerminalWorkspaceTabSnapshot(
+              role: .shell,
+              title: "Codex",
+              workingDirectory: "/tmp/project"
+            )
+          ]
         )
       ]
     )
@@ -140,17 +287,126 @@ struct AgentWorkspacesViewModelTests {
       projectPath: "/tmp/project",
       snapshot: snapshot
     )
-    let detection = WorkspaceDetectionServiceSpy(results: [:])
+    let detection = WorkspaceDetectionServiceSpy(
+      results: [
+        .claude: AccessorySessionDetectionResult(
+          provider: .claude,
+          sessionId: "claude-session",
+          projectPath: "/tmp/project",
+          branchName: "main",
+          sessionFilePath: "/tmp/claude-session.jsonl"
+        ),
+        .codex: AccessorySessionDetectionResult(
+          provider: .codex,
+          sessionId: "codex-session",
+          projectPath: "/tmp/project",
+          branchName: "main",
+          sessionFilePath: "/tmp/codex-session.jsonl"
+        )
+      ]
+    )
+    let coordinator = WorkspaceSessionCoordinatorSpy()
+    let store = WorkspaceStoreSpy(workspaces: [workspace])
+    let surface = WorkspaceTerminalSurfaceSpy()
+    let viewModel = makeViewModel(
+      store: store,
+      surface: surface,
+      coordinator: coordinator,
+      detection: detection
+    )
+    await viewModel.load()
+
+    _ = viewModel.terminalSurface(for: workspace.id, isDark: true)
+    try await Task.sleep(for: .milliseconds(120))
+
+    let savedWorkspace = try #require(await store.workspace(id: workspace.id))
+    let savedTabs = try savedWorkspace.decodedSnapshot().panels.flatMap(\.tabs)
+    #expect(savedTabs[0].linkedSession?.provider == .claude)
+    #expect(savedTabs[0].linkedSession?.sessionId == "claude-session")
+    #expect(savedTabs[1].linkedSession?.provider == .codex)
+    #expect(savedTabs[1].linkedSession?.sessionId == "codex-session")
+    #expect(Set(surface.markedContextIDs) == ["spy-0-0", "spy-1-0"])
+    #expect(Set(coordinator.monitoredSessionIDs) == ["claude-session", "codex-session"])
+    #expect(await store.links(for: workspace.id).count == 2)
+
+    let relaunchedSurface = WorkspaceTerminalSurfaceSpy()
+    let relaunchedCoordinator = WorkspaceSessionCoordinatorSpy()
+    let relaunchedViewModel = makeViewModel(
+      store: store,
+      surface: relaunchedSurface,
+      coordinator: relaunchedCoordinator
+    )
+    await relaunchedViewModel.load()
+    _ = relaunchedViewModel.terminalSurface(for: workspace.id, isDark: true)
+
+    let restoredIdentities = Set(relaunchedCoordinator.restoredReferences.map {
+      "\($0.provider.rawValue):\($0.sessionId)"
+    })
+    #expect(restoredIdentities == ["Claude:claude-session", "Codex:codex-session"])
+    let restoredTabs = try #require(relaunchedSurface.restoredSnapshot).panels.flatMap(\.tabs)
+    #expect(restoredTabs.map(\.role) == [.agent, .agent])
+    #expect(Set(restoredTabs.compactMap(\.linkedSession?.sessionId)) == [
+      "claude-session",
+      "codex-session"
+    ])
+  }
+
+  @Test("One discovered session cannot attach to two same-provider surfaces")
+  func duplicateDetectionDoesNotCrossLinkSurfaces() async throws {
+    let snapshot = TerminalWorkspaceSnapshot(
+      panels: [
+        TerminalWorkspacePanelSnapshot(
+          role: .primary,
+          tabs: [
+            TerminalWorkspaceTabSnapshot(
+              role: .shell,
+              title: "Claude Code",
+              workingDirectory: "/tmp/project"
+            )
+          ]
+        ),
+        TerminalWorkspacePanelSnapshot(
+          role: .auxiliary,
+          tabs: [
+            TerminalWorkspaceTabSnapshot(
+              role: .shell,
+              title: "Claude Code",
+              workingDirectory: "/tmp/project"
+            )
+          ]
+        )
+      ]
+    )
+    let workspace = try AgentWorkspaceRecord(
+      id: "workspace-1",
+      projectPath: "/tmp/project",
+      snapshot: snapshot
+    )
+    let result = AccessorySessionDetectionResult(
+      provider: .claude,
+      sessionId: "shared-session",
+      projectPath: "/tmp/project",
+      branchName: "main",
+      sessionFilePath: "/tmp/shared-session.jsonl"
+    )
+    let detection = WorkspaceDetectionServiceSpy(
+      results: [.claude: result],
+      deliveriesPerProvider: 2
+    )
     let store = WorkspaceStoreSpy(workspaces: [workspace])
     let surface = WorkspaceTerminalSurfaceSpy()
     let viewModel = makeViewModel(store: store, surface: surface, detection: detection)
     await viewModel.load()
 
     _ = viewModel.terminalSurface(for: workspace.id, isDark: true)
-    try await Task.sleep(for: .milliseconds(50))
+    try await Task.sleep(for: .milliseconds(120))
 
-    #expect(detection.detectCallCount == 0)
-    #expect(viewModel.linksByWorkspaceID[workspace.id]?.isEmpty == true)
+    let savedWorkspace = try #require(await store.workspace(id: workspace.id))
+    let linkedTabs = try savedWorkspace.decodedSnapshot().panels
+      .flatMap(\.tabs)
+      .filter { $0.linkedSession != nil }
+    #expect(linkedTabs.count == 1)
+    #expect(await store.links(for: workspace.id).map(\.sessionId) == ["shared-session"])
   }
 }
 
@@ -171,7 +427,7 @@ private func makeViewModel(
   )
 }
 
-private func makeWorkspace(id: String) throws -> AgentWorkspaceRecord {
+private func makeWorkspace(id: String, title: String? = nil) throws -> AgentWorkspaceRecord {
   try AgentWorkspaceRecord(
     id: id,
     projectPath: "/tmp/project",
@@ -179,7 +435,13 @@ private func makeWorkspace(id: String) throws -> AgentWorkspaceRecord {
       panels: [
         TerminalWorkspacePanelSnapshot(
           role: .primary,
-          tabs: [TerminalWorkspaceTabSnapshot(role: .shell, workingDirectory: "/tmp/project")]
+          tabs: [
+            TerminalWorkspaceTabSnapshot(
+              role: .shell,
+              title: title,
+              workingDirectory: "/tmp/project"
+            )
+          ]
         )
       ]
     )
@@ -219,18 +481,31 @@ private actor WorkspaceStoreSpy: AgentWorkspaceStoreProtocol {
   }
 
   func deletedIDs() -> [String] { deletedWorkspaceIDs }
+
+  func workspace(id: String) -> AgentWorkspaceRecord? {
+    workspaces.first { $0.id == id }
+  }
+
+  func links(for workspaceID: String) -> [AgentWorkspaceSessionLink] {
+    links.filter { $0.workspaceId == workspaceID }
+  }
 }
 
 @MainActor
 private final class WorkspaceSessionCoordinatorSpy: AgentWorkspaceSessionCoordinating {
   var monitoredSessionIDs: [String] = []
+  var restoredReferences: [AgentWorkspaceSessionReference] = []
 
   func cliConfiguration(for provider: SessionProviderKind) -> CLICommandConfiguration {
     provider == .claude ? .claudeDefault : .codexDefault
   }
 
-  func monitorDetectedSession(_ result: AccessorySessionDetectionResult) {
+  func monitorDetectedSession(_ result: AccessorySessionDetectionResult) async {
     monitoredSessionIDs.append(result.sessionId)
+  }
+
+  func restorePersistedSessions(_ references: [AgentWorkspaceSessionReference]) async {
+    restoredReferences.append(contentsOf: references)
   }
 
   func activity(for links: [AgentWorkspaceSessionLink]) -> AgentWorkspaceActivity {
@@ -241,11 +516,17 @@ private final class WorkspaceSessionCoordinatorSpy: AgentWorkspaceSessionCoordin
 private final class WorkspaceDetectionServiceSpy: AccessorySessionDetectionServiceProtocol, @unchecked Sendable {
   private let lock = NSLock()
   private let results: [SessionProviderKind: AccessorySessionDetectionResult]
-  private var deliveredProviders: Set<SessionProviderKind> = []
+  private var remainingDeliveries: [SessionProviderKind: Int]
   private(set) var detectCallCount = 0
 
-  init(results: [SessionProviderKind: AccessorySessionDetectionResult]) {
+  init(
+    results: [SessionProviderKind: AccessorySessionDetectionResult],
+    deliveriesPerProvider: Int = 1
+  ) {
     self.results = results
+    remainingDeliveries = Dictionary(
+      uniqueKeysWithValues: results.keys.map { ($0, deliveriesPerProvider) }
+    )
   }
 
   func makeBaseline(
@@ -269,9 +550,10 @@ private final class WorkspaceDetectionServiceSpy: AccessorySessionDetectionServi
   ) -> AccessorySessionDetectionResult? {
     lock.lock()
     detectCallCount += 1
-    let wasInserted = deliveredProviders.insert(provider).inserted
+    let remaining = remainingDeliveries[provider] ?? 0
+    remainingDeliveries[provider] = max(0, remaining - 1)
     lock.unlock()
-    return wasInserted ? results[provider] : nil
+    return remaining > 0 ? results[provider] : nil
   }
 }
 
@@ -309,6 +591,8 @@ private final class WorkspaceTerminalSurfaceSpy: NSView, EmbeddedTerminalSurface
   private(set) var restoredSnapshot: TerminalWorkspaceSnapshot?
   private(set) var launches: [Launch] = []
   private(set) var markedSessions: [String] = []
+  private(set) var markedContextIDs: [String] = []
+  private(set) var focusedSessions: [String] = []
 
   func updateContext(terminalSessionKey: String?, sessionViewModel: CLISessionsViewModel?) {
     self.terminalSessionKey = terminalSessionKey
@@ -352,17 +636,91 @@ private final class WorkspaceTerminalSurfaceSpy: NSView, EmbeddedTerminalSurface
     launches.append(Launch(kind: kind, placement: placement, configuration: cliConfiguration))
     guard var snapshot = restoredSnapshot else { return nil }
     let role: TerminalWorkspaceTabRole = if case .agent = kind { .agent } else { .shell }
-    let tab = TerminalWorkspaceTabSnapshot(role: role, workingDirectory: projectPath)
+    let provider: SessionProviderKind? = if case .agent(let provider) = kind { provider } else { nil }
+    let tab = TerminalWorkspaceTabSnapshot(
+      role: role,
+      name: provider?.rawValue,
+      workingDirectory: projectPath
+    )
+    let contextID: String
     switch placement {
     case .tab:
       snapshot.panels[0].tabs.append(tab)
+      contextID = "spy-0-\(snapshot.panels[0].tabs.count - 1)"
     case .splitRight, .splitDown:
       snapshot.panels.append(TerminalWorkspacePanelSnapshot(role: .auxiliary, tabs: [tab]))
+      contextID = "spy-\(snapshot.panels.count - 1)-0"
     }
     restoredSnapshot = snapshot
     onWorkspaceChanged?(snapshot)
-    let provider: SessionProviderKind? = if case .agent(let provider) = kind { provider } else { nil }
-    return WorkspaceSurfaceLaunchContext(provider: provider, projectPath: projectPath, startedAt: .now)
+    return WorkspaceSurfaceLaunchContext(
+      provider: provider,
+      projectPath: projectPath,
+      startedAt: .now,
+      detectionContextID: contextID
+    )
+  }
+
+  func workspaceSessionDetectionContexts() -> [WorkspaceSessionDetectionContext] {
+    guard let snapshot = restoredSnapshot else { return [] }
+    return snapshot.panels.enumerated().flatMap { panelIndex, panel in
+      panel.tabs.enumerated().compactMap { tabIndex, tab in
+        guard tab.linkedSession == nil, let projectPath = tab.workingDirectory else { return nil }
+        let label = [tab.name, tab.title]
+          .compactMap { $0?.lowercased() }
+          .joined(separator: " ")
+        let provider: SessionProviderKind? = if label.contains("claude") {
+          .claude
+        } else if label.contains("codex") {
+          .codex
+        } else {
+          nil
+        }
+        return WorkspaceSessionDetectionContext(
+          id: "spy-\(panelIndex)-\(tabIndex)",
+          provider: provider,
+          projectPath: projectPath,
+          foregroundProcessID: nil
+        )
+      }
+    }
+  }
+
+  @discardableResult
+  func focusWorkspaceSession(
+    provider: SessionProviderKind,
+    sessionId: String
+  ) -> Bool {
+    focusedSessions.append("\(provider.rawValue.lowercased()):\(sessionId)")
+    return true
+  }
+
+  func markWorkspaceSession(
+    contextID: String,
+    provider: SessionProviderKind,
+    sessionId: String,
+    projectPath: String,
+    origin: SessionRelationshipOrigin
+  ) -> Bool {
+    guard var snapshot = restoredSnapshot else { return false }
+    for panelIndex in snapshot.panels.indices {
+      for tabIndex in snapshot.panels[panelIndex].tabs.indices
+      where "spy-\(panelIndex)-\(tabIndex)" == contextID {
+        guard snapshot.panels[panelIndex].tabs[tabIndex].linkedSession == nil else {
+          return false
+        }
+        snapshot.panels[panelIndex].tabs[tabIndex].role = .agent
+        snapshot.panels[panelIndex].tabs[tabIndex].name = provider.rawValue
+        snapshot.panels[panelIndex].tabs[tabIndex].linkedSession =
+          TerminalWorkspaceLinkedSessionSnapshot(provider: provider, sessionId: sessionId)
+        restoredSnapshot = snapshot
+        markedSessions.append("\(provider.rawValue.lowercased()):\(sessionId)")
+        markedContextIDs.append(contextID)
+        onWorkspaceChanged?(snapshot)
+        return true
+      }
+    }
+    return false
   }
 
   func markAccessorySession(
@@ -372,24 +730,27 @@ private final class WorkspaceTerminalSurfaceSpy: NSView, EmbeddedTerminalSurface
     origin: SessionRelationshipOrigin
   ) -> Bool {
     guard var snapshot = restoredSnapshot else { return false }
-    for panelIndex in snapshot.panels.indices {
-      for tabIndex in snapshot.panels[panelIndex].tabs.indices {
-        guard snapshot.panels[panelIndex].tabs[tabIndex].linkedSession == nil,
-              snapshot.panels[panelIndex].tabs[tabIndex].workingDirectory == projectPath else {
-          continue
-        }
-        snapshot.panels[panelIndex].tabs[tabIndex].role = .agent
-        snapshot.panels[panelIndex].tabs[tabIndex].linkedSession = TerminalWorkspaceLinkedSessionSnapshot(
-          provider: provider,
-          sessionId: sessionId
-        )
-        restoredSnapshot = snapshot
-        markedSessions.append("\(provider.rawValue.lowercased()):\(sessionId)")
-        onWorkspaceChanged?(snapshot)
-        return true
+    let candidates = snapshot.panels.indices.flatMap { panelIndex in
+      snapshot.panels[panelIndex].tabs.indices.compactMap { tabIndex -> (Int, Int)? in
+        let tab = snapshot.panels[panelIndex].tabs[tabIndex]
+        guard tab.linkedSession == nil, tab.workingDirectory == projectPath else { return nil }
+        return (panelIndex, tabIndex)
       }
     }
-    return false
+    guard let candidate = candidates.first(where: {
+      snapshot.panels[$0.0].tabs[$0.1].role == .agent
+    }) ?? candidates.first else {
+      return false
+    }
+    snapshot.panels[candidate.0].tabs[candidate.1].role = .agent
+    snapshot.panels[candidate.0].tabs[candidate.1].linkedSession = TerminalWorkspaceLinkedSessionSnapshot(
+      provider: provider,
+      sessionId: sessionId
+    )
+    restoredSnapshot = snapshot
+    markedSessions.append("\(provider.rawValue.lowercased()):\(sessionId)")
+    onWorkspaceChanged?(snapshot)
+    return true
   }
 
   func captureWorkspaceSnapshot() -> TerminalWorkspaceSnapshot? { restoredSnapshot }

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/ProjectSimulatorPreferenceTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/ProjectSimulatorPreferenceTests.swift
@@ -108,7 +108,7 @@ struct ProjectSimulatorPreferenceTests {
 
     try await dbQueue.write { db in
       try db.execute(sql: "CREATE TABLE grdb_migrations (identifier TEXT NOT NULL PRIMARY KEY)")
-      for identifier in SessionMetadataStore.migrationIdentifiers.dropLast() {
+      for identifier in SessionMetadataStore.migrationIdentifiers.dropLast(2) {
         try db.execute(sql: "INSERT INTO grdb_migrations (identifier) VALUES (?)", arguments: [identifier])
       }
 

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/TerminalDirectionalFocusResolverTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/TerminalDirectionalFocusResolverTests.swift
@@ -1,0 +1,65 @@
+import CoreGraphics
+import Testing
+
+@testable import AgentHubCore
+
+@Suite("Terminal directional focus")
+struct TerminalDirectionalFocusResolverTests {
+  @Test("Directional focus works across a six-pane geometry")
+  func sixPaneNavigation() {
+    let frames = [
+      "top-left": CGRect(x: 0, y: 0, width: 300, height: 200),
+      "top-center": CGRect(x: 300, y: 0, width: 300, height: 200),
+      "top-right": CGRect(x: 600, y: 0, width: 300, height: 200),
+      "bottom-left": CGRect(x: 0, y: 200, width: 300, height: 200),
+      "bottom-center": CGRect(x: 300, y: 200, width: 300, height: 200),
+      "bottom-right": CGRect(x: 600, y: 200, width: 300, height: 200)
+    ]
+
+    #expect(
+      TerminalDirectionalFocusResolver.target(
+        from: "top-center",
+        frames: frames,
+        direction: .left
+      ) == "top-left"
+    )
+    #expect(
+      TerminalDirectionalFocusResolver.target(
+        from: "top-center",
+        frames: frames,
+        direction: .right
+      ) == "top-right"
+    )
+    #expect(
+      TerminalDirectionalFocusResolver.target(
+        from: "top-center",
+        frames: frames,
+        direction: .down
+      ) == "bottom-center"
+    )
+    #expect(
+      TerminalDirectionalFocusResolver.target(
+        from: "bottom-right",
+        frames: frames,
+        direction: .up
+      ) == "top-right"
+    )
+  }
+
+  @Test("Focus prefers an overlapping pane over a diagonal pane")
+  func overlapPreference() {
+    let frames = [
+      "current": CGRect(x: 0, y: 0, width: 300, height: 300),
+      "overlap": CGRect(x: 320, y: 100, width: 300, height: 100),
+      "diagonal": CGRect(x: 310, y: 400, width: 300, height: 100)
+    ]
+
+    #expect(
+      TerminalDirectionalFocusResolver.target(
+        from: "current",
+        frames: frames,
+        direction: .right
+      ) == "overlap"
+    )
+  }
+}

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/TerminalWorkspaceLinkedSessionSnapshotTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/TerminalWorkspaceLinkedSessionSnapshotTests.swift
@@ -79,6 +79,6 @@ struct TerminalWorkspaceLinkedSessionSnapshotTests {
     let decoded = try JSONDecoder().decode(TerminalWorkspaceSnapshot.self, from: data)
 
     #expect(decoded == snapshot)
-    #expect(decoded.schemaVersion == 3)
+    #expect(decoded.schemaVersion == 4)
   }
 }

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/TerminalWorkspaceSnapshotV4Tests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/TerminalWorkspaceSnapshotV4Tests.swift
@@ -1,0 +1,88 @@
+import Foundation
+import Testing
+
+@testable import AgentHubCore
+
+@Suite("Terminal workspace snapshot v4")
+struct TerminalWorkspaceSnapshotV4Tests {
+  @Test("v3 snapshots decode with equal-ratio fallback data absent")
+  func v3BackwardCompatibility() throws {
+    let json = """
+    {
+      "schemaVersion": 3,
+      "panels": [
+        {
+          "role": "primary",
+          "tabs": [{ "role": "shell", "workingDirectory": "/tmp/project" }],
+          "activeTabIndex": 0
+        }
+      ],
+      "activePanelIndex": 0,
+      "splitLayout": null
+    }
+    """
+
+    let snapshot = try JSONDecoder().decode(
+      TerminalWorkspaceSnapshot.self,
+      from: Data(json.utf8)
+    )
+
+    #expect(snapshot.schemaVersion == 3)
+    #expect(snapshot.splitRatiosByPath.isEmpty)
+    #expect(snapshot.panels.count == 1)
+  }
+
+  @Test("v4 ratios round-trip for more than four panes")
+  func ratiosRoundTrip() throws {
+    let snapshot = TerminalWorkspaceSnapshot(
+      panels: (0..<6).map { index in
+        TerminalWorkspacePanelSnapshot(
+          role: index == 0 ? .primary : .auxiliary,
+          tabs: [TerminalWorkspaceTabSnapshot(role: .shell, workingDirectory: "/tmp/\(index)")]
+        )
+      },
+      splitLayout: .split(
+        axis: .horizontal,
+        children: (0..<6).map { .panel(index: $0) }
+      ),
+      splitRatiosByPath: ["root": [1, 2, 3, 4, 5, 6]]
+    )
+
+    let decoded = try JSONDecoder().decode(
+      TerminalWorkspaceSnapshot.self,
+      from: JSONEncoder().encode(snapshot)
+    )
+
+    #expect(decoded == snapshot)
+    #expect(decoded.schemaVersion == 4)
+    #expect(decoded.panels.count == 6)
+  }
+
+  @Test("Malformed and obsolete ratios normalize safely")
+  func malformedRatiosNormalize() {
+    let snapshot = TerminalWorkspaceSnapshot(
+      panels: [],
+      splitLayout: .split(
+        axis: .horizontal,
+        children: [
+          .panel(index: 0),
+          .split(
+            axis: .vertical,
+            children: [.panel(index: 1), .panel(index: 2)]
+          )
+        ]
+      ),
+      splitRatiosByPath: [
+        "root": [0],
+        "root.1": [2, 6],
+        "obsolete": [0.2, 0.8]
+      ]
+    )
+
+    let normalized = snapshot.normalizedSplitRatios()
+
+    #expect(normalized["root"] == [0.5, 0.5])
+    #expect(normalized["root.1"] == [0.25, 0.75])
+    #expect(normalized["obsolete"] == nil)
+  }
+}

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/WorkspaceSessionProcessProviderResolverTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/WorkspaceSessionProcessProviderResolverTests.swift
@@ -1,0 +1,71 @@
+import Darwin
+import Testing
+
+@testable import AgentHubCore
+
+@Suite("Workspace session process provider resolver")
+struct WorkspaceSessionProcessProviderResolverTests {
+  @Test("Identifies Claude and Codex foreground commands")
+  func identifiesProviders() async {
+    let inspector = WorkspaceProcessInspectorStub(
+      identities: [
+        101: workspaceIdentity(
+          pid: 101,
+          command: "/Users/test/.claude/local/node_modules/.bin/claude --model sonnet"
+        ),
+        202: workspaceIdentity(
+          pid: 202,
+          command: "/opt/codex/vendor/aarch64-apple-darwin/bin/codex"
+        ),
+        303: workspaceIdentity(pid: 303, command: "/bin/zsh")
+      ]
+    )
+    let resolver = WorkspaceSessionProcessProviderResolver(processInspector: inspector)
+    let executables: [SessionProviderKind: String] = [
+      .claude: "claude",
+      .codex: "codex"
+    ]
+
+    #expect(await resolver.provider(for: 101, executableNames: executables) == .claude)
+    #expect(await resolver.provider(for: 202, executableNames: executables) == .codex)
+    #expect(await resolver.provider(for: 303, executableNames: executables) == nil)
+  }
+
+  @Test("Honors custom executable names")
+  func customExecutableNames() async {
+    let inspector = WorkspaceProcessInspectorStub(
+      identities: [
+        404: workspaceIdentity(pid: 404, command: "/usr/local/bin/team-agent --interactive")
+      ]
+    )
+    let resolver = WorkspaceSessionProcessProviderResolver(processInspector: inspector)
+
+    #expect(
+      await resolver.provider(
+        for: 404,
+        executableNames: [.claude: "team-agent", .codex: "codex"]
+      ) == .claude
+    )
+  }
+}
+
+private actor WorkspaceProcessInspectorStub: ProcessInspecting {
+  let identities: [Int32: ManagedProcessIdentity]
+
+  init(identities: [Int32: ManagedProcessIdentity]) {
+    self.identities = identities
+  }
+
+  func identity(for pid: pid_t) async -> ManagedProcessIdentity? {
+    identities[pid]
+  }
+}
+
+private func workspaceIdentity(pid: Int32, command: String) -> ManagedProcessIdentity {
+  ManagedProcessIdentity(
+    pid: pid,
+    processGroupId: pid,
+    startTimeSeconds: 1,
+    commandLine: command
+  )
+}

--- a/app/modules/Ghostty/Package.resolved
+++ b/app/modules/Ghostty/Package.resolved
@@ -1,0 +1,222 @@
+{
+  "originHash" : "023a9c4fd43e10bfd6b0a4bbe1cb326f1a9386b337f08f2387637aae2f775fcf",
+  "pins" : [
+    {
+      "identity" : "beautiful-mermaid-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/lukilabs/beautiful-mermaid-swift",
+      "state" : {
+        "revision" : "c6a63655285c5e479d6641c774acb0a8739f8ad7",
+        "version" : "0.1.1"
+      }
+    },
+    {
+      "identity" : "canvas",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/jamesrochabrun/Canvas",
+      "state" : {
+        "revision" : "1c246e294b615bdd2cea822366facbfc579dd03c",
+        "version" : "1.3.3"
+      }
+    },
+    {
+      "identity" : "codeeditlanguages",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/CodeEditApp/CodeEditLanguages",
+      "state" : {
+        "revision" : "331d5dbc5fc8513be5848fce8a2a312908f36a11",
+        "version" : "0.1.20"
+      }
+    },
+    {
+      "identity" : "codeeditsourceeditor",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/CodeEditApp/CodeEditSourceEditor",
+      "state" : {
+        "revision" : "424453d2232c9912933a3b5a1f3d3df669404ed0",
+        "version" : "0.15.2"
+      }
+    },
+    {
+      "identity" : "codeeditsymbols",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/CodeEditApp/CodeEditSymbols.git",
+      "state" : {
+        "revision" : "ae69712b08571c4469c2ed5cd38ad9f19439793e",
+        "version" : "0.2.3"
+      }
+    },
+    {
+      "identity" : "codeedittextview",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/CodeEditApp/CodeEditTextView.git",
+      "state" : {
+        "revision" : "d7ac3f11f22ec2e820187acce8f3a3fb7aa8ddec",
+        "version" : "0.12.1"
+      }
+    },
+    {
+      "identity" : "dagre-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/lukilabs/dagre-swift",
+      "state" : {
+        "revision" : "92efb78b73a8b665ee74bacfb0f1f5b17bbe1b38",
+        "version" : "0.1.0"
+      }
+    },
+    {
+      "identity" : "ghosttyswift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/jamesrochabrun/GhosttySwift",
+      "state" : {
+        "revision" : "f7286937278044fcfa0d6385b1264fe9cc8195b3",
+        "version" : "1.0.4"
+      }
+    },
+    {
+      "identity" : "grdb.swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/groue/GRDB.swift",
+      "state" : {
+        "revision" : "2cf6c756e1e5ef6901ebae16576a7e4e4b834622",
+        "version" : "6.29.3"
+      }
+    },
+    {
+      "identity" : "highlightswift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/appstefan/HighlightSwift",
+      "state" : {
+        "revision" : "784ca3ccfc8a2cf724fbb2f06cb6ec3329424da3",
+        "version" : "1.1.0"
+      }
+    },
+    {
+      "identity" : "networkimage",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/gonzalezreal/NetworkImage",
+      "state" : {
+        "revision" : "2849f5323265386e200484b0d0f896e73c3411b9",
+        "version" : "6.0.1"
+      }
+    },
+    {
+      "identity" : "pierrediffsswift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/jamesrochabrun/PierreDiffsSwift",
+      "state" : {
+        "revision" : "7720cc32659559b4a3b830ec9d3ef27258fee2c3",
+        "version" : "1.2.2"
+      }
+    },
+    {
+      "identity" : "rearrange",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ChimeHQ/Rearrange",
+      "state" : {
+        "revision" : "4de8be41dba304192e87dc0a11e0aa39e72aa2e8",
+        "version" : "2.1.1"
+      }
+    },
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser",
+      "state" : {
+        "revision" : "626b5b7b2f45e1b0b1c6f4a309296d1d21d7311b",
+        "version" : "1.7.1"
+      }
+    },
+    {
+      "identity" : "swift-cmark",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-cmark",
+      "state" : {
+        "revision" : "924936d0427cb25a61169739a7660230bffa6ea6",
+        "version" : "0.8.0"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections.git",
+      "state" : {
+        "revision" : "03cc312c2c933ed87abace34044a5dff7a3117c1",
+        "version" : "1.5.0"
+      }
+    },
+    {
+      "identity" : "swift-markdown-ui",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/gonzalezreal/swift-markdown-ui",
+      "state" : {
+        "revision" : "5f613358148239d0292c0cef674a3c2314737f9e",
+        "version" : "2.4.1"
+      }
+    },
+    {
+      "identity" : "swiftlintplugin",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/lukepistrol/SwiftLintPlugin",
+      "state" : {
+        "revision" : "a3877065a7d72ee40e1fa64e13b9e33e846c667c",
+        "version" : "0.63.1"
+      }
+    },
+    {
+      "identity" : "swiftterm",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/jamesrochabrun/SwiftTerm",
+      "state" : {
+        "revision" : "d9b10dad741cd9b1d7d36556b4ccdad9a8b8e1ca",
+        "version" : "1.13.0-agenthub.8"
+      }
+    },
+    {
+      "identity" : "swifttreesitter",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ChimeHQ/SwiftTreeSitter.git",
+      "state" : {
+        "revision" : "08ef81eb8620617b55b08868126707ad72bf754f",
+        "version" : "0.25.0"
+      }
+    },
+    {
+      "identity" : "textformation",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ChimeHQ/TextFormation",
+      "state" : {
+        "revision" : "b1ce9a14bd86042bba4de62236028dc4ce9db6a1",
+        "version" : "0.9.0"
+      }
+    },
+    {
+      "identity" : "textstory",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ChimeHQ/TextStory",
+      "state" : {
+        "revision" : "a52db1a2eca74d37c8c19bf3165416941632ed45",
+        "version" : "0.9.2"
+      }
+    },
+    {
+      "identity" : "tree-sitter",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/tree-sitter/tree-sitter",
+      "state" : {
+        "revision" : "da6fe9beb4f7f67beb75914ca8e0d48ae48d6406",
+        "version" : "0.25.10"
+      }
+    },
+    {
+      "identity" : "yams",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/jpsim/Yams",
+      "state" : {
+        "revision" : "3d6871d5b4a5cd519adf233fbb576e0a2af71c17",
+        "version" : "5.4.0"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalPaneHeader.swift
+++ b/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalPaneHeader.swift
@@ -11,7 +11,8 @@ struct AgentHubGhosttyTerminalPaneHeader: View {
   let panel: TerminalPanel
   let isMaximized: Bool
   let canMaximize: Bool
-  let canSplit: Bool
+  let canSplitRight: Bool
+  let canSplitBelow: Bool
   let canClosePanel: Bool
   let canCloseTab: (TerminalTab) -> Bool
   let onSelectTab: (TerminalTab) -> Void
@@ -66,7 +67,7 @@ struct AgentHubGhosttyTerminalPaneHeader: View {
             title: "Split Right",
             systemImage: "rectangle.split.2x1",
             help: "Split terminal to the right",
-            isDisabled: !canSplit,
+            isDisabled: !canSplitRight,
             action: onSplitRight
           )
 
@@ -74,7 +75,7 @@ struct AgentHubGhosttyTerminalPaneHeader: View {
             title: "Split Below",
             systemImage: "rectangle.split.1x2",
             help: "Split terminal below",
-            isDisabled: !canSplit,
+            isDisabled: !canSplitBelow,
             action: onSplitBelow
           )
 

--- a/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalPaneView.swift
+++ b/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalPaneView.swift
@@ -17,6 +17,7 @@ struct AgentHubGhosttyTerminalPaneView: View {
   let canMaximize: Bool
   let canClosePanel: (TerminalPanel) -> Bool
   let canCloseTab: (TerminalPanel, TerminalTab) -> Bool
+  let canSplitPanel: (TerminalPanel, TerminalSplitAxis) -> Bool
   let onActivatePanel: (TerminalPanel) -> Void
   let onSelectTab: (TerminalPanel, TerminalTab) -> Void
   let onClosePanel: (TerminalPanel) -> Void
@@ -32,7 +33,8 @@ struct AgentHubGhosttyTerminalPaneView: View {
         panel: panel,
         isMaximized: isMaximized,
         canMaximize: canMaximize,
-        canSplit: session.canOpenPanel,
+        canSplitRight: canSplitPanel(panel, .horizontal),
+        canSplitBelow: canSplitPanel(panel, .vertical),
         canClosePanel: canClosePanel(panel),
         canCloseTab: { tab in canCloseTab(panel, tab) },
         onSelectTab: { tab in onSelectTab(panel, tab) },

--- a/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalSplitView.swift
+++ b/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalSplitView.swift
@@ -14,8 +14,11 @@ struct AgentHubGhosttyTerminalSplitView: View {
   let node: TerminalSplitLayout.Node
   let session: TerminalSession
   let maximizedPanelID: TerminalPanelID?
+  let nodePath: String
+  let splitRatiosByPath: [String: [Double]]
   let canClosePanel: (TerminalPanel) -> Bool
   let canCloseTab: (TerminalPanel, TerminalTab) -> Bool
+  let canSplitPanel: (TerminalPanel, TerminalSplitAxis) -> Bool
   let onActivatePanel: (TerminalPanel) -> Void
   let onSelectTab: (TerminalPanel, TerminalTab) -> Void
   let onClosePanel: (TerminalPanel) -> Void
@@ -23,6 +26,7 @@ struct AgentHubGhosttyTerminalSplitView: View {
   let onOpenTab: (TerminalPanel) -> Void
   let onSplitPanel: (TerminalPanel, TerminalSplitAxis) -> Void
   let onToggleMaximizedPanel: (TerminalPanel) -> Void
+  let onSplitRatiosChanged: (String, [Double]) -> Void
   let activityForPanel: (TerminalPanelID) -> AgentHubGhosttyTerminalPaneActivity?
 
   var body: some View {
@@ -42,6 +46,7 @@ struct AgentHubGhosttyTerminalSplitView: View {
           canMaximize: session.visiblePanels.count > 1,
           canClosePanel: canClosePanel,
           canCloseTab: canCloseTab,
+          canSplitPanel: canSplitPanel,
           onActivatePanel: onActivatePanel,
           onSelectTab: onSelectTab,
           onClosePanel: onClosePanel,
@@ -103,8 +108,11 @@ struct AgentHubGhosttyTerminalSplitView: View {
           node: child,
           session: session,
           maximizedPanelID: maximizedPanelID,
+          nodePath: "\(nodePath).\(offset)",
+          splitRatiosByPath: splitRatiosByPath,
           canClosePanel: canClosePanel,
           canCloseTab: canCloseTab,
+          canSplitPanel: canSplitPanel,
           onActivatePanel: onActivatePanel,
           onSelectTab: onSelectTab,
           onClosePanel: onClosePanel,
@@ -112,6 +120,7 @@ struct AgentHubGhosttyTerminalSplitView: View {
           onOpenTab: onOpenTab,
           onSplitPanel: onSplitPanel,
           onToggleMaximizedPanel: onToggleMaximizedPanel,
+          onSplitRatiosChanged: onSplitRatiosChanged,
           activityForPanel: activityForPanel
         )
         .frame(width: childDimension(childWidths, at: offset), height: size.height)
@@ -123,6 +132,9 @@ struct AgentHubGhosttyTerminalSplitView: View {
     }
     .onChange(of: children.count) { _, childCount in
       reconcileRatios(childCount: childCount)
+    }
+    .onChange(of: splitRatiosByPath[nodePath]) { _, _ in
+      restoreSavedRatios(childCount: children.count)
     }
   }
 
@@ -152,8 +164,11 @@ struct AgentHubGhosttyTerminalSplitView: View {
           node: child,
           session: session,
           maximizedPanelID: maximizedPanelID,
+          nodePath: "\(nodePath).\(offset)",
+          splitRatiosByPath: splitRatiosByPath,
           canClosePanel: canClosePanel,
           canCloseTab: canCloseTab,
+          canSplitPanel: canSplitPanel,
           onActivatePanel: onActivatePanel,
           onSelectTab: onSelectTab,
           onClosePanel: onClosePanel,
@@ -161,6 +176,7 @@ struct AgentHubGhosttyTerminalSplitView: View {
           onOpenTab: onOpenTab,
           onSplitPanel: onSplitPanel,
           onToggleMaximizedPanel: onToggleMaximizedPanel,
+          onSplitRatiosChanged: onSplitRatiosChanged,
           activityForPanel: activityForPanel
         )
         .frame(width: size.width, height: childDimension(childHeights, at: offset))
@@ -172,6 +188,9 @@ struct AgentHubGhosttyTerminalSplitView: View {
     }
     .onChange(of: children.count) { _, childCount in
       reconcileRatios(childCount: childCount)
+    }
+    .onChange(of: splitRatiosByPath[nodePath]) { _, _ in
+      restoreSavedRatios(childCount: children.count)
     }
   }
 
@@ -211,8 +230,19 @@ struct AgentHubGhosttyTerminalSplitView: View {
   }
 
   private func reconcileRatios(childCount: Int) {
+    if childRatios.isEmpty {
+      restoreSavedRatios(childCount: childCount)
+    } else {
+      childRatios = TerminalPanelKit.SplitSizing.normalizedRatios(
+        childRatios,
+        childCount: childCount
+      )
+    }
+  }
+
+  private func restoreSavedRatios(childCount: Int) {
     childRatios = TerminalPanelKit.SplitSizing.normalizedRatios(
-      childRatios,
+      (splitRatiosByPath[nodePath] ?? []).map { CGFloat($0) },
       childCount: childCount
     )
   }
@@ -255,6 +285,7 @@ struct AgentHubGhosttyTerminalSplitView: View {
       containerLength: containerLength,
       minimumChildDimension: TerminalPanelKit.SplitSizing.minimumChildDimension(for: axis)
     )
+    onSplitRatiosChanged(nodePath, childRatios.map { Double($0) })
   }
 }
 

--- a/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalSurface.swift
+++ b/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalSurface.swift
@@ -26,6 +26,7 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
   private var accessoryAgentProvidersByTabID: [TerminalTabID: SessionProviderKind] = [:]
   private var linkedSessionsByTabID: [TerminalTabID: TerminalWorkspaceLinkedSessionSnapshot] = [:]
   private var splitRoot: TerminalSplitLayout.Node?
+  private var splitRatiosByPath: [String: [Double]] = [:]
   private var maximizedPanelID: TerminalPanelID?
   private var pendingMount: PendingMount?
   private var pendingMountTask: Task<Void, Never>?
@@ -49,7 +50,7 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
   private var configuredProcessProvider: SessionProviderKind?
   private var configuredExpectedExecutable: String?
   private var metadataStore: SessionMetadataStore?
-  private static let terminalPaneDividerSize: CGFloat = 1
+  private static let terminalPaneDividerSize = TerminalPanelKit.SplitSizing.dividerDimension
   private static let terminalTabStripHeight = AgentHubGhosttyTerminalTabChrome.stripHeight
   private static let shellStartupFallbackDelay: Duration = .milliseconds(900)
   private static let pendingPaneRenderDelay: Duration = .milliseconds(16)
@@ -58,6 +59,7 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
   public var onRequestShowEditor: (() -> Void)?
   public var consumeQueuedWebPreviewContextOnSubmit: (() -> String?)?
   public var onWorkspaceChanged: ((TerminalWorkspaceSnapshot) -> Void)?
+  public var workspaceCLIConfigurationProvider: ((SessionProviderKind) -> CLICommandConfiguration)?
   private var terminalSessionKey: String?
   private weak var sessionViewModel: CLISessionsViewModel?
   var terminateProcessCallCount = 0
@@ -202,6 +204,7 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
     accessoryAgentProvidersByTabID.removeAll()
     linkedSessionsByTabID.removeAll()
     splitRoot = nil
+    splitRatiosByPath.removeAll()
     maximizedPanelID = nil
     resetPaneActivities()
     isConfigured = false
@@ -331,7 +334,11 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
     if let metadataStore {
       self.metadataStore = metadataStore
     }
-    guard let terminalSession, terminalSession.canOpenPanel else { return nil }
+    guard let terminalSession,
+          canSplitPanel(
+            terminalSession.panel(for: terminalSession.activePanelID),
+            axis: .horizontal
+          ) else { return nil }
     let workingDirectory = resolvedExistingDirectory(projectPath)
     let startedAt = Date()
     guard let configuration = accessoryAgentConfiguration(
@@ -389,6 +396,53 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
     return true
   }
 
+  public func openWorkspaceSurface(
+    kind: WorkspaceTerminalLaunchKind,
+    placement: WorkspaceSurfacePlacement,
+    cliConfiguration: CLICommandConfiguration?,
+    projectPath: String,
+    metadataStore: SessionMetadataStore?
+  ) -> WorkspaceSurfaceLaunchContext? {
+    if let metadataStore {
+      self.metadataStore = metadataStore
+    }
+    guard terminalSession != nil else { return nil }
+
+    let workingDirectory = resolvedExistingDirectory(
+      activeWorkingDirectory() ?? projectPath
+    )
+    let startedAt = Date.now
+    let didOpen: Bool
+
+    switch kind {
+    case .shell:
+      didOpen = openWorkspaceShell(
+        placement: placement,
+        workingDirectory: workingDirectory
+      )
+    case .agent(let provider):
+      guard let cliConfiguration else { return nil }
+      didOpen = openWorkspaceAgent(
+        provider: provider,
+        placement: placement,
+        cliConfiguration: cliConfiguration,
+        workingDirectory: workingDirectory
+      )
+    }
+
+    guard didOpen else { return nil }
+    let provider: SessionProviderKind? = if case .agent(let provider) = kind {
+      provider
+    } else {
+      nil
+    }
+    return WorkspaceSurfaceLaunchContext(
+      provider: provider,
+      projectPath: workingDirectory,
+      startedAt: startedAt
+    )
+  }
+
   public func captureWorkspaceSnapshot() -> TerminalWorkspaceSnapshot? {
     guard let terminalSession else { return nil }
 
@@ -417,7 +471,7 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
       )
     }
 
-    return TerminalWorkspaceSnapshot(
+    var snapshot = TerminalWorkspaceSnapshot(
       panels: panels,
       activePanelIndex: terminalSession.panels.firstIndex { $0.id == terminalSession.activePanelID } ?? 0,
       splitLayout: currentSplitRoot().flatMap {
@@ -425,8 +479,11 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
           from: $0,
           panelIDs: terminalSession.panels.map(\.id)
         )
-      }
+      },
+      splitRatiosByPath: splitRatiosByPath
     )
+    snapshot.splitRatiosByPath = snapshot.normalizedSplitRatios()
+    return snapshot
   }
 
   public func restoreWorkspaceSnapshot(_ snapshot: TerminalWorkspaceSnapshot) {
@@ -438,6 +495,7 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
 
     isRestoringWorkspace = true
     maximizedPanelID = nil
+    splitRatiosByPath = snapshot.normalizedSplitRatios()
     defer {
       isRestoringWorkspace = false
       lastWorkspaceSnapshot = captureWorkspaceSnapshot()
@@ -461,12 +519,12 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
       restoredTabIDs[0] = restoreShellTabs(
         from: primarySnapshot,
         in: terminalSession.primaryPanelID,
-        existingTabIDs: restoredTabIDs[0]
+        existingTabIDs: restoredTabIDs[0],
+        skippingFirstShellTab: protectedAgentTabID == nil
       )
     }
 
     for (panelIndex, panelSnapshot) in panelSnapshots.enumerated().dropFirst() {
-      guard terminalSession.canOpenPanel else { break }
       guard let firstAccessoryTab = firstRestorableAccessoryTab(in: panelSnapshot) else { continue }
       guard let configuration = configurationForRestoredAccessoryTab(firstAccessoryTab) else { continue }
 
@@ -644,11 +702,15 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
       session: session,
       splitRoot: splitRoot,
       maximizedPanelID: maximizedPanelID,
+      splitRatiosByPath: splitRatiosByPath,
       canClosePanel: { [weak self] panel in
         self?.canCloseGhosttyPanel(panel) ?? false
       },
       canCloseTab: { [weak self] panel, tab in
         self?.canCloseGhosttyTab(tab, in: panel) ?? false
+      },
+      canSplitPanel: { [weak self] panel, axis in
+        self?.canSplitPanel(panel, axis: axis) ?? false
       },
       onActivatePanel: { [weak self] panel in
         self?.activateGhosttyPanel(panel)
@@ -670,6 +732,11 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
       },
       onToggleMaximizedPanel: { [weak self] panel in
         self?.toggleMaximizedPanel(panel)
+      },
+      onSplitRatiosChanged: { [weak self] path, ratios in
+        guard let self else { return }
+        self.splitRatiosByPath[path] = ratios
+        self.notifyWorkspaceChanged()
       },
       activityForPanel: { [weak self] panelID in
         self?.paneActivityRegistry.activity(for: panelID)
@@ -791,6 +858,7 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
     initialSize: GhosttySurfaceInitialSize? = nil
   ) -> GhosttySurfaceConfiguration? {
     let cliConfiguration = cliConfigurationOverride
+      ?? workspaceCLIConfigurationProvider?(provider)
       ?? sessionViewModel?.cliConfiguration(for: provider)
       ?? (provider == .claude ? .claudeDefault : .codexDefault)
     let launch = EmbeddedTerminalLaunchBuilder.cliLaunch(
@@ -816,7 +884,8 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
 
   private func expectedExecutable(for provider: SessionProviderKind?) -> String? {
     guard let provider else { return configuredExpectedExecutable }
-    return sessionViewModel?.cliConfiguration(for: provider).executableName
+    return workspaceCLIConfigurationProvider?(provider).executableName
+      ?? sessionViewModel?.cliConfiguration(for: provider).executableName
       ?? (provider == .claude
         ? CLICommandConfiguration.claudeDefault.executableName
         : CLICommandConfiguration.codexDefault.executableName)
@@ -896,7 +965,7 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
     let auxiliaries = panels.enumerated()
       .filter { $0.element.role == .auxiliary && $0.offset != primaryIndex }
       .map { (originalIndex: $0.offset, snapshot: $0.element) }
-    return Array(([primaryEntry].compactMap { $0 } + auxiliaries).prefix(4))
+    return [primaryEntry].compactMap { $0 } + auxiliaries
   }
 
   private func resetToPrimaryAgentTab(in terminalSession: TerminalSession) {
@@ -905,12 +974,18 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
       _ = terminalSession.closePanel(panel.id)
     }
 
-    for tab in terminalSession.primaryPanel.tabs where !isProtectedAgentTab(tab, in: terminalSession.primaryPanelID) {
+    let retainedTabID = protectedAgentTabID ?? terminalSession.primaryPanel.tabs.first?.id
+    for tab in terminalSession.primaryPanel.tabs where tab.id != retainedTabID {
       requestClose(tab)
       _ = terminalSession.closeTab(tab.id, in: terminalSession.primaryPanelID)
     }
 
-    focusProtectedAgentTab()
+    if let retainedTabID {
+      accessoryAgentTabIDs.remove(retainedTabID)
+      accessoryAgentProvidersByTabID.removeValue(forKey: retainedTabID)
+      linkedSessionsByTabID.removeValue(forKey: retainedTabID)
+      _ = terminalSession.selectTab(retainedTabID, in: terminalSession.primaryPanelID)
+    }
     splitRoot = .panel(terminalSession.primaryPanelID)
     maximizedPanelID = nil
   }
@@ -1147,8 +1222,7 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
         toggleMaximizedPanel(activePanel)
       }
     case .focusPanel(let direction):
-      if maximizedPanelID == nil,
-         terminalSession?.focusPanel(direction: direction) == true {
+      if maximizedPanelID == nil, focusPanel(direction: direction) {
         notifyWorkspaceChanged()
       }
     case .selectTab(let direction):
@@ -1158,8 +1232,127 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
     }
   }
 
-  private func openShellTab(in panelID: TerminalPanelID? = nil) {
-    guard let terminalSession else { return }
+  private func openWorkspaceShell(
+    placement: WorkspaceSurfacePlacement,
+    workingDirectory: String
+  ) -> Bool {
+    switch placement {
+    case .tab:
+      guard let terminalSession else { return false }
+      do {
+        let panelID = terminalSession.activePanelID
+        let tab = try terminalSession.openTab(
+          in: panelID,
+          named: "Shell",
+          configuration: shellConfiguration(
+            forRestoredWorkingDirectory: workingDirectory,
+            in: panelID
+          )
+        )
+        configureControllerHooks(for: tab.controller)
+        markPaneStarting(panelID)
+        refreshWorkspaceRootView()
+        notifyWorkspaceChanged()
+        return true
+      } catch {
+        AppLogger.session.error("Failed to open Ghostty workspace shell tab: \(error.localizedDescription)")
+        return false
+      }
+
+    case .splitRight:
+      return openShellPane(axis: .horizontal)
+    case .splitDown:
+      return openShellPane(axis: .vertical)
+    }
+  }
+
+  private func openWorkspaceAgent(
+    provider: SessionProviderKind,
+    placement: WorkspaceSurfacePlacement,
+    cliConfiguration: CLICommandConfiguration,
+    workingDirectory: String
+  ) -> Bool {
+    guard let terminalSession else { return false }
+
+    switch placement {
+    case .tab:
+      let panelID = terminalSession.activePanelID
+      guard let configuration = accessoryAgentConfiguration(
+        provider: provider,
+        sessionId: nil,
+        workingDirectory: workingDirectory,
+        cliConfigurationOverride: cliConfiguration,
+        initialSize: predictedInitialSizeForNewTerminal(in: panelID)
+      ) else {
+        return false
+      }
+      do {
+        let tab = try terminalSession.openTab(
+          in: panelID,
+          named: provider.rawValue,
+          configuration: configuration
+        )
+        accessoryAgentTabIDs.insert(tab.id)
+        accessoryAgentProvidersByTabID[tab.id] = provider
+        configureControllerHooks(for: tab.controller)
+        markPaneStarting(panelID)
+        refreshWorkspaceRootView()
+        notifyWorkspaceChanged()
+        tab.controller.focusTerminal()
+        return true
+      } catch {
+        AppLogger.session.error("Failed to open Ghostty workspace agent tab: \(error.localizedDescription)")
+        return false
+      }
+
+    case .splitRight, .splitDown:
+      let axis: TerminalSplitAxis = placement == .splitRight ? .horizontal : .vertical
+      guard canSplitPanel(
+        terminalSession.panel(for: terminalSession.activePanelID),
+        axis: axis
+      ) else {
+        return false
+      }
+      guard let configuration = accessoryAgentConfiguration(
+        provider: provider,
+        sessionId: nil,
+        workingDirectory: workingDirectory,
+        cliConfigurationOverride: cliConfiguration,
+        initialSize: predictedInitialSizeForNewTerminal(
+          splitAxis: axis,
+          anchorPanelID: terminalSession.activePanelID
+        )
+      ) else {
+        return false
+      }
+      do {
+        let panel = try terminalSession.openPanel(
+          named: provider.rawValue,
+          configuration: configuration,
+          axis: axis
+        )
+        if let tab = panel.activeTab {
+          accessoryAgentTabIDs.insert(tab.id)
+          accessoryAgentProvidersByTabID[tab.id] = provider
+        }
+        configureControllerHooks(for: panel.activeTab?.controller)
+        markPaneStarting(panel.id)
+        splitRoot = terminalSession.splitLayout?.root ?? .panel(terminalSession.primaryPanelID)
+        maximizedPanelID = nil
+        refreshWorkspaceRootView()
+        notifyWorkspaceChanged()
+        panel.activeTab?.controller.focusTerminal()
+        return true
+      } catch {
+        AppLogger.session.error("Failed to open Ghostty workspace agent pane: \(error.localizedDescription)")
+        return false
+      }
+    }
+  }
+
+  @discardableResult
+  private func openShellTab(in panelID: TerminalPanelID? = nil) -> Bool {
+    guard let terminalSession else { return false }
     do {
       let tab = try terminalSession.openTab(
         in: panelID,
@@ -1170,18 +1363,27 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
       markPaneStarting(panelID ?? terminalSession.activePanelID)
       refreshWorkspaceRootView()
       notifyWorkspaceChanged()
+      return true
     } catch {
       AppLogger.session.error("Failed to open Ghostty shell tab: \(error.localizedDescription)")
+      return false
     }
   }
 
+  @discardableResult
   private func openShellPane(
     axis: TerminalSplitAxis = .horizontal,
     anchorPanelID: TerminalPanelID? = nil
-  ) {
-    guard let terminalSession, terminalSession.canOpenPanel else { return }
+  ) -> Bool {
+    guard let terminalSession else { return false }
     maximizedPanelID = nil
     let resolvedAnchorPanelID = anchorPanelID ?? terminalSession.activePanelID
+    guard canSplitPanel(
+      terminalSession.panel(for: resolvedAnchorPanelID),
+      axis: axis
+    ) else {
+      return false
+    }
     let projectedPlaceholderID = TerminalPanelID()
     let projectedRoot = projectedSplitRoot(
       adding: projectedPlaceholderID,
@@ -1205,6 +1407,7 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
         projectedRoot: projectedRoot
       )
     }
+    return true
   }
 
   private func finishOpeningShellPane(
@@ -1213,7 +1416,7 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
     placeholderPanelID: TerminalPanelID,
     projectedRoot: TerminalSplitLayout.Node
   ) {
-    guard let terminalSession, terminalSession.canOpenPanel else {
+    guard let terminalSession else {
       removePendingShellPane(placeholderPanelID)
       return
     }
@@ -1256,6 +1459,49 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
   private func canCloseGhosttyPanel(_ panel: TerminalPanel) -> Bool {
     guard let terminalSession else { return false }
     return panel.id != terminalSession.primaryPanelID
+  }
+
+  private func focusPanel(direction: TerminalPanelNavigationDirection) -> Bool {
+    guard let terminalSession, let root = currentSplitRoot() else { return false }
+    let frames = Self.panelFrames(
+      for: root,
+      in: CGRect(origin: .zero, size: bounds.size),
+      splitRatiosByPath: splitRatiosByPath
+    )
+    let mappedDirection: TerminalFocusDirection = switch direction {
+    case .left: .left
+    case .right: .right
+    case .up: .up
+    case .down: .down
+    }
+    guard let targetID = TerminalDirectionalFocusResolver.target(
+      from: terminalSession.activePanelID,
+      frames: frames,
+      direction: mappedDirection
+    ), terminalSession.focusPanel(targetID) else {
+      return false
+    }
+    terminalSession.panel(for: targetID)?.activeTab?.controller.focusTerminal()
+    return true
+  }
+
+  private func canSplitPanel(
+    _ panel: TerminalPanel?,
+    axis: TerminalSplitAxis
+  ) -> Bool {
+    guard let panel, let root = currentSplitRoot(), bounds.width > 0, bounds.height > 0 else {
+      return false
+    }
+    let frames = Self.panelFrames(
+      for: root,
+      in: CGRect(origin: .zero, size: bounds.size),
+      splitRatiosByPath: splitRatiosByPath
+    )
+    guard let frame = frames[panel.id] else { return false }
+    let sizingAxis: TerminalPanelKit.SplitAxis = axis == .horizontal ? .horizontal : .vertical
+    let length = axis == .horizontal ? frame.width : frame.height
+    let minimum = TerminalPanelKit.SplitSizing.minimumChildDimension(for: sizingAxis)
+    return length >= (minimum * 2) + Self.terminalPaneDividerSize
   }
 
   private func canCloseGhosttyTab(_ tab: TerminalTab, in panel: TerminalPanel) -> Bool {
@@ -1435,56 +1681,80 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
 
   private static func panelFrames(
     for node: TerminalSplitLayout.Node,
-    in rect: CGRect
+    in rect: CGRect,
+    splitRatiosByPath: [String: [Double]] = [:],
+    nodePath: String = "root"
   ) -> [TerminalPanelID: CGRect] {
     switch node {
     case .panel(let panelID):
       return [panelID: rect]
     case .split(let axis, let children):
-      return splitPanelFrames(axis: axis, children: children, in: rect)
+      return splitPanelFrames(
+        axis: axis,
+        children: children,
+        in: rect,
+        ratios: splitRatiosByPath,
+        nodePath: nodePath
+      )
     }
   }
 
   private static func splitPanelFrames(
     axis: TerminalSplitAxis,
     children: [TerminalSplitLayout.Node],
-    in rect: CGRect
+    in rect: CGRect,
+    ratios: [String: [Double]],
+    nodePath: String
   ) -> [TerminalPanelID: CGRect] {
     guard !children.isEmpty else { return [:] }
 
     var result: [TerminalPanelID: CGRect] = [:]
-    let childCount = CGFloat(children.count)
+    let sizingAxis: TerminalPanelKit.SplitAxis = axis == .horizontal ? .horizontal : .vertical
+    let childDimensions = TerminalPanelKit.SplitSizing.childDimensions(
+      ratios: (ratios[nodePath] ?? []).map { CGFloat($0) },
+      childCount: children.count,
+      containerLength: axis == .horizontal ? rect.width : rect.height,
+      minimumChildDimension: TerminalPanelKit.SplitSizing.minimumChildDimension(for: sizingAxis)
+    )
 
     switch axis {
     case .horizontal:
-      let totalDividerWidth = terminalPaneDividerSize * CGFloat(max(children.count - 1, 0))
-      let childWidth = max(0, rect.width - totalDividerWidth) / childCount
       var nextX = rect.minX
 
       for (index, child) in children.enumerated() {
         if index > 0 {
           nextX += terminalPaneDividerSize
         }
+        let childWidth = childDimensions.indices.contains(index) ? childDimensions[index] : 0
         let childRect = CGRect(x: nextX, y: rect.minY, width: childWidth, height: rect.height)
         result.merge(
-          panelFrames(for: child, in: childRect),
+          panelFrames(
+            for: child,
+            in: childRect,
+            splitRatiosByPath: ratios,
+            nodePath: "\(nodePath).\(index)"
+          ),
           uniquingKeysWith: { current, _ in current }
         )
         nextX += childWidth
       }
 
     case .vertical:
-      let totalDividerHeight = terminalPaneDividerSize * CGFloat(max(children.count - 1, 0))
-      let childHeight = max(0, rect.height - totalDividerHeight) / childCount
       var nextY = rect.minY
 
       for (index, child) in children.enumerated() {
         if index > 0 {
           nextY += terminalPaneDividerSize
         }
+        let childHeight = childDimensions.indices.contains(index) ? childDimensions[index] : 0
         let childRect = CGRect(x: rect.minX, y: nextY, width: rect.width, height: childHeight)
         result.merge(
-          panelFrames(for: child, in: childRect),
+          panelFrames(
+            for: child,
+            in: childRect,
+            splitRatiosByPath: ratios,
+            nodePath: "\(nodePath).\(index)"
+          ),
           uniquingKeysWith: { current, _ in current }
         )
         nextY += childHeight

--- a/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalSurface.swift
+++ b/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalSurface.swift
@@ -18,6 +18,11 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
     let protectsPrimaryTab: Bool
   }
 
+  private struct PendingLinkedSessionFocus {
+    let provider: SessionProviderKind
+    let sessionId: String
+  }
+
   private var terminalSession: TerminalSession?
   private var hostingView: NSHostingView<AgentHubGhosttyTerminalWorkspaceView>?
   private var protectedAgentPanelID: TerminalPanelID?
@@ -31,6 +36,7 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
   private var pendingMount: PendingMount?
   private var pendingMountTask: Task<Void, Never>?
   private var pendingWorkspaceSnapshot: TerminalWorkspaceSnapshot?
+  private var pendingLinkedSessionFocus: PendingLinkedSessionFocus?
   private var pendingInitialPrompt: String?
   private var isConfigured = false
   private var hasDeliveredInitialPrompt = false
@@ -396,6 +402,92 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
     return true
   }
 
+  public func workspaceSessionDetectionContexts() -> [WorkspaceSessionDetectionContext] {
+    allTabs().compactMap { tab in
+      guard let located = locateTab(tab) else { return nil }
+      guard !isProtectedAgentTab(tab, in: located.panel.id) else { return nil }
+      guard linkedSessionsByTabID[tab.id] == nil else { return nil }
+      return WorkspaceSessionDetectionContext(
+        id: workspaceDetectionContextID(for: tab),
+        provider: inferredProvider(for: tab),
+        projectPath: resolvedExistingDirectory(
+          tab.controller.workingDirectory
+            ?? tab.controller.configuration.workingDirectory
+        ),
+        foregroundProcessID: tab.controller.foregroundProcessID
+      )
+    }
+  }
+
+  public func markWorkspaceSession(
+    contextID: String,
+    provider: SessionProviderKind,
+    sessionId: String,
+    projectPath: String,
+    origin: SessionRelationshipOrigin
+  ) -> Bool {
+    guard let located = allTabs().compactMap({ locateTab($0) }).first(where: {
+      workspaceDetectionContextID(for: $0.tab) == contextID
+    }) else {
+      return false
+    }
+    guard !isProtectedAgentTab(located.tab, in: located.panel.id) else { return false }
+    guard linkedSessionsByTabID[located.tab.id] == nil else { return false }
+
+    let linkedSession = TerminalWorkspaceLinkedSessionSnapshot(
+      provider: provider,
+      sessionId: sessionId,
+      relationshipKind: .accessoryChild
+    )
+    accessoryAgentTabIDs.insert(located.tab.id)
+    accessoryAgentProvidersByTabID[located.tab.id] = provider
+    linkedSessionsByTabID[located.tab.id] = linkedSession
+    refreshWorkspaceRootView()
+    notifyWorkspaceChanged()
+    return true
+  }
+
+  @discardableResult
+  public func focusWorkspaceSession(
+    provider: SessionProviderKind,
+    sessionId: String
+  ) -> Bool {
+    guard terminalSession != nil, pendingWorkspaceSnapshot == nil else {
+      // The surface hasn't mounted or applied its snapshot yet; retry once
+      // the linked tabs exist.
+      pendingLinkedSessionFocus = PendingLinkedSessionFocus(
+        provider: provider,
+        sessionId: sessionId
+      )
+      return true
+    }
+    guard let located = allTabs().compactMap({ locateTab($0) }).first(where: { located in
+      guard let linkedSession = linkedSessionsByTabID[located.tab.id] else { return false }
+      return linkedSession.provider == provider && linkedSession.sessionId == sessionId
+    }) else {
+      return false
+    }
+    focusRestorableTab(located)
+    return true
+  }
+
+  private func focusRestorableTab(_ located: (panel: TerminalPanel, tab: TerminalTab)) {
+    guard let terminalSession else { return }
+    if let maximizedPanelID, maximizedPanelID != located.panel.id {
+      self.maximizedPanelID = nil
+      refreshWorkspaceRootView()
+    }
+    _ = terminalSession.selectTab(located.tab.id, in: located.panel.id)
+    _ = terminalSession.focusPanel(located.panel.id)
+    located.tab.controller.focusTerminal()
+  }
+
+  private func consumePendingLinkedSessionFocus() {
+    guard let pending = pendingLinkedSessionFocus else { return }
+    pendingLinkedSessionFocus = nil
+    _ = focusWorkspaceSession(provider: pending.provider, sessionId: pending.sessionId)
+  }
+
   public func openWorkspaceSurface(
     kind: WorkspaceTerminalLaunchKind,
     placement: WorkspaceSurfacePlacement,
@@ -412,6 +504,7 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
       activeWorkingDirectory() ?? projectPath
     )
     let startedAt = Date.now
+    let existingTabIDs = Set(allTabs().map(\.id))
     let didOpen: Bool
 
     switch kind {
@@ -431,6 +524,7 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
     }
 
     guard didOpen else { return nil }
+    let openedTab = allTabs().first { !existingTabIDs.contains($0.id) }
     let provider: SessionProviderKind? = if case .agent(let provider) = kind {
       provider
     } else {
@@ -439,7 +533,8 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
     return WorkspaceSurfaceLaunchContext(
       provider: provider,
       projectPath: workingDirectory,
-      startedAt: startedAt
+      startedAt: startedAt,
+      detectionContextID: openedTab.map(workspaceDetectionContextID(for:))
     )
   }
 
@@ -516,24 +611,30 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
     var restoredTabIDs: [[TerminalTabID]] = [[protectedAgentTabID ?? terminalSession.primaryPanel.activeTabID]]
 
     if let primarySnapshot = panelSnapshots.first {
-      restoredTabIDs[0] = restoreShellTabs(
-        from: primarySnapshot,
-        in: terminalSession.primaryPanelID,
-        existingTabIDs: restoredTabIDs[0],
-        skippingFirstShellTab: protectedAgentTabID == nil
+      let plan = AgentHubGhosttyWorkspaceRestorePlanner.primaryPlan(
+        for: primarySnapshot,
+        hasProtectedAgentTab: protectedAgentTabID != nil
       )
+      restoredTabIDs[0] = openRestoredTabs(
+        plan.tabsToOpen,
+        in: terminalSession.primaryPanelID,
+        existingTabIDs: restoredTabIDs[0]
+      )
+      if !plan.reusesExistingTab {
+        closeRedundantPrimaryPlaceholderTab(in: terminalSession, restoredTabIDs: &restoredTabIDs[0])
+      }
     }
 
     for (panelIndex, panelSnapshot) in panelSnapshots.enumerated().dropFirst() {
-      guard let firstAccessoryTab = firstRestorableAccessoryTab(in: panelSnapshot) else { continue }
-      guard let configuration = configurationForRestoredAccessoryTab(firstAccessoryTab) else { continue }
+      guard let plan = AgentHubGhosttyWorkspaceRestorePlanner.auxiliaryPlan(for: panelSnapshot) else { continue }
+      guard let configuration = configurationForRestoredAccessoryTab(plan.anchorTab) else { continue }
 
       do {
         let panel = try terminalSession.openPanel(
-          named: restoredTabName(for: firstAccessoryTab),
+          named: restoredTabName(for: plan.anchorTab),
           configuration: configuration
         )
-        if let tab = panel.activeTab, let linkedSession = firstAccessoryTab.linkedSession {
+        if let tab = panel.activeTab, let linkedSession = plan.anchorTab.linkedSession {
           accessoryAgentTabIDs.insert(tab.id)
           accessoryAgentProvidersByTabID[tab.id] = linkedSession.provider
           linkedSessionsByTabID[tab.id] = linkedSession
@@ -543,11 +644,10 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
         restoredPanelIDByIndex[panelIndex] = panel.id
 
         var tabIDs = panel.activeTab.map { [$0.id] } ?? []
-        tabIDs = restoreShellTabs(
-          from: panelSnapshot,
+        tabIDs = openRestoredTabs(
+          plan.additionalTabs,
           in: panel.id,
-          existingTabIDs: tabIDs,
-          skippingFirstShellTab: true
+          existingTabIDs: tabIDs
         )
         restoredTabIDs.append(tabIDs)
       } catch {
@@ -573,6 +673,7 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
       panelIDs: restoredPanelIDs,
       tabIDs: restoredTabIDs
     )
+    consumePendingLinkedSessionFocus()
   }
 
   private var resolvedProjectPath: String {
@@ -626,6 +727,7 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
       mount(session)
       terminalSession = session
       restorePendingWorkspaceSnapshotIfNeeded()
+      consumePendingLinkedSessionFocus()
       installInteractionMonitorIfNeeded()
       deliverPendingInitialPromptIfNeeded()
     } catch {
@@ -990,22 +1092,15 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
     maximizedPanelID = nil
   }
 
-  private func restoreShellTabs(
-    from panelSnapshot: TerminalWorkspacePanelSnapshot,
+  private func openRestoredTabs(
+    _ tabSnapshots: [TerminalWorkspaceTabSnapshot],
     in panelID: TerminalPanelID,
-    existingTabIDs: [TerminalTabID],
-    skippingFirstShellTab: Bool = false
+    existingTabIDs: [TerminalTabID]
   ) -> [TerminalTabID] {
     guard let terminalSession else { return existingTabIDs }
     var restoredTabIDs = existingTabIDs
-    var hasSkippedFirstShellTab = false
 
-    for tabSnapshot in panelSnapshot.tabs where tabSnapshot.role == .shell || tabSnapshot.linkedSession != nil {
-      if skippingFirstShellTab && !hasSkippedFirstShellTab {
-        hasSkippedFirstShellTab = true
-        continue
-      }
-
+    for tabSnapshot in tabSnapshots {
       do {
         guard let configuration = configurationForRestoredAccessoryTab(tabSnapshot, in: panelID) else {
           continue
@@ -1030,10 +1125,21 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
     return restoredTabIDs
   }
 
-  private func firstRestorableAccessoryTab(
-    in panelSnapshot: TerminalWorkspacePanelSnapshot
-  ) -> TerminalWorkspaceTabSnapshot? {
-    panelSnapshot.tabs.first { $0.linkedSession != nil || $0.role == .shell }
+  /// Closes the placeholder shell the surface pre-spawned when the snapshot's
+  /// primary panel does not begin with a plain shell tab, so a restored agent
+  /// tab is not displaced by an empty shell.
+  private func closeRedundantPrimaryPlaceholderTab(
+    in terminalSession: TerminalSession,
+    restoredTabIDs: inout [TerminalTabID]
+  ) {
+    guard protectedAgentTabID == nil,
+          restoredTabIDs.count > 1,
+          let placeholderID = restoredTabIDs.first,
+          let placeholderTab = terminalSession.primaryPanel.tabs.first(where: { $0.id == placeholderID })
+    else { return }
+    requestClose(placeholderTab)
+    _ = terminalSession.closeTab(placeholderID, in: terminalSession.primaryPanelID)
+    restoredTabIDs.removeFirst()
   }
 
   private func configurationForRestoredAccessoryTab(
@@ -1078,8 +1184,13 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
   }
 
   private func restoredTabName(for tab: TerminalWorkspaceTabSnapshot) -> String? {
+    if let linkedSession = tab.linkedSession {
+      return linkedSession.provider.rawValue
+    }
     if tab.role == .agent {
-      return protectedAgentTabName
+      // No linked session to resume — the tab restores as a plain shell, so
+      // an agent-flavored name would mislead provider inference.
+      return "Shell"
     }
     return Self.nonEmpty(tab.name) ?? Self.nonEmpty(tab.title) ?? "Shell"
   }
@@ -1912,6 +2023,28 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
     }
 
     return candidates.first { accessoryAgentTabIDs.contains($0.tab.id) } ?? candidates.first
+  }
+
+  private func workspaceDetectionContextID(for tab: TerminalTab) -> String {
+    "ghostty-\(tab.id.id.uuidString)"
+  }
+
+  private func inferredProvider(for tab: TerminalTab) -> SessionProviderKind? {
+    if let provider = accessoryAgentProvidersByTabID[tab.id] {
+      return provider
+    }
+
+    let label = [tab.name, tab.title, tab.controller.title]
+      .compactMap(Self.nonEmpty)
+      .joined(separator: " ")
+      .lowercased()
+    if label.contains("claude") {
+      return .claude
+    }
+    if label.contains("codex") {
+      return .codex
+    }
+    return nil
   }
 
   private func allTabs() -> [TerminalTab] {

--- a/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalWorkspaceView.swift
+++ b/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalWorkspaceView.swift
@@ -11,8 +11,10 @@ struct AgentHubGhosttyTerminalWorkspaceView: View {
   let session: TerminalSession
   let splitRoot: TerminalSplitLayout.Node?
   let maximizedPanelID: TerminalPanelID?
+  let splitRatiosByPath: [String: [Double]]
   let canClosePanel: (TerminalPanel) -> Bool
   let canCloseTab: (TerminalPanel, TerminalTab) -> Bool
+  let canSplitPanel: (TerminalPanel, TerminalSplitAxis) -> Bool
   let onActivatePanel: (TerminalPanel) -> Void
   let onSelectTab: (TerminalPanel, TerminalTab) -> Void
   let onClosePanel: (TerminalPanel) -> Void
@@ -20,6 +22,7 @@ struct AgentHubGhosttyTerminalWorkspaceView: View {
   let onOpenTab: (TerminalPanel) -> Void
   let onSplitPanel: (TerminalPanel, TerminalSplitAxis) -> Void
   let onToggleMaximizedPanel: (TerminalPanel) -> Void
+  let onSplitRatiosChanged: (String, [Double]) -> Void
   let activityForPanel: (TerminalPanelID) -> AgentHubGhosttyTerminalPaneActivity?
 
   var body: some View {
@@ -32,8 +35,11 @@ struct AgentHubGhosttyTerminalWorkspaceView: View {
         node: resolvedSplitRoot,
         session: session,
         maximizedPanelID: effectiveMaximizedPanelID,
+        nodePath: "root",
+        splitRatiosByPath: splitRatiosByPath,
         canClosePanel: canClosePanel,
         canCloseTab: canCloseTab,
+        canSplitPanel: canSplitPanel,
         onActivatePanel: onActivatePanel,
         onSelectTab: onSelectTab,
         onClosePanel: onClosePanel,
@@ -41,6 +47,7 @@ struct AgentHubGhosttyTerminalWorkspaceView: View {
         onOpenTab: onOpenTab,
         onSplitPanel: onSplitPanel,
         onToggleMaximizedPanel: onToggleMaximizedPanel,
+        onSplitRatiosChanged: onSplitRatiosChanged,
         activityForPanel: activityForPanel
       )
     }

--- a/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyWorkspaceRestorePlanner.swift
+++ b/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyWorkspaceRestorePlanner.swift
@@ -1,0 +1,70 @@
+//
+//  AgentHubGhosttyWorkspaceRestorePlanner.swift
+//  Ghostty
+//
+//  Pure planning for rebuilding workspace panels from a persisted snapshot.
+//  Restore must never silently drop a tab that carries a linked session:
+//  once a tab is missing from the rebuilt surface, the next workspace-changed
+//  reconcile deletes its session link from the database permanently.
+//
+
+import AgentHubCore
+
+enum AgentHubGhosttyWorkspaceRestorePlanner {
+
+  struct PrimaryPlan: Equatable {
+    /// Snapshot tabs to open as new tabs, in order.
+    let tabsToOpen: [TerminalWorkspaceTabSnapshot]
+    /// True when the surface's pre-existing tab stands in for the snapshot's
+    /// first tab. False means every snapshot tab is opened anew and the
+    /// pre-created placeholder shell is redundant.
+    let reusesExistingTab: Bool
+  }
+
+  struct AuxiliaryPlan: Equatable {
+    /// Tab restored together with the panel itself.
+    let anchorTab: TerminalWorkspaceTabSnapshot
+    /// Remaining tabs opened after the anchor, in order.
+    let additionalTabs: [TerminalWorkspaceTabSnapshot]
+  }
+
+  static func primaryPlan(
+    for panel: TerminalWorkspacePanelSnapshot,
+    hasProtectedAgentTab: Bool
+  ) -> PrimaryPlan {
+    if hasProtectedAgentTab {
+      // The retained protected agent tab stands in for the snapshot's own
+      // protected tab (captured as an unlinked agent tab), so only plain
+      // shells and linked agent tabs are recreated.
+      return PrimaryPlan(
+        tabsToOpen: panel.tabs.filter { $0.role == .shell || $0.linkedSession != nil },
+        reusesExistingTab: true
+      )
+    }
+
+    // Neutral workspace: the pre-created placeholder is a plain shell, so it
+    // may only stand in for a leading plain-shell tab — never for an agent
+    // tab whose linked session would otherwise be lost.
+    let reusesExistingTab = panel.tabs.first.map(isPlainShell) ?? false
+    return PrimaryPlan(
+      tabsToOpen: reusesExistingTab ? Array(panel.tabs.dropFirst()) : panel.tabs,
+      reusesExistingTab: reusesExistingTab
+    )
+  }
+
+  static func auxiliaryPlan(
+    for panel: TerminalWorkspacePanelSnapshot
+  ) -> AuxiliaryPlan? {
+    var tabs = panel.tabs
+    guard !tabs.isEmpty else { return nil }
+    let anchorTab = tabs.removeFirst()
+    return AuxiliaryPlan(anchorTab: anchorTab, additionalTabs: tabs)
+  }
+
+  /// An agent tab without a linked session has no session identity to resume;
+  /// it restores as a plain shell in its working directory so the pane
+  /// layout survives instead of vanishing.
+  static func isPlainShell(_ tab: TerminalWorkspaceTabSnapshot) -> Bool {
+    tab.role == .shell && tab.linkedSession == nil
+  }
+}

--- a/app/modules/Ghostty/Tests/GhosttyTests/AgentHubGhosttyWorkspaceRestorePlannerTests.swift
+++ b/app/modules/Ghostty/Tests/GhosttyTests/AgentHubGhosttyWorkspaceRestorePlannerTests.swift
@@ -1,0 +1,167 @@
+import AgentHubCore
+import Foundation
+import Testing
+
+@testable import Ghostty
+
+@Suite("AgentHub Ghostty workspace restore planner")
+struct AgentHubGhosttyWorkspaceRestorePlannerTests {
+
+  // MARK: - Primary panel, neutral workspace
+
+  @Test("Placeholder shell stands in for a leading plain shell tab")
+  func primaryReusesPlaceholderForLeadingPlainShell() {
+    let shell = Self.shellTab()
+    let agent = Self.linkedAgentTab(provider: .claude, sessionId: "claude-1")
+
+    let plan = AgentHubGhosttyWorkspaceRestorePlanner.primaryPlan(
+      for: TerminalWorkspacePanelSnapshot(role: .primary, tabs: [shell, agent]),
+      hasProtectedAgentTab: false
+    )
+
+    #expect(plan.reusesExistingTab)
+    #expect(plan.tabsToOpen == [agent])
+  }
+
+  @Test("A leading linked agent tab is restored, never replaced by the placeholder shell")
+  func primaryRestoresLeadingLinkedAgentTab() {
+    let agent = Self.linkedAgentTab(provider: .claude, sessionId: "claude-1")
+
+    let plan = AgentHubGhosttyWorkspaceRestorePlanner.primaryPlan(
+      for: TerminalWorkspacePanelSnapshot(role: .primary, tabs: [agent]),
+      hasProtectedAgentTab: false
+    )
+
+    #expect(!plan.reusesExistingTab)
+    #expect(plan.tabsToOpen == [agent])
+  }
+
+  @Test("Snapshot order is preserved when an agent tab precedes a shell tab")
+  func primaryPreservesOrderWhenAgentTabLeads() {
+    let agent = Self.linkedAgentTab(provider: .codex, sessionId: "codex-1")
+    let shell = Self.shellTab()
+
+    let plan = AgentHubGhosttyWorkspaceRestorePlanner.primaryPlan(
+      for: TerminalWorkspacePanelSnapshot(role: .primary, tabs: [agent, shell]),
+      hasProtectedAgentTab: false
+    )
+
+    #expect(!plan.reusesExistingTab)
+    #expect(plan.tabsToOpen == [agent, shell])
+  }
+
+  @Test("An unlinked agent tab degrades to a restorable tab instead of vanishing")
+  func primaryKeepsUnlinkedAgentTab() {
+    let shell = Self.shellTab()
+    let unlinkedAgent = Self.unlinkedAgentTab()
+
+    let plan = AgentHubGhosttyWorkspaceRestorePlanner.primaryPlan(
+      for: TerminalWorkspacePanelSnapshot(role: .primary, tabs: [shell, unlinkedAgent]),
+      hasProtectedAgentTab: false
+    )
+
+    #expect(plan.reusesExistingTab)
+    #expect(plan.tabsToOpen == [unlinkedAgent])
+  }
+
+  @Test("An empty primary snapshot keeps the placeholder shell")
+  func primaryWithNoTabsKeepsPlaceholder() {
+    let plan = AgentHubGhosttyWorkspaceRestorePlanner.primaryPlan(
+      for: TerminalWorkspacePanelSnapshot(role: .primary, tabs: []),
+      hasProtectedAgentTab: false
+    )
+
+    #expect(!plan.reusesExistingTab)
+    #expect(plan.tabsToOpen.isEmpty)
+  }
+
+  // MARK: - Primary panel, protected session surface
+
+  @Test("Protected surfaces keep the retained agent tab and skip its snapshot twin")
+  func protectedPrimarySkipsUnlinkedAgentTabs() {
+    let protectedTwin = Self.unlinkedAgentTab()
+    let shell = Self.shellTab()
+    let linkedChild = Self.linkedAgentTab(provider: .codex, sessionId: "codex-child")
+
+    let plan = AgentHubGhosttyWorkspaceRestorePlanner.primaryPlan(
+      for: TerminalWorkspacePanelSnapshot(role: .primary, tabs: [protectedTwin, shell, linkedChild]),
+      hasProtectedAgentTab: true
+    )
+
+    #expect(plan.reusesExistingTab)
+    #expect(plan.tabsToOpen == [shell, linkedChild])
+  }
+
+  // MARK: - Auxiliary panels
+
+  @Test("Auxiliary panels anchor on their first tab and keep the rest in order")
+  func auxiliaryAnchorsFirstTab() {
+    let codex = Self.linkedAgentTab(provider: .codex, sessionId: "codex-1")
+    let claude = Self.linkedAgentTab(provider: .claude, sessionId: "claude-1")
+
+    let plan = AgentHubGhosttyWorkspaceRestorePlanner.auxiliaryPlan(
+      for: TerminalWorkspacePanelSnapshot(role: .auxiliary, tabs: [codex, claude])
+    )
+
+    #expect(plan?.anchorTab == codex)
+    #expect(plan?.additionalTabs == [claude])
+  }
+
+  @Test("An auxiliary panel holding only an unlinked agent tab is preserved")
+  func auxiliaryKeepsUnlinkedAgentPanel() {
+    let unlinkedAgent = Self.unlinkedAgentTab()
+
+    let plan = AgentHubGhosttyWorkspaceRestorePlanner.auxiliaryPlan(
+      for: TerminalWorkspacePanelSnapshot(role: .auxiliary, tabs: [unlinkedAgent])
+    )
+
+    #expect(plan?.anchorTab == unlinkedAgent)
+    #expect(plan?.additionalTabs.isEmpty == true)
+  }
+
+  @Test("An auxiliary panel with no tabs is dropped")
+  func auxiliaryWithNoTabsIsDropped() {
+    let plan = AgentHubGhosttyWorkspaceRestorePlanner.auxiliaryPlan(
+      for: TerminalWorkspacePanelSnapshot(role: .auxiliary, tabs: [])
+    )
+
+    #expect(plan == nil)
+  }
+
+  // MARK: - Helpers
+
+  private static func shellTab(workingDirectory: String = "/tmp/project") -> TerminalWorkspaceTabSnapshot {
+    TerminalWorkspaceTabSnapshot(
+      role: .shell,
+      name: "Shell",
+      title: "Shell",
+      workingDirectory: workingDirectory
+    )
+  }
+
+  private static func unlinkedAgentTab() -> TerminalWorkspaceTabSnapshot {
+    TerminalWorkspaceTabSnapshot(
+      role: .agent,
+      name: "Claude",
+      title: "Claude",
+      workingDirectory: "/tmp/project"
+    )
+  }
+
+  private static func linkedAgentTab(
+    provider: SessionProviderKind,
+    sessionId: String
+  ) -> TerminalWorkspaceTabSnapshot {
+    TerminalWorkspaceTabSnapshot(
+      role: .agent,
+      name: provider.rawValue,
+      title: provider.rawValue,
+      workingDirectory: "/tmp/project",
+      linkedSession: TerminalWorkspaceLinkedSessionSnapshot(
+        provider: provider,
+        sessionId: sessionId,
+        relationshipKind: .accessoryChild
+      )
+    )
+  }
+}


### PR DESCRIPTION
## Summary

Workspaces launched Claude/Codex agents fine, but their sessions weren't durable: links could be silently dropped on relaunch, and the sidebar showed workspace-owned sessions as unrelated top-level rows. This PR makes workspace agent sessions persist reliably across relaunches and groups them under their workspace in the sidebar.

### Session persistence & detection

- Per-tab session detection: launches carry a `detectionContextID` so a detected JSONL session binds to the exact tab that spawned it, instead of the first candidate pane (`WorkspaceSessionDetectionContext`, `markWorkspaceSession(contextID:)`).
- `WorkspaceSessionProcessProviderResolver` identifies the CLI running in a shell tab from its foreground PID before passive detection may claim it, so manual `claude`/`codex` starts attach to the right pane and shells never false-attach.
- Workspace-owned sessions reconcile into the normal monitored-session flow on launch (`AgentWorkspaceSessionReference`, `CLISessionsViewModel.restoreWorkspaceSessions`), keeping approvals, notifications, and activity rollups working without mounting terminals.

### Restore correctness (fixes lost sessions on relaunch)

Workspace session links are rebuilt from the surface snapshot on every workspace change, so any tab the Ghostty restore fails to rebuild has its link **permanently deleted** from SQLite. The old restore skipped the first snapshot tab on the assumption it was the placeholder shell — when the primary panel led with a linked agent tab, the agent was silently replaced by an empty shell and its session lost.

- New pure `AgentHubGhosttyWorkspaceRestorePlanner`: the placeholder shell may only stand in for a leading plain-shell tab; a leading linked agent tab is restored and the redundant placeholder closed.
- Unlinked agent tabs degrade to shells in their working directory instead of vanishing (pane layout survives even when detection hadn't resolved before quit).
- Restored linked tabs are named by their own provider instead of the surface's protected-tab name.

### Sidebar: workspace-owned sessions are nested, not siblings

- Sessions linked to a workspace render as an indented, collapsed-by-default group under the workspace row (chevron toggle); they're deduped out of repo groups, status groups, the pinned section, ⌘[/⌘] navigation, and auto-primary selection.
- Selecting a nested row — or picking an owned session from the command palette or global Sessions panel — focuses the exact pane hosting it inside the workspace (`focusWorkspaceSession`, with pending focus until the surface mounts). This closes the double-attach trap where a standalone monitoring card in Terminal mode could `claude -r` a session already live in a workspace pane.
- Workspace row gains a hover-revealed "…" menu (Rename / Close Workspace), matching the repo header pattern.

## Testing

- `./scripts/test.sh` (full gate): packages pass; AgentHubCore suite 963/988 passed with 8 failures in the known timing-flaky tail (TestQuarantine.md / #380 territory) — all 8 pass when their suites are rerun serially (48/48, 0 failures).
- New coverage: `AgentHubGhosttyWorkspaceRestorePlannerTests` (9 tests), `AgentWorkspaceSessionCoordinatorTests`, `WorkspaceSessionProcessProviderResolverTests`, plus ownership/focus-routing and detection tests in `AgentWorkspacesViewModelTests`.
- Ghostty module suite (32 tests) — pass.

## Known follow-ups (not in this PR)

- `AccessorySessionDetectionService.detectNewSession` requires exactly one new JSONL candidate; two same-provider launches inside one poll window can deadlock detection and never link.
- `rebaselineDetection`/`refreshPassiveDetectionBaselines` re-baseline at `Date.now`, which can swallow a session file created since the original baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
