### PR TITLE
Make embedded Ghostty terminals legible in light mode

### DIFF
--- a/app/AgentHub.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/app/AgentHub.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -69,8 +69,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/jamesrochabrun/GhosttySwift",
       "state" : {
-        "revision" : "f7286937278044fcfa0d6385b1264fe9cc8195b3",
-        "version" : "1.0.4"
+        "revision" : "98c553a64e518f32ab311278d5471ed9439f86bc",
+        "version" : "1.0.8"
       }
     },
     {

--- a/app/AgentHubTests/ThemeSelectionPolicyTests.swift
+++ b/app/AgentHubTests/ThemeSelectionPolicyTests.swift
@@ -102,21 +102,27 @@ struct ThemeSelectionPolicyTests {
     let parser = YAMLThemeParser()
     let theme = try parser.parse(fileURL: ghosttyThemeURL())
     let runtime = RuntimeTheme(from: theme, sourceFileName: "ghostty.yaml")
-    let primaryHex = try hexString(from: runtime.brandPrimary)
-    let secondaryHex = try hexString(from: runtime.brandSecondary)
-    let tertiaryHex = try hexString(from: runtime.brandTertiary)
+    let primaryDarkHex = try hexString(from: runtime.brandPrimary, appearance: .darkAqua)
+    let secondaryDarkHex = try hexString(from: runtime.brandSecondary, appearance: .darkAqua)
+    let tertiaryDarkHex = try hexString(from: runtime.brandTertiary, appearance: .darkAqua)
+    let primaryLightHex = try hexString(from: runtime.brandPrimary, appearance: .aqua)
+    let secondaryLightHex = try hexString(from: runtime.brandSecondary, appearance: .aqua)
+    let tertiaryLightHex = try hexString(from: runtime.brandTertiary, appearance: .aqua)
     let backgroundDarkHex = try hexString(from: #require(runtime.backgroundDark))
     let backgroundLightHex = try hexString(from: #require(runtime.backgroundLight))
     let terminalBackgroundHex = try Color.hexString(from: #require(runtime.terminalBackground))
 
-    #expect(primaryHex == "#A0AEC0")
-    #expect(secondaryHex == "#2D3748")
-    #expect(tertiaryHex == "#CBD5E0")
+    #expect(primaryDarkHex == "#A0AEC0")
+    #expect(secondaryDarkHex == "#2D3748")
+    #expect(tertiaryDarkHex == "#CBD5E0")
+    #expect(primaryLightHex == "#4A5568")
+    #expect(secondaryLightHex == "#2D3748")
+    #expect(tertiaryLightHex == "#64748B")
     #expect(runtime.hasCustomBackgrounds == true)
-    #expect(backgroundDarkHex == "#040F16")
+    #expect(backgroundDarkHex == "#252627")
     #expect(backgroundLightHex == "#FBFBFF")
     #expect(runtime.expandedContentBackgroundDark == nil)
-    #expect(terminalBackgroundHex == "#040F16")
+    #expect(terminalBackgroundHex == "#252627")
     #expect(runtime.terminalAnsiColors?.count == 16)
   }
 
@@ -138,8 +144,19 @@ struct ThemeSelectionPolicyTests {
       .deletingLastPathComponent()
   }
 
-  private func hexString(from color: Color) throws -> String {
-    let nsColor = try #require(NSColor(color).usingColorSpace(.sRGB))
-    return Color.hexString(from: nsColor)
+  private func hexString(
+    from color: Color,
+    appearance appearanceName: NSAppearance.Name? = nil
+  ) throws -> String {
+    guard let appearanceName else {
+      return Color.hexString(from: try #require(NSColor(color).usingColorSpace(.sRGB)))
+    }
+
+    let appearance = try #require(NSAppearance(named: appearanceName))
+    var resolvedColor: NSColor?
+    appearance.performAsCurrentDrawingAppearance {
+      resolvedColor = NSColor(color).usingColorSpace(.sRGB)
+    }
+    return Color.hexString(from: try #require(resolvedColor))
   }
 }

--- a/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubDefaults.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubDefaults.swift
@@ -256,6 +256,30 @@ public enum AgentHubDefaults {
   /// Type: String (default: unset)
   public static let yamlTertiaryHex = "\(keyPrefix)theme.yamlTertiaryHex"
 
+  /// Active YAML theme light appearance primary color hex value cache
+  /// Type: String (default: unset)
+  public static let yamlLightPrimaryHex = "\(keyPrefix)theme.yamlLightPrimaryHex"
+
+  /// Active YAML theme light appearance secondary color hex value cache
+  /// Type: String (default: unset)
+  public static let yamlLightSecondaryHex = "\(keyPrefix)theme.yamlLightSecondaryHex"
+
+  /// Active YAML theme light appearance tertiary color hex value cache
+  /// Type: String (default: unset)
+  public static let yamlLightTertiaryHex = "\(keyPrefix)theme.yamlLightTertiaryHex"
+
+  /// Active YAML theme dark appearance primary color hex value cache
+  /// Type: String (default: unset)
+  public static let yamlDarkPrimaryHex = "\(keyPrefix)theme.yamlDarkPrimaryHex"
+
+  /// Active YAML theme dark appearance secondary color hex value cache
+  /// Type: String (default: unset)
+  public static let yamlDarkSecondaryHex = "\(keyPrefix)theme.yamlDarkSecondaryHex"
+
+  /// Active YAML theme dark appearance tertiary color hex value cache
+  /// Type: String (default: unset)
+  public static let yamlDarkTertiaryHex = "\(keyPrefix)theme.yamlDarkTertiaryHex"
+
   /// Installed bundled theme version for a given theme name
   /// Type: String (default: unset)
   /// Usage: `UserDefaults.standard.string(forKey: AgentHubDefaults.installedBundledThemeVersion(for: "sentry"))`

--- a/app/modules/AgentHubCore/Sources/AgentHub/Design/Color+Extension.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Design/Color+Extension.swift
@@ -3,8 +3,8 @@
 //
 //  Created by James Rochabrun on 6/8/25.
 
-import SwiftUI
 import AppKit
+import SwiftUI
 
 // MARK: - Design Tokens
 
@@ -110,6 +110,21 @@ extension Color {
     self.init(red: Int(r), green: Int(g), blue: Int(b), alpha: alpha)
   }
 
+  static func appearanceAdaptive(lightHex: String, darkHex: String) -> Color {
+    guard lightHex != darkHex else {
+      return Color(hex: lightHex)
+    }
+
+    let lightColor = NSColor.fromHex(lightHex)
+    let darkColor = NSColor.fromHex(darkHex)
+    let dynamicColor = NSColor(name: nil) { appearance in
+      appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+        ? darkColor
+        : lightColor
+    }
+    return Color(nsColor: dynamicColor)
+  }
+
   // MARK: - Named Colors (Legacy - use brand colors instead)
 
   static let bookCloth = Color(hex: "#CC785C")
@@ -176,9 +191,24 @@ extension Color {
       let yamlSecondary = UserDefaults.standard.string(forKey: AgentHubDefaults.yamlSecondaryHex) ?? "#D4A27F"
       let yamlTertiary = UserDefaults.standard.string(forKey: AgentHubDefaults.yamlTertiaryHex) ?? "#EBDBBC"
       return ThemeColors(
-        brandPrimary: Color(hex: yamlPrimary),
-        brandSecondary: Color(hex: yamlSecondary),
-        brandTertiary: Color(hex: yamlTertiary)
+        brandPrimary: appearanceAdaptive(
+          lightHex: UserDefaults.standard.string(forKey: AgentHubDefaults.yamlLightPrimaryHex)
+            ?? yamlPrimary,
+          darkHex: UserDefaults.standard.string(forKey: AgentHubDefaults.yamlDarkPrimaryHex)
+            ?? yamlPrimary
+        ),
+        brandSecondary: appearanceAdaptive(
+          lightHex: UserDefaults.standard.string(forKey: AgentHubDefaults.yamlLightSecondaryHex)
+            ?? yamlSecondary,
+          darkHex: UserDefaults.standard.string(forKey: AgentHubDefaults.yamlDarkSecondaryHex)
+            ?? yamlSecondary
+        ),
+        brandTertiary: appearanceAdaptive(
+          lightHex: UserDefaults.standard.string(forKey: AgentHubDefaults.yamlLightTertiaryHex)
+            ?? yamlTertiary,
+          darkHex: UserDefaults.standard.string(forKey: AgentHubDefaults.yamlDarkTertiaryHex)
+            ?? yamlTertiary
+        )
       )
     }
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/Design/Theme/BundledThemes/ghostty.yaml
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Design/Theme/BundledThemes/ghostty.yaml
@@ -1,5 +1,5 @@
 name: "Ghostty"
-version: "1.3"
+version: "1.4"
 author: "AgentHub"
 description: "Ghostty-only theme with Singularity highlights and soft app backgrounds"
 
@@ -8,6 +8,10 @@ colors:
     primary: "#A0AEC0"
     secondary: "#2D3748"
     tertiary: "#CBD5E0"
+    light:
+      primary: "#4A5568"
+      secondary: "#2D3748"
+      tertiary: "#64748B"
 
   backgrounds:
     dark: "#252627"

--- a/app/modules/AgentHubCore/Sources/AgentHub/Design/Theme/Management/ThemeLoadingService.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Design/Theme/Management/ThemeLoadingService.swift
@@ -6,9 +6,31 @@
 import Foundation
 
 struct ThemePalette: Equatable, Sendable {
+  struct Variant: Equatable, Sendable {
+    let primary: String
+    let secondary: String
+    let tertiary: String
+  }
+
   let primary: String
   let secondary: String
   let tertiary: String
+  let light: Variant?
+  let dark: Variant?
+
+  init(
+    primary: String,
+    secondary: String,
+    tertiary: String,
+    light: Variant? = nil,
+    dark: Variant? = nil
+  ) {
+    self.primary = primary
+    self.secondary = secondary
+    self.tertiary = tertiary
+    self.light = light
+    self.dark = dark
+  }
 }
 
 struct DiscoveredYAMLTheme: Equatable, Sendable {
@@ -79,8 +101,20 @@ actor ThemeLoadingService: ThemeLoadingServiceProtocol {
       palette: ThemePalette(
         primary: theme.colors.brand.primary,
         secondary: theme.colors.brand.secondary,
-        tertiary: theme.colors.brand.tertiary
+        tertiary: theme.colors.brand.tertiary,
+        light: theme.colors.brand.light.map { Self.paletteVariant(from: $0) },
+        dark: theme.colors.brand.dark.map { Self.paletteVariant(from: $0) }
       )
+    )
+  }
+
+  private nonisolated static func paletteVariant(
+    from variant: YAMLTheme.BrandColorVariant
+  ) -> ThemePalette.Variant {
+    ThemePalette.Variant(
+      primary: variant.primary,
+      secondary: variant.secondary,
+      tertiary: variant.tertiary
     )
   }
 
@@ -100,9 +134,23 @@ actor ThemePreferenceWriter: ThemePreferenceWriting {
     defaults.set(palette.primary, forKey: AgentHubDefaults.yamlPrimaryHex)
     defaults.set(palette.secondary, forKey: AgentHubDefaults.yamlSecondaryHex)
     defaults.set(palette.tertiary, forKey: AgentHubDefaults.yamlTertiaryHex)
+    persist(palette.light?.primary, forKey: AgentHubDefaults.yamlLightPrimaryHex)
+    persist(palette.light?.secondary, forKey: AgentHubDefaults.yamlLightSecondaryHex)
+    persist(palette.light?.tertiary, forKey: AgentHubDefaults.yamlLightTertiaryHex)
+    persist(palette.dark?.primary, forKey: AgentHubDefaults.yamlDarkPrimaryHex)
+    persist(palette.dark?.secondary, forKey: AgentHubDefaults.yamlDarkSecondaryHex)
+    persist(palette.dark?.tertiary, forKey: AgentHubDefaults.yamlDarkTertiaryHex)
   }
 
   func persistThemeSelection(_ themeId: String, backend: EmbeddedTerminalBackend) async {
     ThemeSelectionPolicy.persistThemeSelection(themeId, defaults: defaults, backend: backend)
+  }
+
+  private func persist(_ value: String?, forKey key: String) {
+    if let value {
+      defaults.set(value, forKey: key)
+    } else {
+      defaults.removeObject(forKey: key)
+    }
   }
 }

--- a/app/modules/AgentHubCore/Sources/AgentHub/Design/Theme/Management/ThemeManager.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Design/Theme/Management/ThemeManager.swift
@@ -95,7 +95,7 @@ public final class ThemeManager {
 
   private static let bundledGhosttyYAML = """
   name: "Ghostty"
-  version: "1.2"
+  version: "1.4"
   author: "AgentHub"
   description: "Ghostty-only theme with Singularity highlights and soft app backgrounds"
 
@@ -104,13 +104,17 @@ public final class ThemeManager {
       primary: "#A0AEC0"
       secondary: "#2D3748"
       tertiary: "#CBD5E0"
+      light:
+        primary: "#4A5568"
+        secondary: "#2D3748"
+        tertiary: "#64748B"
 
     backgrounds:
-      dark: "#040F16"
+      dark: "#252627"
       light: "#FBFBFF"
 
     terminal:
-      background: "#040F16"
+      background: "#252627"
       foreground: "#E2E8F0"
       cursor: "#A0AEC0"
       ansi:
@@ -320,11 +324,11 @@ public final class ThemeManager {
   ) async throws {
     let cacheKey = fileURL.lastPathComponent
     if !forceReload, let cached = themeCache[cacheKey] {
+      await persistYAMLPalette(for: cacheKey)
       guard isCurrentGeneration(generation) else { return }
       stopWatchingInactiveThemeFile(nextThemeURL: fileURL)
       self.currentTheme = cached
       setupHotReload(for: fileURL)
-      await persistYAMLPalette(for: cacheKey)
       await saveCurrentThemeSelection(cacheKey, backend: backend)
       return
     }
@@ -332,15 +336,16 @@ public final class ThemeManager {
     let loaded = try await loadingService.loadTheme(fileURL: fileURL)
     guard isCurrentGeneration(generation) else { return }
 
-    stopWatchingInactiveThemeFile(nextThemeURL: fileURL)
     let runtime = RuntimeTheme(from: loaded.theme, sourceFileName: cacheKey)
     themeCache[cacheKey] = runtime
     yamlColorCache[cacheKey] = loaded.palette
-    self.currentTheme = runtime
 
-    // Setup hot-reload
-    setupHotReload(for: fileURL)
     await persistYAMLPalette(for: cacheKey)
+    guard isCurrentGeneration(generation) else { return }
+
+    stopWatchingInactiveThemeFile(nextThemeURL: fileURL)
+    self.currentTheme = runtime
+    setupHotReload(for: fileURL)
     await saveCurrentThemeSelection(cacheKey, backend: backend)
   }
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/Design/Theme/Models/RuntimeTheme.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Design/Theme/Models/RuntimeTheme.swift
@@ -54,10 +54,21 @@ public struct RuntimeTheme: Identifiable {
     self.sourceFileName = sourceFileName
     self.version = yaml.version
 
-    // Resolve brand colors
-    self.brandPrimary = Color(hex: yaml.colors.brand.primary)
-    self.brandSecondary = Color(hex: yaml.colors.brand.secondary)
-    self.brandTertiary = Color(hex: yaml.colors.brand.tertiary)
+    // Resolve brand colors, preserving legacy single-palette themes while
+    // allowing appearance-specific contrast where a theme provides it.
+    let brand = yaml.colors.brand
+    self.brandPrimary = Color.appearanceAdaptive(
+      lightHex: brand.light?.primary ?? brand.primary,
+      darkHex: brand.dark?.primary ?? brand.primary
+    )
+    self.brandSecondary = Color.appearanceAdaptive(
+      lightHex: brand.light?.secondary ?? brand.secondary,
+      darkHex: brand.dark?.secondary ?? brand.secondary
+    )
+    self.brandTertiary = Color.appearanceAdaptive(
+      lightHex: brand.light?.tertiary ?? brand.tertiary,
+      darkHex: brand.dark?.tertiary ?? brand.tertiary
+    )
 
     // Resolve optional backgrounds
     if let bg = yaml.colors.backgrounds {

--- a/app/modules/AgentHubCore/Sources/AgentHub/Design/Theme/Models/YAMLTheme.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Design/Theme/Models/YAMLTheme.swift
@@ -52,6 +52,14 @@ public struct YAMLTheme: Codable, Sendable {
     public let primary: String    // Hex color
     public let secondary: String
     public let tertiary: String
+    public let light: BrandColorVariant?
+    public let dark: BrandColorVariant?
+  }
+
+  public struct BrandColorVariant: Codable, Sendable {
+    public let primary: String
+    public let secondary: String
+    public let tertiary: String
   }
 
   public struct BackgroundColors: Codable, Sendable {

--- a/app/modules/AgentHubCore/Sources/AgentHub/Design/Theme/Parsing/YAMLThemeParser.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Design/Theme/Parsing/YAMLThemeParser.swift
@@ -60,6 +60,12 @@ public struct YAMLThemeParser {
     try validateColor(theme.colors.brand.primary, field: "colors.brand.primary")
     try validateColor(theme.colors.brand.secondary, field: "colors.brand.secondary")
     try validateColor(theme.colors.brand.tertiary, field: "colors.brand.tertiary")
+    if let light = theme.colors.brand.light {
+      try validateBrandVariant(light, field: "colors.brand.light")
+    }
+    if let dark = theme.colors.brand.dark {
+      try validateBrandVariant(dark, field: "colors.brand.dark")
+    }
 
     // Validate optional background colors
     if let bg = theme.colors.backgrounds {
@@ -93,5 +99,14 @@ public struct YAMLThemeParser {
     guard regex.firstMatch(in: hex, range: range) != nil else {
       throw ThemeError.invalidColorFormat(hex, field)
     }
+  }
+
+  private func validateBrandVariant(
+    _ variant: YAMLTheme.BrandColorVariant,
+    field: String
+  ) throws {
+    try validateColor(variant.primary, field: "\(field).primary")
+    try validateColor(variant.secondary, field: "\(field).secondary")
+    try validateColor(variant.tertiary, field: "\(field).tertiary")
   }
 }

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/RuntimeThemeAppearanceTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/RuntimeThemeAppearanceTests.swift
@@ -1,0 +1,110 @@
+import AppKit
+import Foundation
+import SwiftUI
+import Testing
+
+@testable import AgentHubCore
+
+@MainActor
+@Suite("Runtime theme appearance")
+struct RuntimeThemeAppearanceTests {
+  @Test("Appearance-specific brand colors resolve for light and dark mode")
+  func appearanceSpecificBrandColorsResolve() throws {
+    let runtime = try runtimeTheme(
+      light: ["#445566", "#556677", "#667788"],
+      dark: ["#AABBCC", "#BBCCDD", "#CCDDEE"]
+    )
+
+    #expect(try hexString(runtime.brandPrimary, appearance: .aqua) == "#445566")
+    #expect(try hexString(runtime.brandSecondary, appearance: .aqua) == "#556677")
+    #expect(try hexString(runtime.brandTertiary, appearance: .aqua) == "#667788")
+    #expect(try hexString(runtime.brandPrimary, appearance: .darkAqua) == "#AABBCC")
+    #expect(try hexString(runtime.brandSecondary, appearance: .darkAqua) == "#BBCCDD")
+    #expect(try hexString(runtime.brandTertiary, appearance: .darkAqua) == "#CCDDEE")
+  }
+
+  @Test("Legacy brand colors remain unchanged in both appearances")
+  func legacyBrandColorsRemainAppearanceIndependent() throws {
+    let runtime = try runtimeTheme()
+
+    #expect(try hexString(runtime.brandPrimary, appearance: .aqua) == "#112233")
+    #expect(try hexString(runtime.brandPrimary, appearance: .darkAqua) == "#112233")
+  }
+
+  @Test("Bundled Ghostty theme uses readable light and dark palettes")
+  func bundledGhosttyThemeUsesAppearanceSpecificPalettes() throws {
+    let theme = try YAMLThemeParser().parse(fileURL: bundledGhosttyThemeURL())
+    let runtime = RuntimeTheme(from: theme, sourceFileName: "ghostty.yaml")
+
+    #expect(try hexString(runtime.brandPrimary, appearance: .aqua) == "#4A5568")
+    #expect(try hexString(runtime.brandSecondary, appearance: .aqua) == "#2D3748")
+    #expect(try hexString(runtime.brandTertiary, appearance: .aqua) == "#64748B")
+    #expect(try hexString(runtime.brandPrimary, appearance: .darkAqua) == "#A0AEC0")
+    #expect(try hexString(runtime.brandSecondary, appearance: .darkAqua) == "#2D3748")
+    #expect(try hexString(runtime.brandTertiary, appearance: .darkAqua) == "#CBD5E0")
+  }
+
+  @Test("Invalid appearance-specific brand colors are rejected")
+  func invalidAppearanceSpecificBrandColorIsRejected() {
+    #expect(throws: ThemeError.self) {
+      _ = try runtimeTheme(
+        light: ["not-a-color", "#556677", "#667788"]
+      )
+    }
+  }
+
+  private func runtimeTheme(
+    light: [String]? = nil,
+    dark: [String]? = nil
+  ) throws -> RuntimeTheme {
+    var lines = [
+      "name: \"Adaptive\"",
+      "version: \"1.0\"",
+      "colors:",
+      "  brand:",
+      "    primary: \"#112233\"",
+      "    secondary: \"#223344\"",
+      "    tertiary: \"#334455\"",
+    ]
+    appendVariant(light, named: "light", to: &lines)
+    appendVariant(dark, named: "dark", to: &lines)
+
+    let yaml = lines.joined(separator: "\n")
+    let theme = try YAMLThemeParser().parse(data: Data(yaml.utf8))
+    return RuntimeTheme(from: theme, sourceFileName: "adaptive.yaml")
+  }
+
+  private func appendVariant(
+    _ colors: [String]?,
+    named name: String,
+    to lines: inout [String]
+  ) {
+    guard let colors, colors.count == 3 else { return }
+    lines.append(contentsOf: [
+      "    \(name):",
+      "      primary: \"\(colors[0])\"",
+      "      secondary: \"\(colors[1])\"",
+      "      tertiary: \"\(colors[2])\"",
+    ])
+  }
+
+  private func bundledGhosttyThemeURL() -> URL {
+    URL(fileURLWithPath: #filePath)
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+      .appendingPathComponent("Sources/AgentHub/Design/Theme/BundledThemes/ghostty.yaml")
+  }
+
+  private func hexString(
+    _ color: Color,
+    appearance appearanceName: NSAppearance.Name
+  ) throws -> String {
+    let appearance = try #require(NSAppearance(named: appearanceName))
+    var resolvedColor: NSColor?
+    appearance.performAsCurrentDrawingAppearance {
+      resolvedColor = NSColor(color).usingColorSpace(.sRGB)
+    }
+    return Color.hexString(from: try #require(resolvedColor))
+  }
+}

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/ThemeLoadingServiceTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/ThemeLoadingServiceTests.swift
@@ -56,6 +56,78 @@ struct ThemeLoadingServiceTests {
     ))
   }
 
+  @Test("Loads appearance-specific YAML palette variants")
+  func loadsAppearanceSpecificPaletteVariants() async throws {
+    let directory = try temporaryDirectory()
+    defer { try? FileManager.default.removeItem(at: directory) }
+    let fileURL = directory.appendingPathComponent("adaptive.yaml")
+    let yaml = """
+    name: "Adaptive"
+    version: "1.0"
+    colors:
+      brand:
+        primary: "#112233"
+        secondary: "#445566"
+        tertiary: "#778899"
+        light:
+          primary: "#223344"
+          secondary: "#556677"
+          tertiary: "#8899AA"
+        dark:
+          primary: "#AABBCC"
+          secondary: "#BBCCDD"
+          tertiary: "#CCDDEE"
+    """
+    try yaml.write(to: fileURL, atomically: true, encoding: .utf8)
+
+    let loaded = try await ThemeLoadingService().loadTheme(fileURL: fileURL)
+
+    #expect(loaded.palette.light == ThemePalette.Variant(
+      primary: "#223344",
+      secondary: "#556677",
+      tertiary: "#8899AA"
+    ))
+    #expect(loaded.palette.dark == ThemePalette.Variant(
+      primary: "#AABBCC",
+      secondary: "#BBCCDD",
+      tertiary: "#CCDDEE"
+    ))
+  }
+
+  @Test("Persisting a plain palette clears stale appearance variants")
+  func persistingPlainPaletteClearsStaleAppearanceVariants() async throws {
+    let suiteName = "ThemeLoadingServiceTests.\(UUID().uuidString)"
+    let defaults = try #require(UserDefaults(suiteName: suiteName))
+    defer { defaults.removePersistentDomain(forName: suiteName) }
+    let writer = ThemePreferenceWriter(defaults: defaults)
+    let variant = ThemePalette.Variant(
+      primary: "#223344",
+      secondary: "#556677",
+      tertiary: "#8899AA"
+    )
+
+    await writer.persistYAMLPalette(ThemePalette(
+      primary: "#112233",
+      secondary: "#445566",
+      tertiary: "#778899",
+      light: variant,
+      dark: variant
+    ))
+    await writer.persistYAMLPalette(ThemePalette(
+      primary: "#AABBCC",
+      secondary: "#BBCCDD",
+      tertiary: "#CCDDEE"
+    ))
+
+    #expect(defaults.string(forKey: AgentHubDefaults.yamlPrimaryHex) == "#AABBCC")
+    #expect(defaults.string(forKey: AgentHubDefaults.yamlLightPrimaryHex) == nil)
+    #expect(defaults.string(forKey: AgentHubDefaults.yamlLightSecondaryHex) == nil)
+    #expect(defaults.string(forKey: AgentHubDefaults.yamlLightTertiaryHex) == nil)
+    #expect(defaults.string(forKey: AgentHubDefaults.yamlDarkPrimaryHex) == nil)
+    #expect(defaults.string(forKey: AgentHubDefaults.yamlDarkSecondaryHex) == nil)
+    #expect(defaults.string(forKey: AgentHubDefaults.yamlDarkTertiaryHex) == nil)
+  }
+
   @discardableResult
   private func writeTheme(
     named fileName: String,

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/ThemeManagerTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/ThemeManagerTests.swift
@@ -97,6 +97,31 @@ private actor DelayedThemeLoadingService: ThemeLoadingServiceProtocol {
   }
 }
 
+private actor DelayedThemePreferenceWriter: ThemePreferenceWriting {
+  private var paletteContinuation: CheckedContinuation<Void, Never>?
+  private var paletteWriteStarted = false
+
+  func persistYAMLPalette(_ palette: ThemePalette) async {
+    paletteWriteStarted = true
+    await withCheckedContinuation { continuation in
+      paletteContinuation = continuation
+    }
+  }
+
+  func persistThemeSelection(_ themeId: String, backend: EmbeddedTerminalBackend) async {}
+
+  func waitUntilPaletteWriteStarts() async {
+    while !paletteWriteStarted || paletteContinuation == nil {
+      await Task.yield()
+    }
+  }
+
+  func finishPaletteWrite() {
+    paletteContinuation?.resume()
+    paletteContinuation = nil
+  }
+}
+
 @Suite("Theme manager", .serialized)
 struct ThemeManagerTests {
 
@@ -205,6 +230,30 @@ struct ThemeManagerTests {
     #expect(fixture.defaults.string(forKey: AgentHubDefaults.yamlTertiaryHex) == "#778899")
   }
 
+  @MainActor
+  @Test("A YAML theme is published only after its palette is persisted")
+  func yamlThemePublishesAfterPalettePersistence() async throws {
+    let fixture = try Fixture()
+    defer { fixture.teardown() }
+    let loader = RecordingThemeLoadingService(loadedThemes: [
+      "adaptive.yaml": try loadedTheme(name: "Adaptive")
+    ])
+    let writer = DelayedThemePreferenceWriter()
+    let manager = fixture.makeManager(loader: loader, preferenceWriter: writer)
+
+    let selection = Task { @MainActor in
+      await manager.applySelection("adaptive.yaml", backend: .regular)
+    }
+    await writer.waitUntilPaletteWriteStarts()
+
+    #expect(manager.currentTheme.id == AppTheme.neutral.rawValue)
+
+    await writer.finishPaletteWrite()
+    _ = await selection.value
+
+    #expect(manager.currentTheme.sourceFileName == "adaptive.yaml")
+  }
+
   private final class Fixture {
     let themesDirectory: URL
     let suiteName: String
@@ -224,11 +273,15 @@ struct ThemeManagerTests {
     }
 
     @MainActor
-    func makeManager(loader: any ThemeLoadingServiceProtocol) -> ThemeManager {
+    func makeManager(
+      loader: any ThemeLoadingServiceProtocol,
+      preferenceWriter: (any ThemePreferenceWriting)? = nil
+    ) -> ThemeManager {
       ThemeManager(
         defaults: defaults,
         themesDirectory: themesDirectory,
         loadingService: loader,
+        preferenceWriter: preferenceWriter,
         fileWatcher: NoOpThemeFileWatcher(),
         installBundledThemes: false,
         loadSavedThemeAsync: false

--- a/app/modules/Ghostty/Package.resolved
+++ b/app/modules/Ghostty/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "023a9c4fd43e10bfd6b0a4bbe1cb326f1a9386b337f08f2387637aae2f775fcf",
+  "originHash" : "f0fdce706ad9849e6905d783e25f9e33e462d0fe1d3086536c16423afe7fe9b9",
   "pins" : [
     {
       "identity" : "beautiful-mermaid-swift",
@@ -69,8 +69,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/jamesrochabrun/GhosttySwift",
       "state" : {
-        "revision" : "f7286937278044fcfa0d6385b1264fe9cc8195b3",
-        "version" : "1.0.4"
+        "revision" : "98c553a64e518f32ab311278d5471ed9439f86bc",
+        "version" : "1.0.8"
       }
     },
     {

--- a/app/modules/Ghostty/Package.swift
+++ b/app/modules/Ghostty/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
   ],
   dependencies: [
     .package(path: "../AgentHubCore"),
-    .package(url: "https://github.com/jamesrochabrun/GhosttySwift", exact: "1.0.4"),
+    .package(url: "https://github.com/jamesrochabrun/GhosttySwift", exact: "1.0.8"),
   ],
   targets: [
     .target(
@@ -25,6 +25,9 @@ let package = Package(
         .product(name: "GhosttySwift", package: "GhosttySwift"),
       ],
       path: "Sources/Ghostty",
+      resources: [
+        .process("Resources"),
+      ],
       swiftSettings: [
         .swiftLanguageMode(.v5)
       ]

--- a/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyAppearanceConfiguration.swift
+++ b/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyAppearanceConfiguration.swift
@@ -1,0 +1,15 @@
+import Foundation
+import GhosttySwift
+
+enum AgentHubGhosttyAppearanceConfiguration {
+  static func path(isDark: Bool) -> String? {
+    Bundle.module.url(
+      forResource: isDark ? "ghostty-dark" : "ghostty-light",
+      withExtension: "conf"
+    )?.path
+  }
+
+  static func colorScheme(isDark: Bool) -> GhosttyColorScheme {
+    isDark ? .dark : .light
+  }
+}

--- a/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalSurface.swift
+++ b/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalSurface.swift
@@ -56,6 +56,7 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
   private var configuredProcessProvider: SessionProviderKind?
   private var configuredExpectedExecutable: String?
   private var metadataStore: SessionMetadataStore?
+  private var currentIsDark = true
   private static let terminalPaneDividerSize = TerminalPanelKit.SplitSizing.dividerDimension
   private static let terminalTabStripHeight = AgentHubGhosttyTerminalTabChrome.stripHeight
   private static let shellStartupFallbackDelay: Duration = .milliseconds(900)
@@ -140,6 +141,7 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
   ) {
     guard !isConfigured else { return }
     isConfigured = true
+    currentIsDark = isDark
     self.projectPath = projectPath
     configuredSessionId = sessionId
     configuredProcessProvider = SessionProviderKind(cliMode: cliConfiguration.mode)
@@ -176,6 +178,7 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
   public func configureShell(projectPath: String, isDark: Bool, shellPath: String?) {
     guard !isConfigured else { return }
     isConfigured = true
+    currentIsDark = isDark
     self.projectPath = projectPath
     configuredSessionId = nil
     configuredProcessProvider = sessionViewModel?.providerKind
@@ -223,7 +226,7 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
       cliConfiguration: cliConfiguration,
       initialPrompt: nil,
       initialInputText: nil,
-      isDark: true,
+      isDark: currentIsDark,
       dangerouslySkipPermissions: false,
       permissionModePlan: false,
       worktreeName: nil,
@@ -318,7 +321,35 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
   }
 
   public func syncAppearance(isDark: Bool, fontSize: CGFloat, fontFamily: String, theme: RuntimeTheme?) {
-    // Ghostty owns live appearance through its config. Font size is applied at surface creation.
+    currentIsDark = isDark
+    guard let configurationPath = AgentHubGhosttyAppearanceConfiguration.path(isDark: isDark) else {
+      AppLogger.session.error("Unable to locate the bundled Ghostty appearance configuration.")
+      return
+    }
+
+    let controllers = allTabs().map(\.controller)
+    if let runtime = controllers.first?.runtime {
+      do {
+        _ = try runtime.applyConfigurationOverlay(at: configurationPath)
+      } catch {
+        AppLogger.session.error(
+          "Failed to update Ghostty appearance: \(error.localizedDescription)"
+        )
+      }
+    }
+
+    let colorScheme = AgentHubGhosttyAppearanceConfiguration.colorScheme(isDark: isDark)
+    for controller in controllers {
+      _ = controller.setColorScheme(colorScheme)
+      guard controller.configurationOverlayPath != configurationPath else { continue }
+      do {
+        _ = try controller.applyConfigurationOverlay(at: configurationPath)
+      } catch {
+        AppLogger.session.error(
+          "Failed to update Ghostty surface appearance: \(error.localizedDescription)"
+        )
+      }
+    }
   }
 
   public func focus() {
@@ -712,6 +743,11 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
       // which is the bulk of the per-mount cold-start cost.
       let runtime = try await AgentHubSharedGhosttyRuntime.acquire()
       guard !Task.isCancelled else { return }
+      if let configurationPath = AgentHubGhosttyAppearanceConfiguration.path(
+        isDark: currentIsDark
+      ) {
+        _ = try runtime.applyConfigurationOverlay(at: configurationPath)
+      }
       let session = try TerminalSession(
         runtime: runtime,
         primaryConfiguration: primaryConfiguration,
@@ -908,7 +944,13 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
       environment: environment,
       initialInput: initialInput,
       fontSize: resolvedFontSize(),
-      initialSize: initialSize
+      initialSize: initialSize,
+      configurationOverlayPath: AgentHubGhosttyAppearanceConfiguration.path(
+        isDark: currentIsDark
+      ),
+      colorScheme: AgentHubGhosttyAppearanceConfiguration.colorScheme(
+        isDark: currentIsDark
+      )
     )
   }
 

--- a/app/modules/Ghostty/Sources/Ghostty/Resources/ghostty-dark.conf
+++ b/app/modules/Ghostty/Sources/Ghostty/Resources/ghostty-dark.conf
@@ -1,0 +1,28 @@
+background = #252627
+foreground = #E2E8F0
+cursor-color = #A0AEC0
+cursor-text = #252627
+selection-background = #4A5568
+selection-foreground = #F7FAFC
+# minimum-contrast is only safe in this dark profile: with background-opacity 0
+# Ghostty's contrast reference degrades to black, which approximates the app's
+# dark backdrop. The light profile must NOT set it (see ghostty-light.conf).
+minimum-contrast = 4.5
+background-opacity = 0
+
+palette = 0=#0D0D0D
+palette = 1=#E06C75
+palette = 2=#98C379
+palette = 3=#ECC94B
+palette = 4=#61AFEF
+palette = 5=#C678DD
+palette = 6=#56B6C2
+palette = 7=#E2E8F0
+palette = 8=#718096
+palette = 9=#E88A91
+palette = 10=#B5D4A1
+palette = 11=#F6E05E
+palette = 12=#8CC8F5
+palette = 13=#D8A0E8
+palette = 14=#7DCBD5
+palette = 15=#F7FAFC

--- a/app/modules/Ghostty/Sources/Ghostty/Resources/ghostty-light.conf
+++ b/app/modules/Ghostty/Sources/Ghostty/Resources/ghostty-light.conf
@@ -1,0 +1,29 @@
+background = #FBFBFF
+foreground = #2D3748
+cursor-color = #4A5568
+cursor-text = #FBFBFF
+selection-background = #CBD5E0
+selection-foreground = #1A202C
+# Never set minimum-contrast here: Ghostty's contrast pass compares text
+# against the terminal background premultiplied by background-opacity. With
+# background-opacity = 0 that reference is transparent black, so every glyph
+# on the default background fails the ratio and gets flipped to white —
+# invisible over the app's light backdrop.
+background-opacity = 0
+
+palette = 0=#2D3748
+palette = 1=#C53030
+palette = 2=#2F855A
+palette = 3=#975A16
+palette = 4=#2B6CB0
+palette = 5=#805AD5
+palette = 6=#287A8A
+palette = 7=#718096
+palette = 8=#4A5568
+palette = 9=#C53030
+palette = 10=#276749
+palette = 11=#744210
+palette = 12=#2C5282
+palette = 13=#6B46C1
+palette = 14=#285E61
+palette = 15=#2D3748

--- a/app/modules/Ghostty/Tests/GhosttyTests/AgentHubGhosttyAppearanceConfigurationTests.swift
+++ b/app/modules/Ghostty/Tests/GhosttyTests/AgentHubGhosttyAppearanceConfigurationTests.swift
@@ -1,0 +1,46 @@
+import Foundation
+import GhosttySwift
+import Testing
+@testable import Ghostty
+
+@Suite("AgentHub Ghostty appearance configuration")
+struct AgentHubGhosttyAppearanceConfigurationTests {
+  @Test("Light appearance uses a high-contrast foreground and ANSI white")
+  func lightAppearanceUsesReadableColors() throws {
+    let path = try #require(
+      AgentHubGhosttyAppearanceConfiguration.path(isDark: false)
+    )
+    let contents = try String(contentsOfFile: path, encoding: .utf8)
+
+    #expect(contents.contains("background = #FBFBFF"))
+    #expect(contents.contains("foreground = #2D3748"))
+    #expect(contents.contains("palette = 15=#2D3748"))
+    // minimum-contrast must never be set in the light profile: with
+    // background-opacity 0, Ghostty computes contrast against transparent
+    // black and flips dark text to white, making light mode illegible.
+    let activeLines = contents
+      .split(separator: "\n")
+      .filter { !$0.trimmingCharacters(in: .whitespaces).hasPrefix("#") }
+    #expect(!activeLines.contains { $0.contains("minimum-contrast") })
+    #expect(contents.contains("background-opacity = 0"))
+  }
+
+  @Test("Dark appearance preserves the Ghostty palette")
+  func darkAppearanceUsesGhosttyColors() throws {
+    let path = try #require(
+      AgentHubGhosttyAppearanceConfiguration.path(isDark: true)
+    )
+    let contents = try String(contentsOfFile: path, encoding: .utf8)
+
+    #expect(contents.contains("background = #252627"))
+    #expect(contents.contains("foreground = #E2E8F0"))
+    #expect(contents.contains("palette = 15=#F7FAFC"))
+    #expect(contents.contains("minimum-contrast = 4.5"))
+  }
+
+  @Test("System appearance maps to Ghostty's native color scheme")
+  func appearanceMapsToNativeColorScheme() {
+    #expect(AgentHubGhosttyAppearanceConfiguration.colorScheme(isDark: false) == .light)
+    #expect(AgentHubGhosttyAppearanceConfiguration.colorScheme(isDark: true) == .dark)
+  }
+}


### PR DESCRIPTION
## Summary

Light mode previously rendered agent terminal output (Codex/Claude) as near-white text on a white background — completely illegible. This PR fixes it at every layer and makes the theme system appearance-aware.

### Appearance pipeline (Ghostty module)
- Pin **GhosttySwift 1.0.8** and add bundled `ghostty-light.conf` / `ghostty-dark.conf` overlays plus `AgentHubGhosttyAppearanceConfiguration`.
- The overlay is applied to the shared runtime **before** surface creation and passed per-surface together with the native color scheme, so child CLIs see correct OSC 10/11 colors and a light/dark report at spawn (verified with a live probe: fg `#2D3748`, bg `#FBFBFF`, DSR 996 → light).
- `syncAppearance` now live-applies the overlay and color scheme to all tabs when the system appearance changes; focused surfaces get a focus refresh so TUIs re-query colors immediately.

### The rendering root cause
Even with correct colors reported, light mode stayed illegible: Ghostty's `minimum-contrast` shader pass compares each glyph against the terminal background **premultiplied by `background-opacity`**. With AgentHub's `background-opacity = 0` (transparent surface over the app backdrop), that reference degrades to transparent black — so every dark glyph on the default background fails 4.5:1 against black and is force-flipped to white. Only cells with explicit backgrounds (e.g. Codex's input rows) survived, which matched the observed symptom exactly.

Fix: the light profile no longer sets `minimum-contrast` (the dark profile keeps it — black approximates the dark backdrop there). Verified by rendering a styled text battery in a real surface: the old conf reproduces the bug pixel-for-pixel, the fixed conf renders every style legibly. Regression-guarded in `AgentHubGhosttyAppearanceConfigurationTests` (asserts no active line sets `minimum-contrast` in the light conf).

### Theme system (AgentHubCore)
- YAML brand colors gain optional `light:` / `dark:` variants (`BrandColorVariant`), with legacy single-palette themes preserved.
- `RuntimeTheme` resolves brand colors as appearance-adaptive colors.
- Cached brand hexes are stored per appearance (`yamlLight*/yamlDark*` defaults keys) so pre-load theming matches the active appearance.
- Bundled Ghostty theme bumps to 1.4 with a light brand palette.

## Testing
- `GhosttyTests` (35/35) including the new appearance-configuration regression tests — via xcodebuild package scheme.
- New/updated theme tests: `RuntimeThemeAppearanceTests`, `ThemeLoadingServiceTests`, `ThemeManagerTests`, `ThemeSelectionPolicyTests`.
- Full `./scripts/test.sh` gate: fast packages green; the `AgentHubCore` suite (947 tests) had a handful of failures from load-sensitive timing suites (`AgentWorkspacesViewModelTests`, `WorktreeGenerationProgressCoordinatorTests`, `DiffAvailabilityServiceTests`, one WebKit 60s timeout) — the failing set differed between two runs, none touch code changed here, and **all pass when run in isolation**. One genuine environmental failure (`EmbeddedTerminalLaunchBuilderAgentHubCLITests`) was caused by a stray `.xcworkspace` under `/tmp` from an earlier inspection session; removed, suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)