### PR TITLE
Fix launch beach ball from per-launch window autosave defaults keys

### DIFF
--- a/app/AgentHub/AgentHubApp.swift
+++ b/app/AgentHub/AgentHubApp.swift
@@ -40,6 +40,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
     // session begins monitoring.
     provider.reconcileClaudeHooksOnLaunch()
     provider.cleanupOrphanedProcesses()
+    provider.purgeStaleWindowAutosaveDefaults()
     provider.startWorktreeLaunchRequestMonitoring()
     provider.globalSessionControlPanelCoordinator.start()
   }

--- a/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubEnvironment.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubEnvironment.swift
@@ -39,7 +39,14 @@ extension EnvironmentValues {
 // MARK: - View Modifier
 
 /// View modifier that injects AgentHub provider into the environment
-private struct AgentHubModifier: ViewModifier {
+///
+/// Intentionally not `private`: this modifier is part of the window's root view
+/// type, and SwiftUI derives the `NSWindow Frame` / `NSSplitView Subview Frames`
+/// autosave defaults keys from that type's name. A `private` type's runtime name
+/// embeds an ASLR-dependent `(unknown context at $…)` discriminator, which mints
+/// a new dead defaults key every launch and bloats the app's defaults domain
+/// until CFPrefs work hangs the main thread.
+struct AgentHubModifier: ViewModifier {
   let provider: AgentHubProvider
   let themeManager: ThemeManager
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubProvider.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubProvider.swift
@@ -425,6 +425,19 @@ public final class AgentHubProvider {
     }
   }
 
+  /// Purges window/split-view autosave defaults keys that earlier builds
+  /// minted with per-launch-unique names (see `StaleWindowAutosaveDefaultsCleaner`).
+  /// Call this on app launch; the scan runs off the main thread because its
+  /// cost is proportional to the size of the defaults domain being cleaned.
+  public func purgeStaleWindowAutosaveDefaults() {
+    Task.detached(priority: .utility) {
+      let removed = StaleWindowAutosaveDefaultsCleaner().purgeStaleAutosaveKeys()
+      if removed > 0 {
+        AppLogger.ui.info("Removed \(removed) stale window autosave defaults keys")
+      }
+    }
+  }
+
   public func shutdownMCPAppDiscoveryService() {
     let service = mcpAppDiscoveryService
     let semaphore = DispatchSemaphore(value: 0)

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/StaleWindowAutosaveDefaultsCleaner.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/StaleWindowAutosaveDefaultsCleaner.swift
@@ -1,0 +1,75 @@
+//
+//  StaleWindowAutosaveDefaultsCleaner.swift
+//  AgentHub
+//
+//  Purges dead window/split-view autosave keys from UserDefaults.
+//
+
+import Foundation
+
+// MARK: - StaleWindowAutosaveDefaultsCleanerProtocol
+
+/// Removes window/split-view autosave defaults keys that older builds minted
+/// with per-launch-unique names.
+///
+/// SwiftUI derives the `NSWindow Frame …` and `NSSplitView Subview Frames …`
+/// autosave keys from the window's root view type name. While
+/// `AgentHubModifier` was `private`, its runtime type name embedded an
+/// ASLR-dependent `(unknown context at $…)` discriminator, so every launch
+/// wrote a fresh key that no later launch could ever read. Thousands of dead
+/// keys make CFPrefs dictionary merges and KVO delivery O(domain size), which
+/// hangs the main thread whenever AppKit persists the window frame.
+public protocol StaleWindowAutosaveDefaultsCleanerProtocol: Sendable {
+  /// Deletes stale autosave keys and returns how many were removed.
+  @discardableResult
+  func purgeStaleAutosaveKeys() -> Int
+}
+
+// MARK: - StaleWindowAutosaveDefaultsCleaner
+
+public struct StaleWindowAutosaveDefaultsCleaner: StaleWindowAutosaveDefaultsCleanerProtocol {
+
+  private let defaults: UserDefaults
+  private let domainName: String?
+
+  public init(defaults: UserDefaults = .standard, domainName: String? = Bundle.main.bundleIdentifier) {
+    self.defaults = defaults
+    self.domainName = domainName
+  }
+
+  @discardableResult
+  public func purgeStaleAutosaveKeys() -> Int {
+    // Per-key removeObject(forKey:) is one cfprefsd round trip per key against
+    // a domain whose per-operation cost grows with its size — O(N²) across a
+    // multi-thousand-key backlog. CFPreferencesSetMultiple removes the whole
+    // batch in a single call without replacing the domain, so concurrent
+    // writes to other keys are never clobbered.
+    if let domainName, let domain = defaults.persistentDomain(forName: domainName) {
+      let staleKeys = domain.keys.filter(Self.isStaleAutosaveKey)
+      guard !staleKeys.isEmpty else { return 0 }
+      CFPreferencesSetMultiple(
+        nil,
+        staleKeys as CFArray,
+        domainName as CFString,
+        kCFPreferencesCurrentUser,
+        kCFPreferencesAnyHost
+      )
+      CFPreferencesAppSynchronize(domainName as CFString)
+      return staleKeys.count
+    }
+    let staleKeys = defaults.dictionaryRepresentation().keys.filter(Self.isStaleAutosaveKey)
+    for key in staleKeys {
+      defaults.removeObject(forKey: key)
+    }
+    return staleKeys.count
+  }
+
+  /// A key is stale only when it is a window/split-view autosave entry whose
+  /// embedded view type name contains a private-context discriminator — such
+  /// keys are unreadable on any later launch by construction, so removing
+  /// them can never lose state a future launch could use.
+  static func isStaleAutosaveKey(_ key: String) -> Bool {
+    (key.hasPrefix("NSWindow Frame ") || key.hasPrefix("NSSplitView Subview Frames "))
+      && key.contains("(unknown context at $")
+  }
+}

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/EmbeddedTerminalLaunchBuilderTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/EmbeddedTerminalLaunchBuilderTests.swift
@@ -9,9 +9,9 @@ struct EmbeddedTerminalLaunchBuilderAgentHubCLITests {
 
   @Test("CLI environment variables are empty by default")
   func cliEnvironmentVariablesAreEmptyByDefault() {
-    let suiteName = "AgentHubTests.CLIEnvironment.\(UUID().uuidString)"
-    let defaults = UserDefaults(suiteName: suiteName)!
-    defer { defaults.removePersistentDomain(forName: suiteName) }
+    let suite = EphemeralDefaultsSuite(prefix: "AgentHubTests.CLIEnvironment")
+    defer { suite.cleanUp() }
+    let defaults = suite.defaults
 
     #expect(CLIEnvironmentOverrides.variables(defaults: defaults).isEmpty)
     #expect(CLIEnvironmentOverrides.environment(from: CLIEnvironmentOverrides.variables(defaults: defaults)).isEmpty)
@@ -33,9 +33,9 @@ struct EmbeddedTerminalLaunchBuilderAgentHubCLITests {
 
   @Test("CLI environment variable values persist through UserDefaults")
   func cliEnvironmentVariablesPersistThroughUserDefaults() {
-    let suiteName = "AgentHubTests.CLIEnvironment.\(UUID().uuidString)"
-    let defaults = UserDefaults(suiteName: suiteName)!
-    defer { defaults.removePersistentDomain(forName: suiteName) }
+    let suite = EphemeralDefaultsSuite(prefix: "AgentHubTests.CLIEnvironment")
+    defer { suite.cleanUp() }
+    let defaults = suite.defaults
 
     let variables = [
       CLIEnvironmentVariable(id: UUID(), name: "ONE", value: "1"),

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/EphemeralDefaultsSuite.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/EphemeralDefaultsSuite.swift
@@ -1,0 +1,55 @@
+//
+//  EphemeralDefaultsSuite.swift
+//  AgentHubTests
+//
+//  Ephemeral UserDefaults suite for tests.
+//
+
+import Foundation
+
+/// Ephemeral UserDefaults suite for tests. Call `cleanUp()` (in a `defer`) so
+/// the suite leaves nothing behind under ~/Library/Preferences — neither its
+/// keys nor the empty plist cfprefsd materializes for a touched domain.
+struct EphemeralDefaultsSuite {
+  let defaults: UserDefaults
+  let suiteName: String
+  private let prefix: String
+
+  init(prefix: String = "com.agenthub.tests.suite") {
+    self.prefix = prefix
+    // The UUID guarantees a fresh domain, so nothing pre-existing needs to
+    // be cleared here — and not touching the domain up front keeps cfprefsd
+    // from materializing a plist for suites that only ever read.
+    suiteName = "\(prefix).\(UUID().uuidString)"
+    defaults = UserDefaults(suiteName: suiteName)!
+  }
+
+  func cleanUp() {
+    defaults.removePersistentDomain(forName: suiteName)
+    EphemeralDefaultsSuite.sweepResidue(prefix: prefix, ownSuiteName: suiteName)
+  }
+
+  /// cfprefsd flushes an empty plist for every touched domain when the test
+  /// process exits — after any in-test code has run — so a suite usually
+  /// cannot delete its own file. Instead each cleanUp removes what it can and
+  /// sweeps residue that earlier test runs left for the same prefix; the age
+  /// gate keeps files belonging to concurrently running suites safe.
+  private static func sweepResidue(prefix: String, ownSuiteName: String) {
+    let fileManager = FileManager.default
+    let preferences = fileManager.homeDirectoryForCurrentUser
+      .appendingPathComponent("Library/Preferences", isDirectory: true)
+    try? fileManager.removeItem(at: preferences.appendingPathComponent("\(ownSuiteName).plist"))
+    let staleCutoff = Date(timeIntervalSinceNow: -600)
+    let files = (try? fileManager.contentsOfDirectory(
+      at: preferences,
+      includingPropertiesForKeys: [.contentModificationDateKey]
+    )) ?? []
+    for file in files where file.lastPathComponent.hasPrefix("\(prefix).") {
+      let modified = (try? file.resourceValues(forKeys: [.contentModificationDateKey]))?
+        .contentModificationDate ?? .distantFuture
+      if modified < staleCutoff {
+        try? fileManager.removeItem(at: file)
+      }
+    }
+  }
+}

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/GhosttyUserThemeScannerTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/GhosttyUserThemeScannerTests.swift
@@ -131,7 +131,7 @@ struct GhosttyUserThemeScannerTests {
 private struct ScannerEnvironment {
   let home: URL
   let defaults: UserDefaults
-  private let suiteName: String
+  private let suite: EphemeralDefaultsSuite
   private let bundledThemesURL: URL
 
   init() throws {
@@ -139,13 +139,12 @@ private struct ScannerEnvironment {
       .appendingPathComponent("ghostty-scanner-\(UUID().uuidString)", isDirectory: true)
     bundledThemesURL = home.appendingPathComponent("bundled-themes", isDirectory: true)
     try FileManager.default.createDirectory(at: bundledThemesURL, withIntermediateDirectories: true)
-    suiteName = "com.agenthub.tests.ghostty-scanner.\(UUID().uuidString)"
-    defaults = UserDefaults(suiteName: suiteName)!
-    defaults.removePersistentDomain(forName: suiteName)
+    suite = EphemeralDefaultsSuite(prefix: "com.agenthub.tests.ghostty-scanner")
+    defaults = suite.defaults
   }
 
   func cleanUp() {
-    defaults.removePersistentDomain(forName: suiteName)
+    suite.cleanUp()
     try? FileManager.default.removeItem(at: home)
   }
 

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/StaleWindowAutosaveDefaultsCleanerTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/StaleWindowAutosaveDefaultsCleanerTests.swift
@@ -1,0 +1,81 @@
+//
+//  StaleWindowAutosaveDefaultsCleanerTests.swift
+//  AgentHubTests
+//
+
+import Foundation
+import Testing
+@testable import AgentHubCore
+
+@Suite("StaleWindowAutosaveDefaultsCleaner")
+struct StaleWindowAutosaveDefaultsCleanerTests {
+
+  private static let staleWindowFrameKey =
+    "NSWindow Frame SwiftUI.ModifiedContent<AgentHubCore.AgentHubSessionsView, "
+    + "AgentHubCore.(unknown context at $10154d75c).AgentHubModifier>-1-AppWindow-1"
+
+  private static let staleSplitViewKey =
+    "NSSplitView Subview Frames SwiftUI.ModifiedContent<AgentHubCore.AgentHubSessionsView, "
+    + "AgentHubCore.(unknown context at $100b5575c).AgentHubModifier>-1-AppWindow-1, SidebarNavigationSplitView"
+
+  private static let stableWindowFrameKey =
+    "NSWindow Frame SwiftUI.ModifiedContent<AgentHubCore.AgentHubSessionsView, "
+    + "AgentHubCore.AgentHubModifier>-1-AppWindow-1"
+
+  @Test("removes per-launch autosave keys and reports the count")
+  func removesStaleAutosaveKeys() {
+    let suite = EphemeralDefaultsSuite(prefix: "com.agenthub.tests.autosave-cleaner")
+    defer { suite.cleanUp() }
+    suite.defaults.set("10 10 100 100", forKey: Self.staleWindowFrameKey)
+    suite.defaults.set(["260.0", "1180.0"], forKey: Self.staleSplitViewKey)
+
+    let removed = StaleWindowAutosaveDefaultsCleaner(defaults: suite.defaults, domainName: suite.suiteName).purgeStaleAutosaveKeys()
+
+    #expect(removed == 2)
+    #expect(suite.defaults.object(forKey: Self.staleWindowFrameKey) == nil)
+    #expect(suite.defaults.object(forKey: Self.staleSplitViewKey) == nil)
+  }
+
+  @Test("preserves stable autosave keys and unrelated keys")
+  func preservesLiveKeys() {
+    let suite = EphemeralDefaultsSuite(prefix: "com.agenthub.tests.autosave-cleaner")
+    defer { suite.cleanUp() }
+    suite.defaults.set("10 10 100 100", forKey: Self.stableWindowFrameKey)
+    suite.defaults.set(true, forKey: "com.agenthub.hub.someSetting")
+    // Unrelated key that merely mentions a private context must survive:
+    // only window/split-view autosave entries are ever dead by construction.
+    suite.defaults.set("x", forKey: "com.agenthub.debug.(unknown context at $1234).note")
+
+    let removed = StaleWindowAutosaveDefaultsCleaner(defaults: suite.defaults, domainName: suite.suiteName).purgeStaleAutosaveKeys()
+
+    #expect(removed == 0)
+    #expect(suite.defaults.string(forKey: Self.stableWindowFrameKey) == "10 10 100 100")
+    #expect(suite.defaults.bool(forKey: "com.agenthub.hub.someSetting"))
+    #expect(suite.defaults.string(forKey: "com.agenthub.debug.(unknown context at $1234).note") == "x")
+  }
+
+  @Test("falls back to per-key removal when no domain name is available")
+  func fallbackPathRemovesStaleKeys() {
+    let suite = EphemeralDefaultsSuite(prefix: "com.agenthub.tests.autosave-cleaner")
+    defer { suite.cleanUp() }
+    suite.defaults.set("10 10 100 100", forKey: Self.staleWindowFrameKey)
+    suite.defaults.set(true, forKey: "com.agenthub.hub.someSetting")
+
+    let removed = StaleWindowAutosaveDefaultsCleaner(defaults: suite.defaults, domainName: nil).purgeStaleAutosaveKeys()
+
+    #expect(removed == 1)
+    #expect(suite.defaults.object(forKey: Self.staleWindowFrameKey) == nil)
+    #expect(suite.defaults.bool(forKey: "com.agenthub.hub.someSetting"))
+  }
+
+  @Test("second purge is a no-op")
+  func secondPurgeRemovesNothing() {
+    let suite = EphemeralDefaultsSuite(prefix: "com.agenthub.tests.autosave-cleaner")
+    defer { suite.cleanUp() }
+    suite.defaults.set("10 10 100 100", forKey: Self.staleWindowFrameKey)
+
+    let cleaner = StaleWindowAutosaveDefaultsCleaner(defaults: suite.defaults, domainName: suite.suiteName)
+    #expect(cleaner.purgeStaleAutosaveKeys() == 1)
+    #expect(cleaner.purgeStaleAutosaveKeys() == 0)
+  }
+}

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/WorktreeBranchNamingServiceTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/WorktreeBranchNamingServiceTests.swift
@@ -8,6 +8,12 @@ import ClaudeCodeClient
 @Suite("ClaudeWorktreeBranchNamingService")
 struct WorktreeBranchNamingServiceTests {
 
+  private let defaultsPool = DefaultsSuitePool()
+
+  private func makeDefaults(prefix: String = "") -> UserDefaults {
+    defaultsPool.makeDefaults(prefix: prefix)
+  }
+
   @Test("AI result is sanitized, prefixed, and suffixed")
   func aiResultUsesSanitizedStem() async throws {
     let defaults = makeDefaults(prefix: "feature/")
@@ -313,6 +319,12 @@ struct WorktreeBranchNamingServiceTests {
 @Suite("WorktreeBranchNamingSettings")
 struct WorktreeBranchNamingSettingsTests {
 
+  private let defaultsPool = DefaultsSuitePool()
+
+  private func makeDefaults(prefix: String = "") -> UserDefaults {
+    defaultsPool.makeDefaults(prefix: prefix)
+  }
+
   @Test("Default prefix is empty")
   func defaultPrefixIsEmpty() {
     let defaults = makeDefaults()
@@ -382,13 +394,28 @@ private func makeSequencedService(
   )
 }
 
-private func makeDefaults(prefix: String = "") -> UserDefaults {
-  let suiteName = "com.agenthub.tests.worktree-branch-\(UUID().uuidString)"
-  let defaults = UserDefaults(suiteName: suiteName)!
-  defaults.removePersistentDomain(forName: suiteName)
-  defaults.set(prefix, forKey: AgentHubDefaults.worktreeBranchPrefix)
-  defaults.set("claude", forKey: AgentHubDefaults.claudeCommand)
-  return defaults
+/// Hands out ephemeral defaults suites and cleans all of them up when the
+/// per-test suite instance holding the pool is released, so test runs stop
+/// accumulating plists under ~/Library/Preferences.
+private final class DefaultsSuitePool {
+  private var suites: [EphemeralDefaultsSuite] = []
+  private let lock = NSLock()
+
+  func makeDefaults(prefix: String = "") -> UserDefaults {
+    let suite = EphemeralDefaultsSuite(prefix: "com.agenthub.tests.worktree-branch")
+    suite.defaults.set(prefix, forKey: AgentHubDefaults.worktreeBranchPrefix)
+    suite.defaults.set("claude", forKey: AgentHubDefaults.claudeCommand)
+    lock.lock()
+    suites.append(suite)
+    lock.unlock()
+    return suite.defaults
+  }
+
+  deinit {
+    for suite in suites {
+      suite.cleanUp()
+    }
+  }
 }
 
 private func chunkPublisher(_ chunks: [StreamJSONChunk]) -> AnyPublisher<StreamJSONChunk, Error> {

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/XcodeBuildMCPPreflightTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/XcodeBuildMCPPreflightTests.swift
@@ -76,9 +76,9 @@ struct XcodeBuildMCPPreflightTests {
 
   @Test("Bootstrap setting defaults to enabled and honors an explicit opt-out")
   func settingDefaultsToEnabledAndHonorsOptOut() throws {
-    let suiteName = "AgentHubTests.XcodeBuildMCPPreflight.\(UUID().uuidString)"
-    let defaults = try #require(UserDefaults(suiteName: suiteName))
-    defer { defaults.removePersistentDomain(forName: suiteName) }
+    let suite = EphemeralDefaultsSuite(prefix: "AgentHubTests.XcodeBuildMCPPreflight")
+    defer { suite.cleanUp() }
+    let defaults = suite.defaults
 
     #expect(XcodeBuildMCPPreflight.isEnabled(defaults: defaults))
 

--- a/app/modules/Ghostty/Tests/GhosttyTests/GhosttyTestDefaults.swift
+++ b/app/modules/Ghostty/Tests/GhosttyTests/GhosttyTestDefaults.swift
@@ -6,13 +6,38 @@ struct GhosttyTestDefaults {
   let defaults: UserDefaults
   let suiteName: String
 
+  private static let suitePrefix = "com.agenthub.tests.ghostty-config"
+
   init() {
-    suiteName = "com.agenthub.tests.ghostty-config.\(UUID().uuidString)"
+    // The UUID guarantees a fresh domain, so nothing pre-existing needs to
+    // be cleared here — and not touching the domain up front keeps cfprefsd
+    // from materializing a plist for suites that only ever read.
+    suiteName = "\(Self.suitePrefix).\(UUID().uuidString)"
     defaults = UserDefaults(suiteName: suiteName)!
-    defaults.removePersistentDomain(forName: suiteName)
   }
 
   func cleanUp() {
     defaults.removePersistentDomain(forName: suiteName)
+    // cfprefsd flushes an empty plist for every touched domain when the test
+    // process exits — after any in-test code has run — so a suite usually
+    // cannot delete its own file. Instead each cleanUp removes what it can
+    // and sweeps residue that earlier test runs left for the same prefix;
+    // the age gate keeps files belonging to concurrently running suites safe.
+    let fileManager = FileManager.default
+    let preferences = fileManager.homeDirectoryForCurrentUser
+      .appendingPathComponent("Library/Preferences", isDirectory: true)
+    try? fileManager.removeItem(at: preferences.appendingPathComponent("\(suiteName).plist"))
+    let staleCutoff = Date(timeIntervalSinceNow: -600)
+    let files = (try? fileManager.contentsOfDirectory(
+      at: preferences,
+      includingPropertiesForKeys: [.contentModificationDateKey]
+    )) ?? []
+    for file in files where file.lastPathComponent.hasPrefix("\(Self.suitePrefix).") {
+      let modified = (try? file.resourceValues(forKeys: [.contentModificationDateKey]))?
+        .contentModificationDate ?? .distantFuture
+      if modified < staleCutoff {
+        try? fileManager.removeItem(at: file)
+      }
+    }
   }
 }


### PR DESCRIPTION
## Problem

Launching AgentHub beach-balled with a ~772 ms main-thread hang (verified with Instruments). Time Profiler showed 85% of the hang inside `NSUserDefaults objectForKey:` under AppKit's window-frame persist, with the leaf work being CFPrefs dictionary merges/rehashes and KVO delivery.

**Root cause:** `AgentHubModifier` was `private`, so its runtime type name embeds an ASLR-dependent `(unknown context at $…)` discriminator. SwiftUI derives the `NSWindow Frame` / `NSSplitView Subview Frames` autosave defaults keys from the window's root view type name — so every launch minted a brand-new key no later launch could read. The defaults domain had accumulated **5,092 dead keys (1.2 MB)**, making every CFPrefs operation O(domain size) on the main thread. Side effect: window frames never restored across launches.

## Fix

- **`AgentHubModifier` is now internal** — stable type name → one stable autosave key. Window frame restore works for the first time as a bonus.
- **`StaleWindowAutosaveDefaultsCleaner`** (protocol + injectable impl) runs at launch off-main via `AgentHubProvider.purgeStaleWindowAutosaveDefaults()`. It only deletes window/split-view autosave keys containing `(unknown context at $` — unreadable dead weight by construction — and batch-removes them in **one atomic `CFPreferencesSetMultiple` call** (per-key `removeObject` measured ~70 keys/sec through cfprefsd, i.e. O(N²) across the backlog; the batch call also can't clobber concurrent writes to other keys). Existing installs self-heal on first launch after updating.
- **Test-suite plist leaks fixed:** tests using ephemeral `UserDefaults` suites left hundreds of plists in `~/Library/Preferences` — `WorktreeBranchNamingServiceTests` leaked real data (no teardown), and the rest left 42-byte empty files because cfprefsd flushes a touched domain *at process exit*, after any in-test cleanup can run. New shared `EphemeralDefaultsSuite` helper (and the patched `GhosttyTestDefaults`) sweeps same-prefix residue older than 10 minutes on every cleanUp; the age gate keeps concurrently running suites safe.

## Verification

A/B Instruments attach profiles at launch (same recording setup):

| | Before | After |
|---|---|---|
| Main-thread hang | 772 ms | none detected |
| Defaults plist | 5,215 keys / 1.2 MB | 124 keys / 9.7 KB |

- Targeted suites for all touched code: cleaner (4), worktree-branch naming (2 suites), embedded-terminal launch builder, XcodeBuildMCP preflight, Ghostty theme scanner — 48 tests passed; GhosttyTests 58 passed.
- Full gate: `./scripts/test.sh packages` green; `./scripts/test.sh core` 993/1,015 passed with 5 failures in unrelated timing-sensitive suites (diff availability throttle, workspace session attach, side-panel notification) that all pass when re-run in isolation — load-induced flakes while 3 app instances were running, not regressions.
- Test runs now leave zero plist residue in `~/Library/Preferences` (verified before/after).

🤖 Generated with [Claude Code](https://claude.com/claude-code)