### PR TITLE
Bump GhosttySwift to 1.0.10 (ReleaseFast GhosttyKit)

### DIFF
--- a/app/AgentHub.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/app/AgentHub.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -69,8 +69,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/jamesrochabrun/GhosttySwift",
       "state" : {
-        "revision" : "98c553a64e518f32ab311278d5471ed9439f86bc",
-        "version" : "1.0.8"
+        "revision" : "50e0ce720b43c21cad229e8787a6dd914944a605",
+        "version" : "1.0.10"
       }
     },
     {

--- a/app/modules/Ghostty/Package.resolved
+++ b/app/modules/Ghostty/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "f0fdce706ad9849e6905d783e25f9e33e462d0fe1d3086536c16423afe7fe9b9",
+  "originHash" : "82627f6050b7e6b3d4a3960da3abd600295b738ea8bad219444c6eab41b08620",
   "pins" : [
     {
       "identity" : "beautiful-mermaid-swift",
@@ -69,8 +69,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/jamesrochabrun/GhosttySwift",
       "state" : {
-        "revision" : "98c553a64e518f32ab311278d5471ed9439f86bc",
-        "version" : "1.0.8"
+        "revision" : "50e0ce720b43c21cad229e8787a6dd914944a605",
+        "version" : "1.0.10"
       }
     },
     {

--- a/app/modules/Ghostty/Package.swift
+++ b/app/modules/Ghostty/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
   ],
   dependencies: [
     .package(path: "../AgentHubCore"),
-    .package(url: "https://github.com/jamesrochabrun/GhosttySwift", exact: "1.0.8"),
+    .package(url: "https://github.com/jamesrochabrun/GhosttySwift", exact: "1.0.10"),
   ],
   targets: [
     .target(


### PR DESCRIPTION
## Summary
- Fixes app-wide beach balls when 2+ embedded Ghostty panes have busy output (SwiftTerm backend unaffected).
- Root cause: the GhosttyKit.xcframework shipped in GhosttySwift 1.0.7/1.0.8 was a **zig Debug build** (`Thread.Mutex.DebugImpl` in hang stacks, safety-panic strings in the archive, 384 MB macOS slice). Debug-mode IO/renderer threads held each surface's `renderer_state` mutex for tens of milliseconds, starving main-thread input callbacks (`ghostty_surface_mouse_scroll` etc.) — pure contention, matching the busy-CPU/0-FPS profile.
- [GhosttySwift 1.0.10](https://github.com/jamesrochabrun/GhosttySwift/releases/tag/1.0.10) is the first artifact actually built with `-Doptimize=ReleaseFast`, verified at build time via `ghostty_info().build_mode == GHOSTTY_BUILD_MODE_RELEASE_FAST` (macOS slice: 384 → 270 MB, no `DebugImpl` symbols). It also completes clipboard reads asynchronously (`ghostty_surface_complete_clipboard_request`) instead of a synchronous main-thread hop, removing a latent deadlock.
- **1.0.9 is a dead release** (tagged before the rebuild existed: no asset, stale 1.0.8 binary URL) — superseded by 1.0.10, do not pin it.
- GhosttySwift's `build-ghostty.sh` gained a probe + `xcrun` shim working around zig 0.15.2 being unable to link native binaries against the macOS 26.x SDK (the reason the 1.0.9 release ended up empty).

## Test plan
- [x] `GhosttyTests` via `xcodebuild test -scheme Ghostty` from the package dir: **58 tests in 10 suites passed**, linking the new ReleaseFast artifact.
- [ ] Manual: two Ghostty panes streaming heavy output simultaneously; scroll and type — no main-thread hangs > 100 ms in an Instruments hang trace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)