### PR TITLE
Stop session-list renders from tracking full monitor state

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubEnvironment.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubEnvironment.swift
@@ -13,6 +13,10 @@ private struct AgentHubProviderKey: EnvironmentKey {
   static let defaultValue: AgentHubProvider? = nil
 }
 
+private struct AppVisibilityKey: EnvironmentKey {
+  static let defaultValue: AppVisibilityMonitor? = nil
+}
+
 extension EnvironmentValues {
   /// Access to the AgentHub provider from the environment
   ///
@@ -34,6 +38,13 @@ extension EnvironmentValues {
     get { self[AgentHubProviderKey.self] }
     set { self[AgentHubProviderKey.self] = newValue }
   }
+
+  /// App-level occlusion state. `nil` outside an `agentHub(_:)` hierarchy
+  /// (previews, isolated tests), which callers treat as "visible".
+  public var appVisibility: AppVisibilityMonitor? {
+    get { self[AppVisibilityKey.self] }
+    set { self[AppVisibilityKey.self] = newValue }
+  }
 }
 
 // MARK: - View Modifier
@@ -49,10 +60,12 @@ extension EnvironmentValues {
 struct AgentHubModifier: ViewModifier {
   let provider: AgentHubProvider
   let themeManager: ThemeManager
+  let appVisibilityMonitor: AppVisibilityMonitor
 
   init(provider: AgentHubProvider) {
     self.provider = provider
     self.themeManager = provider.themeManager
+    self.appVisibilityMonitor = provider.appVisibilityMonitor
   }
 
   func body(content: Content) -> some View {
@@ -63,6 +76,7 @@ struct AgentHubModifier: ViewModifier {
       .environment(provider.worktreeGenerationProgressCoordinator)
       .environment(themeManager)
       .environment(\.runtimeTheme, themeManager.currentTheme)
+      .environment(\.appVisibility, appVisibilityMonitor)
   }
 }
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubProvider.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubProvider.swift
@@ -63,6 +63,10 @@ public final class AgentHubProvider {
   /// Git worktree service for branch/worktree operations
   public private(set) lazy var gitService: GitWorktreeService = .init()
 
+  /// App-level occlusion state; views use it to stop repeating animations when
+  /// no window is on screen.
+  public private(set) lazy var appVisibilityMonitor: AppVisibilityMonitor = .init()
+
   /// Global stats service for Claude usage metrics
   public private(set) lazy var statsService: GlobalStatsService = .init(claudePath: configuration.claudeDataPath)
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/CollapsibleSelectedSessionsPanel.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/CollapsibleSelectedSessionsPanel.swift
@@ -268,8 +268,10 @@ public struct CollapsibleSelectedSessionsPanel: View {
     }
   }
 
+  /// Memoized — see `GitHubPullRequestURLReferenceCache`.
+  @MainActor
   private static func pullRequestReferences(in links: [ResourceLink]) -> [GitHubPullRequestURLReference] {
-    links.compactMap { GitHubPullRequestURLReference(urlString: $0.url) }
+    GitHubPullRequestURLReferenceCache.references(in: links.map(\.url))
   }
 
   private func ensurePrimarySelection() {
@@ -494,7 +496,9 @@ public struct SingleProviderCollapsibleSelectedSessionsPanel: View {
     primarySessionId = items.first?.id
   }
 
+  /// Memoized — see `GitHubPullRequestURLReferenceCache`.
+  @MainActor
   private static func pullRequestReferences(in links: [ResourceLink]) -> [GitHubPullRequestURLReference] {
-    links.compactMap { GitHubPullRequestURLReference(urlString: $0.url) }
+    GitHubPullRequestURLReferenceCache.references(in: links.map(\.url))
   }
 }

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/CollapsibleSessionRow.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/CollapsibleSessionRow.swift
@@ -28,6 +28,7 @@ struct CollapsibleSessionRow: View {
   @State private var isPulseAnimating = false
   @State private var sessionGitHubQuickAccessViewModel = SessionGitHubQuickAccessViewModel()
   @Environment(\.agentHub) private var agentHub
+  @Environment(\.appVisibility) private var appVisibility
 
   // MARK: - Computed
 
@@ -54,7 +55,16 @@ struct CollapsibleSessionRow: View {
     }
   }
 
-  private var shouldPulse: Bool { isActiveStatus }
+  /// A `repeatForever` animation keeps the SwiftUI display link — and the
+  /// per-frame CoreAnimation commit — alive for as long as it runs, so it stops
+  /// while the app is occluded. There is always at least one active session in
+  /// a working hub, which is exactly when this would otherwise never idle.
+  private var shouldPulse: Bool {
+    StatusPulsePolicy.shouldPulse(
+      isActiveStatus: isActiveStatus,
+      isAppVisible: appVisibility?.isVisible ?? true
+    )
+  }
 
   private func statusDisplayText(_ status: SessionStatus) -> String {
     switch status {
@@ -196,6 +206,7 @@ struct CollapsibleSessionRow: View {
     .onAppear { startPulseAnimation() }
     .onChange(of: sessionStatus) { _, _ in startPulseAnimation() }
     .onChange(of: isPending) { _, _ in startPulseAnimation() }
+    .onChange(of: appVisibility?.isVisible ?? true) { _, _ in startPulseAnimation() }
     .task(id: gitHubObservationTaskID) {
       await observeGitHubIfAvailable()
     }

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringCardView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringCardView.swift
@@ -220,8 +220,9 @@ public struct MonitoringCardView: View {
     mcpAppResourceCount == 1 ? "Open 1 MCP app" : "Open \(mcpAppResourceCount) MCP apps"
   }
 
+  /// Memoized: read from `body`, so it re-parsed every detected link on each render.
   private var linkedPullRequests: [GitHubPullRequestURLReference] {
-    resourceLinks.compactMap { GitHubPullRequestURLReference(urlString: $0.url) }
+    GitHubPullRequestURLReferenceCache.references(in: resourceLinks.map(\.url))
   }
 
   private var localDiffSummary: LocalDiffSummary? {

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
@@ -252,19 +252,21 @@ public struct MultiProviderSessionsListView: View {
     .onChange(of: claudeViewModel.lastCreatedPendingId) { _, newId in
       guard let newId else { return }
       selectedWorkspaceID = nil
-      primarySessionId = "pending-claude-\(newId.uuidString)"
+      primarySessionId = Self.pendingItemID(.claude, newId)
       claudeViewModel.lastCreatedPendingId = nil
     }
     .onChange(of: codexViewModel.lastCreatedPendingId) { _, newId in
       guard let newId else { return }
       selectedWorkspaceID = nil
-      primarySessionId = "pending-codex-\(newId.uuidString)"
+      primarySessionId = Self.pendingItemID(.codex, newId)
       codexViewModel.lastCreatedPendingId = nil
     }
-    .onChange(of: selectedSessionItems.map(\.id)) { _, _ in
-      syncModuleLandingSelection()
-      ensurePrimarySelection()
-      if selectedSessionItems.isEmpty {
+    .onChange(of: selectedSessionItemIDs) { _, _ in
+      // Build once and share: each of these used to re-derive the full list.
+      let items = selectedSessionItems
+      syncModuleLandingSelection(items: items)
+      ensurePrimarySelection(items: items)
+      if items.isEmpty {
         setAuxiliaryShellVisible(false)
       }
       scheduleInitialGitHubStateRefreshIfNeeded()
@@ -590,7 +592,7 @@ public struct MultiProviderSessionsListView: View {
       inlineSelectedSessions
     }
     .animation(.easeInOut(duration: 0.2), value: isSearchExpanded)
-    .animation(.easeInOut(duration: 0.22), value: selectedSessionItems.count)
+    .animation(.easeInOut(duration: 0.22), value: selectedSessionItemIDs.count)
     .onChange(of: currentViewModel.hasPerformedSearch) { oldValue, newValue in
       if oldValue && !newValue && isSearchExpanded {
         withAnimation(.easeInOut(duration: 0.25)) {
@@ -852,12 +854,47 @@ public struct MultiProviderSessionsListView: View {
     let linkedPullRequests: [GitHubPullRequestURLReference]
   }
 
+  /// Identity of a sidebar row. Shared by the full build and the cheap token
+  /// below so the two can never disagree about what a row is called.
+  private static func pendingItemID(_ providerKind: SessionProviderKind, _ pendingID: UUID) -> String {
+    "pending-\(providerKind.rawValue.lowercased())-\(pendingID.uuidString)"
+  }
+
+  private static func monitoredItemID(_ providerKind: SessionProviderKind, _ sessionID: String) -> String {
+    "\(providerKind.rawValue.lowercased())-\(sessionID)"
+  }
+
+  /// The ordered ids of `selectedSessionItems`, derived without building the
+  /// items. `.onChange`/`.animation` re-evaluate their `value:` on every render
+  /// pass, and the full build allocates a struct per session and re-derives
+  /// every session's PR links — measured at 3–4 rebuilds per state publish.
+  /// Ordering and identity match the full build exactly, so the modifiers below
+  /// keep their existing semantics.
+  private var selectedSessionItemIDs: [String] {
+    var entries: [(id: String, timestamp: Date)] = []
+
+    for pending in claudeViewModel.pendingHubSessions {
+      entries.append((Self.pendingItemID(.claude, pending.id), pending.startedAt))
+    }
+    for pending in codexViewModel.pendingHubSessions {
+      entries.append((Self.pendingItemID(.codex, pending.id), pending.startedAt))
+    }
+    for session in claudeViewModel.monitoredCLISessions {
+      entries.append((Self.monitoredItemID(.claude, session.id), session.lastActivityAt))
+    }
+    for session in codexViewModel.monitoredCLISessions {
+      entries.append((Self.monitoredItemID(.codex, session.id), session.lastActivityAt))
+    }
+
+    return entries.sorted { $0.timestamp > $1.timestamp }.map(\.id)
+  }
+
   private var selectedSessionItems: [SelectedSessionItem] {
     var results: [SelectedSessionItem] = []
 
     for pending in claudeViewModel.pendingHubSessions {
       results.append(SelectedSessionItem(
-        id: "pending-claude-\(pending.id.uuidString)",
+        id: Self.pendingItemID(.claude, pending.id),
         session: pending.placeholderSession,
         providerKind: .claude,
         timestamp: pending.startedAt,
@@ -869,7 +906,7 @@ public struct MultiProviderSessionsListView: View {
 
     for pending in codexViewModel.pendingHubSessions {
       results.append(SelectedSessionItem(
-        id: "pending-codex-\(pending.id.uuidString)",
+        id: Self.pendingItemID(.codex, pending.id),
         session: pending.placeholderSession,
         providerKind: .codex,
         timestamp: pending.startedAt,
@@ -879,27 +916,30 @@ public struct MultiProviderSessionsListView: View {
       ))
     }
 
-    for item in claudeViewModel.monitoredSessions {
+    // Reads the narrow `sessionStatus`/`pullRequestReferences` projections rather
+    // than `monitorStates`, so a publish that only moves token counts or the
+    // activity feed no longer rebuilds this list or re-creates every row.
+    for session in claudeViewModel.monitoredCLISessions {
       results.append(SelectedSessionItem(
-        id: "claude-\(item.session.id)",
-        session: item.session,
+        id: Self.monitoredItemID(.claude, session.id),
+        session: session,
         providerKind: .claude,
-        timestamp: item.session.lastActivityAt,
+        timestamp: session.lastActivityAt,
         isPending: false,
-        sessionStatus: item.state?.status,
-        linkedPullRequests: Self.pullRequestReferences(in: item.state?.detectedResourceLinks ?? [])
+        sessionStatus: claudeViewModel.sessionStatus(for: session.id),
+        linkedPullRequests: claudeViewModel.pullRequestReferences(for: session.id)
       ))
     }
 
-    for item in codexViewModel.monitoredSessions {
+    for session in codexViewModel.monitoredCLISessions {
       results.append(SelectedSessionItem(
-        id: "codex-\(item.session.id)",
-        session: item.session,
+        id: Self.monitoredItemID(.codex, session.id),
+        session: session,
         providerKind: .codex,
-        timestamp: item.session.lastActivityAt,
+        timestamp: session.lastActivityAt,
         isPending: false,
-        sessionStatus: item.state?.status,
-        linkedPullRequests: Self.pullRequestReferences(in: item.state?.detectedResourceLinks ?? [])
+        sessionStatus: codexViewModel.sessionStatus(for: session.id),
+        linkedPullRequests: codexViewModel.pullRequestReferences(for: session.id)
       ))
     }
 
@@ -943,18 +983,20 @@ public struct MultiProviderSessionsListView: View {
     )
   }
 
-  private var pinnedSessionItems: [SelectedSessionItem] {
+  private func pinnedSessionItems(from items: [SelectedSessionItem]) -> [SelectedSessionItem] {
     SidebarSessionOrdering.pinnedItems(
-      from: selectedSessionItems.filter { !isWorkspaceOwned($0) },
+      from: items.filter { !isWorkspaceOwned($0) },
       isPinned: isPinned,
       timestamp: { $0.timestamp },
       id: { $0.id }
     )
   }
 
-  private var groupedSelectedSessionSections: [SidebarRepositoryModuleSection<SelectedSessionItem>] {
+  private func groupedSelectedSessionSections(
+    from items: [SelectedSessionItem]
+  ) -> [SidebarRepositoryModuleSection<SelectedSessionItem>] {
     SidebarSessionOrdering.repositoryModuleSections(
-      from: selectedSessionItems,
+      from: items,
       repositories: Array(orderedTrackedRepos),
       worktreeDisplayMode: worktreeDisplayMode,
       isPinned: isPinned,
@@ -1120,9 +1162,11 @@ public struct MultiProviderSessionsListView: View {
   }
 
   /// Sessions grouped by status category (Working / Needs Attention / Idle).
-  private var statusGroupedSessions: [StatusGroupCategory: [SelectedSessionItem]] {
+  private func statusGroupedSessions(
+    from items: [SelectedSessionItem]
+  ) -> [StatusGroupCategory: [SelectedSessionItem]] {
     SidebarSessionOrdering.statusGroups(
-      from: selectedSessionItems,
+      from: items,
       isPinned: isPinned,
       status: { $0.sessionStatus },
       timestamp: { $0.timestamp },
@@ -1149,7 +1193,14 @@ public struct MultiProviderSessionsListView: View {
 
   @ViewBuilder
   private var inlineSelectedSessions: some View {
-    VStack(alignment: .leading, spacing: 0) {
+    // Built once per render pass and threaded through every grouping helper.
+    // These derivations used to each re-read `selectedSessionItems`, and
+    // `workspaceRows` did so once per repository group — turning one render into
+    // O(groups) full rebuilds of the session list.
+    let allItems = selectedSessionItems
+    let workspaceOwnedItems = workspaceOwnedItemsByWorkspaceID(from: allItems)
+
+    return VStack(alignment: .leading, spacing: 0) {
       SessionsSectionHeader(
         groupMode: $sidebarGroupMode,
         repos: orderedTrackedRepos,
@@ -1174,7 +1225,7 @@ public struct MultiProviderSessionsListView: View {
       }
 
       // Pinned sessions section
-      let pinned = pinnedSessionItems
+      let pinned = pinnedSessionItems(from: allItems)
       if !pinned.isEmpty {
         PinnedSectionHeader(
           count: pinned.count,
@@ -1194,7 +1245,7 @@ public struct MultiProviderSessionsListView: View {
 
       switch sidebarGroupMode {
       case .repo:
-        let sections = groupedSelectedSessionSections
+        let sections = groupedSelectedSessionSections(from: allItems)
         if !sections.isEmpty {
           ForEach(sections) { section in
             ForEach(section.groups) { group in
@@ -1270,7 +1321,7 @@ public struct MultiProviderSessionsListView: View {
               )
 
               if isExpanded {
-                workspaceRows(for: groupWorkspaces)
+                workspaceRows(for: groupWorkspaces, ownedItems: workspaceOwnedItems)
                 sessionRows(for: group.items.filter { !isWorkspaceOwned($0) })
               }
             }
@@ -1288,10 +1339,10 @@ public struct MultiProviderSessionsListView: View {
               .font(.caption.weight(.semibold))
               .foregroundStyle(.secondary)
               .padding(.top, 6)
-            workspaceRows(for: workspaceViewModel.workspaces)
+            workspaceRows(for: workspaceViewModel.workspaces, ownedItems: workspaceOwnedItems)
           }
         }
-        let grouped = statusGroupedSessions
+        let grouped = statusGroupedSessions(from: allItems)
         ForEach(StatusGroupCategory.allCases) { category in
           let items = (grouped[category] ?? []).filter { !isWorkspaceOwned($0) }
           if !items.isEmpty {
@@ -1327,9 +1378,11 @@ public struct MultiProviderSessionsListView: View {
   /// Sessions owned by a workspace render nested under its row instead of as
   /// top-level siblings; they stay registered for monitoring (approvals,
   /// notifications, activity rollups) — only the presentation is grouped.
-  private var workspaceOwnedItemsByWorkspaceID: [String: [SelectedSessionItem]] {
+  private func workspaceOwnedItemsByWorkspaceID(
+    from items: [SelectedSessionItem]
+  ) -> [String: [SelectedSessionItem]] {
     var owned: [String: [SelectedSessionItem]] = [:]
-    for item in selectedSessionItems where !item.isPending {
+    for item in items where !item.isPending {
       if let workspaceID = workspaceViewModel.workspaceID(
         owningSession: item.session.id,
         provider: item.providerKind
@@ -1362,8 +1415,10 @@ public struct MultiProviderSessionsListView: View {
   }
 
   @ViewBuilder
-  private func workspaceRows(for workspaces: [AgentWorkspaceRecord]) -> some View {
-    let ownedItems = workspaceOwnedItemsByWorkspaceID
+  private func workspaceRows(
+    for workspaces: [AgentWorkspaceRecord],
+    ownedItems: [String: [SelectedSessionItem]]
+  ) -> some View {
     VStack(spacing: 2) {
       ForEach(workspaces) { workspace in
         let sessionItems = ownedItems[workspace.id] ?? []
@@ -1850,8 +1905,10 @@ public struct MultiProviderSessionsListView: View {
       ?? codexViewModel.agentHubProvider?.gitHubPRObservationService
   }
 
+  /// Memoized: this runs for every session on every rebuild of
+  /// `selectedSessionItems`, which SwiftUI drives from monitor-state publishes.
   private static func pullRequestReferences(in links: [ResourceLink]) -> [GitHubPullRequestURLReference] {
-    links.compactMap { GitHubPullRequestURLReference(urlString: $0.url) }
+    GitHubPullRequestURLReferenceCache.references(in: links.map(\.url))
   }
 
   private var gitHubRefreshTargets: [GitHubPRObservationTarget] {
@@ -1871,8 +1928,17 @@ public struct MultiProviderSessionsListView: View {
     return targets
   }
 
+  /// Read from `inlineSelectedSessions` on every render, so it must not touch
+  /// `gitHubRefreshTargets` — that builds the full item list *and* a deduped
+  /// target set just to test emptiness. Targets come only from non-pending
+  /// items, which are exactly the monitored sessions, so an id count answers it.
+  ///
+  /// Slight widening: an id whose session cannot be resolved yet now leaves the
+  /// control enabled where it used to be disabled. That is transient, and the
+  /// refresh itself is already a no-op when there is nothing to refresh.
   private var canRefreshGitHubStates: Bool {
-    gitHubPRObservationService != nil && !gitHubRefreshTargets.isEmpty
+    gitHubPRObservationService != nil
+      && !(claudeViewModel.monitoredSessionIds.isEmpty && codexViewModel.monitoredSessionIds.isEmpty)
   }
 
   private var hasCurrentProviderRepositories: Bool {
@@ -1942,7 +2008,10 @@ public struct MultiProviderSessionsListView: View {
     viewModel.resolvedPendingSessions.removeValue(forKey: pendingUUID)
   }
 
-  private func ensurePrimarySelection() {
+  /// - Parameter items: Prebuilt list, when the caller already has one. Deriving
+  ///   it is not free, so callers that need several of these helpers build once
+  ///   and pass it down.
+  private func ensurePrimarySelection(items prebuiltItems: [SelectedSessionItem]? = nil) {
     guard selectedModuleLandingPath == nil, selectedWorkspaceID == nil else {
       primarySessionId = nil
       return
@@ -1950,7 +2019,7 @@ public struct MultiProviderSessionsListView: View {
 
     // Workspace-owned sessions never auto-select as the primary standalone
     // card; their PTY lives inside the workspace surface.
-    let items = selectedSessionItems.filter { !isWorkspaceOwned($0) }
+    let items = (prebuiltItems ?? selectedSessionItems).filter { !isWorkspaceOwned($0) }
     guard !items.isEmpty else {
       primarySessionId = nil
       return
@@ -1998,7 +2067,8 @@ public struct MultiProviderSessionsListView: View {
     setAuxiliaryShellVisible(false)
   }
 
-  private func syncModuleLandingSelection() {
+  /// - Parameter items: See `ensurePrimarySelection(items:)`.
+  private func syncModuleLandingSelection(items prebuiltItems: [SelectedSessionItem]? = nil) {
     if let selectedModuleLandingPath,
        pendingModulePaths.contains(selectedModuleLandingPath) {
       return
@@ -2007,7 +2077,7 @@ public struct MultiProviderSessionsListView: View {
     let activePath = ModuleLandingSelection.activeModulePath(
       selectedPath: selectedModuleLandingPath,
       repositories: orderedTrackedRepos,
-      itemProjectPaths: selectedSessionItems.map { $0.session.projectPath },
+      itemProjectPaths: (prebuiltItems ?? selectedSessionItems).map { $0.session.projectPath },
       mode: worktreeDisplayMode
     )
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/SessionMonitorPanel.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/SessionMonitorPanel.swift
@@ -121,6 +121,16 @@ public struct SessionMonitorPanel: View {
 private struct StatusBadge: View {
   let status: SessionStatus
   @State private var pulse = false
+  @Environment(\.appVisibility) private var appVisibility
+
+  /// See `CollapsibleSessionRow.shouldPulse` — a `repeatForever` animation
+  /// pins the display link, so it stops while the app is occluded.
+  private var shouldPulse: Bool {
+    StatusPulsePolicy.shouldPulse(
+      isActiveStatus: isActiveStatus,
+      isAppVisible: appVisibility?.isVisible ?? true
+    )
+  }
 
   var body: some View {
     HStack(spacing: 6) {
@@ -155,21 +165,17 @@ private struct StatusBadge: View {
       Capsule()
         .stroke(statusColor.opacity(0.25), lineWidth: 1)
     )
-    .onAppear {
-      if isActiveStatus {
-        withAnimation(.easeInOut(duration: 1.5).repeatForever(autoreverses: false)) {
-          pulse = true
-        }
-      }
+    .onAppear { syncPulseAnimation() }
+    .onChange(of: shouldPulse) { _, _ in syncPulseAnimation() }
+  }
+
+  private func syncPulseAnimation() {
+    guard shouldPulse else {
+      pulse = false
+      return
     }
-    .onChange(of: isActiveStatus) { _, newValue in
-      if newValue {
-        withAnimation(.easeInOut(duration: 1.5).repeatForever(autoreverses: false)) {
-          pulse = true
-        }
-      } else {
-        pulse = false
-      }
+    withAnimation(.easeInOut(duration: 1.5).repeatForever(autoreverses: false)) {
+      pulse = true
     }
   }
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/Utils/AppVisibilityMonitor.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Utils/AppVisibilityMonitor.swift
@@ -1,0 +1,75 @@
+//
+//  AppVisibilityMonitor.swift
+//  AgentHub
+//
+//  App-level occlusion state, so repeating animations can stop when nobody
+//  can see them.
+//
+
+import AppKit
+import Observation
+
+/// Tracks whether any of the app's windows are actually visible on screen.
+///
+/// AppKit posts `didChangeOcclusionState` when the app's windows become fully
+/// covered, minimized, or hidden. Nothing in AgentHub used to observe it, so the
+/// `repeatForever` status pulses kept the SwiftUI display link — and with it the
+/// per-frame CoreAnimation commit and view-graph update — running for the whole
+/// time an agent was working, visible or not. Sessions are long-running and
+/// often left in the background, so that is a battery cost with no user-visible
+/// benefit.
+///
+/// Views read `isVisible` and stop their repeating animations when it is false.
+@MainActor
+@Observable
+public final class AppVisibilityMonitor {
+  /// `true` while at least one app window is on screen and unoccluded.
+  public private(set) var isVisible: Bool
+
+  @ObservationIgnored private var observer: (any NSObjectProtocol)?
+
+  /// - Parameters:
+  ///   - isVisible: Seed value. Defaults to the application's current occlusion
+  ///     state when observing, so a monitor created while hidden starts correct.
+  ///   - observesApplication: Pass `false` in tests to get a monitor that only
+  ///     changes through `setVisible(_:)`.
+  public init(isVisible: Bool? = nil, observesApplication: Bool = true) {
+    self.isVisible = isVisible
+      ?? (observesApplication ? NSApplication.shared.occlusionState.contains(.visible) : true)
+
+    guard observesApplication else { return }
+    observer = NotificationCenter.default.addObserver(
+      forName: NSApplication.didChangeOcclusionStateNotification,
+      object: NSApplication.shared,
+      queue: .main
+    ) { [weak self] _ in
+      MainActor.assumeIsolated {
+        self?.setVisible(NSApplication.shared.occlusionState.contains(.visible))
+      }
+    }
+  }
+
+  deinit {
+    if let observer {
+      NotificationCenter.default.removeObserver(observer)
+    }
+  }
+
+  /// Write-on-change: this feeds `@Observable` invalidation, and the
+  /// notification fires for transitions we may already reflect.
+  public func setVisible(_ newValue: Bool) {
+    guard isVisible != newValue else { return }
+    isVisible = newValue
+  }
+}
+
+// MARK: - Pulse policy
+
+/// Whether a status pulse animation should be running.
+///
+/// Split out from the views so the rule is testable without AppKit windows.
+public enum StatusPulsePolicy {
+  public static func shouldPulse(isActiveStatus: Bool, isAppVisible: Bool) -> Bool {
+    isActiveStatus && isAppVisible
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/CLISessionsViewModel.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/CLISessionsViewModel.swift
@@ -6,6 +6,7 @@
 //
 
 import AgentHubGitDiff
+import AgentHubGitHub
 import AgentHubMCPUI
 import Foundation
 import Combine
@@ -282,6 +283,33 @@ public final class CLISessionsViewModel {
   /// Fetched app shells keyed by "serverName|projectPath|resourceUri".
   private var mcpAppShellsByKey: [String: AgentHubMCPUIResource] = [:]
 
+  /// Derived app titles keyed by tool_use id. `mcpAppRenderItems` is read from
+  /// SwiftUI `body` getters (several times per card header render) and the
+  /// derivation JSON-decodes the invocation's element payload, so the decode ran
+  /// once per access per frame. A tool_use id is unique and its arguments never
+  /// change, so the derived title is stable for the invocation's lifetime.
+  ///
+  /// `@ObservationIgnored` is required, not incidental: this is written from a
+  /// read that happens during view evaluation, and an observable write there
+  /// would invalidate the view that is mid-render.
+  @ObservationIgnored private var mcpAppTitlesByInvocationID: [String: String?] = [:]
+
+  /// Long-lived sessions keep emitting invocations; flush wholesale rather than
+  /// tracking an LRU, since a miss only costs one decode.
+  @ObservationIgnored private static let mcpAppTitleCacheCapacity = 512
+
+  private func cachedMCPAppTitle(for invocation: MCPAppInvocation) -> String? {
+    if let cached = mcpAppTitlesByInvocationID[invocation.id] {
+      return cached
+    }
+    if mcpAppTitlesByInvocationID.count >= Self.mcpAppTitleCacheCapacity {
+      mcpAppTitlesByInvocationID.removeAll(keepingCapacity: true)
+    }
+    let derived = Self.deriveMCPAppTitle(from: invocation)
+    mcpAppTitlesByInvocationID[invocation.id] = derived
+    return derived
+  }
+
   private func mcpAppShellCacheKey(serverName: String, projectPath: String, uri: String) -> String {
     [providerKind.rawValue, projectPath, serverName, uri].joined(separator: "|")
   }
@@ -403,7 +431,7 @@ public final class CLISessionsViewModel {
         uri: template.resourceUri
       )
       guard let shell = mcpAppShellsByKey[shellKey] else { return nil }
-      let title = Self.deriveMCPAppTitle(from: invocation)
+      let title = cachedMCPAppTitle(for: invocation)
         ?? template.title
         ?? shell.metadata.title
         ?? invocation.toolName
@@ -1647,6 +1675,38 @@ public final class CLISessionsViewModel {
 
   /// Per-session state models keyed by session ID.
   private var monitorStateModels: [String: SessionMonitorStateModel] = [:]
+
+  // MARK: Sidebar projections
+  //
+  // `monitorStates` carries ~15 fields that move on nearly every JSONL append —
+  // token counts, activity feed, current tool. The session list renders only a
+  // status dot and PR links, but reading `monitorStates` subscribed it to all of
+  // it, so a token counter ticking re-created every row. These two projections
+  // are written only when their value actually changes, so an append that moves
+  // nothing the sidebar can see invalidates nothing.
+
+  /// Per-session status, the only part of `SessionMonitorState` the session list
+  /// renders directly (and the only part status-mode grouping needs).
+  public private(set) var sessionStatuses: [String: SessionStatus] = [:]
+
+  /// PR references detected in a session's output.
+  ///
+  /// Deliberately the *derived* references rather than the raw `ResourceLink`s:
+  /// `ResourceLink` defaults its `id` to a fresh `UUID()` per parse, so a link
+  /// array never compares equal across publishes and would defeat the
+  /// write-on-change guard. A `GitHubPullRequestURLReference` is a pure function
+  /// of the URL string, so it compares stably.
+  public private(set) var sessionPullRequestReferences: [String: [GitHubPullRequestURLReference]] = [:]
+
+  /// Status for a monitored session, or `nil` if it has not reported yet.
+  public func sessionStatus(for sessionId: String) -> SessionStatus? {
+    sessionStatuses[sessionId]
+  }
+
+  /// PR references detected for a monitored session.
+  public func pullRequestReferences(for sessionId: String) -> [GitHubPullRequestURLReference] {
+    sessionPullRequestReferences[sessionId] ?? []
+  }
 
   /// Cached project-level preview eligibility keyed by normalized project path.
   public private(set) var webPreviewCandidates: [String: WebPreviewCandidateStatus] = [:]
@@ -3929,6 +3989,23 @@ public final class CLISessionsViewModel {
     monitoredSessionIds.contains(sessionId)
   }
 
+  /// Monitored sessions *without* their monitor state.
+  ///
+  /// The session list renders from this plus the narrow projections above, so it
+  /// never touches `monitorStates` and is not invalidated by publishes that only
+  /// move token counts. Use `monitoredSessions` when you genuinely need state.
+  public var monitoredCLISessions: [CLISession] {
+    var sessionsById: [String: CLISession] = [:]
+    for session in allSessions where monitoredSessionIds.contains(session.id) {
+      if sessionsById[session.id] == nil {
+        sessionsById[session.id] = session
+      }
+    }
+    return monitoredSessionIds.compactMap { sessionId in
+      sessionsById[sessionId] ?? monitoredSessionBackup[sessionId]
+    }
+  }
+
   /// Get all currently monitored sessions with their states.
   /// Uses a backup store to preserve sessions that may not yet be in history.jsonl.
   public var monitoredSessions: [(session: CLISession, state: SessionMonitorState?)] {
@@ -3984,11 +4061,26 @@ public final class CLISessionsViewModel {
 
   private func updateMonitorState(_ state: SessionMonitorState, for sessionId: String) {
     monitorStates[sessionId] = state
+
+    // Write-on-change: see the projection declarations. Cards that need the full
+    // state observe `monitorStateModels`; the session list observes only these.
+    if sessionStatuses[sessionId] != state.status {
+      sessionStatuses[sessionId] = state.status
+    }
+    let references = GitHubPullRequestURLReferenceCache.references(
+      in: state.detectedResourceLinks.map(\.url)
+    )
+    if sessionPullRequestReferences[sessionId] != references {
+      sessionPullRequestReferences[sessionId] = references
+    }
+
     monitorStateModels[sessionId]?.update(state)
   }
 
   private func removeMonitorState(for sessionId: String) {
     monitorStates.removeValue(forKey: sessionId)
+    sessionStatuses.removeValue(forKey: sessionId)
+    sessionPullRequestReferences.removeValue(forKey: sessionId)
     monitorStateModels[sessionId]?.update(nil)
     monitorStateModels.removeValue(forKey: sessionId)
   }

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/AppVisibilityMonitorTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/AppVisibilityMonitorTests.swift
@@ -1,0 +1,62 @@
+import Testing
+
+@testable import AgentHubCore
+
+@Suite("AppVisibilityMonitor")
+@MainActor
+struct AppVisibilityMonitorTests {
+
+  @Test("Defaults to visible when not observing the application")
+  func defaultsToVisibleWithoutObservation() {
+    let monitor = AppVisibilityMonitor(observesApplication: false)
+    #expect(monitor.isVisible)
+  }
+
+  @Test("Honors a seeded visibility value")
+  func honorsSeededValue() {
+    let monitor = AppVisibilityMonitor(isVisible: false, observesApplication: false)
+    #expect(!monitor.isVisible)
+  }
+
+  @Test("setVisible flips state")
+  func setVisibleFlipsState() {
+    let monitor = AppVisibilityMonitor(observesApplication: false)
+
+    monitor.setVisible(false)
+    #expect(!monitor.isVisible)
+
+    monitor.setVisible(true)
+    #expect(monitor.isVisible)
+  }
+
+  @Test("Redundant setVisible calls are no-ops")
+  func redundantSetVisibleIsNoOp() {
+    let monitor = AppVisibilityMonitor(isVisible: true, observesApplication: false)
+
+    monitor.setVisible(true)
+    #expect(monitor.isVisible)
+
+    monitor.setVisible(false)
+    monitor.setVisible(false)
+    #expect(!monitor.isVisible)
+  }
+}
+
+@Suite("StatusPulsePolicy")
+struct StatusPulsePolicyTests {
+
+  @Test("Pulses only when the session is active and the app is visible")
+  func pulsesOnlyWhenActiveAndVisible() {
+    #expect(StatusPulsePolicy.shouldPulse(isActiveStatus: true, isAppVisible: true))
+    #expect(!StatusPulsePolicy.shouldPulse(isActiveStatus: true, isAppVisible: false))
+    #expect(!StatusPulsePolicy.shouldPulse(isActiveStatus: false, isAppVisible: true))
+    #expect(!StatusPulsePolicy.shouldPulse(isActiveStatus: false, isAppVisible: false))
+  }
+
+  @Test("An occluded app never pulses, whatever the session status")
+  func occludedAppNeverPulses() {
+    for isActive in [true, false] {
+      #expect(!StatusPulsePolicy.shouldPulse(isActiveStatus: isActive, isAppVisible: false))
+    }
+  }
+}

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/CLISessionsViewModelMCPAppDiscoveryTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/CLISessionsViewModelMCPAppDiscoveryTests.swift
@@ -309,6 +309,67 @@ struct CLISessionsViewModelMCPAppDiscoveryTests {
     #expect(item?.invocation?.id == "tu-1")
   }
 
+  /// The title derivation JSON-decodes the invocation payload and is read from
+  /// SwiftUI body getters, so it is memoized by tool_use id. Repeated reads must
+  /// keep returning the derived title — including for distinct invocations that
+  /// share nothing but the cache.
+  @Test("Memoized titles stay correct across repeated render-item reads")
+  @MainActor
+  func memoizedTitlesStayCorrectAcrossReads() async {
+    let viewModel = makeViewModel(provider: .claude, service: RecordingMCPAppDiscoveryService())
+    let session = CLISession(id: "session-1", projectPath: "/tmp/agenthub-mcp-project")
+    let state = SessionMonitorState(detectedMCPAppInvocations: [
+      MCPAppInvocation(
+        id: "tu-1",
+        serverName: "excalidraw",
+        toolName: "create_view",
+        arguments: .object([
+          "elements": .string("[{\"type\":\"text\",\"text\":\"Login Flow\"}]")
+        ])
+      ),
+      MCPAppInvocation(
+        id: "tu-2",
+        serverName: "excalidraw",
+        toolName: "create_view",
+        arguments: .object([
+          "elements": .array([
+            .object(["type": .string("rectangle"), "label": .object(["text": .string("Start")])])
+          ])
+        ])
+      )
+    ])
+
+    await viewModel.ensureMCPAppRenderItems(for: session, state: state)
+
+    // Mirrors a card header, which reads these getters several times per render.
+    for _ in 0..<5 {
+      let titles = viewModel.mcpAppRenderItems(for: session, state: state).map(\.resource.title)
+      #expect(titles == ["Login Flow", "Start"])
+    }
+  }
+
+  @Test("An invocation with no derivable title still falls back to the tool title")
+  @MainActor
+  func fallsBackToToolTitleWhenNoneDerivable() async {
+    let viewModel = makeViewModel(provider: .claude, service: RecordingMCPAppDiscoveryService())
+    let session = CLISession(id: "session-1", projectPath: "/tmp/agenthub-mcp-project")
+    let state = SessionMonitorState(detectedMCPAppInvocations: [
+      MCPAppInvocation(
+        id: "tu-blank",
+        serverName: "excalidraw",
+        toolName: "create_view",
+        arguments: .object(["elements": .array([])])
+      )
+    ])
+
+    await viewModel.ensureMCPAppRenderItems(for: session, state: state)
+
+    // The cached `nil` must not shadow the template title on later reads.
+    for _ in 0..<3 {
+      #expect(viewModel.mcpAppRenderItems(for: session, state: state).first?.resource.title == "Draw Diagram")
+    }
+  }
+
   @Test("Derives a diagram title from the drawing's first text element")
   @MainActor
   func derivesTitleFromDiagramContent() {

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/CLISessionsViewModelSidebarProjectionTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/CLISessionsViewModelSidebarProjectionTests.swift
@@ -1,0 +1,238 @@
+import AgentHubGitHub
+import Combine
+import Foundation
+import Observation
+import Testing
+
+@testable import AgentHubCore
+
+private final class ProjectionMonitorService: SessionMonitorServiceProtocol, @unchecked Sendable {
+  private let subject = PassthroughSubject<[SelectedRepository], Never>()
+
+  var repositoriesPublisher: AnyPublisher<[SelectedRepository], Never> {
+    subject.eraseToAnyPublisher()
+  }
+
+  func addRepository(_ path: String) async -> SelectedRepository? { nil }
+  func removeRepository(_ path: String) async {}
+  func getSelectedRepositories() async -> [SelectedRepository] { [] }
+  func setSelectedRepositories(_ repositories: [SelectedRepository]) async {}
+  func refreshSessions(skipWorktreeRedetection: Bool) async {}
+}
+
+private final class ProjectionFileWatcher: SessionFileWatcherProtocol, @unchecked Sendable {
+  private let subject = PassthroughSubject<SessionFileWatcher.StateUpdate, Never>()
+
+  var statePublisher: AnyPublisher<SessionFileWatcher.StateUpdate, Never> {
+    subject.eraseToAnyPublisher()
+  }
+
+  func send(sessionId: String, state: SessionMonitorState) {
+    subject.send(SessionFileWatcher.StateUpdate(sessionId: sessionId, state: state))
+  }
+
+  func startMonitoring(sessionId: String, projectPath: String, sessionFilePath: String?) async {}
+  func stopMonitoring(sessionId: String) async {}
+  func getState(sessionId: String) async -> SessionMonitorState? { nil }
+  func refreshState(sessionId: String) async {}
+  func setApprovalTimeout(_ seconds: Int) async {}
+}
+
+@MainActor
+private func makeProjectionViewModel(fileWatcher: ProjectionFileWatcher) -> CLISessionsViewModel {
+  CLISessionsViewModel(
+    monitorService: ProjectionMonitorService(),
+    fileWatcher: fileWatcher,
+    searchService: nil,
+    cliConfiguration: CLICommandConfiguration(command: "claude", mode: .claude),
+    providerKind: .claude,
+    approvalNotificationService: NoOpApprovalNotificationService()
+  )
+}
+
+@MainActor
+private func waitUntil(_ condition: () -> Bool, timeoutAttempts: Int = 50) async throws {
+  for _ in 0..<timeoutAttempts {
+    if condition() { return }
+    try await Task.sleep(for: .milliseconds(20))
+  }
+  #expect(condition())
+}
+
+/// The session list renders only a status dot and PR links, but used to read the
+/// whole `SessionMonitorState` — so a token counter ticking at ~10 Hz re-created
+/// every sidebar row. These tests pin the narrow projections that fixed it.
+@Suite("CLISessionsViewModel sidebar projections")
+struct CLISessionsViewModelSidebarProjectionTests {
+
+  @Test("Publishing populates the status and pull-request projections")
+  @MainActor
+  func publishPopulatesProjections() async throws {
+    let fileWatcher = ProjectionFileWatcher()
+    let viewModel = makeProjectionViewModel(fileWatcher: fileWatcher)
+    let session = CLISession(id: "session-1", projectPath: "/tmp/project")
+    viewModel.startMonitoring(session: session)
+
+    fileWatcher.send(
+      sessionId: session.id,
+      state: SessionMonitorState(
+        status: .executingTool(name: "Bash"),
+        detectedResourceLinks: [
+          ResourceLink(url: "https://github.com/owner/repo/pull/7"),
+          ResourceLink(url: "https://example.com/not-a-pr")
+        ]
+      )
+    )
+
+    try await waitUntil { viewModel.sessionStatus(for: session.id) != nil }
+
+    #expect(viewModel.sessionStatus(for: session.id) == .executingTool(name: "Bash"))
+    #expect(viewModel.pullRequestReferences(for: session.id).map(\.number) == [7])
+  }
+
+  /// The regression this whole change exists for.
+  @Test("A publish that moves only token counts does not invalidate the projections")
+  @MainActor
+  func tokenOnlyPublishDoesNotInvalidateProjections() async throws {
+    let fileWatcher = ProjectionFileWatcher()
+    let viewModel = makeProjectionViewModel(fileWatcher: fileWatcher)
+    let session = CLISession(id: "session-1", projectPath: "/tmp/project")
+    viewModel.startMonitoring(session: session)
+
+    let links = [ResourceLink(url: "https://github.com/owner/repo/pull/7")]
+    fileWatcher.send(
+      sessionId: session.id,
+      state: SessionMonitorState(status: .thinking, inputTokens: 10, detectedResourceLinks: links)
+    )
+    try await waitUntil { viewModel.sessionStatus(for: session.id) == .thinking }
+
+    var statusesInvalidated = false
+    withObservationTracking {
+      _ = viewModel.sessionStatuses
+    } onChange: {
+      statusesInvalidated = true
+    }
+
+    var referencesInvalidated = false
+    withObservationTracking {
+      _ = viewModel.sessionPullRequestReferences
+    } onChange: {
+      referencesInvalidated = true
+    }
+
+    // Same status, same links, different token counts — what an agent mid-turn
+    // emits on nearly every append. Fresh `ResourceLink` values on purpose: the
+    // parser mints a new `UUID` per parse, so the projection must compare on the
+    // derived references, not on link identity.
+    fileWatcher.send(
+      sessionId: session.id,
+      state: SessionMonitorState(
+        status: .thinking,
+        inputTokens: 9_999,
+        outputTokens: 1_234,
+        messageCount: 42,
+        detectedResourceLinks: [ResourceLink(url: "https://github.com/owner/repo/pull/7")]
+      )
+    )
+    try await waitUntil { viewModel.monitorStates[session.id]?.inputTokens == 9_999 }
+
+    #expect(!statusesInvalidated)
+    #expect(!referencesInvalidated)
+  }
+
+  @Test("A status change does invalidate the status projection")
+  @MainActor
+  func statusChangeInvalidatesStatusProjection() async throws {
+    let fileWatcher = ProjectionFileWatcher()
+    let viewModel = makeProjectionViewModel(fileWatcher: fileWatcher)
+    let session = CLISession(id: "session-1", projectPath: "/tmp/project")
+    viewModel.startMonitoring(session: session)
+
+    fileWatcher.send(sessionId: session.id, state: SessionMonitorState(status: .thinking))
+    try await waitUntil { viewModel.sessionStatus(for: session.id) == .thinking }
+
+    var statusesInvalidated = false
+    withObservationTracking {
+      _ = viewModel.sessionStatuses
+    } onChange: {
+      statusesInvalidated = true
+    }
+
+    fileWatcher.send(sessionId: session.id, state: SessionMonitorState(status: .waitingForUser))
+    try await waitUntil { viewModel.sessionStatus(for: session.id) == .waitingForUser }
+
+    #expect(statusesInvalidated)
+  }
+
+  @Test("A newly detected pull request invalidates the reference projection")
+  @MainActor
+  func newPullRequestInvalidatesReferenceProjection() async throws {
+    let fileWatcher = ProjectionFileWatcher()
+    let viewModel = makeProjectionViewModel(fileWatcher: fileWatcher)
+    let session = CLISession(id: "session-1", projectPath: "/tmp/project")
+    viewModel.startMonitoring(session: session)
+
+    fileWatcher.send(sessionId: session.id, state: SessionMonitorState(status: .thinking))
+    try await waitUntil { viewModel.sessionStatus(for: session.id) == .thinking }
+
+    var referencesInvalidated = false
+    withObservationTracking {
+      _ = viewModel.sessionPullRequestReferences
+    } onChange: {
+      referencesInvalidated = true
+    }
+
+    fileWatcher.send(
+      sessionId: session.id,
+      state: SessionMonitorState(
+        status: .thinking,
+        detectedResourceLinks: [ResourceLink(url: "https://github.com/owner/repo/pull/12")]
+      )
+    )
+    try await waitUntil { !viewModel.pullRequestReferences(for: session.id).isEmpty }
+
+    #expect(referencesInvalidated)
+    #expect(viewModel.pullRequestReferences(for: session.id).map(\.number) == [12])
+  }
+
+  @Test("Stopping monitoring clears both projections")
+  @MainActor
+  func stopMonitoringClearsProjections() async throws {
+    let fileWatcher = ProjectionFileWatcher()
+    let viewModel = makeProjectionViewModel(fileWatcher: fileWatcher)
+    let session = CLISession(id: "session-1", projectPath: "/tmp/project")
+    viewModel.startMonitoring(session: session)
+
+    fileWatcher.send(
+      sessionId: session.id,
+      state: SessionMonitorState(
+        status: .thinking,
+        detectedResourceLinks: [ResourceLink(url: "https://github.com/owner/repo/pull/7")]
+      )
+    )
+    try await waitUntil { viewModel.sessionStatus(for: session.id) != nil }
+
+    viewModel.stopMonitoring(session: session)
+
+    #expect(viewModel.sessionStatus(for: session.id) == nil)
+    #expect(viewModel.pullRequestReferences(for: session.id).isEmpty)
+  }
+
+  @Test("monitoredCLISessions mirrors monitoredSessions without carrying state")
+  @MainActor
+  func monitoredCLISessionsMirrorsMonitoredSessions() {
+    let fileWatcher = ProjectionFileWatcher()
+    let viewModel = makeProjectionViewModel(fileWatcher: fileWatcher)
+    let first = CLISession(id: "session-1", projectPath: "/tmp/project-a")
+    let second = CLISession(id: "session-2", projectPath: "/tmp/project-b")
+
+    viewModel.startMonitoring(session: first)
+    viewModel.startMonitoring(session: second)
+
+    #expect(viewModel.monitoredCLISessions.map(\.id) == viewModel.monitoredSessions.map(\.session.id))
+
+    viewModel.stopMonitoring(session: first)
+
+    #expect(viewModel.monitoredCLISessions.map(\.id) == viewModel.monitoredSessions.map(\.session.id))
+  }
+}

--- a/app/modules/AgentHubGitHub/Sources/AgentHubGitHub/Models/GitHubPullRequestURLReferenceCache.swift
+++ b/app/modules/AgentHubGitHub/Sources/AgentHubGitHub/Models/GitHubPullRequestURLReferenceCache.swift
@@ -1,0 +1,59 @@
+//
+//  GitHubPullRequestURLReferenceCache.swift
+//  AgentHubGitHub
+//
+//  Memoized lookup for PR references parsed out of session output.
+//
+
+import Foundation
+
+/// Memoizes `GitHubPullRequestURLReference(urlString:)`.
+///
+/// Parsing is a pure function of the URL string, so this is a plain cache with
+/// no invalidation. It exists because the sidebar's session list is rebuilt on
+/// every monitor-state publish (up to 10 Hz per session) and each pass re-parsed
+/// every detected resource link with `URLComponents` — measurable main-thread
+/// cost inside a SwiftUI `body`.
+///
+/// Main-actor isolated because every caller is a view or view model; that also
+/// makes the unsynchronized storage safe.
+@MainActor
+public enum GitHubPullRequestURLReferenceCache {
+  /// Detected links are dominated by a handful of URLs repeated across sessions,
+  /// so a small cache covers effectively every lookup.
+  static let capacity = 512
+
+  /// `nil` values are cached too — most detected links are not PR URLs, and
+  /// re-parsing those is exactly the cost this avoids.
+  private static var entries: [String: GitHubPullRequestURLReference?] = [:]
+
+  /// The parsed reference for `urlString`, or `nil` if it is not a GitHub PR URL.
+  public static func reference(for urlString: String) -> GitHubPullRequestURLReference? {
+    if let cached = entries[urlString] {
+      return cached
+    }
+    // Flush wholesale rather than tracking an LRU: entries are tiny, lookups are
+    // hot, and the working set only grows when a session emits many new links.
+    if entries.count >= capacity {
+      entries.removeAll(keepingCapacity: true)
+    }
+    let parsed = GitHubPullRequestURLReference(urlString: urlString)
+    entries[urlString] = parsed
+    return parsed
+  }
+
+  /// The PR references among `urlStrings`, preserving order and dropping non-PR URLs.
+  public static func references(in urlStrings: [String]) -> [GitHubPullRequestURLReference] {
+    urlStrings.compactMap { reference(for: $0) }
+  }
+
+  /// Test hook — production code never needs to invalidate a pure memo.
+  public static func resetForTesting() {
+    entries.removeAll()
+  }
+
+  /// Test hook for asserting cache occupancy.
+  static var cachedEntryCount: Int {
+    entries.count
+  }
+}

--- a/app/modules/AgentHubGitHub/Tests/AgentHubGitHubTests/GitHubPullRequestURLReferenceCacheTests.swift
+++ b/app/modules/AgentHubGitHub/Tests/AgentHubGitHubTests/GitHubPullRequestURLReferenceCacheTests.swift
@@ -1,0 +1,86 @@
+import Testing
+
+@testable import AgentHubGitHub
+
+/// Serialized: the suite asserts on shared cache occupancy.
+@Suite("GitHubPullRequestURLReferenceCache", .serialized)
+@MainActor
+struct GitHubPullRequestURLReferenceCacheTests {
+
+  @Test("Returns the same result as direct parsing")
+  func matchesDirectParsing() {
+    GitHubPullRequestURLReferenceCache.resetForTesting()
+
+    let urls = [
+      "https://github.com/jamesrochabrun/AgentHub/pull/322",
+      "https://www.github.com/owner/repo/pull/7",
+      "https://github.com/jamesrochabrun/AgentHub/issues/322",
+      "https://example.com/page",
+      "not a url at all"
+    ]
+
+    for url in urls {
+      #expect(
+        GitHubPullRequestURLReferenceCache.reference(for: url)
+          == GitHubPullRequestURLReference(urlString: url)
+      )
+    }
+  }
+
+  @Test("Repeated lookups are served from one cached entry")
+  func repeatedLookupsReuseEntry() throws {
+    GitHubPullRequestURLReferenceCache.resetForTesting()
+    let url = "https://github.com/jamesrochabrun/AgentHub/pull/322"
+
+    let first = try #require(GitHubPullRequestURLReferenceCache.reference(for: url))
+    #expect(GitHubPullRequestURLReferenceCache.cachedEntryCount == 1)
+
+    for _ in 0..<50 {
+      #expect(GitHubPullRequestURLReferenceCache.reference(for: url) == first)
+    }
+    #expect(GitHubPullRequestURLReferenceCache.cachedEntryCount == 1)
+  }
+
+  @Test("Caches non-PR URLs so they are not re-parsed")
+  func cachesNegativeResults() {
+    GitHubPullRequestURLReferenceCache.resetForTesting()
+
+    #expect(GitHubPullRequestURLReferenceCache.reference(for: "https://example.com/page") == nil)
+    #expect(GitHubPullRequestURLReferenceCache.cachedEntryCount == 1)
+    #expect(GitHubPullRequestURLReferenceCache.reference(for: "https://example.com/page") == nil)
+    #expect(GitHubPullRequestURLReferenceCache.cachedEntryCount == 1)
+  }
+
+  @Test("references(in:) preserves order and drops non-PR URLs")
+  func referencesPreserveOrder() {
+    GitHubPullRequestURLReferenceCache.resetForTesting()
+
+    let references = GitHubPullRequestURLReferenceCache.references(in: [
+      "https://example.com/page",
+      "https://github.com/owner/repo/pull/2",
+      "https://github.com/owner/repo/tree/main",
+      "https://github.com/owner/repo/pull/1"
+    ])
+
+    #expect(references.map(\.number) == [2, 1])
+  }
+
+  @Test("Stays bounded once capacity is reached")
+  func staysBounded() {
+    GitHubPullRequestURLReferenceCache.resetForTesting()
+
+    let overflow = GitHubPullRequestURLReferenceCache.capacity + 10
+    for index in 0..<overflow {
+      _ = GitHubPullRequestURLReferenceCache.reference(
+        for: "https://github.com/owner/repo/pull/\(index)"
+      )
+    }
+
+    #expect(GitHubPullRequestURLReferenceCache.cachedEntryCount <= GitHubPullRequestURLReferenceCache.capacity)
+    // Correct results survive the flush.
+    let reference = GitHubPullRequestURLReferenceCache.reference(
+      for: "https://github.com/owner/repo/pull/1"
+    )
+    #expect(reference?.number == 1)
+  }
+}


### PR DESCRIPTION
## What

The sidebar re-rendered every session row on every monitor-state publish. With N monitored sessions each publishing at up to 10 Hz, that meant ~20 full row bodies rebuilt continuously for as long as any agent was working — including while the window was covered.

`SessionMonitorState` carries ~15 fields; the session list renders **two** of them (status dot, PR links). Reading `monitorStates` subscribed it to all of them, so a token counter ticking re-created every row.

## How

- **Narrow the observation.** New write-on-change `sessionStatuses` / `sessionPullRequestReferences` projections plus `monitoredCLISessions` (carries no state). `selectedSessionItems` builds from those, so the sidebar no longer reads `monitorStates` at all. Cards that need full state still observe `monitorStateModels`.

  The projection stores *derived* PR references rather than raw `ResourceLink`s deliberately: `ResourceLink` defaults its `id` to a fresh `UUID()` per parse, so a link array never compares equal across publishes and would have defeated the write-on-change guard entirely. There's a test that sends fresh `ResourceLink`s with identical URLs to pin this.

- **Build `selectedSessionItems` once per render**, down from once per repository group — `workspaceRows` recomputed it inside `ForEach(section.groups)`, and `.onChange`/`.animation` re-derived it for their `value:`. Measured 3–4 full rebuilds per publish; now 1.

- **Get parsing out of `body`.** `URLComponents` ran per detected link per render; a `JSONDecoder` decode ran ~4× per card header render inside `body` getters. Both memoized.

- **Pause `repeatForever` pulses while occluded.** New `AppVisibilityMonitor`; nothing observed `NSApplication` occlusion state before.

## Intentional behavior changes

- `canRefreshGitHubStates` answers from `monitoredSessionIds` instead of building the deduped target set. A session id that can't be resolved yet now leaves the refresh control **enabled** where it used to be disabled — transient, and the refresh is already a no-op with nothing to refresh.
- Status pulses stop while the app is occluded.

## Testing

- 12 new tests: 6 for the sidebar projections (including a negative-invalidation test via `withObservationTracking`, paired with a positive control so it isn't vacuous), 6 for `AppVisibilityMonitor` / `StatusPulsePolicy`, 5 for the PR URL cache.
- `AgentHubGitHub`: 96/96 pass.
- Targeted `AgentHubCore` suites: 61/61 pass.
- Full `AgentHubCore` suite fails on a **clean tree** as well (parallel/timing flakes in `AgentWorkspacesViewModel`, `DiffAvailabilityService`, `WorktreeGenerationProgressCoordinator`). Baseline 21 issues; this branch 9; all three suites pass in isolation (35/35). No new suite fails.
- Verified live across three instrumented runs: `\CLISessionsViewModel.monitorStates changed` no longer appears as a sidebar trigger, and `MultiProviderSessionsListView.body` stops running during steady agent work.

## What this does *not* claim

Measured in **body-evaluation counts, not CPU.** No before/after CPU number exists.

The report that prompted this quoted 15–21% CPU and 1418 MB — those came from a Debug (`-Onone`) build running under `debugserver` with MainThreadChecker, BacktraceRecording, and ViewDebuggerSupport interposed. A Release instance idled at ~2% / 261 MB. The eliminated work sits on exactly the path that profile showed hot (`CA::Transaction::commit` → `NSHostingView.layout` → `ViewGraph.renderDisplayList`), but the real-world magnitude is unquantified.

The same profiling **disproved the leading hypothesis** — that `repeatForever` animations were ticking the view graph every frame. No capture showed any frame-rate body churn; `withAnimation` on `@State` produces one body pass, then CoreAnimation interpolates. Occlusion handling was billed as the single highest-leverage battery fix; it is not, since row churn continued unchanged while the window was covered until the observation narrowing landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)