### PR TITLE
Improve pinned session drag reordering

### DIFF
--- a/app/AgentHubTests/SessionMetadataMigrationSafetyTests.swift
+++ b/app/AgentHubTests/SessionMetadataMigrationSafetyTests.swift
@@ -59,6 +59,16 @@ struct SessionMetadataMigrationSafetyTests {
     #expect(try await store.getManagedProcesses() == [seed.managedProcess])
     #expect(try await store.loadClaudeHookInstalledPaths().isEmpty)
     #expect(try await store.sessionRelationships(from: .claude, sessionId: seed.sessionId, kind: nil).isEmpty)
+
+    // v13 adds the pinned drag order. A database seeded before it has no
+    // positions, and must migrate into an empty — not missing — table.
+    #expect(try await store.getPinnedSessionOrder().isEmpty)
+    try await store.setPinnedSessionOrder(["claude-\(seed.sessionId)"])
+    #expect(try await store.getPinnedSessionOrder() == ["claude-\(seed.sessionId)": 0])
+
+    // The pre-existing pin flag must survive alongside the new order table.
+    #expect(try await store.getPinnedSessionIds() == Set([seed.sessionId]))
+    #expect(try await store.getCustomName(for: seed.sessionId) == "Important session")
   }
 }
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/Models/PinnedSessionOrderRecord.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Models/PinnedSessionOrderRecord.swift
@@ -1,0 +1,42 @@
+//
+//  PinnedSessionOrderRecord.swift
+//  AgentHub
+//
+//  Manual drag order for the sidebar's pinned section, stored in SQLite
+//
+
+import Foundation
+import GRDB
+
+/// One pinned sidebar row's manual position.
+///
+/// Keyed by the provider-scoped sidebar item id (`"claude-<sessionId>"`), not
+/// the bare session id: the pinned section is a single list unioned across
+/// Claude and Codex, so its order has to be expressible across both.
+public struct PinnedSessionOrderRecord: Codable, Sendable, FetchableRecord, PersistableRecord {
+
+  /// The sidebar item id this position belongs to
+  public var itemId: String
+
+  /// Zero-based position within the pinned section
+  public var sortIndex: Int
+
+  /// When the position was last written
+  public var updatedAt: Date
+
+  // MARK: - GRDB Configuration
+
+  public static var databaseTableName: String { "pinned_session_order" }
+
+  // MARK: - Initialization
+
+  public init(
+    itemId: String,
+    sortIndex: Int,
+    updatedAt: Date = Date()
+  ) {
+    self.itemId = itemId
+    self.sortIndex = sortIndex
+    self.updatedAt = updatedAt
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/SessionMetadataStore.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/SessionMetadataStore.swift
@@ -27,6 +27,7 @@ public actor SessionMetadataStore: TerminalWorkspaceStoreProtocol, AgentWorkspac
     static let createSessionRelationships = "v10_create_session_relationships"
     static let createProjectSimulatorPreferences = "v11_create_project_simulator_preferences"
     static let createAgentWorkspaces = "v12_create_agent_workspaces"
+    static let createPinnedSessionOrder = "v13_create_pinned_session_order"
   }
 
   static let migrationIdentifiers = [
@@ -41,7 +42,8 @@ public actor SessionMetadataStore: TerminalWorkspaceStoreProtocol, AgentWorkspac
     MigrationID.addOwnedWorktreePaths,
     MigrationID.createSessionRelationships,
     MigrationID.createProjectSimulatorPreferences,
-    MigrationID.createAgentWorkspaces
+    MigrationID.createAgentWorkspaces,
+    MigrationID.createPinnedSessionOrder
   ]
 
   private let dbQueue: DatabaseQueue
@@ -234,6 +236,17 @@ public actor SessionMetadataStore: TerminalWorkspaceStoreProtocol, AgentWorkspac
       )
     }
 
+    // Manual drag order for the sidebar's pinned section. Keyed by the
+    // provider-scoped sidebar item id ("claude-<sessionId>") rather than the
+    // bare session id, because the pinned list is a union across providers.
+    migrator.registerMigration(MigrationID.createPinnedSessionOrder) { db in
+      try db.create(table: "pinned_session_order") { t in
+        t.column("itemId", .text).primaryKey()
+        t.column("sortIndex", .integer).notNull()
+        t.column("updatedAt", .datetime).notNull()
+      }
+    }
+
     return migrator
   }
 
@@ -305,6 +318,62 @@ public actor SessionMetadataStore: TerminalWorkspaceStoreProtocol, AgentWorkspac
     }) ?? []
   }
 
+  // MARK: - Pinned Section Manual Order
+
+  /// Replaces the pinned section's manual order with `orderedItemIds`.
+  ///
+  /// Positions are rewritten as a dense `0..<count` range in one transaction so
+  /// a partial write can never leave two rows fighting for the same slot. Rows
+  /// for items not in the list are left alone — unpinning a session keeps its
+  /// slot, so re-pinning it restores the position the user chose.
+  public func setPinnedSessionOrder(_ orderedItemIds: [String]) throws {
+    try dbQueue.write { db in
+      let now = Date()
+      for (index, itemId) in orderedItemIds.enumerated() {
+        try PinnedSessionOrderRecord(
+          itemId: itemId,
+          sortIndex: index,
+          updatedAt: now
+        ).save(db)
+      }
+    }
+  }
+
+  /// Gets the manual pinned order as `itemId -> sortIndex`
+  public func getPinnedSessionOrder() throws -> [String: Int] {
+    try dbQueue.read { db in
+      try Self.readPinnedSessionOrder(db)
+    }
+  }
+
+  /// Synchronous read for the manual pinned order — safe to call from
+  /// non-async contexts. Mirrors `getPinnedSessionIdsSync()` so the sidebar can
+  /// render the user's order on the first frame instead of flashing the
+  /// activity sort and then resorting.
+  public nonisolated func getPinnedSessionOrderSync() -> [String: Int] {
+    (try? dbQueue.read { db in
+      try Self.readPinnedSessionOrder(db)
+    }) ?? [:]
+  }
+
+  /// Removes any stored pinned position for a sidebar item
+  public func deletePinnedSessionOrder(forItemIds itemIds: [String]) throws {
+    guard !itemIds.isEmpty else { return }
+    _ = try dbQueue.write { db in
+      try PinnedSessionOrderRecord
+        .filter(itemIds.contains(Column("itemId")))
+        .deleteAll(db)
+    }
+  }
+
+  private static func readPinnedSessionOrder(_ db: Database) throws -> [String: Int] {
+    let records = try PinnedSessionOrderRecord.fetchAll(db)
+    return Dictionary(
+      records.map { ($0.itemId, $0.sortIndex) },
+      uniquingKeysWith: { first, _ in first }
+    )
+  }
+
   /// Gets all metadata for multiple sessions at once (batch fetch)
   public func getMetadata(for sessionIds: [String]) throws -> [String: SessionMetadata] {
     try dbQueue.read { db in
@@ -323,6 +392,14 @@ public actor SessionMetadataStore: TerminalWorkspaceStoreProtocol, AgentWorkspac
         .filter(Column("sessionId") == sessionId)
         .deleteAll(db)
       _ = try SessionMetadata.deleteOne(db, key: sessionId)
+      // Pinned positions are keyed by provider-scoped item id, so clear the
+      // slot this session could hold under either provider.
+      let itemIds = SessionProviderKind.allCases.map {
+        SidebarSessionItemID.monitored(provider: $0, sessionId: sessionId)
+      }
+      _ = try PinnedSessionOrderRecord
+        .filter(itemIds.contains(Column("itemId")))
+        .deleteAll(db)
     }
   }
 
@@ -339,6 +416,7 @@ public actor SessionMetadataStore: TerminalWorkspaceStoreProtocol, AgentWorkspac
       _ = try ProjectSimulatorPreference.deleteAll(db)
       _ = try AIConfigRecord.deleteAll(db)
       _ = try SessionRepoMapping.deleteAll(db)
+      _ = try PinnedSessionOrderRecord.deleteAll(db)
       _ = try SessionMetadata.deleteAll(db)
     }
   }

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
@@ -147,6 +147,12 @@ public struct MultiProviderSessionsListView: View {
   @State private var sidebarGroupMode: SidebarGroupMode = .repo
   @State private var collapsedStatusGroups: Set<StatusGroupCategory> = []
   @State private var isPinnedSectionCollapsed: Bool = false
+  /// Manual drag order for the pinned section, `itemId -> position`. Seeded
+  /// synchronously from SQLite on first render so the user's arrangement is
+  /// there on the first frame rather than snapping into place after a load.
+  @State private var pinnedSessionOrder: [String: Int] = [:]
+  @State private var didLoadPinnedSessionOrder = false
+  @State private var pinnedSessionOrderPersistenceTask: Task<Void, Never>?
   @State private var scrollToSessionId: String?
   @State private var launchExpandRequestID = 0
   @State private var createWorktreeContext: WorktreeCreateContext?
@@ -233,6 +239,7 @@ public struct MultiProviderSessionsListView: View {
       if multiLaunchViewModel == nil {
         multiLaunchViewModel = makeLaunchViewModel()
       }
+      loadPinnedSessionOrderIfNeeded()
       ensurePrimarySelection()
       scheduleInitialGitHubStateRefreshIfNeeded()
       consumeGlobalSessionSelectionIfNeeded()
@@ -857,11 +864,11 @@ public struct MultiProviderSessionsListView: View {
   /// Identity of a sidebar row. Shared by the full build and the cheap token
   /// below so the two can never disagree about what a row is called.
   private static func pendingItemID(_ providerKind: SessionProviderKind, _ pendingID: UUID) -> String {
-    "pending-\(providerKind.rawValue.lowercased())-\(pendingID.uuidString)"
+    SidebarSessionItemID.pending(provider: providerKind, pendingId: pendingID)
   }
 
   private static func monitoredItemID(_ providerKind: SessionProviderKind, _ sessionID: String) -> String {
-    "\(providerKind.rawValue.lowercased())-\(sessionID)"
+    SidebarSessionItemID.monitored(provider: providerKind, sessionId: sessionID)
   }
 
   /// The ordered ids of `selectedSessionItems`, derived without building the
@@ -988,8 +995,84 @@ public struct MultiProviderSessionsListView: View {
       from: items.filter { !isWorkspaceOwned($0) },
       isPinned: isPinned,
       timestamp: { $0.timestamp },
-      id: { $0.id }
+      id: { $0.id },
+      manualOrder: { pinnedSessionOrder[$0.id] }
     )
+  }
+
+  // MARK: - Pinned Section Reordering
+
+  private func loadPinnedSessionOrderIfNeeded() {
+    guard !didLoadPinnedSessionOrder else { return }
+    didLoadPinnedSessionOrder = true
+    guard let store = agentHub?.metadataStore else { return }
+    pinnedSessionOrder = store.getPinnedSessionOrderSync()
+  }
+
+  /// Applies the placement chosen by the row under the pointer. The parent
+  /// resolves IDs against the current order, so a stale drop-delegate snapshot
+  /// can never move the wrong row.
+  private func movePinnedItem(
+    _ movingID: String,
+    relativeTo targetID: String,
+    placement: PinnedSessionDropPlacement
+  ) {
+    let currentIDs = pinnedSessionItems(from: selectedSessionItems).map(\.id)
+    guard let reordered = SidebarSessionOrdering.reorderedIDs(
+      currentIDs,
+      movingID: movingID,
+      targetID: targetID,
+      placement: placement
+    ) else { return }
+
+    withAnimation(accessibilityReduceMotion ? nil : .snappy(duration: 0.18)) {
+      pinnedSessionOrder = Dictionary(
+        uniqueKeysWithValues: reordered.enumerated().map { ($1, $0) }
+      )
+    }
+
+    schedulePinnedSessionOrderPersistence(reordered)
+  }
+
+  /// Coalesces the rapid updates emitted while the pointer moves through the
+  /// list. This prevents a queue of obsolete SQLite writes from outliving the
+  /// animation. A drop inside the list flushes immediately; a drag abandoned
+  /// outside still persists its last visible order after the short debounce.
+  private func schedulePinnedSessionOrderPersistence(_ orderedIDs: [String]) {
+    pinnedSessionOrderPersistenceTask?.cancel()
+    guard let store = agentHub?.metadataStore else { return }
+
+    pinnedSessionOrderPersistenceTask = Task {
+      do {
+        try await Task.sleep(for: .milliseconds(180))
+        try Task.checkCancellation()
+        try await store.setPinnedSessionOrder(orderedIDs)
+      } catch is CancellationError {
+        return
+      } catch {
+        AppLogger.session.error(
+          "Failed to persist pinned session order: \(error.localizedDescription)"
+        )
+      }
+    }
+  }
+
+  private func finishMovingPinnedItems() {
+    pinnedSessionOrderPersistenceTask?.cancel()
+    pinnedSessionOrderPersistenceTask = nil
+
+    let orderedIDs = pinnedSessionItems(from: selectedSessionItems).map(\.id)
+    guard let store = agentHub?.metadataStore else { return }
+
+    Task {
+      do {
+        try await store.setPinnedSessionOrder(orderedIDs)
+      } catch {
+        AppLogger.session.error(
+          "Failed to persist pinned session order: \(error.localizedDescription)"
+        )
+      }
+    }
   }
 
   private func groupedSelectedSessionSections(
@@ -1187,7 +1270,8 @@ public struct MultiProviderSessionsListView: View {
       projectPath: { $0.session.projectPath },
       status: { $0.sessionStatus },
       timestamp: { $0.timestamp },
-      id: { $0.id }
+      id: { $0.id },
+      manualOrder: { pinnedSessionOrder[$0.id] }
     )
   }
 
@@ -1239,7 +1323,14 @@ public struct MultiProviderSessionsListView: View {
         .transition(.opacity)
 
         if !isPinnedSectionCollapsed {
-          sessionRows(for: pinned)
+          PinnedReorderableList(
+            items: pinned,
+            onMove: movePinnedItem,
+            onDrop: finishMovingPinnedItems
+          ) { item in
+            sessionRow(for: item)
+          }
+          .padding(.top, 2)
         }
       }
 
@@ -1509,55 +1600,62 @@ public struct MultiProviderSessionsListView: View {
   private func sessionRows(for items: [SelectedSessionItem]) -> some View {
     VStack(spacing: 2) {
       ForEach(items) { item in
-        CollapsibleSessionRow(
-          session: item.session,
-          providerKind: item.providerKind,
-          timestamp: item.timestamp,
-          isPending: item.isPending,
-          isPrimary: item.id == primarySessionId,
-          customName: selectedSessionCustomName(for: item),
-          sessionStatus: item.sessionStatus,
-          linkedPullRequests: item.linkedPullRequests,
-          colorScheme: colorScheme,
-          isPinned: isPinned(item),
-          onPin: item.isPending ? nil : {
-            withAnimation(.easeInOut(duration: 0.3)) {
-              switch item.providerKind {
-              case .claude: claudeViewModel.togglePin(for: item.session)
-              case .codex: codexViewModel.togglePin(for: item.session)
-              }
-            }
-          },
-          onArchive: item.isPending ? nil : {
-            withAnimation(.easeInOut(duration: 0.25)) {
-              switch item.providerKind {
-              case .claude: claudeViewModel.stopMonitoring(session: item.session)
-              case .codex: codexViewModel.stopMonitoring(session: item.session)
-              }
-            }
-          },
-          onDeleteWorktree: (!item.isPending && item.session.isWorktree) ? {
-            sessionToDeleteWorktree = item.session
-            showDeleteWorktreeAlert = true
-          } : nil,
-          isDeletingWorktree: item.session.isWorktree && {
-            switch item.providerKind {
-            case .claude: return claudeViewModel.deletingWorktreePath == item.session.projectPath
-            case .codex: return codexViewModel.deletingWorktreePath == item.session.projectPath
-            }
-          }(),
-          onSelect: {
-            selectedWorkspaceID = nil
-            selectedModuleLandingPath = nil
-            primarySessionId = item.id
-          }
-        )
-        .transition(.opacity)
-        .id(item.id)
+        sessionRow(for: item)
+          .transition(.opacity)
+          .id(item.id)
       }
     }
     .padding(.top, 2)
     .animation(.easeInOut(duration: 0.25), value: pinnedSessionSnapshot)
+  }
+
+  /// One sidebar session row. Shared by the plain stacked sections and by the
+  /// reorderable pinned list, so a row looks and behaves the same either way.
+  @ViewBuilder
+  private func sessionRow(for item: SelectedSessionItem) -> some View {
+    CollapsibleSessionRow(
+      session: item.session,
+      providerKind: item.providerKind,
+      timestamp: item.timestamp,
+      isPending: item.isPending,
+      isPrimary: item.id == primarySessionId,
+      customName: selectedSessionCustomName(for: item),
+      sessionStatus: item.sessionStatus,
+      linkedPullRequests: item.linkedPullRequests,
+      colorScheme: colorScheme,
+      isPinned: isPinned(item),
+      onPin: item.isPending ? nil : {
+        withAnimation(.easeInOut(duration: 0.3)) {
+          switch item.providerKind {
+          case .claude: claudeViewModel.togglePin(for: item.session)
+          case .codex: codexViewModel.togglePin(for: item.session)
+          }
+        }
+      },
+      onArchive: item.isPending ? nil : {
+        withAnimation(.easeInOut(duration: 0.25)) {
+          switch item.providerKind {
+          case .claude: claudeViewModel.stopMonitoring(session: item.session)
+          case .codex: codexViewModel.stopMonitoring(session: item.session)
+          }
+        }
+      },
+      onDeleteWorktree: (!item.isPending && item.session.isWorktree) ? {
+        sessionToDeleteWorktree = item.session
+        showDeleteWorktreeAlert = true
+      } : nil,
+      isDeletingWorktree: item.session.isWorktree && {
+        switch item.providerKind {
+        case .claude: return claudeViewModel.deletingWorktreePath == item.session.projectPath
+        case .codex: return codexViewModel.deletingWorktreePath == item.session.projectPath
+        }
+      }(),
+      onSelect: {
+        selectedWorkspaceID = nil
+        selectedModuleLandingPath = nil
+        primarySessionId = item.id
+      }
+    )
   }
 
   @ViewBuilder

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/PinnedReorderableList.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/PinnedReorderableList.swift
@@ -1,0 +1,189 @@
+//
+//  PinnedReorderableList.swift
+//  AgentHub
+//
+
+import SwiftUI
+
+/// Hosts the sidebar's pinned rows with drag-to-reorder: grab a row anywhere,
+/// the others slide aside, drop.
+///
+/// This is a plain `VStack` rather than a nested `List`, because the sidebar
+/// already owns the surrounding scroll view. Each row is a native macOS drop
+/// destination, and its upper/lower half selects whether the dragged row lands
+/// before or after it. The midpoint threshold keeps the order stable while
+/// rows animate around the pointer.
+///
+/// The floating drag image — not the in-place row — carries the theme-color
+/// treatment (translucent fill, border, glow), via the `onDrag` custom
+/// preview. The in-place row is left untouched so the styling reads as "the
+/// thing in your hand", not "the slot it came from".
+struct PinnedReorderableList<Item: Identifiable, Row: View>: View where Item.ID == String {
+  let items: [Item]
+  let onMove: (String, String, PinnedSessionDropPlacement) -> Void
+  let onDrop: () -> Void
+  @ViewBuilder let row: (Item) -> Row
+
+  @Environment(\.runtimeTheme) private var runtimeTheme
+  @State private var draggingID: String?
+  @State private var rowHeights: [String: Double] = [:]
+  /// Measured list width. The drag preview renders offscreen with no width
+  /// proposal, and rows are `maxWidth: .infinity`, so the preview must be
+  /// pinned to the width the row actually renders at in the sidebar.
+  @State private var rowWidth: CGFloat = 0
+
+  private var accent: Color { Color.brandPrimary(from: runtimeTheme) }
+
+  init(
+    items: [Item],
+    onMove: @escaping (String, String, PinnedSessionDropPlacement) -> Void,
+    onDrop: @escaping () -> Void,
+    @ViewBuilder row: @escaping (Item) -> Row
+  ) {
+    self.items = items
+    self.onMove = onMove
+    self.onDrop = onDrop
+    self.row = row
+  }
+
+  var body: some View {
+    VStack(spacing: 2) {
+      ForEach(items) { item in
+        row(item)
+          .onDrag {
+            draggingID = item.id
+            return NSItemProvider(object: item.id as NSString)
+          } preview: {
+            DraggedRowPreview(accent: accent, width: rowWidth) {
+              row(item)
+            }
+          }
+          .background {
+            GeometryReader { proxy in
+              Color.clear.preference(
+                key: PinnedRowHeightPreferenceKey.self,
+                value: [item.id: Double(proxy.size.height)]
+              )
+            }
+          }
+          .onDrop(
+            of: [.text],
+            delegate: PinnedRowDropDelegate(
+              targetID: item.id,
+              targetHeight: rowHeights[item.id] ?? 0,
+              draggingID: $draggingID,
+              onMove: onMove,
+              onDrop: onDrop
+            )
+          )
+          .id(item.id)
+      }
+    }
+    .onPreferenceChange(PinnedRowHeightPreferenceKey.self) { heights in
+      rowHeights = heights
+    }
+    .background {
+      GeometryReader { proxy in
+        Color.clear
+          .onAppear { rowWidth = proxy.size.width }
+          .onChange(of: proxy.size.width) { _, width in
+            rowWidth = width
+          }
+      }
+    }
+  }
+}
+
+// MARK: - DraggedRowPreview
+
+/// The floating drag image: the row itself, dressed in the theme color — a
+/// translucent fill, a border, and a glow cast by that border. The shadow
+/// lives on the stroke shape (shadowing the content would outline every text
+/// glyph), and the padding gives the glow room inside the snapshot bounds so
+/// it is not clipped at the image edge.
+private struct DraggedRowPreview<Content: View>: View {
+  let accent: Color
+  let width: CGFloat
+  @ViewBuilder let content: Content
+
+  var body: some View {
+    content
+      .frame(width: width > 0 ? width : nil)
+      .background(
+        RoundedRectangle(cornerRadius: 6)
+          .fill(accent.opacity(0.15))
+      )
+      .overlay(
+        RoundedRectangle(cornerRadius: 6)
+          .strokeBorder(accent.opacity(0.8), lineWidth: 1)
+          .shadow(color: accent.opacity(0.5), radius: 4)
+      )
+      .padding(6)
+  }
+}
+
+// MARK: - PinnedRowDropDelegate
+
+/// Reorders against a stable before/after threshold within one row.
+///
+/// `dropExited` intentionally does not clear the drag identity: the same drag
+/// must remain valid when the pointer leaves the list and comes back.
+private struct PinnedRowDropDelegate: DropDelegate {
+  let targetID: String
+  let targetHeight: Double
+  @Binding var draggingID: String?
+  let onMove: (String, String, PinnedSessionDropPlacement) -> Void
+  let onDrop: () -> Void
+
+  func dropEntered(info: DropInfo) {
+    updateOrder(info: info)
+  }
+
+  func dropUpdated(info: DropInfo) -> DropProposal? {
+    updateOrder(info: info)
+    return DropProposal(operation: .move)
+  }
+
+  func performDrop(info: DropInfo) -> Bool {
+    guard acceptsDrop(info) else { return false }
+    updateOrder(info: info)
+    draggingID = nil
+    onDrop()
+    return true
+  }
+
+  func validateDrop(info: DropInfo) -> Bool {
+    acceptsDrop(info)
+  }
+
+  private func acceptsDrop(_ info: DropInfo) -> Bool {
+    draggingID != nil && info.hasItemsConforming(to: [.text])
+  }
+
+  private func updateOrder(info: DropInfo) {
+    guard
+      acceptsDrop(info),
+      let draggingID,
+      draggingID != targetID
+    else { return }
+
+    // Preferences normally provide the exact height before a drag can begin.
+    // Keep a sensible fallback so a drag started during the first layout pass
+    // still reorders instead of silently doing nothing.
+    let midpoint = targetHeight > 0 ? targetHeight / 2 : 22
+    let placement: PinnedSessionDropPlacement =
+      Double(info.location.y) < midpoint ? .before : .after
+    onMove(draggingID, targetID, placement)
+  }
+}
+
+private struct PinnedRowHeightPreferenceKey: PreferenceKey {
+  static let defaultValue: [String: Double] = [:]
+
+  static func reduce(
+    value: inout [String: Double],
+    nextValue: () -> [String: Double]
+  ) {
+    value.merge(nextValue(), uniquingKeysWith: { _, latest in latest })
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/PinnedSessionDropPlacement.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/PinnedSessionDropPlacement.swift
@@ -1,0 +1,9 @@
+//
+//  PinnedSessionDropPlacement.swift
+//  AgentHub
+//
+
+enum PinnedSessionDropPlacement: Equatable {
+  case before
+  case after
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/SidebarSessionOrdering.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/SidebarSessionOrdering.swift
@@ -50,15 +50,35 @@ struct SidebarRepositoryModuleSection<Item>: Identifiable {
 }
 
 enum SidebarSessionOrdering {
+  /// The pinned section, in the order the user sees it.
+  ///
+  /// Pinned rows are the only ones the user can drag, so they are the only ones
+  /// with a manual order. Rows the user has positioned come first in that
+  /// order; rows that have never been positioned (a freshly pinned session)
+  /// keep the activity sort and land after them, so pinning something new never
+  /// disturbs an arrangement the user built by hand.
   static func pinnedItems<Item>(
     from items: [Item],
     isPinned: (Item) -> Bool,
     timestamp: (Item) -> Date,
-    id: (Item) -> String
+    id: (Item) -> String,
+    manualOrder: (Item) -> Int? = { _ in nil }
   ) -> [Item] {
     items
       .filter(isPinned)
-      .sorted { orderedByActivity($0, $1, timestamp: timestamp, id: id) }
+      .sorted { lhs, rhs in
+        switch (manualOrder(lhs), manualOrder(rhs)) {
+        case let (lhsIndex?, rhsIndex?):
+          if lhsIndex != rhsIndex { return lhsIndex < rhsIndex }
+          return orderedByActivity(lhs, rhs, timestamp: timestamp, id: id)
+        case (.some, .none):
+          return true
+        case (.none, .some):
+          return false
+        case (.none, .none):
+          return orderedByActivity(lhs, rhs, timestamp: timestamp, id: id)
+        }
+      }
   }
 
   static func moduleGroups<Item>(
@@ -193,7 +213,8 @@ enum SidebarSessionOrdering {
     projectPath: (Item) -> String,
     status: (Item) -> SessionStatus?,
     timestamp: (Item) -> Date,
-    id: (Item) -> String
+    id: (Item) -> String,
+    manualOrder: (Item) -> Int? = { _ in nil }
   ) -> [Item] {
     var result: [Item] = []
 
@@ -202,7 +223,8 @@ enum SidebarSessionOrdering {
         from: items,
         isPinned: isPinned,
         timestamp: timestamp,
-        id: id
+        id: id,
+        manualOrder: manualOrder
       ))
     }
 
@@ -237,6 +259,34 @@ enum SidebarSessionOrdering {
     }
 
     return result
+  }
+
+  /// Repositions one pinned row before or after the row under the pointer.
+  ///
+  /// The dragged row is removed before the target index is calculated, so the
+  /// operation remains correct regardless of which direction the row moves.
+  /// Returns `nil` for invalid inputs and unchanged placements.
+  static func reorderedIDs(
+    _ ids: [String],
+    movingID: String,
+    targetID: String,
+    placement: PinnedSessionDropPlacement
+  ) -> [String]? {
+    guard movingID != targetID,
+          ids.contains(movingID),
+          ids.contains(targetID)
+    else { return nil }
+
+    let remainingIDs = ids.filter { $0 != movingID }
+    guard let targetIndex = remainingIDs.firstIndex(of: targetID) else {
+      return nil
+    }
+
+    var reorderedIDs = remainingIDs
+    let insertionIndex = placement == .before ? targetIndex : targetIndex + 1
+    reorderedIDs.insert(movingID, at: insertionIndex)
+
+    return reorderedIDs == ids ? nil : reorderedIDs
   }
 
   static func nextID(

--- a/app/modules/AgentHubCore/Sources/AgentHub/Utils/SidebarSessionItemID.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Utils/SidebarSessionItemID.swift
@@ -1,0 +1,25 @@
+//
+//  SidebarSessionItemID.swift
+//  AgentHub
+//
+
+import Foundation
+
+/// Identity of a sidebar session row.
+///
+/// A row is not identified by its bare session id: the sidebar unions Claude
+/// and Codex sessions into one list, and pending (not-yet-real) sessions have
+/// no session id at all. Everything that persists or scrolls to a row keys off
+/// these strings, so they live in one place rather than being re-spelled at
+/// each call site.
+enum SidebarSessionItemID {
+  /// Identity of a row backed by a real, monitored session.
+  static func monitored(provider: SessionProviderKind, sessionId: String) -> String {
+    "\(provider.rawValue.lowercased())-\(sessionId)"
+  }
+
+  /// Identity of a row for a session that is still launching.
+  static func pending(provider: SessionProviderKind, pendingId: UUID) -> String {
+    "pending-\(provider.rawValue.lowercased())-\(pendingId.uuidString)"
+  }
+}

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/PinnedSessionOrderStoreTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/PinnedSessionOrderStoreTests.swift
@@ -1,0 +1,158 @@
+import Foundation
+import GRDB
+import Testing
+
+@testable import AgentHubCore
+
+@Suite("Pinned session order store")
+struct PinnedSessionOrderStoreTests {
+  @Test("Order round-trips as dense positions")
+  func orderRoundTrips() async throws {
+    let store = try SessionMetadataStore(path: temporaryPinnedOrderDatabasePath())
+
+    try await store.setPinnedSessionOrder(["claude-a", "codex-b", "claude-c"])
+
+    #expect(try await store.getPinnedSessionOrder() == [
+      "claude-a": 0,
+      "codex-b": 1,
+      "claude-c": 2
+    ])
+  }
+
+  @Test("Rewriting the order replaces earlier positions instead of stacking them")
+  func rewritingOrderReplacesPositions() async throws {
+    let store = try SessionMetadataStore(path: temporaryPinnedOrderDatabasePath())
+
+    try await store.setPinnedSessionOrder(["claude-a", "claude-b", "claude-c"])
+    try await store.setPinnedSessionOrder(["claude-c", "claude-a", "claude-b"])
+
+    let order = try await store.getPinnedSessionOrder()
+    #expect(order == ["claude-c": 0, "claude-a": 1, "claude-b": 2])
+    // No duplicate slots — every pinned row must have a position of its own.
+    #expect(Set(order.values).count == order.count)
+  }
+
+  @Test("Synchronous read matches the async read")
+  func syncReadMatchesAsyncRead() async throws {
+    let store = try SessionMetadataStore(path: temporaryPinnedOrderDatabasePath())
+
+    try await store.setPinnedSessionOrder(["claude-a", "codex-b"])
+
+    #expect(store.getPinnedSessionOrderSync() == ["claude-a": 0, "codex-b": 1])
+  }
+
+  @Test("Empty order reads back empty rather than failing")
+  func emptyOrderReadsBackEmpty() async throws {
+    let store = try SessionMetadataStore(path: temporaryPinnedOrderDatabasePath())
+
+    #expect(try await store.getPinnedSessionOrder().isEmpty)
+    #expect(store.getPinnedSessionOrderSync().isEmpty)
+
+    try await store.setPinnedSessionOrder([])
+    #expect(try await store.getPinnedSessionOrder().isEmpty)
+  }
+
+  @Test("Order survives reopening the database")
+  func orderSurvivesReopen() async throws {
+    let path = temporaryPinnedOrderDatabasePath()
+    let store = try SessionMetadataStore(path: path)
+    try await store.setPinnedSessionOrder(["claude-a", "claude-b"])
+
+    let reopened = try SessionMetadataStore(path: path)
+    #expect(try await reopened.getPinnedSessionOrder() == ["claude-a": 0, "claude-b": 1])
+  }
+
+  @Test("Positions are provider-scoped, so identical session ids do not collide")
+  func positionsAreProviderScoped() async throws {
+    let store = try SessionMetadataStore(path: temporaryPinnedOrderDatabasePath())
+    let sharedSessionId = "same-id"
+
+    try await store.setPinnedSessionOrder([
+      SidebarSessionItemID.monitored(provider: .codex, sessionId: sharedSessionId),
+      SidebarSessionItemID.monitored(provider: .claude, sessionId: sharedSessionId)
+    ])
+
+    let order = try await store.getPinnedSessionOrder()
+    #expect(order["codex-\(sharedSessionId)"] == 0)
+    #expect(order["claude-\(sharedSessionId)"] == 1)
+  }
+
+  @Test("Explicitly deleting positions clears only the named rows")
+  func deletingPositionsClearsOnlyNamedRows() async throws {
+    let store = try SessionMetadataStore(path: temporaryPinnedOrderDatabasePath())
+    try await store.setPinnedSessionOrder(["claude-a", "claude-b", "claude-c"])
+
+    try await store.deletePinnedSessionOrder(forItemIds: ["claude-b"])
+
+    #expect(try await store.getPinnedSessionOrder() == ["claude-a": 0, "claude-c": 2])
+  }
+
+  @Test("Deleting a session's metadata drops its pinned position")
+  func deletingMetadataDropsPinnedPosition() async throws {
+    let store = try SessionMetadataStore(path: temporaryPinnedOrderDatabasePath())
+    let sessionId = "session-1"
+
+    try await store.setPinnedSessionOrder([
+      SidebarSessionItemID.monitored(provider: .claude, sessionId: sessionId),
+      "claude-other"
+    ])
+
+    try await store.deleteMetadata(for: sessionId)
+
+    #expect(try await store.getPinnedSessionOrder() == ["claude-other": 1])
+  }
+
+  @Test("Unpinning leaves the slot behind so re-pinning restores the position")
+  func unpinningPreservesTheSlot() async throws {
+    let store = try SessionMetadataStore(path: temporaryPinnedOrderDatabasePath())
+    let itemId = SidebarSessionItemID.monitored(provider: .claude, sessionId: "session-1")
+
+    try await store.setPinnedSessionOrder([itemId, "claude-other"])
+    try await store.setPinned(true, for: "session-1")
+    try await store.setPinned(false, for: "session-1")
+
+    #expect(try await store.getPinnedSessionOrder()[itemId] == 0)
+  }
+
+  @Test("v13 migration preserves existing metadata on a pre-v13 database")
+  func migrationPreservesExistingMetadata() async throws {
+    let path = temporaryPinnedOrderDatabasePath()
+    let sessionId = "session-1"
+
+    // Build a real database, then rewind it to the pre-v13 schema so the
+    // migration runs against rows that already exist — the case that matters.
+    let seeded = try SessionMetadataStore(path: path)
+    try await seeded.setCustomName("Important session", for: sessionId)
+    try await seeded.setPinned(true, for: sessionId)
+    try await rewindPastPinnedSessionOrderMigration(at: path)
+
+    let migrated = try SessionMetadataStore(path: path)
+
+    #expect(try await migrated.getCustomName(for: sessionId) == "Important session")
+    #expect(try await migrated.getPinnedSessionIds() == Set([sessionId]))
+    #expect(try await migrated.getPinnedSessionOrder().isEmpty)
+
+    // And the freshly created table is usable, not just present.
+    try await migrated.setPinnedSessionOrder(["claude-\(sessionId)"])
+    #expect(try await migrated.getPinnedSessionOrder() == ["claude-\(sessionId)": 0])
+  }
+}
+
+/// Drops the v13 table and its migration record, leaving every earlier
+/// migration and all existing rows in place.
+private func rewindPastPinnedSessionOrderMigration(at path: String) throws {
+  let queue = try DatabaseQueue(path: path)
+  try queue.write { db in
+    try db.execute(sql: "DROP TABLE IF EXISTS pinned_session_order")
+    try db.execute(
+      sql: "DELETE FROM grdb_migrations WHERE identifier = ?",
+      arguments: [SessionMetadataStore.MigrationID.createPinnedSessionOrder]
+    )
+  }
+}
+
+private func temporaryPinnedOrderDatabasePath() -> String {
+  FileManager.default.temporaryDirectory
+    .appending(path: "test_pinned_session_order_\(UUID().uuidString).sqlite")
+    .path
+}

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/SidebarSessionOrderingTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/SidebarSessionOrderingTests.swift
@@ -138,6 +138,167 @@ struct SidebarSessionOrderingTests {
     #expect(ids == ["b"])
   }
 
+  // MARK: - Manual pinned order
+
+  @Test("Manual pinned order overrides the activity sort")
+  func manualPinnedOrderOverridesActivitySort() {
+    let items = [
+      item("newest", timestamp: 500, isPinned: true),
+      item("middle", timestamp: 300, isPinned: true),
+      item("oldest", timestamp: 100, isPinned: true)
+    ]
+
+    let ids = pinnedIDs(items, manualOrder: ["oldest": 0, "newest": 1, "middle": 2])
+
+    #expect(ids == ["oldest", "newest", "middle"])
+  }
+
+  @Test("Freshly pinned sessions sort after arranged ones, by activity")
+  func unorderedPinnedItemsFallInAfterArrangedOnes() {
+    let items = [
+      item("arranged-second", timestamp: 100, isPinned: true),
+      item("just-pinned-old", timestamp: 200, isPinned: true),
+      item("arranged-first", timestamp: 300, isPinned: true),
+      item("just-pinned-new", timestamp: 400, isPinned: true)
+    ]
+
+    let ids = pinnedIDs(items, manualOrder: ["arranged-first": 0, "arranged-second": 1])
+
+    #expect(ids == ["arranged-first", "arranged-second", "just-pinned-new", "just-pinned-old"])
+  }
+
+  @Test("Keyboard navigation order follows the manual pinned order")
+  func flattenedOrderFollowsManualPinnedOrder() {
+    let items = [
+      item("pinned-newest", timestamp: 500, isPinned: true),
+      item("pinned-oldest", timestamp: 100, isPinned: true),
+      item("unpinned", timestamp: 400)
+    ]
+
+    let ids = flattenedIDs(
+      items,
+      groupMode: .repo,
+      manualOrder: ["pinned-oldest": 0, "pinned-newest": 1]
+    )
+
+    #expect(ids == ["pinned-oldest", "pinned-newest", "unpinned"])
+  }
+
+  @Test("Manual order is ignored for sessions that are not pinned")
+  func manualOrderDoesNotPromoteUnpinnedSessions() {
+    let items = [
+      item("pinned", timestamp: 100, isPinned: true),
+      item("unpinned", timestamp: 500)
+    ]
+
+    let ids = pinnedIDs(items, manualOrder: ["unpinned": 0, "pinned": 1])
+
+    #expect(ids == ["pinned"])
+  }
+
+  // MARK: - Reorder math
+
+  @Test("Dropping in a row's lower half inserts the dragged row after it")
+  func dropPlacementMovesRowDown() {
+    let result = SidebarSessionOrdering.reorderedIDs(
+      ["a", "b", "c"],
+      movingID: "a",
+      targetID: "b",
+      placement: .after
+    )
+
+    #expect(result == ["b", "a", "c"])
+  }
+
+  @Test("Dropping in the first row's upper half moves the dragged row to the top")
+  func dropPlacementMovesRowToTop() {
+    let result = SidebarSessionOrdering.reorderedIDs(
+      ["a", "b", "c"],
+      movingID: "c",
+      targetID: "a",
+      placement: .before
+    )
+
+    #expect(result == ["c", "a", "b"])
+  }
+
+  @Test("Dropping in the last row's lower half moves the dragged row to the end")
+  func dropPlacementMovesRowToEnd() {
+    let result = SidebarSessionOrdering.reorderedIDs(
+      ["a", "b", "c"],
+      movingID: "a",
+      targetID: "c",
+      placement: .after
+    )
+
+    #expect(result == ["b", "c", "a"])
+  }
+
+  @Test("A placement that resolves to the current slot is a no-op")
+  func unchangedDropPlacementReturnsNil() {
+    #expect(SidebarSessionOrdering.reorderedIDs(
+      ["a", "b", "c"],
+      movingID: "b",
+      targetID: "a",
+      placement: .after
+    ) == nil)
+  }
+
+  @Test("Reorder rejects unknown rows and self-targeting")
+  func reorderRejectsInvalidInput() {
+    #expect(SidebarSessionOrdering.reorderedIDs(
+      ["a", "b"],
+      movingID: "missing",
+      targetID: "a",
+      placement: .before
+    ) == nil)
+
+    #expect(SidebarSessionOrdering.reorderedIDs(
+      ["a", "b"],
+      movingID: "a",
+      targetID: "missing",
+      placement: .after
+    ) == nil)
+
+    #expect(SidebarSessionOrdering.reorderedIDs(
+      ["a", "b"],
+      movingID: "a",
+      targetID: "a",
+      placement: .after
+    ) == nil)
+  }
+
+  @Test("The same target placement stays stable after rows animate around it")
+  func reorderDoesNotOscillateAfterLayoutUpdate() {
+    let firstResult = SidebarSessionOrdering.reorderedIDs(
+      ["a", "b", "c"],
+      movingID: "a",
+      targetID: "b",
+      placement: .after
+    )
+    #expect(firstResult == ["b", "a", "c"])
+
+    let settledResult = SidebarSessionOrdering.reorderedIDs(
+      firstResult ?? [],
+      movingID: "a",
+      targetID: "b",
+      placement: .after
+    )
+    #expect(settledResult == nil)
+  }
+
+  @Test("Crossing back over a target midpoint reverses the previous move")
+  func reorderCanReverseDirection() {
+    let result = SidebarSessionOrdering.reorderedIDs(
+      ["b", "a", "c"],
+      movingID: "a",
+      targetID: "b",
+      placement: .before
+    )
+
+    #expect(result == ["a", "b", "c"])
+  }
+
   @Test("Next ID indexes through the flattened order without wrapping")
   func nextIDIndexesThroughFlattenedOrder() {
     let ids = ["first", "second", "third"]
@@ -180,7 +341,8 @@ private func flattenedIDs(
   worktreeDisplayMode: WorktreeDisplayMode = .parent,
   collapsedProjectGroups: Set<String> = [],
   collapsedStatusGroups: Set<StatusGroupCategory> = [],
-  isPinnedSectionCollapsed: Bool = false
+  isPinnedSectionCollapsed: Bool = false,
+  manualOrder: [String: Int] = [:]
 ) -> [String] {
   SidebarSessionOrdering.flattenedItems(
     from: items,
@@ -194,7 +356,22 @@ private func flattenedIDs(
     projectPath: { $0.projectPath },
     status: { $0.status },
     timestamp: { $0.timestamp },
-    id: { $0.id }
+    id: { $0.id },
+    manualOrder: { manualOrder[$0.id] }
+  )
+  .map(\.id)
+}
+
+private func pinnedIDs(
+  _ items: [SidebarTestItem],
+  manualOrder: [String: Int] = [:]
+) -> [String] {
+  SidebarSessionOrdering.pinnedItems(
+    from: items,
+    isPinned: { $0.isPinned },
+    timestamp: { $0.timestamp },
+    id: { $0.id },
+    manualOrder: { manualOrder[$0.id] }
   )
   .map(\.id)
 }


### PR DESCRIPTION
## Summary

- add smooth, midpoint-based drag reordering for pinned sidebar sessions
- keep row-level macOS drop destinations active when a drag leaves and re-enters the list
- persist the manual cross-provider pinned order in SQLite and restore it on first render
- debounce intermediate persistence writes and flush the final order on drop
- add ordering, persistence, provider-identity, and migration-preservation coverage

## Root cause

The earlier list-level drop handling could lose its active destination when the pointer left the pinned-list bounds, so returning to the list did not reliably resume reordering. Reordering could also depend on row positions that became stale while SwiftUI animated the list.

This keeps native per-row `.onDrop(.text)` destinations, retains drag identity across exit/re-entry, measures the target row midpoint for before/after placement, and resolves every move from stable session IDs against the current order.

## Impact

Pinned sessions can be rearranged more smoothly and reliably, including after moving the pointer outside the list and back. Their order survives app relaunches and remains distinct across Claude and Codex sessions.

## Validation

- `xcodebuild test -scheme AgentHubCore-Tests -destination 'platform=macOS' -test-timeouts-enabled YES -skipPackagePluginValidation -only-testing:AgentHubTests/SidebarSessionOrderingTests -only-testing:AgentHubTests/PinnedSessionOrderStoreTests` — 28 tests passed
- `xcodebuild build -project app/AgentHub.xcodeproj -scheme AgentHub -destination 'platform=macOS' -skipPackagePluginValidation` — succeeded
- `git diff --check` — passed