### PR TITLE
Notify on CI failures with tap-to-open and a Fix CI action

### DIFF
--- a/GitHubMonitor.md
+++ b/GitHubMonitor.md
@@ -7,7 +7,8 @@ AgentHub observes GitHub pull request state and CI checks through a shared servi
 - GitHub monitoring is optional and only works when the GitHub CLI (`gh`) is installed, authenticated, and the session project is a GitHub repository.
 - Session rows show GitHub status only when the current session branch has a pull request. Branches with no PR stay visually quiet.
 - When a PR exists, the side-panel session row shows a compact bottom line with PR state and CI summary, for example `Draft PR #20 - CI passing 1/1`.
-- CI failures, requested changes, and merge conflicts are in-app attention states. They affect compact row styling and idle-session ordering, but do not produce macOS notifications.
+- CI failures, requested changes, and merge conflicts are in-app attention states. They affect compact row styling and idle-session ordering.
+- A newly failing CI run on an observed open PR additionally posts one macOS notification per PR head commit (gated by the Settings toggles for push and CI-failure notifications). Tapping it selects the session and opens its GitHub side panel; the notification's **Fix CI** action instead fetches the failed-run logs (`gh run view <runId> --log-failed`) and injects a fix prompt into the session's agent terminal. Requested changes and merge conflicts still do not notify.
 - If a refresh fails after a PR has been observed, the row keeps safe last-known data and marks it unavailable instead of replacing useful state with an empty result.
 - Monitoring cards can expose the current branch PR as quick access.
 - The GitHub panel observes the current branch PR and the selected PR detail/check state.
@@ -112,6 +113,13 @@ The selected PR observation keeps PR metadata and CI checks fresh without reload
 
 The global session panel derives GitHub attention from the same observation snapshots. Idle sessions with CI failure, requested changes, or merge conflicts are raised above ordinary idle work without displacing actively working sessions.
 
+## CI Failure Notifications And Fix CI
+
+- `SessionGitHubQuickAccessViewModel.onSnapshotApplied` is the per-session snapshot hook. `CollapsibleSessionRow` and `MonitoringCardView` set it with their session identity and forward snapshots to `GitHubCIFailureNotifier` (AgentHubCore).
+- `GitHubCIFailureNotifier` posts one notification per `(projectPath, PR number, head commit)` per app run, only for `.ready` non-stale snapshots of open PRs with failed checks. The notification carries a `GitHubCIFailureNotificationPayload` (session id, provider, project path, branch, PR, failed checks) in `userInfo` and uses the `GitHubCIFailureNotification` category, whose single action is **Fix CI**.
+- The app delegate registers the category, and on response routes through `GlobalSessionSelectionRouter` (session selection) plus `GitHubCIFailureActionRouter` (panel action). `MultiProviderMonitoringPanelView` consumes the action request: default tap opens the `.gitHub` side panel for the session; **Fix CI** switches the card to terminal mode and injects the prompt built by `GitHubCIFixService`.
+- `GitHubCIFixService` (AgentHubGitHub) parses Actions run ids from failed checks' `detailsUrl` (`GitHubActionsRunReference`), fetches `gh run view <runId> --log-failed` via `GitHubCLIServiceProtocol.getFailedRunLogs`, truncates to the log tail, and composes the prompt with `GitHubCIFixPromptBuilder`. Log fetch failures degrade to a prompt that tells the agent which `gh` commands to run itself.
+
 ## Testing
 
 Tests cover:
@@ -140,6 +148,8 @@ Relevant test files:
 - `app/modules/AgentHubGitHub/Tests/AgentHubGitHubTests/SessionGitHubQuickAccessViewModelTests.swift`
 - `app/modules/AgentHubGitHub/Tests/AgentHubGitHubTests/GitHubViewModelObservationTests.swift`
 - `app/modules/AgentHubGitHub/Tests/AgentHubGitHubTests/GitHubCLIServiceTests.swift`
+- `app/modules/AgentHubGitHub/Tests/AgentHubGitHubTests/GitHubCIFixTests.swift`
+- `app/modules/AgentHubCore/Tests/AgentHubTests/GitHubCIFailureNotifierTests.swift`
 
 ## Editing Guidelines
 

--- a/app/AgentHub/AgentHubApp.swift
+++ b/app/AgentHub/AgentHubApp.swift
@@ -34,6 +34,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
 
   func applicationDidFinishLaunching(_ notification: Notification) {
     UNUserNotificationCenter.current().delegate = self
+    UNUserNotificationCenter.current().setNotificationCategories([
+      GitHubCIFailureNotification.category()
+    ])
     registerBundledFonts()
     // Sweep any approval hooks left installed by a previous crash/force-quit
     // before sessions start restoring. Re-installs happen naturally as each
@@ -91,8 +94,23 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
     didReceive response: UNNotificationResponse,
     withCompletionHandler completionHandler: @escaping () -> Void
   ) {
+    let ciFailurePayload = GitHubCIFailureNotificationPayload(
+      userInfo: response.notification.request.content.userInfo
+    )
+    let isFixCIAction = response.actionIdentifier == GitHubCIFailureNotification.fixActionIdentifier
     Task { @MainActor in
       NSApp.activate(ignoringOtherApps: true)
+      if let ciFailurePayload, let providerKind = ciFailurePayload.providerKind {
+        provider.globalSessionSelectionRouter.select(
+          providerKind: providerKind,
+          sessionId: ciFailurePayload.sessionId,
+          projectPath: ciFailurePayload.projectPath
+        )
+        provider.gitHubCIFailureActionRouter.request(
+          payload: ciFailurePayload,
+          action: isFixCIAction ? .fixCI : .openGitHubPanel
+        )
+      }
     }
     completionHandler()
   }

--- a/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubDefaults.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubDefaults.swift
@@ -44,6 +44,10 @@ public enum AgentHubDefaults {
   /// Type: Bool (default: true)
   public static let pushNotificationsEnabled = "\(keyPrefix)notifications.pushEnabled"
 
+  /// Whether notifications are posted when an observed PR's CI starts failing
+  /// Type: Bool (default: true)
+  public static let ciFailureNotificationsEnabled = "\(keyPrefix)notifications.ciFailureEnabled"
+
   // MARK: - Provider Settings
 
   /// Base key for enabled providers

--- a/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubProvider.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubProvider.swift
@@ -211,6 +211,15 @@ public final class AgentHubProvider {
   /// Shared GitHub PR/check observation service for panels and session rows
   public private(set) lazy var gitHubPRObservationService: any GitHubPRObservationServiceProtocol = GitHubPRObservationService(service: gitHubService)
 
+  /// Fetches failing CI logs and composes the "Fix CI" agent prompt
+  public private(set) lazy var gitHubCIFixService: any GitHubCIFixServiceProtocol = GitHubCIFixService(service: gitHubService)
+
+  /// Posts macOS notifications when an observed PR's CI starts failing
+  public private(set) lazy var gitHubCIFailureNotifier: any GitHubCIFailureNotifierProtocol = GitHubCIFailureNotifier()
+
+  /// Routes CI-failure notification taps into the monitoring UI
+  public private(set) lazy var gitHubCIFailureActionRouter: GitHubCIFailureActionRouter = .init()
+
   // MARK: - Global Session Control Panel
 
   /// Routes global-panel session selections into the main sessions UI.

--- a/app/modules/AgentHubCore/Sources/AgentHub/Models/GitHubCIFailureActionRouter.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Models/GitHubCIFailureActionRouter.swift
@@ -1,0 +1,59 @@
+//
+//  GitHubCIFailureActionRouter.swift
+//  AgentHub
+//
+//  Routes CI-failure notification taps into the monitoring UI
+//
+
+import Foundation
+
+// MARK: - GitHubCIFailureActionRequest
+
+public struct GitHubCIFailureActionRequest: Identifiable, Equatable, Sendable {
+
+  public enum Action: Equatable, Sendable {
+    /// Default notification tap: select the session and open its GitHub panel.
+    case openGitHubPanel
+    /// "Fix CI" action button: fetch the failure and inject a fix prompt into
+    /// the session's agent terminal.
+    case fixCI
+  }
+
+  public let id: UUID
+  public let payload: GitHubCIFailureNotificationPayload
+  public let action: Action
+
+  public init(
+    id: UUID = UUID(),
+    payload: GitHubCIFailureNotificationPayload,
+    action: Action
+  ) {
+    self.id = id
+    self.payload = payload
+    self.action = action
+  }
+}
+
+// MARK: - GitHubCIFailureActionRouter
+
+/// Publishes pending CI-failure notification actions for the monitoring panel
+/// to consume, mirroring `GlobalSessionSelectionRouter`'s request/consume flow.
+@MainActor
+@Observable
+public final class GitHubCIFailureActionRouter {
+  public private(set) var pendingRequest: GitHubCIFailureActionRequest?
+
+  public init() {}
+
+  public func request(
+    payload: GitHubCIFailureNotificationPayload,
+    action: GitHubCIFailureActionRequest.Action
+  ) {
+    pendingRequest = GitHubCIFailureActionRequest(payload: payload, action: action)
+  }
+
+  public func markConsumed(_ request: GitHubCIFailureActionRequest) {
+    guard pendingRequest?.id == request.id else { return }
+    pendingRequest = nil
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/Models/GitHubCIFailureNotificationPayload.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Models/GitHubCIFailureNotificationPayload.swift
@@ -1,0 +1,79 @@
+//
+//  GitHubCIFailureNotificationPayload.swift
+//  AgentHub
+//
+//  Session/PR identity carried through CI-failure notification userInfo
+//
+
+import Foundation
+
+/// Everything a CI-failure notification tap needs to route back into the app:
+/// which session to select, which PR is failing, and which checks failed.
+///
+/// Encoded as a JSON string inside `UNNotificationContent.userInfo` so the
+/// payload survives the plist-only userInfo round-trip.
+public struct GitHubCIFailureNotificationPayload: Equatable, Sendable, Codable {
+
+  public struct FailedCheck: Equatable, Sendable, Codable {
+    public let name: String
+    public let workflowName: String?
+    public let detailsUrl: String?
+
+    public init(name: String, workflowName: String? = nil, detailsUrl: String? = nil) {
+      self.name = name
+      self.workflowName = workflowName
+      self.detailsUrl = detailsUrl
+    }
+  }
+
+  public let sessionId: String
+  public let providerKindRawValue: String
+  public let projectPath: String
+  public let branchName: String
+  public let prNumber: Int
+  public let prTitle: String
+  public let failedChecks: [FailedCheck]
+
+  public var providerKind: SessionProviderKind? {
+    SessionProviderKind(rawValue: providerKindRawValue)
+  }
+
+  public init(
+    sessionId: String,
+    providerKindRawValue: String,
+    projectPath: String,
+    branchName: String,
+    prNumber: Int,
+    prTitle: String,
+    failedChecks: [FailedCheck]
+  ) {
+    self.sessionId = sessionId
+    self.providerKindRawValue = providerKindRawValue
+    self.projectPath = projectPath
+    self.branchName = branchName
+    self.prNumber = prNumber
+    self.prTitle = prTitle
+    self.failedChecks = failedChecks
+  }
+
+  // MARK: - userInfo round-trip
+
+  private static let userInfoKey = "com.agenthub.notification.ciFailurePayload"
+
+  public var userInfo: [String: Any] {
+    guard let data = try? JSONEncoder().encode(self),
+          let json = String(data: data, encoding: .utf8) else {
+      return ["sessionId": sessionId]
+    }
+    return [Self.userInfoKey: json, "sessionId": sessionId]
+  }
+
+  public init?(userInfo: [AnyHashable: Any]) {
+    guard let json = userInfo[Self.userInfoKey] as? String,
+          let data = json.data(using: .utf8),
+          let payload = try? JSONDecoder().decode(Self.self, from: data) else {
+      return nil
+    }
+    self = payload
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/GitHubCIFailureNotifier.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/GitHubCIFailureNotifier.swift
@@ -1,0 +1,167 @@
+//
+//  GitHubCIFailureNotifier.swift
+//  AgentHub
+//
+//  Posts macOS notifications when an observed PR's CI starts failing
+//
+
+import AgentHubGitHub
+import Foundation
+import UserNotifications
+#if canImport(AppKit)
+import AppKit
+#endif
+
+// MARK: - GitHubCIFailureNotification (category)
+
+/// Identifiers for the CI-failure notification category and its actions.
+/// The app delegate registers the category at launch and matches these
+/// identifiers when handling notification responses.
+public enum GitHubCIFailureNotification {
+  public static let categoryIdentifier = "com.agenthub.notification.ciFailure"
+  public static let fixActionIdentifier = "com.agenthub.notification.ciFailure.fixAction"
+
+  public static func category() -> UNNotificationCategory {
+    let fixAction = UNNotificationAction(
+      identifier: fixActionIdentifier,
+      title: "Fix CI",
+      options: [.foreground]
+    )
+    return UNNotificationCategory(
+      identifier: categoryIdentifier,
+      actions: [fixAction],
+      intentIdentifiers: []
+    )
+  }
+}
+
+// MARK: - GitHubCIFailureSessionContext
+
+/// The session a CI snapshot was observed for — supplied by the UI surface
+/// that owns the observation subscription, since snapshots themselves only
+/// know the repository/branch target.
+public struct GitHubCIFailureSessionContext: Equatable, Sendable {
+  public let sessionId: String
+  public let providerKind: SessionProviderKind
+  public let projectPath: String
+  public let branchName: String?
+
+  public init(
+    sessionId: String,
+    providerKind: SessionProviderKind,
+    projectPath: String,
+    branchName: String?
+  ) {
+    self.sessionId = sessionId
+    self.providerKind = providerKind
+    self.projectPath = projectPath
+    self.branchName = branchName
+  }
+}
+
+// MARK: - GitHubCIFailureNotifierProtocol
+
+public protocol GitHubCIFailureNotifierProtocol: AnyObject {
+  /// Evaluates an observation snapshot for a session and posts a notification
+  /// when its PR's CI is newly failing. Deduplicates per PR head commit, so
+  /// multiple surfaces observing the same session can all feed snapshots.
+  @MainActor
+  func evaluate(snapshot: GitHubPRObservationSnapshot, context: GitHubCIFailureSessionContext)
+}
+
+// MARK: - GitHubCIFailureNotifier
+
+@MainActor
+public final class GitHubCIFailureNotifier: GitHubCIFailureNotifierProtocol {
+
+  public typealias SendNotification = @Sendable (UNNotificationRequest) async -> Void
+
+  /// Caps how many failed checks ride along in the notification payload.
+  private static let maximumPayloadChecks = 5
+
+  private var notifiedFailureKeys: Set<String> = []
+  private let isEnabled: () -> Bool
+  private let sendNotification: SendNotification
+
+  public init(
+    isEnabled: (() -> Bool)? = nil,
+    sendNotification: SendNotification? = nil
+  ) {
+    self.isEnabled = isEnabled ?? {
+      let defaults = UserDefaults.standard
+      let pushEnabled = defaults.object(forKey: AgentHubDefaults.pushNotificationsEnabled) as? Bool ?? true
+      let ciEnabled = defaults.object(forKey: AgentHubDefaults.ciFailureNotificationsEnabled) as? Bool ?? true
+      return pushEnabled && ciEnabled
+    }
+    self.sendNotification = sendNotification ?? { request in
+      #if canImport(AppKit)
+      if UserDefaults.standard.object(forKey: AgentHubDefaults.notificationSoundsEnabled) as? Bool ?? true {
+        await MainActor.run { NSSound.beep() }
+      }
+      #endif
+      try? await UNUserNotificationCenter.current().add(request)
+    }
+  }
+
+  public func evaluate(
+    snapshot: GitHubPRObservationSnapshot,
+    context: GitHubCIFailureSessionContext
+  ) {
+    guard isEnabled() else { return }
+    // Only act on complete, fresh refreshes — refreshing/error states rebroadcast
+    // carried-over data and must not trigger (or re-trigger) notifications.
+    guard snapshot.state == .ready, !snapshot.isStale else { return }
+    guard let pullRequest = snapshot.pullRequest, pullRequest.stateKind == .open else { return }
+    guard snapshot.ciSummary.failed > 0 else { return }
+    let failedChecks = snapshot.checks.filter { $0.ciStatus == .failure }
+    guard !failedChecks.isEmpty else { return }
+
+    let failureKey = [
+      context.projectPath,
+      "\(pullRequest.number)",
+      pullRequest.headRefOid ?? "no-head"
+    ].joined(separator: "|")
+    guard !notifiedFailureKeys.contains(failureKey) else { return }
+    notifiedFailureKeys.insert(failureKey)
+
+    let payload = GitHubCIFailureNotificationPayload(
+      sessionId: context.sessionId,
+      providerKindRawValue: context.providerKind.rawValue,
+      projectPath: context.projectPath,
+      branchName: context.branchName ?? pullRequest.headRefName,
+      prNumber: pullRequest.number,
+      prTitle: pullRequest.title,
+      failedChecks: failedChecks.prefix(Self.maximumPayloadChecks).map {
+        GitHubCIFailureNotificationPayload.FailedCheck(
+          name: $0.name,
+          workflowName: $0.workflowName,
+          detailsUrl: $0.detailsUrl
+        )
+      }
+    )
+
+    let content = UNMutableNotificationContent()
+    content.title = "CI failing on PR #\(pullRequest.number)"
+    content.subtitle = URL(fileURLWithPath: context.projectPath).lastPathComponent
+    content.body = Self.body(failedCheckNames: failedChecks.map(\.name))
+    content.sound = .none
+    content.categoryIdentifier = GitHubCIFailureNotification.categoryIdentifier
+    content.userInfo = payload.userInfo
+
+    let request = UNNotificationRequest(
+      identifier: "ci-failure-\(failureKey)",
+      content: content,
+      trigger: UNTimeIntervalNotificationTrigger(timeInterval: 0.1, repeats: false)
+    )
+    let sendNotification = sendNotification
+    Task(priority: .userInitiated) {
+      await sendNotification(request)
+    }
+  }
+
+  nonisolated static func body(failedCheckNames: [String]) -> String {
+    let shown = failedCheckNames.prefix(3).joined(separator: ", ")
+    let remainder = failedCheckNames.count - min(failedCheckNames.count, 3)
+    return remainder > 0 ? "\(shown) and \(remainder) more failed" : "\(shown) failed"
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/CollapsibleSessionRow.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/CollapsibleSessionRow.swift
@@ -354,6 +354,18 @@ struct CollapsibleSessionRow: View {
       guard !Task.isCancelled else { return }
     }
 
+    if let notifier = agentHub?.gitHubCIFailureNotifier {
+      let context = GitHubCIFailureSessionContext(
+        sessionId: session.id,
+        providerKind: providerKind,
+        projectPath: session.projectPath,
+        branchName: session.branchName
+      )
+      sessionGitHubQuickAccessViewModel.onSnapshotApplied = { snapshot in
+        notifier.evaluate(snapshot: snapshot, context: context)
+      }
+    }
+
     await sessionGitHubQuickAccessViewModel.load(
       projectPath: session.projectPath,
       branchName: session.branchName,

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringCardView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringCardView.swift
@@ -321,6 +321,17 @@ public struct MonitoringCardView: View {
         try? await Task.sleep(for: .seconds(2))
         guard !Task.isCancelled else { return }
       }
+      if let notifier = viewModel?.agentHubProvider?.gitHubCIFailureNotifier ?? agentHub?.gitHubCIFailureNotifier {
+        let context = GitHubCIFailureSessionContext(
+          sessionId: session.id,
+          providerKind: providerKind,
+          projectPath: session.projectPath,
+          branchName: session.branchName
+        )
+        sessionGitHubQuickAccessViewModel.onSnapshotApplied = { snapshot in
+          notifier.evaluate(snapshot: snapshot, context: context)
+        }
+      }
       await sessionGitHubQuickAccessViewModel.load(
         projectPath: session.projectPath,
         branchName: session.branchName,

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderMonitoringPanelView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderMonitoringPanelView.swift
@@ -310,6 +310,9 @@ public struct MultiProviderMonitoringPanelView: View {
     .onChange(of: autoOpenCandidate?.key) { _, _ in
       openAutoSidePanelIfNeeded()
     }
+    .task(id: pendingCIFailureRequestID) {
+      await consumeCIFailureActionRequestIfNeeded()
+    }
     .overlay {
       Group {
         Button("") { showQuickFilePicker = true }
@@ -1464,6 +1467,98 @@ public struct MultiProviderMonitoringPanelView: View {
       diffDisplayMode: diffDisplayMode,
       diffAvailabilityStatus: item.viewModel.diffAvailabilityStatus(for: item.projectPath)
     )
+  }
+
+  // MARK: - CI Failure Notification Actions
+
+  private var ciFailureActionRouter: GitHubCIFailureActionRouter? {
+    claudeViewModel.agentHubProvider?.gitHubCIFailureActionRouter
+  }
+
+  private var pendingCIFailureRequestID: UUID? {
+    ciFailureActionRouter?.pendingRequest?.id
+  }
+
+  private func consumeCIFailureActionRequestIfNeeded() async {
+    guard let router = ciFailureActionRouter, let request = router.pendingRequest else { return }
+    guard let providerKind = request.payload.providerKind else {
+      router.markConsumed(request)
+      return
+    }
+    let itemID = GlobalSessionSelectionRequest.itemId(
+      providerKind: providerKind,
+      sessionId: request.payload.sessionId
+    )
+    // The notification can arrive with the app closed or the session not yet
+    // selected, so wait briefly for the session card to exist before acting.
+    for _ in 0..<40 {
+      guard router.pendingRequest?.id == request.id else { return }
+      if let item = allItems.first(where: { $0.id == itemID }) {
+        router.markConsumed(request)
+        handleCIFailureAction(request, item: item)
+        return
+      }
+      do {
+        try await Task.sleep(for: .milliseconds(250))
+      } catch {
+        return
+      }
+    }
+    router.markConsumed(request)
+  }
+
+  private func handleCIFailureAction(_ request: GitHubCIFailureActionRequest, item: ProviderMonitoringItem) {
+    guard case .monitored(_, let viewModel, let session, _) = item else { return }
+    switch request.action {
+    case .openGitHubPanel:
+      openCIFailureGitHubPanel(item: item, session: session)
+    case .fixCI:
+      startCIFixFlow(request.payload, item: item, session: session, viewModel: viewModel)
+    }
+  }
+
+  private func openCIFailureGitHubPanel(item: ProviderMonitoringItem, session: CLISession) {
+    let payload = SidePanelPayload(
+      itemID: item.id,
+      providerKind: item.providerKind,
+      content: .gitHub(sessionId: session.id, session: session, projectPath: item.projectPath)
+    )
+    performWithoutAnimation {
+      if primarySessionId != item.id {
+        primarySessionId = item.id
+      }
+    }
+    guard sidePanelPresentation.currentPayload != payload else { return }
+    openEmbeddedSidePanel(payload)
+  }
+
+  private func startCIFixFlow(
+    _ payload: GitHubCIFailureNotificationPayload,
+    item: ProviderMonitoringItem,
+    session: CLISession,
+    viewModel: CLISessionsViewModel
+  ) {
+    guard let fixService = viewModel.agentHubProvider?.gitHubCIFixService else { return }
+    setContentMode(.terminal, for: item)
+    Task {
+      let prompt = await fixService.buildFixPrompt(
+        projectPath: payload.projectPath,
+        prNumber: payload.prNumber,
+        prTitle: payload.prTitle,
+        branchName: payload.branchName,
+        failedChecks: payload.failedChecks.map {
+          GitHubCIFixPromptBuilder.FailedCheck(
+            name: $0.name,
+            workflowName: $0.workflowName,
+            detailsUrl: $0.detailsUrl
+          )
+        }
+      )
+      if !viewModel.sendPromptToActiveTerminal(forKey: session.id, prompt: prompt) {
+        viewModel.showTerminalWithPrompt(for: session, prompt: prompt)
+      }
+      viewModel.focusTerminal(forKey: session.id)
+    }
   }
 
   private func showTerminalWithPrompt(

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/SettingsView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/SettingsView.swift
@@ -57,6 +57,9 @@ public struct SettingsView: View {
   @AppStorage(AgentHubDefaults.pushNotificationsEnabled)
   private var pushNotificationsEnabled: Bool = true
 
+  @AppStorage(AgentHubDefaults.ciFailureNotificationsEnabled)
+  private var ciFailureNotificationsEnabled: Bool = true
+
   @AppStorage(AgentHubDefaults.globalSessionPanelEnabled)
   private var globalSessionPanelEnabled: Bool = true
 
@@ -225,6 +228,12 @@ public struct SettingsView: View {
           title: "Push notifications",
           description: "Show a notification banner when tools require approval",
           isOn: $pushNotificationsEnabled
+        )
+
+        settingsToggle(
+          title: "CI failure notifications",
+          description: "Notify when a monitored session's pull request starts failing CI, with a Fix CI action",
+          isOn: $ciFailureNotificationsEnabled
         )
       }
 

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/GitHubCIFailureNotifierTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/GitHubCIFailureNotifierTests.swift
@@ -1,0 +1,255 @@
+//
+//  GitHubCIFailureNotifierTests.swift
+//  AgentHubTests
+//
+//  Tests for CI failure notification dedupe, gating, payload, and routing
+//
+
+import AgentHubGitHub
+import Foundation
+import Testing
+import UserNotifications
+
+@testable import AgentHubCore
+
+// MARK: - Fixtures
+
+private func makeCIFailurePR(
+  number: Int = 10,
+  title: String = "Fix everything",
+  state: String = "OPEN",
+  headRefOid: String? = "abc123"
+) -> GitHubPullRequest {
+  GitHubPullRequest(
+    number: number,
+    title: title,
+    body: nil,
+    state: state,
+    url: "https://github.com/test/repo/pull/\(number)",
+    headRefName: "feature-branch",
+    headRefOid: headRefOid,
+    baseRefName: "main",
+    author: nil,
+    createdAt: .now,
+    updatedAt: .now,
+    isDraft: false,
+    mergeable: "MERGEABLE",
+    additions: 1,
+    deletions: 1,
+    changedFiles: 1,
+    reviewDecision: nil,
+    statusCheckRollup: nil,
+    labels: nil,
+    reviewRequests: nil,
+    comments: nil
+  )
+}
+
+private func makeCIFailureSnapshot(
+  pullRequest: GitHubPullRequest? = makeCIFailurePR(),
+  checks: [GitHubCheckRun] = [
+    GitHubCheckRun(
+      name: "test",
+      status: "COMPLETED",
+      conclusion: "FAILURE",
+      detailsUrl: "https://github.com/test/repo/actions/runs/99/job/1",
+      workflowName: "Tests"
+    )
+  ],
+  state: GitHubPRObservationState = .ready
+) -> GitHubPRObservationSnapshot {
+  GitHubPRObservationSnapshot(
+    target: .currentBranch(projectPath: "/tmp/repo", branchName: "feature-branch"),
+    pullRequest: pullRequest,
+    checks: checks,
+    state: state,
+    lastRefreshedAt: .now
+  )
+}
+
+private func makeCIFailureContext(sessionId: String = "session-1") -> GitHubCIFailureSessionContext {
+  GitHubCIFailureSessionContext(
+    sessionId: sessionId,
+    providerKind: .claude,
+    projectPath: "/tmp/repo",
+    branchName: "feature-branch"
+  )
+}
+
+private actor NotificationRequestRecorder {
+  private(set) var requests: [UNNotificationRequest] = []
+
+  func record(_ request: UNNotificationRequest) {
+    requests.append(request)
+  }
+}
+
+// MARK: - GitHubCIFailureNotifier
+
+@Suite("GitHubCIFailureNotifier")
+struct GitHubCIFailureNotifierTests {
+
+  @MainActor
+  private func makeNotifier(
+    enabled: Bool = true,
+    recorder: NotificationRequestRecorder
+  ) -> GitHubCIFailureNotifier {
+    GitHubCIFailureNotifier(
+      isEnabled: { enabled },
+      sendNotification: { await recorder.record($0) }
+    )
+  }
+
+  @Test("posts one notification with Fix CI category and routable payload")
+  @MainActor
+  func postsNotificationForFailingCI() async {
+    let recorder = NotificationRequestRecorder()
+    let notifier = makeNotifier(recorder: recorder)
+
+    notifier.evaluate(snapshot: makeCIFailureSnapshot(), context: makeCIFailureContext())
+    try? await Task.sleep(for: .milliseconds(50))
+
+    let requests = await recorder.requests
+    #expect(requests.count == 1)
+    let content = requests.first?.content
+    #expect(content?.categoryIdentifier == GitHubCIFailureNotification.categoryIdentifier)
+    #expect(content?.title == "CI failing on PR #10")
+    #expect(content?.subtitle == "repo")
+    #expect(content?.body == "test failed")
+
+    let payload = content.flatMap { GitHubCIFailureNotificationPayload(userInfo: $0.userInfo) }
+    #expect(payload?.sessionId == "session-1")
+    #expect(payload?.providerKind == .claude)
+    #expect(payload?.projectPath == "/tmp/repo")
+    #expect(payload?.prNumber == 10)
+    #expect(payload?.failedChecks.first?.detailsUrl == "https://github.com/test/repo/actions/runs/99/job/1")
+  }
+
+  @Test("deduplicates repeat snapshots for the same PR head commit")
+  @MainActor
+  func deduplicatesSameHead() async {
+    let recorder = NotificationRequestRecorder()
+    let notifier = makeNotifier(recorder: recorder)
+
+    notifier.evaluate(snapshot: makeCIFailureSnapshot(), context: makeCIFailureContext())
+    notifier.evaluate(snapshot: makeCIFailureSnapshot(), context: makeCIFailureContext(sessionId: "other-surface"))
+    try? await Task.sleep(for: .milliseconds(50))
+
+    #expect(await recorder.requests.count == 1)
+  }
+
+  @Test("notifies again when the PR head commit changes")
+  @MainActor
+  func notifiesAgainForNewHead() async {
+    let recorder = NotificationRequestRecorder()
+    let notifier = makeNotifier(recorder: recorder)
+
+    notifier.evaluate(snapshot: makeCIFailureSnapshot(), context: makeCIFailureContext())
+    notifier.evaluate(
+      snapshot: makeCIFailureSnapshot(pullRequest: makeCIFailurePR(headRefOid: "def456")),
+      context: makeCIFailureContext()
+    )
+    try? await Task.sleep(for: .milliseconds(50))
+
+    #expect(await recorder.requests.count == 2)
+  }
+
+  @Test("ignores passing, refreshing, closed-PR, and disabled evaluations")
+  @MainActor
+  func ignoresNonActionableSnapshots() async {
+    let recorder = NotificationRequestRecorder()
+    let notifier = makeNotifier(recorder: recorder)
+
+    let passingChecks = [GitHubCheckRun(name: "test", status: "COMPLETED", conclusion: "SUCCESS")]
+    notifier.evaluate(snapshot: makeCIFailureSnapshot(checks: passingChecks), context: makeCIFailureContext())
+    notifier.evaluate(snapshot: makeCIFailureSnapshot(state: .refreshing), context: makeCIFailureContext())
+    notifier.evaluate(snapshot: makeCIFailureSnapshot(state: .error("boom")), context: makeCIFailureContext())
+    notifier.evaluate(
+      snapshot: makeCIFailureSnapshot(pullRequest: makeCIFailurePR(state: "MERGED")),
+      context: makeCIFailureContext()
+    )
+    notifier.evaluate(snapshot: makeCIFailureSnapshot(pullRequest: nil), context: makeCIFailureContext())
+
+    let disabledNotifier = makeNotifier(enabled: false, recorder: recorder)
+    disabledNotifier.evaluate(snapshot: makeCIFailureSnapshot(), context: makeCIFailureContext())
+    try? await Task.sleep(for: .milliseconds(50))
+
+    #expect(await recorder.requests.isEmpty)
+  }
+
+  @Test("body summarizes many failed checks")
+  func bodySummarizesManyChecks() {
+    #expect(GitHubCIFailureNotifier.body(failedCheckNames: ["a"]) == "a failed")
+    #expect(GitHubCIFailureNotifier.body(failedCheckNames: ["a", "b", "c"]) == "a, b, c failed")
+    #expect(GitHubCIFailureNotifier.body(failedCheckNames: ["a", "b", "c", "d", "e"]) == "a, b, c and 2 more failed")
+  }
+}
+
+// MARK: - Payload round-trip
+
+@Suite("GitHubCIFailureNotificationPayload")
+struct GitHubCIFailureNotificationPayloadTests {
+
+  @Test("round-trips through notification userInfo")
+  func roundTripsThroughUserInfo() {
+    let payload = GitHubCIFailureNotificationPayload(
+      sessionId: "abc",
+      providerKindRawValue: "Codex",
+      projectPath: "/tmp/repo",
+      branchName: "feature",
+      prNumber: 7,
+      prTitle: "Title",
+      failedChecks: [.init(name: "test", workflowName: "CI", detailsUrl: "https://example.com")]
+    )
+
+    let decoded = GitHubCIFailureNotificationPayload(userInfo: payload.userInfo)
+    #expect(decoded == payload)
+    #expect(decoded?.providerKind == .codex)
+    #expect(payload.userInfo["sessionId"] as? String == "abc")
+  }
+
+  @Test("returns nil for foreign userInfo")
+  func rejectsForeignUserInfo() {
+    #expect(GitHubCIFailureNotificationPayload(userInfo: ["sessionId": "abc"]) == nil)
+    #expect(GitHubCIFailureNotificationPayload(userInfo: [:]) == nil)
+  }
+}
+
+// MARK: - Action router
+
+@Suite("GitHubCIFailureActionRouter")
+@MainActor
+struct GitHubCIFailureActionRouterTests {
+
+  @Test("publishes requests and consumes only matching ids")
+  func publishesAndConsumes() {
+    let router = GitHubCIFailureActionRouter()
+    let payload = GitHubCIFailureNotificationPayload(
+      sessionId: "abc",
+      providerKindRawValue: "Claude",
+      projectPath: "/tmp/repo",
+      branchName: "feature",
+      prNumber: 1,
+      prTitle: "Title",
+      failedChecks: []
+    )
+
+    router.request(payload: payload, action: .fixCI)
+    let first = router.pendingRequest
+    #expect(first?.action == .fixCI)
+    #expect(first?.payload == payload)
+
+    router.request(payload: payload, action: .openGitHubPanel)
+    let second = router.pendingRequest
+    #expect(second?.action == .openGitHubPanel)
+
+    if let first {
+      router.markConsumed(first)
+      #expect(router.pendingRequest?.id == second?.id)
+    }
+    if let second {
+      router.markConsumed(second)
+      #expect(router.pendingRequest == nil)
+    }
+  }
+}

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/LazyBrowseSessionsLoadingTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/LazyBrowseSessionsLoadingTests.swift
@@ -589,7 +589,11 @@ struct LazyBrowseSessionsLoadingTests {
     }
 
     #expect(viewModel.findSession(byId: sessionId)?.projectPath == projectURL.path)
-    #expect((await watcher.startedSessionIds()).contains(sessionId))
+    // The watcher starts asynchronously after the session lands in
+    // monitoredSessions, so poll instead of asserting immediately.
+    await waitUntilAsync {
+      (await watcher.startedSessionIds()).contains(sessionId)
+    }
   }
 }
 

--- a/app/modules/AgentHubGitHub/Sources/AgentHubGitHub/Models/GitHubActionsRunReference.swift
+++ b/app/modules/AgentHubGitHub/Sources/AgentHubGitHub/Models/GitHubActionsRunReference.swift
@@ -1,0 +1,48 @@
+//
+//  GitHubActionsRunReference.swift
+//  AgentHub
+//
+//  Parses GitHub Actions run/job identity out of check-run details URLs
+//
+
+import Foundation
+
+/// A workflow run (and optionally job) referenced by a check run's `detailsUrl`.
+///
+/// GitHub Actions check runs report URLs shaped like
+/// `https://github.com/{owner}/{repo}/actions/runs/{runId}/job/{jobId}?pr=1`.
+/// External CI systems report arbitrary URLs, which parse to `nil`.
+public struct GitHubActionsRunReference: Equatable, Sendable {
+  public let runId: String
+  public let jobId: String?
+
+  public init(runId: String, jobId: String? = nil) {
+    self.runId = runId
+    self.jobId = jobId
+  }
+
+  public init?(detailsUrl: String?) {
+    guard let detailsUrl, let url = URL(string: detailsUrl) else { return nil }
+    let components = url.pathComponents
+    guard
+      let actionsIndex = components.firstIndex(of: "actions"),
+      components.indices.contains(actionsIndex + 2),
+      components[actionsIndex + 1] == "runs",
+      Self.isIdentifier(components[actionsIndex + 2])
+    else { return nil }
+
+    runId = components[actionsIndex + 2]
+    if let jobIndex = components.firstIndex(of: "job"),
+       jobIndex > actionsIndex,
+       components.indices.contains(jobIndex + 1),
+       Self.isIdentifier(components[jobIndex + 1]) {
+      jobId = components[jobIndex + 1]
+    } else {
+      jobId = nil
+    }
+  }
+
+  private static func isIdentifier(_ component: String) -> Bool {
+    !component.isEmpty && component.allSatisfy(\.isNumber)
+  }
+}

--- a/app/modules/AgentHubGitHub/Sources/AgentHubGitHub/Services/GitHubCIFixPromptBuilder.swift
+++ b/app/modules/AgentHubGitHub/Sources/AgentHubGitHub/Services/GitHubCIFixPromptBuilder.swift
@@ -1,0 +1,114 @@
+//
+//  GitHubCIFixPromptBuilder.swift
+//  AgentHub
+//
+//  Composes the "Fix CI" prompt sent to a session's agent terminal
+//
+
+import Foundation
+
+/// Builds the prompt injected into an agent session when the user asks
+/// AgentHub to fix a failing CI run.
+public enum GitHubCIFixPromptBuilder {
+
+  public struct FailedCheck: Equatable, Sendable {
+    public let name: String
+    public let workflowName: String?
+    public let detailsUrl: String?
+
+    public init(name: String, workflowName: String? = nil, detailsUrl: String? = nil) {
+      self.name = name
+      self.workflowName = workflowName
+      self.detailsUrl = detailsUrl
+    }
+
+    public init(check: GitHubCheckRun) {
+      self.init(name: check.name, workflowName: check.workflowName, detailsUrl: check.detailsUrl)
+    }
+
+    public var displayName: String {
+      guard let workflowName, !workflowName.isEmpty, workflowName != name else { return name }
+      return "\(workflowName) / \(name)"
+    }
+  }
+
+  public struct LogExcerpt: Equatable, Sendable {
+    public let runId: String
+    public let text: String
+
+    public init(runId: String, text: String) {
+      self.runId = runId
+      self.text = text
+    }
+  }
+
+  /// Keeps injected prompts small enough for a terminal paste while retaining
+  /// the failure tail, where build/test errors actually appear.
+  public static let defaultMaximumLogCharacters = 6_000
+
+  public static func prompt(
+    prNumber: Int,
+    prTitle: String?,
+    branchName: String?,
+    failedChecks: [FailedCheck],
+    logExcerpts: [LogExcerpt]
+  ) -> String {
+    var lines: [String] = []
+    var headline = "CI is failing on PR #\(prNumber)"
+    if let prTitle, !prTitle.isEmpty {
+      headline += " (\"\(prTitle)\")"
+    }
+    if let branchName, !branchName.isEmpty {
+      headline += " for branch `\(branchName)`"
+    }
+    lines.append(headline + ".")
+
+    if !failedChecks.isEmpty {
+      lines.append("")
+      lines.append("Failed checks:")
+      for check in failedChecks {
+        if let detailsUrl = check.detailsUrl, !detailsUrl.isEmpty {
+          lines.append("- \(check.displayName) — \(detailsUrl)")
+        } else {
+          lines.append("- \(check.displayName)")
+        }
+      }
+    }
+
+    if logExcerpts.isEmpty {
+      lines.append("")
+      lines.append(
+        "Log output could not be fetched automatically. Run `gh pr checks \(prNumber)` and `gh run view <run-id> --log-failed` (or open the check URLs above) to inspect the failure."
+      )
+    } else {
+      for excerpt in logExcerpts {
+        lines.append("")
+        lines.append("Failing step logs from `gh run view \(excerpt.runId) --log-failed`:")
+        lines.append("```")
+        lines.append(excerpt.text)
+        lines.append("```")
+      }
+    }
+
+    lines.append("")
+    lines.append(
+      "Diagnose the CI failure, fix the underlying issue, run the relevant local tests to confirm, and push the fix to this PR's branch. If you need more log context, run `gh run view <run-id> --log-failed`."
+    )
+    return lines.joined(separator: "\n")
+  }
+
+  /// Returns the tail of a CI log, annotated when truncation occurred.
+  public static func truncatedLogTail(
+    _ log: String,
+    maximumCharacters: Int = defaultMaximumLogCharacters
+  ) -> String {
+    let trimmed = log.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard trimmed.count > maximumCharacters else { return trimmed }
+    var tail = String(trimmed.suffix(maximumCharacters))
+    if let firstNewline = tail.firstIndex(of: "\n") {
+      // Drop the likely-partial first line so the excerpt starts clean.
+      tail = String(tail[tail.index(after: firstNewline)...])
+    }
+    return "… (log truncated, showing the last \(tail.count) of \(trimmed.count) characters)\n" + tail
+  }
+}

--- a/app/modules/AgentHubGitHub/Sources/AgentHubGitHub/Services/GitHubCIFixService.swift
+++ b/app/modules/AgentHubGitHub/Sources/AgentHubGitHub/Services/GitHubCIFixService.swift
@@ -1,0 +1,75 @@
+//
+//  GitHubCIFixService.swift
+//  AgentHub
+//
+//  Fetches failing CI logs and builds the agent-facing fix prompt
+//
+
+import Foundation
+
+// MARK: - GitHubCIFixServiceProtocol
+
+public protocol GitHubCIFixServiceProtocol: AnyObject, Sendable {
+  /// Builds the prompt for an agent to fix the failing checks of a PR,
+  /// fetching failed-run logs when the checks reference GitHub Actions runs.
+  /// Never throws — log fetch failures degrade to a prompt without logs.
+  func buildFixPrompt(
+    projectPath: String,
+    prNumber: Int,
+    prTitle: String?,
+    branchName: String?,
+    failedChecks: [GitHubCIFixPromptBuilder.FailedCheck]
+  ) async -> String
+}
+
+// MARK: - GitHubCIFixService
+
+public actor GitHubCIFixService: GitHubCIFixServiceProtocol {
+
+  private let service: any GitHubCLIServiceProtocol
+  private let maximumRunLogFetches: Int
+  private let maximumLogCharacters: Int
+
+  public init(
+    service: any GitHubCLIServiceProtocol = GitHubCLIService(),
+    maximumRunLogFetches: Int = 2,
+    maximumLogCharacters: Int = GitHubCIFixPromptBuilder.defaultMaximumLogCharacters
+  ) {
+    self.service = service
+    self.maximumRunLogFetches = max(0, maximumRunLogFetches)
+    self.maximumLogCharacters = maximumLogCharacters
+  }
+
+  public func buildFixPrompt(
+    projectPath: String,
+    prNumber: Int,
+    prTitle: String?,
+    branchName: String?,
+    failedChecks: [GitHubCIFixPromptBuilder.FailedCheck]
+  ) async -> String {
+    var runIds: [String] = []
+    for check in failedChecks {
+      guard let reference = GitHubActionsRunReference(detailsUrl: check.detailsUrl) else { continue }
+      if !runIds.contains(reference.runId) {
+        runIds.append(reference.runId)
+      }
+    }
+
+    var logExcerpts: [GitHubCIFixPromptBuilder.LogExcerpt] = []
+    for runId in runIds.prefix(maximumRunLogFetches) {
+      guard let log = try? await service.getFailedRunLogs(runId: runId, at: projectPath) else { continue }
+      let excerpt = GitHubCIFixPromptBuilder.truncatedLogTail(log, maximumCharacters: maximumLogCharacters)
+      if !excerpt.isEmpty {
+        logExcerpts.append(GitHubCIFixPromptBuilder.LogExcerpt(runId: runId, text: excerpt))
+      }
+    }
+
+    return GitHubCIFixPromptBuilder.prompt(
+      prNumber: prNumber,
+      prTitle: prTitle,
+      branchName: branchName,
+      failedChecks: failedChecks,
+      logExcerpts: logExcerpts
+    )
+  }
+}

--- a/app/modules/AgentHubGitHub/Sources/AgentHubGitHub/Services/GitHubCLIService.swift
+++ b/app/modules/AgentHubGitHub/Sources/AgentHubGitHub/Services/GitHubCLIService.swift
@@ -465,6 +465,20 @@ public actor GitHubCLIService {
     )
   }
 
+  /// Fetches failed-step logs for a workflow run.
+  /// Logs can be large and slow to assemble server-side, so this uses a
+  /// longer timeout than regular metadata calls.
+  public func getFailedRunLogs(
+    runId: String,
+    at repoPath: String
+  ) async throws -> String {
+    try await runGH(
+      ["run", "view", runId, "--log-failed"],
+      at: repoPath,
+      timeout: 60
+    )
+  }
+
   // MARK: - Private Helpers
 
   /// Runs a gh command and returns stdout

--- a/app/modules/AgentHubGitHub/Sources/AgentHubGitHub/Services/GitHubCLIServiceProtocol.swift
+++ b/app/modules/AgentHubGitHub/Sources/AgentHubGitHub/Services/GitHubCLIServiceProtocol.swift
@@ -85,6 +85,9 @@ public protocol GitHubCLIServiceProtocol: AnyObject, Sendable {
 
   /// Lists recent workflow runs
   func listWorkflowRuns(at repoPath: String, limit: Int) async throws -> String
+
+  /// Fetches failed-step logs for a workflow run (`gh run view <runId> --log-failed`)
+  func getFailedRunLogs(runId: String, at repoPath: String) async throws -> String
 }
 
 public extension GitHubCLIServiceProtocol {

--- a/app/modules/AgentHubGitHub/Sources/AgentHubGitHub/ViewModels/SessionGitHubQuickAccessViewModel.swift
+++ b/app/modules/AgentHubGitHub/Sources/AgentHubGitHub/ViewModels/SessionGitHubQuickAccessViewModel.swift
@@ -28,6 +28,11 @@ public final class SessionGitHubQuickAccessViewModel {
     observationState.isUnavailable && lastRefreshedAt != nil
   }
 
+  /// Called with every applied observation snapshot. Session surfaces use this
+  /// to feed shared per-session consumers (e.g. CI failure notifications).
+  @ObservationIgnored
+  public var onSnapshotApplied: (@MainActor (GitHubPRObservationSnapshot) -> Void)?
+
   private var coordinator: (any SessionGitHubQuickAccessCoordinatorProtocol)?
   private var observationService: (any GitHubPRObservationServiceProtocol)?
   private let service: any GitHubCLIServiceProtocol
@@ -226,6 +231,7 @@ public final class SessionGitHubQuickAccessViewModel {
     currentBranchChecks = snapshot.checks
     observationState = snapshot.state
     lastRefreshedAt = snapshot.lastRefreshedAt
+    onSnapshotApplied?(snapshot)
   }
 
   private func clearState(state: GitHubPRObservationState = .idle) {

--- a/app/modules/AgentHubGitHub/Tests/AgentHubGitHubTests/GitHubCIFixTests.swift
+++ b/app/modules/AgentHubGitHub/Tests/AgentHubGitHubTests/GitHubCIFixTests.swift
@@ -1,0 +1,204 @@
+//
+//  GitHubCIFixTests.swift
+//  AgentHubTests
+//
+//  Tests for CI failure run parsing, fix prompt composition, and log fetching
+//
+
+import Foundation
+import Testing
+
+@testable import AgentHubGitHub
+
+// MARK: - GitHubActionsRunReference
+
+@Suite("GitHubActionsRunReference")
+struct GitHubActionsRunReferenceTests {
+
+  @Test("parses run and job ids from an Actions job URL")
+  func parsesRunAndJobIds() {
+    let reference = GitHubActionsRunReference(
+      detailsUrl: "https://github.com/owner/repo/actions/runs/16543219876/job/46781234567?pr=42"
+    )
+    #expect(reference?.runId == "16543219876")
+    #expect(reference?.jobId == "46781234567")
+  }
+
+  @Test("parses a run-only Actions URL without a job component")
+  func parsesRunOnlyURL() {
+    let reference = GitHubActionsRunReference(
+      detailsUrl: "https://github.com/owner/repo/actions/runs/123456"
+    )
+    #expect(reference?.runId == "123456")
+    #expect(reference?.jobId == nil)
+  }
+
+  @Test("rejects non-Actions and malformed URLs")
+  func rejectsNonActionsURLs() {
+    #expect(GitHubActionsRunReference(detailsUrl: "https://circleci.com/gh/owner/repo/123") == nil)
+    #expect(GitHubActionsRunReference(detailsUrl: "https://github.com/owner/repo/pull/12") == nil)
+    #expect(GitHubActionsRunReference(detailsUrl: "https://github.com/owner/repo/actions/runs/not-a-number") == nil)
+    #expect(GitHubActionsRunReference(detailsUrl: nil) == nil)
+    #expect(GitHubActionsRunReference(detailsUrl: "") == nil)
+  }
+}
+
+// MARK: - GitHubCIFixPromptBuilder
+
+@Suite("GitHubCIFixPromptBuilder")
+struct GitHubCIFixPromptBuilderTests {
+
+  @Test("prompt includes PR context, failed checks, and log excerpts")
+  func promptIncludesContextChecksAndLogs() {
+    let prompt = GitHubCIFixPromptBuilder.prompt(
+      prNumber: 42,
+      prTitle: "Add CI notifications",
+      branchName: "jroch-ci",
+      failedChecks: [
+        GitHubCIFixPromptBuilder.FailedCheck(
+          name: "test",
+          workflowName: "Tests",
+          detailsUrl: "https://github.com/owner/repo/actions/runs/99/job/1"
+        )
+      ],
+      logExcerpts: [
+        GitHubCIFixPromptBuilder.LogExcerpt(runId: "99", text: "error: test 'foo' failed")
+      ]
+    )
+
+    #expect(prompt.contains("PR #42"))
+    #expect(prompt.contains("Add CI notifications"))
+    #expect(prompt.contains("`jroch-ci`"))
+    #expect(prompt.contains("Tests / test — https://github.com/owner/repo/actions/runs/99/job/1"))
+    #expect(prompt.contains("gh run view 99 --log-failed"))
+    #expect(prompt.contains("error: test 'foo' failed"))
+    #expect(prompt.contains("push the fix"))
+  }
+
+  @Test("prompt without logs points the agent at gh commands")
+  func promptWithoutLogsMentionsGHFallback() {
+    let prompt = GitHubCIFixPromptBuilder.prompt(
+      prNumber: 7,
+      prTitle: nil,
+      branchName: nil,
+      failedChecks: [GitHubCIFixPromptBuilder.FailedCheck(name: "lint")],
+      logExcerpts: []
+    )
+
+    #expect(prompt.contains("gh pr checks 7"))
+    #expect(prompt.contains("--log-failed"))
+    #expect(prompt.contains("- lint"))
+  }
+
+  @Test("truncatedLogTail keeps the tail and annotates truncation")
+  func truncatedLogTailKeepsTail() {
+    let log = (1...400).map { "line \($0): some CI output" }.joined(separator: "\n")
+    let excerpt = GitHubCIFixPromptBuilder.truncatedLogTail(log, maximumCharacters: 500)
+
+    #expect(excerpt.count < log.count)
+    #expect(excerpt.hasPrefix("… (log truncated"))
+    #expect(excerpt.contains("line 400: some CI output"))
+    #expect(!excerpt.contains("line 1: some CI output\nline 2"))
+  }
+
+  @Test("truncatedLogTail returns short logs unchanged")
+  func truncatedLogTailShortLogUnchanged() {
+    #expect(GitHubCIFixPromptBuilder.truncatedLogTail("  error: boom\n") == "error: boom")
+  }
+}
+
+// MARK: - GitHubCIFixService
+
+@Suite("GitHubCIFixService")
+struct GitHubCIFixServiceTests {
+
+  private func makeFailedCheck(
+    name: String,
+    runId: String? = nil
+  ) -> GitHubCIFixPromptBuilder.FailedCheck {
+    GitHubCIFixPromptBuilder.FailedCheck(
+      name: name,
+      workflowName: "CI",
+      detailsUrl: runId.map { "https://github.com/owner/repo/actions/runs/\($0)/job/1" }
+    )
+  }
+
+  @Test("fetches logs once per unique run id and embeds the excerpt")
+  func fetchesLogsPerUniqueRun() async {
+    let mock = MockGitHubCLIService()
+    mock.failedRunLogsResult = "assertion failed: expected 2 got 3"
+    let service = GitHubCIFixService(service: mock)
+
+    let prompt = await service.buildFixPrompt(
+      projectPath: "/tmp/repo",
+      prNumber: 12,
+      prTitle: "Fix things",
+      branchName: "feature",
+      failedChecks: [
+        makeFailedCheck(name: "build", runId: "555"),
+        makeFailedCheck(name: "test", runId: "555"),
+      ]
+    )
+
+    #expect(mock.getFailedRunLogsCallCount == 1)
+    #expect(mock.getFailedRunLogsRunIds == ["555"])
+    #expect(mock.getFailedRunLogsRepoPath == "/tmp/repo")
+    #expect(prompt.contains("assertion failed: expected 2 got 3"))
+  }
+
+  @Test("caps log fetches at the configured maximum")
+  func capsLogFetches() async {
+    let mock = MockGitHubCLIService()
+    mock.failedRunLogsResult = "log"
+    let service = GitHubCIFixService(service: mock, maximumRunLogFetches: 2)
+
+    _ = await service.buildFixPrompt(
+      projectPath: "/tmp/repo",
+      prNumber: 1,
+      prTitle: nil,
+      branchName: nil,
+      failedChecks: [
+        makeFailedCheck(name: "a", runId: "1"),
+        makeFailedCheck(name: "b", runId: "2"),
+        makeFailedCheck(name: "c", runId: "3"),
+      ]
+    )
+
+    #expect(mock.getFailedRunLogsRunIds == ["1", "2"])
+  }
+
+  @Test("log fetch failure still produces a prompt with gh guidance")
+  func degradesWhenLogFetchFails() async {
+    let mock = MockGitHubCLIService()
+    mock.errorToThrow = GitHubCLIError.timeout
+    let service = GitHubCIFixService(service: mock)
+
+    let prompt = await service.buildFixPrompt(
+      projectPath: "/tmp/repo",
+      prNumber: 9,
+      prTitle: nil,
+      branchName: "feature",
+      failedChecks: [makeFailedCheck(name: "test", runId: "77")]
+    )
+
+    #expect(prompt.contains("CI is failing on PR #9"))
+    #expect(prompt.contains("Log output could not be fetched automatically"))
+  }
+
+  @Test("checks without Actions URLs skip log fetching entirely")
+  func skipsLogFetchForExternalChecks() async {
+    let mock = MockGitHubCLIService()
+    let service = GitHubCIFixService(service: mock)
+
+    let prompt = await service.buildFixPrompt(
+      projectPath: "/tmp/repo",
+      prNumber: 3,
+      prTitle: nil,
+      branchName: nil,
+      failedChecks: [GitHubCIFixPromptBuilder.FailedCheck(name: "external-ci", detailsUrl: "https://ci.example.com/build/9")]
+    )
+
+    #expect(mock.getFailedRunLogsCallCount == 0)
+    #expect(prompt.contains("external-ci — https://ci.example.com/build/9"))
+  }
+}

--- a/app/modules/AgentHubGitHub/Tests/AgentHubGitHubTests/MockGitHubCLIService.swift
+++ b/app/modules/AgentHubGitHub/Tests/AgentHubGitHubTests/MockGitHubCLIService.swift
@@ -335,6 +335,23 @@ final class MockGitHubCLIService: GitHubCLIServiceProtocol, @unchecked Sendable 
     return workflowRunsResult
   }
 
+  var failedRunLogsResult = ""
+  var failedRunLogsResultsByRunId: [String: Result<String, Error>] = [:]
+  var getFailedRunLogsCallCount = 0
+  var getFailedRunLogsRunIds: [String] = []
+  var getFailedRunLogsRepoPath: String?
+
+  func getFailedRunLogs(runId: String, at repoPath: String) async throws -> String {
+    getFailedRunLogsCallCount += 1
+    getFailedRunLogsRunIds.append(runId)
+    getFailedRunLogsRepoPath = repoPath
+    if let result = failedRunLogsResultsByRunId[runId] {
+      return try result.get()
+    }
+    if let error = errorToThrow { throw error }
+    return failedRunLogsResult
+  }
+
   // MARK: - Reset
 
   /// Resets all recorded call state (but keeps configured results)
@@ -386,5 +403,8 @@ final class MockGitHubCLIService: GitHubCLIServiceProtocol, @unchecked Sendable 
     getChecksCallCount = 0
     getChecksPRNumber = nil
     listWorkflowRunsCalled = false
+    getFailedRunLogsCallCount = 0
+    getFailedRunLogsRunIds = []
+    getFailedRunLogsRepoPath = nil
   }
 }

--- a/app/modules/AgentHubGitHub/Tests/AgentHubGitHubTests/SessionGitHubQuickAccessViewModelTests.swift
+++ b/app/modules/AgentHubGitHub/Tests/AgentHubGitHubTests/SessionGitHubQuickAccessViewModelTests.swift
@@ -248,6 +248,30 @@ struct SessionGitHubQuickAccessViewModelTests {
     #expect(await observer.recordedActivityTargets == [target])
   }
 
+  @Test("notifies onSnapshotApplied for every applied observation snapshot")
+  @MainActor
+  func notifiesOnSnapshotApplied() async {
+    let observer = MockSessionGitHubPRObservationService()
+    let viewModel = SessionGitHubQuickAccessViewModel(observationService: observer)
+    let target = GitHubPRObservationTarget.currentBranch(projectPath: "/tmp/repo", branchName: "feature/github")
+    var appliedSnapshots: [GitHubPRObservationSnapshot] = []
+    viewModel.onSnapshotApplied = { appliedSnapshots.append($0) }
+
+    await viewModel.load(projectPath: "/tmp/repo", branchName: "feature/github")
+    await observer.publish(GitHubPRObservationSnapshot(
+      target: target,
+      pullRequest: makeQuickAccessPR(number: 12),
+      checks: [makeQuickAccessCheck(name: "Tests", conclusion: "FAILURE")],
+      state: .ready,
+      lastRefreshedAt: .now
+    ))
+    try? await Task.sleep(for: .milliseconds(10))
+
+    #expect(appliedSnapshots.count >= 1)
+    #expect(appliedSnapshots.last?.pullRequest?.number == 12)
+    #expect(appliedSnapshots.last?.ciSummary.failed == 1)
+  }
+
   @Test("linked pull request subscribes to explicit PR observation")
   @MainActor
   func linkedPullRequestSubscribesToExplicitPRObservation() async throws {


### PR DESCRIPTION
## Summary

AgentHub already reads CI check state for observed PRs but never reacted to failures. This PR closes that loop:

- **macOS notification on CI failure** — when a monitored session's open PR starts failing CI, AgentHub posts one notification per PR head commit (`CI failing on PR #42 · repo · "test, lint failed"`). Deduped across surfaces and re-armed when a new commit is pushed.
- **Tap to open** — activates the app, selects the failing session (via `GlobalSessionSelectionRouter`), and opens its GitHub side panel.
- **Fix CI action** — the notification's action button switches the session card to terminal mode, fetches the failed-run logs (`gh run view <runId> --log-failed`, run id parsed from the failing check's `detailsUrl`), and injects a composed fix prompt — failed checks, URLs, truncated log tail, and fix/push instructions — straight into the agent's terminal through the existing prompt path. Falls back to `gh` guidance in the prompt when logs can't be fetched (external CI, timeout).
- **Settings** — new "CI failure notifications" toggle (default on) under Notifications, gated alongside the existing push toggle.

## Implementation

- `AgentHubGitHub`: `GitHubActionsRunReference` (details-URL → run id), `GitHubCLIServiceProtocol.getFailedRunLogs`, `GitHubCIFixPromptBuilder` + `GitHubCIFixService` (log fetch + prompt composition, never throws), `SessionGitHubQuickAccessViewModel.onSnapshotApplied` hook.
- `AgentHubCore`: `GitHubCIFailureNotifier` (fires only on fresh `.ready` snapshots of open PRs; dedupes per project + PR + head commit), `GitHubCIFailureNotificationPayload` (JSON round-trip through notification userInfo), `GitHubCIFailureActionRouter` (request/consume, mirrors the selection router), provider wiring, session row/card snapshot hooks, monitoring-panel consumer with a short retry window for app-was-closed taps.
- App target: registers the notification category (first `UNNotificationAction` in the app) and routes responses by action identifier.
- `GitHubMonitor.md` updated (CI failures previously documented as never notifying) with a new section describing this flow.

No new polling loops — detection rides the existing shared observation snapshots, per the GitHubMonitor rules.

## Testing

- `AgentHubGitHub` package: 108/108 (new suites: run-reference parsing, prompt builder truncation/fallbacks, fix service dedup/caps/degradation, snapshot hook).
- `AgentHubCore` targeted: `GitHubCIFailureNotifierTests`, `GitHubCIFailureNotificationPayloadTests`, `GitHubCIFailureActionRouterTests` — 8/8.
- Full `./scripts/test.sh` gate: packages leg green; core suite ran 1024 tests with 14 issues confined to the documented clean-tree flaky suites (`AgentWorkspacesViewModel`, `WorktreeGenerationProgressCoordinator`, and a racy final expect in `LazyBrowseSessionsLoadingTests` that passes in isolation on this branch and fails/passes intermittently regardless of the diff — verified against a baseline run on the parent commit).
- App target builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)