### PR TITLE
Adopt Ghostty background for app chrome

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/Design/Theme/Management/ThemeManager.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Design/Theme/Management/ThemeManager.swift
@@ -361,6 +361,13 @@ public final class ThemeManager {
     )
   }
 
+  public func refreshGhosttyUserBackground(backend: EmbeddedTerminalBackend = .storedPreference) {
+    guard backend == .ghostty,
+          currentTheme.sourceFileName == ThemeSelectionPolicy.ghosttyThemeId else { return }
+    let pristineTheme = themeCache[ThemeSelectionPolicy.ghosttyThemeId] ?? currentTheme
+    currentTheme = adoptingGhosttyUserBackgroundIfNeeded(pristineTheme)
+  }
+
   public func loadBuiltInTheme(_ theme: AppTheme) {
     beginThemeSelection()
     let backend = EmbeddedTerminalBackend.storedPreference(in: defaults)

--- a/app/modules/AgentHubCore/Sources/AgentHub/Design/Theme/Management/ThemeManager.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Design/Theme/Management/ThemeManager.swift
@@ -327,7 +327,7 @@ public final class ThemeManager {
       await persistYAMLPalette(for: cacheKey)
       guard isCurrentGeneration(generation) else { return }
       stopWatchingInactiveThemeFile(nextThemeURL: fileURL)
-      self.currentTheme = cached
+      self.currentTheme = adoptingGhosttyUserBackgroundIfNeeded(cached)
       setupHotReload(for: fileURL)
       await saveCurrentThemeSelection(cacheKey, backend: backend)
       return
@@ -344,9 +344,21 @@ public final class ThemeManager {
     guard isCurrentGeneration(generation) else { return }
 
     stopWatchingInactiveThemeFile(nextThemeURL: fileURL)
-    self.currentTheme = runtime
+    self.currentTheme = adoptingGhosttyUserBackgroundIfNeeded(runtime)
     setupHotReload(for: fileURL)
     await saveCurrentThemeSelection(cacheKey, backend: backend)
+  }
+
+  /// With the Ghostty backend the app theme is forced to `ghostty.yaml`
+  /// (see `ThemeSelectionPolicy`); its backdrop adopts the user's own
+  /// Ghostty background colors when they resolve for the appearance. The
+  /// cache keeps the pristine theme so each publish re-resolves the user's
+  /// current config.
+  private func adoptingGhosttyUserBackgroundIfNeeded(_ theme: RuntimeTheme) -> RuntimeTheme {
+    guard theme.sourceFileName == ThemeSelectionPolicy.ghosttyThemeId else { return theme }
+    return theme.applyingGhosttyUserBackground(
+      GhosttyUserThemeScanner.resolveBackground(defaults: defaults)
+    )
   }
 
   public func loadBuiltInTheme(_ theme: AppTheme) {

--- a/app/modules/AgentHubCore/Sources/AgentHub/Design/Theme/Models/RuntimeTheme.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Design/Theme/Models/RuntimeTheme.swift
@@ -20,9 +20,11 @@ public struct RuntimeTheme: Identifiable {
   public let brandSecondary: Color
   public let brandTertiary: Color
 
-  // Background colors (optional)
-  public let backgroundDark: Color?
-  public let backgroundLight: Color?
+  // Background colors (optional). The main pair is mutable so the Ghostty
+  // backend can adopt the user's own Ghostty background (see
+  // `applyingGhosttyUserBackground`).
+  public var backgroundDark: Color?
+  public var backgroundLight: Color?
   public let expandedContentBackgroundDark: Color?
   public let expandedContentBackgroundLight: Color?
 
@@ -44,6 +46,21 @@ public struct RuntimeTheme: Identifiable {
   /// Whether this theme provides custom background colors
   public var hasCustomBackgrounds: Bool {
     backgroundDark != nil || backgroundLight != nil
+  }
+
+  /// Returns a copy whose app backdrop adopts the user's Ghostty background
+  /// where an appearance-matched color resolved (dark color for dark mode,
+  /// light for light — mismatches keep the theme's own backdrop so the
+  /// terminal overlay's text colors stay legible).
+  public func applyingGhosttyUserBackground(_ background: GhosttyUserBackground) -> RuntimeTheme {
+    var theme = self
+    if let dark = background.adoptableHex(isDark: true) {
+      theme.backgroundDark = Color(hex: dark)
+    }
+    if let light = background.adoptableHex(isDark: false) {
+      theme.backgroundLight = Color(hex: light)
+    }
+    return theme
   }
 
   public init(from yaml: YAMLTheme, sourceFileName: String? = nil) {

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/GhosttyConfigLocations.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/GhosttyConfigLocations.swift
@@ -1,0 +1,81 @@
+import Foundation
+
+/// Canonical filesystem locations of the user's Ghostty configuration on
+/// macOS. Shared by the embedded-terminal config layering (Ghostty module)
+/// and the user-theme background resolution (theme system), so both agree on
+/// what "the user's Ghostty config" means.
+public enum GhosttyConfigLocations {
+
+  /// Ghostty's default config file locations, in Ghostty's own load order
+  /// (XDG first, Application Support last so it takes precedence).
+  public static func defaultConfigPaths(
+    environment: [String: String] = ProcessInfo.processInfo.environment,
+    homeDirectoryURL: URL = FileManager.default.homeDirectoryForCurrentUser
+  ) -> [String] {
+    [
+      xdgConfigBaseURL(environment: environment, homeDirectoryURL: homeDirectoryURL)
+        .appendingPathComponent("ghostty", isDirectory: true)
+        .appendingPathComponent("config", isDirectory: false)
+        .path,
+      applicationSupportGhosttyURL(homeDirectoryURL: homeDirectoryURL)
+        .appendingPathComponent("config", isDirectory: false)
+        .path,
+    ]
+  }
+
+  /// Directories searched for a named `theme`, in precedence order (first
+  /// match wins). Mirrors Ghostty: user theme dirs first, then the bundled
+  /// resource themes (`share/ghostty/themes`) supplied by the caller.
+  public static func themeSearchDirectories(
+    environment: [String: String] = ProcessInfo.processInfo.environment,
+    homeDirectoryURL: URL = FileManager.default.homeDirectoryForCurrentUser,
+    bundledThemesDirectoryURL: URL? = nil,
+    includeSystemThemeDirectories: Bool = true
+  ) -> [URL] {
+    var directories = [
+      xdgConfigBaseURL(environment: environment, homeDirectoryURL: homeDirectoryURL)
+        .appendingPathComponent("ghostty", isDirectory: true)
+        .appendingPathComponent("themes", isDirectory: true),
+      applicationSupportGhosttyURL(homeDirectoryURL: homeDirectoryURL)
+        .appendingPathComponent("themes", isDirectory: true),
+    ]
+    if let bundledThemesDirectoryURL {
+      directories.append(bundledThemesDirectoryURL)
+    }
+    if includeSystemThemeDirectories {
+      // GHOSTTY_RESOURCES_DIR is exported by the embedded runtime once it
+      // has configured GhosttySwift's bundled resources; the Ghostty.app
+      // path covers named themes before the runtime exists.
+      if let resourcesDir = environment["GHOSTTY_RESOURCES_DIR"], !resourcesDir.isEmpty {
+        directories.append(
+          URL(fileURLWithPath: resourcesDir, isDirectory: true)
+            .appendingPathComponent("themes", isDirectory: true)
+        )
+      }
+      directories.append(
+        URL(
+          fileURLWithPath: "/Applications/Ghostty.app/Contents/Resources/ghostty/themes",
+          isDirectory: true
+        )
+      )
+    }
+    return directories
+  }
+
+  private static func xdgConfigBaseURL(
+    environment: [String: String],
+    homeDirectoryURL: URL
+  ) -> URL {
+    if let xdgConfigHome = environment["XDG_CONFIG_HOME"], !xdgConfigHome.isEmpty {
+      return URL(fileURLWithPath: (xdgConfigHome as NSString).expandingTildeInPath, isDirectory: true)
+    }
+    return homeDirectoryURL.appendingPathComponent(".config", isDirectory: true)
+  }
+
+  private static func applicationSupportGhosttyURL(homeDirectoryURL: URL) -> URL {
+    homeDirectoryURL
+      .appendingPathComponent("Library", isDirectory: true)
+      .appendingPathComponent("Application Support", isDirectory: true)
+      .appendingPathComponent("com.mitchellh.ghostty", isDirectory: true)
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/GhosttyUserThemeScanner.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/GhosttyUserThemeScanner.swift
@@ -1,0 +1,265 @@
+import Foundation
+
+/// The user's effective Ghostty background color per appearance, resolved
+/// from their Ghostty configuration. Hex strings are normalized `#rrggbb`.
+public struct GhosttyUserBackground: Equatable, Sendable {
+  public let lightHex: String?
+  public let darkHex: String?
+
+  public init(lightHex: String?, darkHex: String?) {
+    self.lightHex = lightHex
+    self.darkHex = darkHex
+  }
+
+  public static let none = GhosttyUserBackground(lightHex: nil, darkHex: nil)
+
+  /// The background to adopt for the given appearance, or nil to keep the
+  /// app's own theme backdrop.
+  ///
+  /// A color is only adoptable when its luminance matches the appearance
+  /// (dark color in dark mode, light color in light mode). The embedded
+  /// terminal's text colors come from AgentHub's appearance overlay, so
+  /// painting e.g. a dark user background behind light-mode (dark) text
+  /// would be illegible.
+  public func adoptableHex(isDark: Bool) -> String? {
+    guard let hex = isDark ? darkHex : lightHex,
+          let luminance = GhosttyUserThemeScanner.luminance(ofHex: hex) else {
+      return nil
+    }
+    let colorIsDark = luminance < 0.5
+    return colorIsDark == isDark ? hex : nil
+  }
+}
+
+/// Resolves the user's Ghostty background colors by scanning the same config
+/// files the embedded runtime loads (default Ghostty locations, then the
+/// custom file from AgentHub Settings on top — see
+/// `GhosttyLayeredConfigComposer`).
+///
+/// This is a deliberately narrow reader, not a full Ghostty config parser:
+/// it understands line comments, `key = value` pairs, `config-file` includes
+/// (BFS, matching `ghostty_config_load_recursive_files`), the `theme` key
+/// (single name, `light:`/`dark:` pairs, or a file path), and hex `background`
+/// values. Ghostty's rule "explicit config colors override the theme" is
+/// honored. Anything it cannot understand resolves to "no adoption" rather
+/// than a guess.
+public enum GhosttyUserThemeScanner {
+
+  public static func resolveBackground(
+    defaults: UserDefaults = .standard,
+    fileManager: FileManager = .default,
+    environment: [String: String] = ProcessInfo.processInfo.environment,
+    homeDirectoryURL: URL = FileManager.default.homeDirectoryForCurrentUser,
+    bundledThemesDirectoryURL: URL? = nil,
+    includeSystemThemeDirectories: Bool = true
+  ) -> GhosttyUserBackground {
+    var rootPaths = GhosttyConfigLocations.defaultConfigPaths(
+      environment: environment,
+      homeDirectoryURL: homeDirectoryURL
+    )
+    if let customPath = validatedCustomConfigPath(defaults: defaults, fileManager: fileManager),
+       !rootPaths.contains(customPath) {
+      rootPaths.append(customPath)
+    }
+
+    let scan = scanConfigFiles(at: rootPaths, fileManager: fileManager)
+
+    if scan.sawUnparseableBackground {
+      return .none
+    }
+
+    if let explicit = scan.backgroundHex {
+      return GhosttyUserBackground(lightHex: explicit, darkHex: explicit)
+    }
+
+    guard let themeSpec = scan.themeSpec else { return .none }
+    let themes = ThemePair(spec: themeSpec)
+    let searchDirectories = GhosttyConfigLocations.themeSearchDirectories(
+      environment: environment,
+      homeDirectoryURL: homeDirectoryURL,
+      bundledThemesDirectoryURL: bundledThemesDirectoryURL,
+      includeSystemThemeDirectories: includeSystemThemeDirectories
+    )
+
+    func backgroundForTheme(_ name: String?) -> String? {
+      guard let name else { return nil }
+      guard let themeURL = locateTheme(
+        named: name,
+        searchDirectories: searchDirectories,
+        fileManager: fileManager
+      ) else { return nil }
+      return scanConfigFiles(at: [themeURL.path], fileManager: fileManager).backgroundHex
+    }
+
+    return GhosttyUserBackground(
+      lightHex: backgroundForTheme(themes.light),
+      darkHex: backgroundForTheme(themes.dark)
+    )
+  }
+
+  // MARK: - Config scanning
+
+  struct ScanResult {
+    var backgroundHex: String?
+    var sawUnparseableBackground = false
+    var themeSpec: String?
+  }
+
+  /// Scans config files with last-wins semantics. `config-file` includes are
+  /// processed breadth-first after the file that declared them, matching
+  /// libghostty's `ghostty_config_load_recursive_files`.
+  static func scanConfigFiles(
+    at rootPaths: [String],
+    fileManager: FileManager,
+    maximumFileCount: Int = 32
+  ) -> ScanResult {
+    var result = ScanResult()
+    var queue = rootPaths
+    var visited = Set<String>()
+
+    while !queue.isEmpty, visited.count < maximumFileCount {
+      let path = (queue.removeFirst() as NSString).expandingTildeInPath
+      let canonical = URL(fileURLWithPath: path).standardizedFileURL.path
+      guard !visited.contains(canonical) else { continue }
+      visited.insert(canonical)
+
+      guard let contents = try? String(contentsOfFile: canonical, encoding: .utf8) else { continue }
+
+      for rawLine in contents.split(separator: "\n", omittingEmptySubsequences: true) {
+        let line = rawLine.trimmingCharacters(in: .whitespaces)
+        guard !line.isEmpty, !line.hasPrefix("#") else { continue }
+        guard let separator = line.firstIndex(of: "=") else { continue }
+
+        let key = line[..<separator].trimmingCharacters(in: .whitespaces)
+        let value = unquote(line[line.index(after: separator)...].trimmingCharacters(in: .whitespaces))
+
+        switch key {
+        case "background":
+          if value.isEmpty {
+            result.backgroundHex = nil
+            result.sawUnparseableBackground = false
+          } else if let hex = normalizedHex(value) {
+            result.backgroundHex = hex
+            result.sawUnparseableBackground = false
+          } else {
+            result.backgroundHex = nil
+            result.sawUnparseableBackground = true
+          }
+
+        case "theme":
+          result.themeSpec = value.isEmpty ? nil : value
+
+        case "config-file":
+          var includePath = value
+          if includePath.hasPrefix("?") {
+            includePath = String(includePath.dropFirst()).trimmingCharacters(in: .whitespaces)
+          }
+          guard !includePath.isEmpty else { continue }
+          let expanded = (includePath as NSString).expandingTildeInPath
+          if expanded.hasPrefix("/") {
+            queue.append(expanded)
+          } else {
+            queue.append(
+              URL(fileURLWithPath: canonical)
+                .deletingLastPathComponent()
+                .appendingPathComponent(expanded)
+                .path
+            )
+          }
+
+        default:
+          break
+        }
+      }
+    }
+
+    return result
+  }
+
+  // MARK: - Theme resolution
+
+  struct ThemePair {
+    var light: String?
+    var dark: String?
+
+    /// Parses `theme = name` or `theme = light:Name A,dark:Name B`.
+    init(spec: String) {
+      for part in spec.split(separator: ",") {
+        let entry = part.trimmingCharacters(in: .whitespaces)
+        if entry.lowercased().hasPrefix("light:") {
+          light = String(entry.dropFirst("light:".count)).trimmingCharacters(in: .whitespaces)
+        } else if entry.lowercased().hasPrefix("dark:") {
+          dark = String(entry.dropFirst("dark:".count)).trimmingCharacters(in: .whitespaces)
+        } else if light == nil, dark == nil {
+          light = entry
+          dark = entry
+        }
+      }
+    }
+  }
+
+  static func locateTheme(
+    named name: String,
+    searchDirectories: [URL],
+    fileManager: FileManager
+  ) -> URL? {
+    if name.contains("/") {
+      let expanded = (name as NSString).expandingTildeInPath
+      return fileManager.fileExists(atPath: expanded) ? URL(fileURLWithPath: expanded) : nil
+    }
+    for directory in searchDirectories {
+      let candidate = directory.appendingPathComponent(name, isDirectory: false)
+      if fileManager.fileExists(atPath: candidate.path) {
+        return candidate
+      }
+    }
+    return nil
+  }
+
+  // MARK: - Colors
+
+  /// Normalizes `#RRGGBB` / `RRGGBB` to lowercase `#rrggbb`; nil for
+  /// anything else (named colors, short hex).
+  static func normalizedHex(_ value: String) -> String? {
+    var hex = value
+    if hex.hasPrefix("#") { hex = String(hex.dropFirst()) }
+    guard hex.count == 6, hex.allSatisfy(\.isHexDigit) else { return nil }
+    return "#" + hex.lowercased()
+  }
+
+  /// Perceived luminance in 0...1 for a normalized hex color.
+  static func luminance(ofHex hex: String) -> Double? {
+    guard let normalized = normalizedHex(hex) else { return nil }
+    let digits = Array(normalized.dropFirst())
+    func channel(_ offset: Int) -> Double {
+      Double(Int(String(digits[offset...(offset + 1)]), radix: 16) ?? 0) / 255.0
+    }
+    return 0.299 * channel(0) + 0.587 * channel(2) + 0.114 * channel(4)
+  }
+
+  // MARK: - Helpers
+
+  private static func validatedCustomConfigPath(
+    defaults: UserDefaults,
+    fileManager: FileManager
+  ) -> String? {
+    guard let rawPath = defaults.string(forKey: AgentHubDefaults.terminalGhosttyConfigPath) else {
+      return nil
+    }
+    let trimmed = rawPath.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else { return nil }
+    let expanded = (trimmed as NSString).expandingTildeInPath
+    var isDirectory: ObjCBool = false
+    guard fileManager.fileExists(atPath: expanded, isDirectory: &isDirectory),
+          !isDirectory.boolValue,
+          fileManager.isReadableFile(atPath: expanded) else {
+      return nil
+    }
+    return expanded
+  }
+
+  private static func unquote(_ value: String) -> String {
+    guard value.count >= 2, value.hasPrefix("\""), value.hasSuffix("\"") else { return value }
+    return String(value.dropFirst().dropLast())
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/AgentWorkspaceDetailView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/AgentWorkspaceDetailView.swift
@@ -62,12 +62,20 @@ struct AgentWorkspaceDetailView: View {
         theme: runtimeTheme
       )
       .frame(maxWidth: .infinity, maxHeight: .infinity)
+      .background(terminalBackdropColor)
     }
     .alert("Rename Workspace", isPresented: $isRenaming) {
       TextField("Workspace name", text: $renameText)
       Button("Cancel", role: .cancel) {}
       Button("Rename", action: commitRename)
     }
+  }
+
+  /// The embedded Ghostty surface is transparent; this backdrop is what the
+  /// terminal visually sits on (same pattern as `MonitoringPanelView`).
+  private var terminalBackdropColor: Color {
+    guard runtimeTheme?.hasCustomBackgrounds == true else { return .clear }
+    return Color.adaptiveBackground(for: colorScheme, theme: runtimeTheme)
   }
 
   private func beginRename() {

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/SettingsView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/SettingsView.swift
@@ -384,7 +384,9 @@ public struct SettingsView: View {
           }
         }
 
-        ghosttyConfigFileSetting
+        if activeTerminalBackend == .ghostty {
+          ghosttyConfigFileSetting
+        }
         #endif
 
         if activeTerminalBackend != .ghostty {

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/SettingsView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/SettingsView.swift
@@ -387,33 +387,35 @@ public struct SettingsView: View {
         ghosttyConfigFileSetting
         #endif
 
-        Picker("Font", selection: $terminalFontFamily) {
-          ForEach(terminalFontFamilies, id: \.self) { family in
-            Text(family)
-              .font(.custom(family, size: 13))
-              .tag(family)
+        if activeTerminalBackend != .ghostty {
+          Picker("Font", selection: $terminalFontFamily) {
+            ForEach(terminalFontFamilies, id: \.self) { family in
+              Text(family)
+                .font(.custom(family, size: 13))
+                .tag(family)
+            }
           }
-        }
 
-        Stepper(value: $terminalFontSize, in: 8...24, step: 1) {
-          HStack {
-            Text("Font size")
-            Spacer()
-            Text("\(Int(terminalFontSize)) pt")
-              .foregroundColor(.secondary)
-              .monospacedDigit()
+          Stepper(value: $terminalFontSize, in: 8...24, step: 1) {
+            HStack {
+              Text("Font size")
+              Spacer()
+              Text("\(Int(terminalFontSize)) pt")
+                .foregroundColor(.secondary)
+                .monospacedDigit()
+            }
+          }
+
+          Picker("Open files with", selection: $fileOpenEditorRawValue) {
+            ForEach(FileOpenEditor.allCases, id: \.rawValue) { editor in
+              Text(editor.label).tag(editor.rawValue)
+            }
           }
         }
 
         Picker("Newline shortcut", selection: $newlineShortcutRawValue) {
           ForEach(NewlineShortcut.allCases, id: \.rawValue) { shortcut in
             Text(shortcut.label).tag(shortcut.rawValue)
-          }
-        }
-
-        Picker("Open files with", selection: $fileOpenEditorRawValue) {
-          ForEach(FileOpenEditor.allCases, id: \.rawValue) { editor in
-            Text(editor.label).tag(editor.rawValue)
           }
         }
       }

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/SettingsView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/SettingsView.swift
@@ -432,39 +432,41 @@ public struct SettingsView: View {
         )
       }
 
-      Section {
-        HStack(spacing: 10) {
-          Picker("Theme", selection: themeSelectionBinding) {
-            ForEach(bundledYAMLThemeFileIds, id: \.self) { fileId in
-              Text(yamlThemeDisplayName(fileId)).tag(fileId)
+      if activeTerminalBackend != .ghostty {
+        Section {
+          HStack(spacing: 10) {
+            Picker("Theme", selection: themeSelectionBinding) {
+              ForEach(bundledYAMLThemeFileIds, id: \.self) { fileId in
+                Text(yamlThemeDisplayName(fileId)).tag(fileId)
+              }
+            }
+
+            if applyingThemeSelectionId != nil {
+              HStack(spacing: 6) {
+                ProgressView()
+                  .controlSize(.small)
+                Text("Applying...")
+                  .font(.caption)
+                  .foregroundStyle(.secondary)
+              }
+              .transition(.opacity)
             }
           }
 
-          if applyingThemeSelectionId != nil {
-            HStack(spacing: 6) {
-              ProgressView()
-                .controlSize(.small)
-              Text("Applying...")
-                .font(.caption)
-                .foregroundStyle(.secondary)
-            }
-            .transition(.opacity)
+          Button {
+            Task { await themeManager.discoverThemes() }
+          } label: {
+            Label("Refresh themes", systemImage: "arrow.clockwise")
           }
-        }
-
-        Button {
-          Task { await themeManager.discoverThemes() }
-        } label: {
-          Label("Refresh themes", systemImage: "arrow.clockwise")
-        }
-        .buttonStyle(.link)
-        .disabled(applyingThemeSelectionId != nil)
-      } header: {
-        Text("Theme")
-      } footer: {
-        if let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String {
-          Text("AgentHub v\(appVersion)")
-            .font(.caption)
+          .buttonStyle(.link)
+          .disabled(applyingThemeSelectionId != nil)
+        } header: {
+          Text("Theme")
+        } footer: {
+          if let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String {
+            Text("AgentHub v\(appVersion)")
+              .font(.caption)
+          }
         }
       }
     }

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/SettingsView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/SettingsView.swift
@@ -175,6 +175,9 @@ public struct SettingsView: View {
     .onChange(of: cliEnvironmentVariables) { _, newValue in
       CLIEnvironmentOverrides.save(newValue)
     }
+    .onChange(of: terminalGhosttyConfigPath) { _, _ in
+      themeManager.refreshGhosttyUserBackground(backend: activeTerminalBackend)
+    }
     .onDisappear {
       themeSelectionTask?.cancel()
       themeSelectionTask = nil
@@ -674,7 +677,7 @@ public struct SettingsView: View {
           .foregroundColor(.orange)
       }
 
-      Text("Layered on top of your Ghostty configuration, for AgentHub terminals only. Relaunch AgentHub to apply changes.")
+      Text("Layered on top of your Ghostty configuration, for AgentHub terminals only. The app backdrop updates immediately; fresh terminal processes may require relaunch.")
         .font(.caption)
         .foregroundColor(.secondary)
     }

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/GhosttyUserThemeScannerTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/GhosttyUserThemeScannerTests.swift
@@ -1,0 +1,202 @@
+import Foundation
+import Testing
+
+@testable import AgentHubCore
+
+@Suite("Ghostty user theme scanner")
+struct GhosttyUserThemeScannerTests {
+
+  @Test("Resolves nothing when no config files exist")
+  func noConfigFiles() throws {
+    let env = try ScannerEnvironment()
+    defer { env.cleanUp() }
+
+    #expect(env.resolve() == .none)
+  }
+
+  @Test("Explicit hex background applies to both modes")
+  func explicitBackground() throws {
+    let env = try ScannerEnvironment()
+    defer { env.cleanUp() }
+    try env.writeAppSupportConfig("background = #1E1E2E\n")
+
+    let background = env.resolve()
+    #expect(background == GhosttyUserBackground(lightHex: "#1e1e2e", darkHex: "#1e1e2e"))
+    #expect(background.adoptableHex(isDark: true) == "#1e1e2e")
+    #expect(background.adoptableHex(isDark: false) == nil)
+  }
+
+  @Test("Split theme resolves per-mode backgrounds from theme files")
+  func splitTheme() throws {
+    let env = try ScannerEnvironment()
+    defer { env.cleanUp() }
+    try env.writeTheme(named: "Latte", contents: "background = eff1f5\nforeground = 4c4f69\n")
+    try env.writeTheme(named: "Mocha", contents: "background = 1e1e2e\nforeground = cdd6f4\n")
+    try env.writeAppSupportConfig("theme = light:Latte,dark:Mocha\n")
+
+    let background = env.resolve()
+    #expect(background == GhosttyUserBackground(lightHex: "#eff1f5", darkHex: "#1e1e2e"))
+    #expect(background.adoptableHex(isDark: false) == "#eff1f5")
+    #expect(background.adoptableHex(isDark: true) == "#1e1e2e")
+  }
+
+  @Test("Single theme name applies to both modes, filtered by luminance")
+  func singleTheme() throws {
+    let env = try ScannerEnvironment()
+    defer { env.cleanUp() }
+    try env.writeTheme(named: "Mocha", contents: "background = 1e1e2e\n")
+    try env.writeAppSupportConfig("theme = Mocha\n")
+
+    let background = env.resolve()
+    #expect(background == GhosttyUserBackground(lightHex: "#1e1e2e", darkHex: "#1e1e2e"))
+    #expect(background.adoptableHex(isDark: true) == "#1e1e2e")
+    #expect(background.adoptableHex(isDark: false) == nil)
+  }
+
+  @Test("Explicit background wins over the theme")
+  func explicitOverridesTheme() throws {
+    let env = try ScannerEnvironment()
+    defer { env.cleanUp() }
+    try env.writeTheme(named: "Mocha", contents: "background = 1e1e2e\n")
+    try env.writeAppSupportConfig("background = #101010\ntheme = Mocha\n")
+
+    #expect(env.resolve() == GhosttyUserBackground(lightHex: "#101010", darkHex: "#101010"))
+  }
+
+  @Test("Empty background resets back to the theme")
+  func emptyBackgroundResets() throws {
+    let env = try ScannerEnvironment()
+    defer { env.cleanUp() }
+    try env.writeTheme(named: "Mocha", contents: "background = 1e1e2e\n")
+    try env.writeAppSupportConfig("background = #101010\ntheme = Mocha\nbackground =\n")
+
+    #expect(env.resolve() == GhosttyUserBackground(lightHex: "#1e1e2e", darkHex: "#1e1e2e"))
+  }
+
+  @Test("Unparseable background resolves to no adoption")
+  func namedColorBackground() throws {
+    let env = try ScannerEnvironment()
+    defer { env.cleanUp() }
+    try env.writeTheme(named: "Mocha", contents: "background = 1e1e2e\n")
+    try env.writeAppSupportConfig("theme = Mocha\nbackground = red\n")
+
+    #expect(env.resolve() == .none)
+  }
+
+  @Test("config-file includes are followed and later files win")
+  func includesFollowed() throws {
+    let env = try ScannerEnvironment()
+    defer { env.cleanUp() }
+    try env.write("extra.conf", inAppSupport: true, contents: "background = #222222\n")
+    try env.writeAppSupportConfig(
+      "background = #111111\nconfig-file = extra.conf\nconfig-file = ?missing.conf\n"
+    )
+
+    #expect(env.resolve().darkHex == "#222222")
+  }
+
+  @Test("Include cycles terminate")
+  func includeCycle() throws {
+    let env = try ScannerEnvironment()
+    defer { env.cleanUp() }
+    try env.write("a.conf", inAppSupport: true, contents: "config-file = b.conf\nbackground = #111111\n")
+    try env.write("b.conf", inAppSupport: true, contents: "config-file = a.conf\n")
+    try env.writeAppSupportConfig("config-file = a.conf\n")
+
+    #expect(env.resolve().darkHex == "#111111")
+  }
+
+  @Test("Custom config from Settings layers on top of default files")
+  func customConfigWins() throws {
+    let env = try ScannerEnvironment()
+    defer { env.cleanUp() }
+    try env.writeAppSupportConfig("background = #111111\n")
+    try env.setCustomConfig("background = #333333\n")
+
+    #expect(env.resolve().darkHex == "#333333")
+  }
+
+  @Test("Quoted theme values and bundled theme directory resolution")
+  func quotedThemeAndBundledDirectory() throws {
+    let env = try ScannerEnvironment()
+    defer { env.cleanUp() }
+    try env.writeBundledTheme(named: "Catppuccin Mocha", contents: "background = 1e1e2e\n")
+    try env.writeAppSupportConfig("theme = \"Catppuccin Mocha\"\n")
+
+    #expect(env.resolve().darkHex == "#1e1e2e")
+  }
+}
+
+/// Sandboxed home directory + defaults suite for scanner tests.
+private struct ScannerEnvironment {
+  let home: URL
+  let defaults: UserDefaults
+  private let suiteName: String
+  private let bundledThemesURL: URL
+
+  init() throws {
+    home = FileManager.default.temporaryDirectory
+      .appendingPathComponent("ghostty-scanner-\(UUID().uuidString)", isDirectory: true)
+    bundledThemesURL = home.appendingPathComponent("bundled-themes", isDirectory: true)
+    try FileManager.default.createDirectory(at: bundledThemesURL, withIntermediateDirectories: true)
+    suiteName = "com.agenthub.tests.ghostty-scanner.\(UUID().uuidString)"
+    defaults = UserDefaults(suiteName: suiteName)!
+    defaults.removePersistentDomain(forName: suiteName)
+  }
+
+  func cleanUp() {
+    defaults.removePersistentDomain(forName: suiteName)
+    try? FileManager.default.removeItem(at: home)
+  }
+
+  func resolve() -> GhosttyUserBackground {
+    GhosttyUserThemeScanner.resolveBackground(
+      defaults: defaults,
+      environment: [:],
+      homeDirectoryURL: home,
+      bundledThemesDirectoryURL: bundledThemesURL,
+      includeSystemThemeDirectories: false
+    )
+  }
+
+  private var appSupportGhostty: URL {
+    home
+      .appendingPathComponent("Library", isDirectory: true)
+      .appendingPathComponent("Application Support", isDirectory: true)
+      .appendingPathComponent("com.mitchellh.ghostty", isDirectory: true)
+  }
+
+  func writeAppSupportConfig(_ contents: String) throws {
+    try write("config", inAppSupport: true, contents: contents)
+  }
+
+  func write(_ name: String, inAppSupport: Bool, contents: String) throws {
+    let directory = inAppSupport ? appSupportGhostty : home
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    try contents.write(
+      to: directory.appendingPathComponent(name),
+      atomically: true,
+      encoding: .utf8
+    )
+  }
+
+  func writeTheme(named name: String, contents: String) throws {
+    let themes = appSupportGhostty.appendingPathComponent("themes", isDirectory: true)
+    try FileManager.default.createDirectory(at: themes, withIntermediateDirectories: true)
+    try contents.write(to: themes.appendingPathComponent(name), atomically: true, encoding: .utf8)
+  }
+
+  func writeBundledTheme(named name: String, contents: String) throws {
+    try contents.write(
+      to: bundledThemesURL.appendingPathComponent(name),
+      atomically: true,
+      encoding: .utf8
+    )
+  }
+
+  func setCustomConfig(_ contents: String) throws {
+    let url = home.appendingPathComponent("custom.conf")
+    try contents.write(to: url, atomically: true, encoding: .utf8)
+    defaults.set(url.path, forKey: AgentHubDefaults.terminalGhosttyConfigPath)
+  }
+}

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/RuntimeThemeGhosttyBackgroundTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/RuntimeThemeGhosttyBackgroundTests.swift
@@ -1,0 +1,72 @@
+import Foundation
+import SwiftUI
+import Testing
+
+@testable import AgentHubCore
+
+@MainActor
+@Suite("Runtime theme Ghostty background adoption")
+struct RuntimeThemeGhosttyBackgroundTests {
+
+  @Test("Adopts appearance-matched user backgrounds")
+  func adoptsMatchedBackgrounds() throws {
+    let theme = try ghosttyLikeTheme()
+    let adopted = theme.applyingGhosttyUserBackground(
+      GhosttyUserBackground(lightHex: "#eff1f5", darkHex: "#1e1e2e")
+    )
+
+    #expect(adopted.backgroundDark == Color(hex: "#1e1e2e"))
+    #expect(adopted.backgroundLight == Color(hex: "#eff1f5"))
+    #expect(adopted.hasCustomBackgrounds)
+  }
+
+  @Test("Keeps the theme backdrop when luminance mismatches the appearance")
+  func rejectsMismatchedLuminance() throws {
+    let theme = try ghosttyLikeTheme()
+    // A dark color offered for light mode and a light color for dark mode
+    // must both be rejected.
+    let adopted = theme.applyingGhosttyUserBackground(
+      GhosttyUserBackground(lightHex: "#1e1e2e", darkHex: "#eff1f5")
+    )
+
+    #expect(adopted.backgroundDark == theme.backgroundDark)
+    #expect(adopted.backgroundLight == theme.backgroundLight)
+  }
+
+  @Test("No resolved background leaves the theme untouched")
+  func noBackgroundIsUntouched() throws {
+    let theme = try ghosttyLikeTheme()
+    let adopted = theme.applyingGhosttyUserBackground(.none)
+
+    #expect(adopted.backgroundDark == theme.backgroundDark)
+    #expect(adopted.backgroundLight == theme.backgroundLight)
+  }
+
+  @Test("Partial resolution adopts only the matching side")
+  func partialResolution() throws {
+    let theme = try ghosttyLikeTheme()
+    let adopted = theme.applyingGhosttyUserBackground(
+      GhosttyUserBackground(lightHex: nil, darkHex: "#101015")
+    )
+
+    #expect(adopted.backgroundDark == Color(hex: "#101015"))
+    #expect(adopted.backgroundLight == theme.backgroundLight)
+  }
+
+  private func ghosttyLikeTheme() throws -> RuntimeTheme {
+    let yaml = """
+      name: "Ghostty"
+      version: "1.0"
+      colors:
+        brand:
+          primary: "#A0AEC0"
+          secondary: "#2D3748"
+          tertiary: "#CBD5E0"
+        backgrounds:
+          dark: "#252627"
+          light: "#FBFBFF"
+      """
+    let theme = try YAMLThemeParser().parse(data: Data(yaml.utf8))
+    return RuntimeTheme(from: theme, sourceFileName: "ghostty.yaml")
+  }
+}

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/ThemeManagerTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/ThemeManagerTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SwiftUI
 import Testing
 
 @testable import AgentHubCore
@@ -252,6 +253,31 @@ struct ThemeManagerTests {
     _ = await selection.value
 
     #expect(manager.currentTheme.sourceFileName == "adaptive.yaml")
+  }
+
+  @MainActor
+  @Test("Refreshing Ghostty user background re-adopts custom config background")
+  func refreshGhosttyUserBackgroundReAdoptsCustomConfigBackground() async throws {
+    let fixture = try Fixture()
+    defer { fixture.teardown() }
+    let loader = RecordingThemeLoadingService(loadedThemes: [
+      "ghostty.yaml": try loadedTheme(name: "Ghostty")
+    ])
+    let initialConfigURL = fixture.themesDirectory.appendingPathComponent("initial-dark")
+    try "background = #1e1e2e\n".write(to: initialConfigURL, atomically: true, encoding: .utf8)
+    fixture.defaults.set(initialConfigURL.path, forKey: AgentHubDefaults.terminalGhosttyConfigPath)
+    let manager = fixture.makeManager(loader: loader)
+
+    await manager.applySelection("ghostty.yaml", backend: .ghostty)
+    #expect(manager.currentTheme.backgroundDark == Color(hex: "#1e1e2e"))
+
+    let configURL = fixture.themesDirectory.appendingPathComponent("solarized-dark")
+    try "background = #002b36\n".write(to: configURL, atomically: true, encoding: .utf8)
+    fixture.defaults.set(configURL.path, forKey: AgentHubDefaults.terminalGhosttyConfigPath)
+
+    manager.refreshGhosttyUserBackground(backend: .ghostty)
+
+    #expect(manager.currentTheme.backgroundDark == Color(hex: "#002b36"))
   }
 
   private final class Fixture {

--- a/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyPendingTerminalPaneView.swift
+++ b/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyPendingTerminalPaneView.swift
@@ -8,14 +8,15 @@ import SwiftUI
 @MainActor
 struct AgentHubGhosttyPendingTerminalPaneView: View {
   let activity: AgentHubGhosttyTerminalPaneActivity
+  let chromeStyle: AgentHubGhosttyTerminalTabChrome.Style
 
   var body: some View {
     VStack(spacing: 0) {
       ZStack(alignment: .bottom) {
-        AgentHubGhosttyTerminalTabChrome.stripBackground
+        chromeStyle.stripBackgroundColor
 
         Rectangle()
-          .fill(AgentHubGhosttyTerminalTabChrome.divider)
+          .fill(chromeStyle.dividerColor)
           .frame(height: 1)
 
         HStack(spacing: 0) {
@@ -24,6 +25,7 @@ struct AgentHubGhosttyPendingTerminalPaneView: View {
             isActive: true,
             isFirst: true,
             canClose: false,
+            chromeStyle: chromeStyle,
             onSelect: {},
             onClose: {}
           )

--- a/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalPaneHeader.swift
+++ b/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalPaneHeader.swift
@@ -15,6 +15,7 @@ struct AgentHubGhosttyTerminalPaneHeader: View {
   let canSplitBelow: Bool
   let canClosePanel: Bool
   let canCloseTab: (TerminalTab) -> Bool
+  let chromeStyle: AgentHubGhosttyTerminalTabChrome.Style
   let onSelectTab: (TerminalTab) -> Void
   let onCloseTab: (TerminalTab) -> Void
   let onOpenTab: () -> Void
@@ -25,10 +26,10 @@ struct AgentHubGhosttyTerminalPaneHeader: View {
 
   var body: some View {
     ZStack(alignment: .bottom) {
-      AgentHubGhosttyTerminalTabChrome.stripBackground
+      chromeStyle.stripBackgroundColor
 
       Rectangle()
-        .fill(AgentHubGhosttyTerminalTabChrome.divider)
+        .fill(chromeStyle.dividerColor)
         .frame(height: 1)
 
       HStack(spacing: 0) {
@@ -47,6 +48,7 @@ struct AgentHubGhosttyTerminalPaneHeader: View {
             title: "New Tab",
             systemImage: "plus",
             help: "New terminal tab",
+            chromeStyle: chromeStyle,
             action: onOpenTab
           )
 
@@ -59,6 +61,7 @@ struct AgentHubGhosttyTerminalPaneHeader: View {
               help: isMaximized
                 ? "Restore terminal panes (Cmd+Shift+M)"
                 : "Maximize terminal pane (Cmd+Shift+M)",
+              chromeStyle: chromeStyle,
               action: onToggleMaximizedPanel
             )
           }
@@ -68,6 +71,7 @@ struct AgentHubGhosttyTerminalPaneHeader: View {
             systemImage: "rectangle.split.2x1",
             help: "Split terminal to the right",
             isDisabled: !canSplitRight,
+            chromeStyle: chromeStyle,
             action: onSplitRight
           )
 
@@ -76,6 +80,7 @@ struct AgentHubGhosttyTerminalPaneHeader: View {
             systemImage: "rectangle.split.1x2",
             help: "Split terminal below",
             isDisabled: !canSplitBelow,
+            chromeStyle: chromeStyle,
             action: onSplitBelow
           )
 
@@ -84,6 +89,7 @@ struct AgentHubGhosttyTerminalPaneHeader: View {
               title: "Close Pane",
               systemImage: "xmark",
               help: "Close terminal pane",
+              chromeStyle: chromeStyle,
               action: onClosePanel
             )
           }
@@ -104,6 +110,7 @@ struct AgentHubGhosttyTerminalPaneHeader: View {
       isActive: isActive,
       isFirst: index == 0,
       canClose: canCloseTab(tab),
+      chromeStyle: chromeStyle,
       onSelect: { onSelectTab(tab) },
       onClose: { onCloseTab(tab) }
     )

--- a/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalPaneView.swift
+++ b/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalPaneView.swift
@@ -26,6 +26,7 @@ struct AgentHubGhosttyTerminalPaneView: View {
   let onSplitPanel: (TerminalPanel, TerminalSplitAxis) -> Void
   let onToggleMaximizedPanel: (TerminalPanel) -> Void
   let activity: AgentHubGhosttyTerminalPaneActivity?
+  let chromeStyle: AgentHubGhosttyTerminalTabChrome.Style
 
   var body: some View {
     VStack(spacing: 0) {
@@ -37,6 +38,7 @@ struct AgentHubGhosttyTerminalPaneView: View {
         canSplitBelow: canSplitPanel(panel, .vertical),
         canClosePanel: canClosePanel(panel),
         canCloseTab: { tab in canCloseTab(panel, tab) },
+        chromeStyle: chromeStyle,
         onSelectTab: { tab in onSelectTab(panel, tab) },
         onCloseTab: closeTab,
         onOpenTab: { onOpenTab(panel) },

--- a/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalSplitView.swift
+++ b/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalSplitView.swift
@@ -28,6 +28,7 @@ struct AgentHubGhosttyTerminalSplitView: View {
   let onToggleMaximizedPanel: (TerminalPanel) -> Void
   let onSplitRatiosChanged: (String, [Double]) -> Void
   let activityForPanel: (TerminalPanelID) -> AgentHubGhosttyTerminalPaneActivity?
+  let chromeStyle: AgentHubGhosttyTerminalTabChrome.Style
 
   var body: some View {
     content(for: node)
@@ -54,10 +55,11 @@ struct AgentHubGhosttyTerminalSplitView: View {
           onOpenTab: onOpenTab,
           onSplitPanel: onSplitPanel,
           onToggleMaximizedPanel: onToggleMaximizedPanel,
-          activity: activityForPanel(panel.id)
+          activity: activityForPanel(panel.id),
+          chromeStyle: chromeStyle
         )
       } else if let activity = activityForPanel(panelID) {
-        AgentHubGhosttyPendingTerminalPaneView(activity: activity)
+        AgentHubGhosttyPendingTerminalPaneView(activity: activity, chromeStyle: chromeStyle)
       } else {
         EmptyView()
       }
@@ -121,7 +123,8 @@ struct AgentHubGhosttyTerminalSplitView: View {
           onSplitPanel: onSplitPanel,
           onToggleMaximizedPanel: onToggleMaximizedPanel,
           onSplitRatiosChanged: onSplitRatiosChanged,
-          activityForPanel: activityForPanel
+          activityForPanel: activityForPanel,
+          chromeStyle: chromeStyle
         )
         .frame(width: childDimension(childWidths, at: offset), height: size.height)
         .zIndex(0)
@@ -177,7 +180,8 @@ struct AgentHubGhosttyTerminalSplitView: View {
           onSplitPanel: onSplitPanel,
           onToggleMaximizedPanel: onToggleMaximizedPanel,
           onSplitRatiosChanged: onSplitRatiosChanged,
-          activityForPanel: activityForPanel
+          activityForPanel: activityForPanel,
+          chromeStyle: chromeStyle
         )
         .frame(width: size.width, height: childDimension(childHeights, at: offset))
         .zIndex(0)

--- a/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalSurface.swift
+++ b/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalSurface.swift
@@ -57,6 +57,7 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
   private var configuredExpectedExecutable: String?
   private var metadataStore: SessionMetadataStore?
   private var currentIsDark = true
+  private var currentChromeStyle = AgentHubGhosttyTerminalTabChrome.systemStyle
   private static let terminalPaneDividerSize = TerminalPanelKit.SplitSizing.dividerDimension
   private static let terminalTabStripHeight = AgentHubGhosttyTerminalTabChrome.stripHeight
   private static let shellStartupFallbackDelay: Duration = .milliseconds(900)
@@ -322,6 +323,7 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
 
   public func syncAppearance(isDark: Bool, fontSize: CGFloat, fontFamily: String, theme: RuntimeTheme?) {
     currentIsDark = isDark
+    updateChromeStyle(isDark: isDark, theme: theme)
     guard let configurationPath = AgentHubGhosttyAppearanceConfiguration.path(isDark: isDark) else {
       AppLogger.session.error("Unable to locate the bundled Ghostty appearance configuration.")
       return
@@ -878,8 +880,16 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
       },
       activityForPanel: { [weak self] panelID in
         self?.paneActivityRegistry.activity(for: panelID)
-      }
+      },
+      chromeStyle: currentChromeStyle
     )
+  }
+
+  private func updateChromeStyle(isDark: Bool, theme: RuntimeTheme?) {
+    let nextStyle = AgentHubGhosttyTerminalTabChrome.style(isDark: isDark, theme: theme)
+    guard nextStyle != currentChromeStyle else { return }
+    currentChromeStyle = nextStyle
+    refreshWorkspaceRootView()
   }
 
   private func refreshWorkspaceRootView() {

--- a/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalTabChrome.swift
+++ b/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalTabChrome.swift
@@ -3,19 +3,112 @@
 //  AgentHub
 //
 
+import AgentHubCore
 import SwiftUI
 
 enum AgentHubGhosttyTerminalTabChrome {
+  struct Style: Equatable {
+    let stripBackground: NSColor
+    let activeBackground: NSColor
+    let hoverBackground: NSColor
+    let closeHoverBackground: NSColor
+    let divider: NSColor
+    let tabEdge: NSColor
+
+    var stripBackgroundColor: Color { Color(nsColor: stripBackground) }
+    var activeBackgroundColor: Color { Color(nsColor: activeBackground) }
+    var hoverBackgroundColor: Color { Color(nsColor: hoverBackground) }
+    var closeHoverBackgroundColor: Color { Color(nsColor: closeHoverBackground) }
+    var dividerColor: Color { Color(nsColor: divider) }
+    var tabEdgeColor: Color { Color(nsColor: tabEdge) }
+
+    static func == (lhs: Style, rhs: Style) -> Bool {
+      AgentHubGhosttyTerminalTabChrome.signature(of: lhs.stripBackground)
+        == AgentHubGhosttyTerminalTabChrome.signature(of: rhs.stripBackground)
+        && AgentHubGhosttyTerminalTabChrome.signature(of: lhs.activeBackground)
+        == AgentHubGhosttyTerminalTabChrome.signature(of: rhs.activeBackground)
+        && AgentHubGhosttyTerminalTabChrome.signature(of: lhs.hoverBackground)
+        == AgentHubGhosttyTerminalTabChrome.signature(of: rhs.hoverBackground)
+        && AgentHubGhosttyTerminalTabChrome.signature(of: lhs.closeHoverBackground)
+        == AgentHubGhosttyTerminalTabChrome.signature(of: rhs.closeHoverBackground)
+        && AgentHubGhosttyTerminalTabChrome.signature(of: lhs.divider)
+        == AgentHubGhosttyTerminalTabChrome.signature(of: rhs.divider)
+        && AgentHubGhosttyTerminalTabChrome.signature(of: lhs.tabEdge)
+        == AgentHubGhosttyTerminalTabChrome.signature(of: rhs.tabEdge)
+    }
+  }
+
   static let stripHeight: CGFloat = 32
   static let tabMinWidth: CGFloat = 118
   static let tabMaxWidth: CGFloat = 192
   static let firstTabCornerRadius: CGFloat = 10
   static let accent = Color.primary
-  static let stripBackground = Color(nsColor: .windowBackgroundColor).opacity(0.78)
-  static let activeBackground = Color(nsColor: .textBackgroundColor).opacity(0.94)
-  static let hoverBackground = Color.primary.opacity(0.07)
-  static let closeHoverBackground = Color.primary.opacity(0.12)
-  static let divider = Color.secondary.opacity(0.18)
 
-  static let tabEdge = Color.secondary.opacity(0.13)
+  static let systemStyle = Style(
+    stripBackground: NSColor.windowBackgroundColor.withAlphaComponent(0.78),
+    activeBackground: NSColor.textBackgroundColor.withAlphaComponent(0.94),
+    hoverBackground: NSColor.labelColor.withAlphaComponent(0.07),
+    closeHoverBackground: NSColor.labelColor.withAlphaComponent(0.12),
+    divider: NSColor.secondaryLabelColor.withAlphaComponent(0.18),
+    tabEdge: NSColor.secondaryLabelColor.withAlphaComponent(0.13)
+  )
+
+  static func style(isDark: Bool, theme: RuntimeTheme?) -> Style {
+    let background = isDark ? theme?.backgroundDark : theme?.backgroundLight
+    guard let background else { return systemStyle }
+    return style(baseBackground: NSColor(background), isDark: isDark)
+  }
+
+  static func style(baseBackground: NSColor, isDark: Bool) -> Style {
+    let stripMix: CGFloat = isDark ? 0.18 : 0.08
+    let activeMix: CGFloat = isDark ? 0.28 : 0.14
+    let hoverMix: CGFloat = isDark ? 0.08 : 0.06
+    let closeHoverMix: CGFloat = isDark ? 0.14 : 0.10
+    let strokeMix: CGFloat = isDark ? 0.22 : 0.18
+    let strokeColor = isDark ? NSColor.white : NSColor.black
+
+    return Style(
+      stripBackground: mix(baseBackground, with: .black, amount: stripMix),
+      activeBackground: mix(baseBackground, with: .black, amount: activeMix),
+      hoverBackground: mix(baseBackground, with: .white, amount: hoverMix),
+      closeHoverBackground: mix(baseBackground, with: .white, amount: closeHoverMix),
+      divider: mix(baseBackground, with: strokeColor, amount: strokeMix).withAlphaComponent(0.82),
+      tabEdge: mix(baseBackground, with: strokeColor, amount: strokeMix).withAlphaComponent(0.64)
+    )
+  }
+
+  static func hexString(from color: NSColor) -> String {
+    let signature = signature(of: color)
+    let red = signature.red
+    let green = signature.green
+    let blue = signature.blue
+    return String(format: "#%02X%02X%02X", red, green, blue)
+  }
+
+  private static func mix(_ color: NSColor, with other: NSColor, amount: CGFloat) -> NSColor {
+    let base = resolvedSRGBColor(color)
+    let overlay = resolvedSRGBColor(other)
+    let clampedAmount = min(max(amount, 0), 1)
+    let baseAmount = 1 - clampedAmount
+    return NSColor(
+      srgbRed: (base.redComponent * baseAmount) + (overlay.redComponent * clampedAmount),
+      green: (base.greenComponent * baseAmount) + (overlay.greenComponent * clampedAmount),
+      blue: (base.blueComponent * baseAmount) + (overlay.blueComponent * clampedAmount),
+      alpha: base.alphaComponent
+    )
+  }
+
+  private static func resolvedSRGBColor(_ color: NSColor) -> NSColor {
+    color.usingColorSpace(.sRGB) ?? color
+  }
+
+  private static func signature(of color: NSColor) -> (red: Int, green: Int, blue: Int, alpha: Int) {
+    let resolved = resolvedSRGBColor(color)
+    return (
+      red: Int(round(resolved.redComponent * 255)),
+      green: Int(round(resolved.greenComponent * 255)),
+      blue: Int(round(resolved.blueComponent * 255)),
+      alpha: Int(round(resolved.alphaComponent * 255))
+    )
+  }
 }

--- a/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalTabItem.swift
+++ b/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalTabItem.swift
@@ -11,6 +11,7 @@ struct AgentHubGhosttyTerminalTabItem: View {
   let isActive: Bool
   let isFirst: Bool
   let canClose: Bool
+  let chromeStyle: AgentHubGhosttyTerminalTabChrome.Style
   let onSelect: () -> Void
   let onClose: () -> Void
 
@@ -44,7 +45,7 @@ struct AgentHubGhosttyTerminalTabItem: View {
         .foregroundStyle(Color.secondary)
         .background {
           RoundedRectangle(cornerRadius: 3, style: .continuous)
-            .fill(isCloseHovered ? AgentHubGhosttyTerminalTabChrome.closeHoverBackground : Color.clear)
+            .fill(isCloseHovered ? chromeStyle.closeHoverBackgroundColor : Color.clear)
         }
         .opacity(closeButtonOpacity)
         .accessibilityHidden(!showsCloseButton)
@@ -76,13 +77,13 @@ struct AgentHubGhosttyTerminalTabItem: View {
     .overlay(alignment: .leading) {
       if isActive {
         Rectangle()
-          .fill(AgentHubGhosttyTerminalTabChrome.tabEdge)
+          .fill(chromeStyle.tabEdgeColor)
           .frame(width: 1)
       }
     }
     .overlay(alignment: .trailing) {
       Rectangle()
-        .fill(isActive ? AgentHubGhosttyTerminalTabChrome.tabEdge : AgentHubGhosttyTerminalTabChrome.divider)
+        .fill(isActive ? chromeStyle.tabEdgeColor : chromeStyle.dividerColor)
         .frame(width: 1)
     }
     .clipShape(tabShape)
@@ -98,9 +99,9 @@ struct AgentHubGhosttyTerminalTabItem: View {
 
   private var tabBackground: Color {
     if isActive {
-      return AgentHubGhosttyTerminalTabChrome.activeBackground
+      return chromeStyle.activeBackgroundColor
     }
-    return isHovered ? AgentHubGhosttyTerminalTabChrome.hoverBackground : Color.clear
+    return isHovered ? chromeStyle.hoverBackgroundColor : Color.clear
   }
 
   private var closeButtonOpacity: Double {

--- a/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalToolbarButton.swift
+++ b/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalToolbarButton.swift
@@ -11,6 +11,7 @@ struct AgentHubGhosttyTerminalToolbarButton: View {
   let systemImage: String
   let help: String
   let isDisabled: Bool
+  let chromeStyle: AgentHubGhosttyTerminalTabChrome.Style
   let action: () -> Void
 
   @State private var isHovered = false
@@ -20,12 +21,14 @@ struct AgentHubGhosttyTerminalToolbarButton: View {
     systemImage: String,
     help: String,
     isDisabled: Bool = false,
+    chromeStyle: AgentHubGhosttyTerminalTabChrome.Style,
     action: @escaping () -> Void
   ) {
     self.title = title
     self.systemImage = systemImage
     self.help = help
     self.isDisabled = isDisabled
+    self.chromeStyle = chromeStyle
     self.action = action
   }
 
@@ -38,7 +41,7 @@ struct AgentHubGhosttyTerminalToolbarButton: View {
       .frame(width: 28, height: 28)
       .background {
         RoundedRectangle(cornerRadius: 4, style: .continuous)
-          .fill(isHovered && !isDisabled ? AgentHubGhosttyTerminalTabChrome.hoverBackground : Color.clear)
+          .fill(isHovered && !isDisabled ? chromeStyle.hoverBackgroundColor : Color.clear)
       }
       .contentShape(Rectangle())
       .disabled(isDisabled)

--- a/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalWorkspaceView.swift
+++ b/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalWorkspaceView.swift
@@ -24,6 +24,7 @@ struct AgentHubGhosttyTerminalWorkspaceView: View {
   let onToggleMaximizedPanel: (TerminalPanel) -> Void
   let onSplitRatiosChanged: (String, [Double]) -> Void
   let activityForPanel: (TerminalPanelID) -> AgentHubGhosttyTerminalPaneActivity?
+  let chromeStyle: AgentHubGhosttyTerminalTabChrome.Style
 
   var body: some View {
     if session.visiblePanels.isEmpty {
@@ -48,7 +49,8 @@ struct AgentHubGhosttyTerminalWorkspaceView: View {
         onSplitPanel: onSplitPanel,
         onToggleMaximizedPanel: onToggleMaximizedPanel,
         onSplitRatiosChanged: onSplitRatiosChanged,
-        activityForPanel: activityForPanel
+        activityForPanel: activityForPanel,
+        chromeStyle: chromeStyle
       )
     }
   }

--- a/app/modules/Ghostty/Sources/Ghostty/GhosttyLayeredConfigComposer.swift
+++ b/app/modules/Ghostty/Sources/Ghostty/GhosttyLayeredConfigComposer.swift
@@ -90,24 +90,9 @@ public enum GhosttyLayeredConfigComposer {
     environment: [String: String],
     homeDirectoryURL: URL
   ) -> [String] {
-    let xdgBase: URL
-    if let xdgConfigHome = environment["XDG_CONFIG_HOME"], !xdgConfigHome.isEmpty {
-      xdgBase = URL(fileURLWithPath: (xdgConfigHome as NSString).expandingTildeInPath, isDirectory: true)
-    } else {
-      xdgBase = homeDirectoryURL.appendingPathComponent(".config", isDirectory: true)
-    }
-
-    return [
-      xdgBase
-        .appendingPathComponent("ghostty", isDirectory: true)
-        .appendingPathComponent("config", isDirectory: false)
-        .path,
-      homeDirectoryURL
-        .appendingPathComponent("Library", isDirectory: true)
-        .appendingPathComponent("Application Support", isDirectory: true)
-        .appendingPathComponent("com.mitchellh.ghostty", isDirectory: true)
-        .appendingPathComponent("config", isDirectory: false)
-        .path,
-    ]
+    GhosttyConfigLocations.defaultConfigPaths(
+      environment: environment,
+      homeDirectoryURL: homeDirectoryURL
+    )
   }
 }

--- a/app/modules/Ghostty/Tests/GhosttyTests/AgentHubGhosttyTerminalTabChromeTests.swift
+++ b/app/modules/Ghostty/Tests/GhosttyTests/AgentHubGhosttyTerminalTabChromeTests.swift
@@ -1,0 +1,27 @@
+import AppKit
+import Testing
+
+@testable import Ghostty
+
+@Suite("AgentHub Ghostty terminal tab chrome")
+struct AgentHubGhosttyTerminalTabChromeTests {
+
+  @Test("Dark themed chrome derives darker surfaces from the theme background")
+  func darkThemedChromeUsesDarkerBackgrounds() {
+    let style = AgentHubGhosttyTerminalTabChrome.style(
+      baseBackground: NSColor(srgbRed: 30 / 255, green: 30 / 255, blue: 46 / 255, alpha: 1),
+      isDark: true
+    )
+
+    #expect(AgentHubGhosttyTerminalTabChrome.hexString(from: style.stripBackground) == "#191926")
+    #expect(AgentHubGhosttyTerminalTabChrome.hexString(from: style.activeBackground) == "#161621")
+  }
+
+  @Test("No matched theme background keeps the system chrome style")
+  func missingThemeBackgroundUsesSystemStyle() {
+    #expect(
+      AgentHubGhosttyTerminalTabChrome.style(isDark: true, theme: nil)
+        == AgentHubGhosttyTerminalTabChrome.systemStyle
+    )
+  }
+}


### PR DESCRIPTION
## Summary

Stacked on #427. This makes embedded Ghostty terminals visually consume the user-selected Ghostty background in the surrounding AgentHub UI, including the terminal backdrop and the tab/header chrome.

## What changed

- Resolve the effective Ghostty background from the default Ghostty config files plus the Settings custom config path.
- Apply that background to the forced `ghostty.yaml` runtime theme when using the Ghostty backend, with the existing luminance guard for light/dark legibility.
- Derive Ghostty terminal tab/header chrome from the active app backdrop instead of hardcoded AppKit system colors.
- Refresh the derived app backdrop/chrome when the Ghostty config path changes in Settings.
- Pass an immutable chrome style through the Ghostty SwiftUI terminal tree so tabs, pending panes, toolbar hover states, dividers, and active tab surfaces stay in sync.
- Simplify Appearance settings by showing Ghostty-specific config only while Ghostty is selected, and hiding regular terminal controls that Ghostty owns: Theme, Font, Font size, and Open files.

## Impact

Users who point AgentHub at a custom Ghostty config now see the embedded terminal area and secondary tab/header surfaces match that theme. The actual terminal process config can still require a fresh terminal process or relaunch, but the app backdrop/chrome refreshes when the setting changes.

## Validation

- `xcodebuild test -scheme AgentHubCore-Tests -destination platform=macOS -test-timeouts-enabled YES -skipPackagePluginValidation -only-testing:AgentHubTests/ThemeManagerTests`
  - 7 tests passed, 0 failures.
- `xcodebuild test -scheme Ghostty -destination platform=macOS -test-timeouts-enabled YES -skipPackagePluginValidation -only-testing:GhosttyTests/AgentHubGhosttyTerminalTabChromeTests`
  - 2 tests passed, 0 failures.
- `git diff --check`
  - passed.

Manual check: temporarily pointed AgentHub at a Solarized Dark config, changed its background to red, and confirmed AgentHub was reading the custom background path.
