### PR TITLE
Update Ghostty font size live

### DIFF
--- a/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyFontSizeSynchronizer.swift
+++ b/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyFontSizeSynchronizer.swift
@@ -1,0 +1,39 @@
+import AppKit
+import GhosttySwift
+
+@MainActor
+protocol AgentHubGhosttyFontSizeControlling: AnyObject {
+  @discardableResult
+  func performBindingAction(_ action: String) -> Bool
+}
+
+extension GhosttyTerminalController: AgentHubGhosttyFontSizeControlling {}
+
+@MainActor
+final class AgentHubGhosttyFontSizeSynchronizer {
+  private(set) var fontSize: Float?
+  private var appliedFontSizes: [ObjectIdentifier: Float] = [:]
+
+  func sync(
+    fontSize: CGFloat,
+    controllers: [any AgentHubGhosttyFontSizeControlling],
+    forceControllerIDs: Set<ObjectIdentifier> = []
+  ) {
+    let resolvedFontSize = Float(max(fontSize, 8))
+    self.fontSize = resolvedFontSize
+
+    let activeControllerIDs = Set(controllers.map(ObjectIdentifier.init))
+    appliedFontSizes = appliedFontSizes.filter { activeControllerIDs.contains($0.key) }
+
+    for controller in controllers {
+      let controllerID = ObjectIdentifier(controller)
+      guard forceControllerIDs.contains(controllerID)
+        || appliedFontSizes[controllerID] != resolvedFontSize
+      else { continue }
+
+      if controller.performBindingAction("set_font_size:\(resolvedFontSize)") {
+        appliedFontSizes[controllerID] = resolvedFontSize
+      }
+    }
+  }
+}

--- a/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalSurface.swift
+++ b/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalSurface.swift
@@ -44,6 +44,7 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
   private var registeredPIDs: [ObjectIdentifier: pid_t] = [:]
   private var pidRegistrationTasks: [ObjectIdentifier: Task<Void, Never>] = [:]
   private var paneActivityRegistry = AgentHubGhosttyPaneActivityRegistry()
+  private let fontSizeSynchronizer = AgentHubGhosttyFontSizeSynchronizer()
   private var paneActivityTasks: [TerminalPanelID: Task<Void, Never>] = [:]
   private var pendingPaneOpenTasks: [TerminalPanelID: Task<Void, Never>] = [:]
   private var pendingPaneCloseTasks: [TerminalPanelID: Task<Void, Never>] = [:]
@@ -326,12 +327,13 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
     currentIsDark = isDark
     currentTheme = theme
     updateChromeStyle(isDark: isDark, theme: theme)
+    let controllers = allTabs().map(\.controller)
     guard let configurationPath = appearanceOverlayPath(isDark: isDark) else {
       AppLogger.session.error("Unable to locate the bundled Ghostty appearance configuration.")
+      fontSizeSynchronizer.sync(fontSize: fontSize, controllers: controllers)
       return
     }
 
-    let controllers = allTabs().map(\.controller)
     if let runtime = controllers.first?.runtime {
       do {
         _ = try runtime.applyConfigurationOverlay(at: configurationPath)
@@ -343,17 +345,25 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
     }
 
     let colorScheme = AgentHubGhosttyAppearanceConfiguration.colorScheme(isDark: isDark)
+    var updatedControllerIDs: Set<ObjectIdentifier> = []
     for controller in controllers {
       _ = controller.setColorScheme(colorScheme)
       guard controller.configurationOverlayPath != configurationPath else { continue }
       do {
-        _ = try controller.applyConfigurationOverlay(at: configurationPath)
+        if try controller.applyConfigurationOverlay(at: configurationPath) {
+          updatedControllerIDs.insert(ObjectIdentifier(controller))
+        }
       } catch {
         AppLogger.session.error(
           "Failed to update Ghostty surface appearance: \(error.localizedDescription)"
         )
       }
     }
+    fontSizeSynchronizer.sync(
+      fontSize: fontSize,
+      controllers: controllers,
+      forceControllerIDs: updatedControllerIDs
+    )
   }
 
   public func focus() {
@@ -1272,6 +1282,9 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
   }
 
   private func resolvedFontSize() -> Float {
+    if let fontSize = fontSizeSynchronizer.fontSize {
+      return fontSize
+    }
     let fontSize = Float(UserDefaults.standard.double(forKey: AgentHubDefaults.terminalFontSize))
     return fontSize > 0 ? fontSize : 12
   }

--- a/app/modules/Ghostty/Tests/GhosttyTests/AgentHubGhosttyFontSizeSynchronizerTests.swift
+++ b/app/modules/Ghostty/Tests/GhosttyTests/AgentHubGhosttyFontSizeSynchronizerTests.swift
@@ -1,0 +1,100 @@
+import AppKit
+import Testing
+@testable import Ghostty
+
+@MainActor
+@Suite("AgentHub Ghostty font size synchronizer")
+struct AgentHubGhosttyFontSizeSynchronizerTests {
+  @Test("Applies the requested font size to every open controller")
+  func appliesFontSizeToEveryController() {
+    let first = MockFontSizeController()
+    let second = MockFontSizeController()
+    let synchronizer = AgentHubGhosttyFontSizeSynchronizer()
+
+    synchronizer.sync(fontSize: 14, controllers: [first, second])
+
+    #expect(first.actions == ["set_font_size:14.0"])
+    #expect(second.actions == ["set_font_size:14.0"])
+    #expect(synchronizer.fontSize == 14)
+  }
+
+  @Test("Skips unchanged controllers but updates newly opened controllers")
+  func skipsUnchangedControllersAndUpdatesNewControllers() {
+    let existing = MockFontSizeController()
+    let added = MockFontSizeController()
+    let synchronizer = AgentHubGhosttyFontSizeSynchronizer()
+
+    synchronizer.sync(fontSize: 13, controllers: [existing])
+    synchronizer.sync(fontSize: 13, controllers: [existing, added])
+
+    #expect(existing.actions == ["set_font_size:13.0"])
+    #expect(added.actions == ["set_font_size:13.0"])
+  }
+
+  @Test("Reapplies font size after a configuration overlay update")
+  func reappliesFontSizeAfterConfigurationUpdate() {
+    let controller = MockFontSizeController()
+    let synchronizer = AgentHubGhosttyFontSizeSynchronizer()
+
+    synchronizer.sync(fontSize: 15, controllers: [controller])
+    synchronizer.sync(
+      fontSize: 15,
+      controllers: [controller],
+      forceControllerIDs: [ObjectIdentifier(controller)]
+    )
+
+    #expect(controller.actions == [
+      "set_font_size:15.0",
+      "set_font_size:15.0",
+    ])
+  }
+
+  @Test("Retries when Ghostty cannot apply the action yet")
+  func retriesFailedAction() {
+    let controller = MockFontSizeController(results: [false, true])
+    let synchronizer = AgentHubGhosttyFontSizeSynchronizer()
+
+    synchronizer.sync(fontSize: 16, controllers: [controller])
+    synchronizer.sync(fontSize: 16, controllers: [controller])
+
+    #expect(controller.actions == [
+      "set_font_size:16.0",
+      "set_font_size:16.0",
+    ])
+  }
+
+  @Test("Clamps font size to the terminal minimum")
+  func clampsFontSizeToMinimum() {
+    let controller = MockFontSizeController()
+    let synchronizer = AgentHubGhosttyFontSizeSynchronizer()
+
+    synchronizer.sync(fontSize: 4, controllers: [controller])
+
+    #expect(controller.actions == ["set_font_size:8.0"])
+    #expect(synchronizer.fontSize == 8)
+  }
+
+  @Test("Retains the requested size before a native controller mounts")
+  func retainsFontSizeWithoutControllers() {
+    let synchronizer = AgentHubGhosttyFontSizeSynchronizer()
+
+    synchronizer.sync(fontSize: 17, controllers: [])
+
+    #expect(synchronizer.fontSize == 17)
+  }
+}
+
+@MainActor
+private final class MockFontSizeController: AgentHubGhosttyFontSizeControlling {
+  private var results: [Bool]
+  private(set) var actions: [String] = []
+
+  init(results: [Bool] = [true]) {
+    self.results = results
+  }
+
+  func performBindingAction(_ action: String) -> Bool {
+    actions.append(action)
+    return results.isEmpty ? true : results.removeFirst()
+  }
+}


### PR DESCRIPTION
## Summary

- apply AgentHub terminal font-size preference changes to every live Ghostty tab and pane
- avoid redundant native font updates while retrying surfaces that are not mounted yet
- preserve the requested size for new surfaces and reapply it after appearance configuration updates

## Root cause

The SwiftUI `@AppStorage` value changed immediately for Cmd++ and Cmd+-, but `AgentHubGhosttyTerminalSurface.syncAppearance` ignored its `fontSize` argument. Ghostty therefore only picked up the persisted size when surfaces were recreated after an app relaunch.

## Impact

Ghostty terminals now resize immediately without restarting terminal processes or relaunching AgentHub. Existing tabs and split panes stay synchronized.

## Validation

- targeted `GhosttyTests/AgentHubGhosttyFontSizeSynchronizerTests` Xcode run: 6 passed, 0 failed
- `git diff --check`