### PR TITLE
Keep pinned sessions across relaunch and worktree cleanup

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/CLISessionsViewModel.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/CLISessionsViewModel.swift
@@ -2166,6 +2166,11 @@ public final class CLISessionsViewModel {
 
       // Store persisted session IDs for progressive restoration
       let persistedSessionIds = Set(workspaceState.monitoredSessionIds)
+      // Pinned sessions are durable anchors: attempt to restore them even when
+      // a past sweep or failed launch dropped them from the persisted monitored
+      // set. IDs that fail to load (other provider, transcript deleted) stay
+      // out of the persisted set and are retried on a future launch.
+      let sessionIdsToRestore = persistedSessionIds.union(pinnedSessionIds)
       if !persistedSessionIds.isEmpty {
         pendingRestorationSessionIds = persistedSessionIds
       }
@@ -2178,8 +2183,8 @@ public final class CLISessionsViewModel {
           restoredOwnedWorktreePaths.insert(normalizedPath)
         }
       }
-      if !persistedSessionIds.isEmpty,
-         let mappings = try? await metadataStore?.getRepoMappings(for: Array(persistedSessionIds)) {
+      if !sessionIdsToRestore.isEmpty,
+         let mappings = try? await metadataStore?.getRepoMappings(for: Array(sessionIdsToRestore)) {
         var restoredRepositoryPaths = Set(paths.map { WorktreeModuleResolver.normalizedDirectoryPath($0) })
         for path in paths {
           let normalizedPath = WorktreeModuleResolver.normalizedDirectoryPath(path)
@@ -2201,7 +2206,7 @@ public final class CLISessionsViewModel {
       }
       restoredOwnedWorktreePaths.formUnion(ownedWorktreePaths)
       await setOwnedWorktreePaths(restoredOwnedWorktreePaths)
-      await monitorService.setFocusedSessionIds(persistedSessionIds)
+      await monitorService.setFocusedSessionIds(sessionIdsToRestore)
 
       // Restore repository/worktree shells first. Full all-session scanning is
       // deferred until the Browse panel is opened.
@@ -2222,10 +2227,10 @@ public final class CLISessionsViewModel {
       persistSelectedRepositories()
       syncClaudeHookInstalls(paths: claudeHookInstallPaths(from: selectedRepositories))
 
-      if !persistedSessionIds.isEmpty {
+      if !sessionIdsToRestore.isEmpty {
         loadingState = .restoringMonitoredSessions
         let restorableProjectRoots = projectRoots(from: selectedRepositories)
-        let sessions = await monitorService.loadSessions(ids: persistedSessionIds)
+        let sessions = await monitorService.loadSessions(ids: sessionIdsToRestore)
         restoreLoadedMonitoredSessions(sessions, allowedProjectRoots: restorableProjectRoots)
       }
 
@@ -2246,8 +2251,12 @@ public final class CLISessionsViewModel {
   private func restoreLoadedMonitoredSessions(_ sessions: [CLISession], allowedProjectRoots: [String]) {
     guard !sessions.isEmpty else { return }
 
+    // Pinned sessions restore even when their project directory vanished
+    // (deleted worktree): the transcript still exists and the pinned section
+    // is where the user expects to keep finding them.
     let restorableSessions = sessions.filter {
-      isProjectPath($0.projectPath, containedInAnyOf: allowedProjectRoots)
+      pinnedSessionIds.contains($0.id) ||
+        isProjectPath($0.projectPath, containedInAnyOf: allowedProjectRoots)
     }
     let rejectedIds = Set(sessions.map(\.id)).subtracting(restorableSessions.map(\.id))
     if !rejectedIds.isEmpty {
@@ -2276,6 +2285,9 @@ public final class CLISessionsViewModel {
 
     pendingRestorationSessionIds.subtract(restoredIds)
     unrestoredSessionIds.subtract(restoredIds)
+    // Restored pinned sessions may be absent from the persisted monitored set;
+    // persist now so they survive a crash before the launch-timeout persist.
+    persistMonitoredSessions()
     expandItemsContainingLoadedSessions(restorableSessions)
     loadCustomNames()
     loadPinnedSessions()
@@ -3923,7 +3935,12 @@ public final class CLISessionsViewModel {
   }
 
   public func archiveMonitoredSessions(inWorktreePath worktreePath: String) {
-    let sessionIds = monitoredSessions(inWorktreePath: worktreePath).map(\.id)
+    // Bulk sweeps (worktree deletion, cleanup suggestions, stop-focusing a
+    // module) must not silently drop sessions the user pinned. Only an
+    // explicit per-session archive removes a pinned session.
+    let sessionIds = monitoredSessions(inWorktreePath: worktreePath)
+      .map(\.id)
+      .filter { !pinnedSessionIds.contains($0) }
     for sessionId in sessionIds {
       stopMonitoring(sessionId: sessionId)
     }
@@ -3931,6 +3948,20 @@ public final class CLISessionsViewModel {
 
   /// Stop monitoring by session ID
   public func stopMonitoring(sessionId: String) {
+    if pinnedSessionIds.contains(sessionId) {
+      // Archiving a pinned session is an explicit choice to let it go; clear
+      // the pin so launch restore does not resurrect it as a durable anchor.
+      pinnedSessionIds.remove(sessionId)
+      if let store = metadataStore {
+        Task {
+          do {
+            try await store.setPinned(false, for: sessionId)
+          } catch {
+            AppLogger.session.error("Failed to unpin archived session: \(error.localizedDescription)")
+          }
+        }
+      }
+    }
     monitoredSessionIds.remove(sessionId)
     unrestoredSessionIds.remove(sessionId)
     pendingRestorationSessionIds.remove(sessionId)

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/PinnedSessionRetentionTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/PinnedSessionRetentionTests.swift
@@ -1,0 +1,258 @@
+import Combine
+import Foundation
+import Testing
+
+@testable import AgentHubCore
+
+private actor PinnedRetentionStubMonitorService: SessionMonitorServiceProtocol {
+  private let skeletonRepositories: [SelectedRepository]
+  private let loadableSessions: [CLISession]
+
+  init(skeletonRepositories: [SelectedRepository], loadableSessions: [CLISession]) {
+    self.skeletonRepositories = skeletonRepositories
+    self.loadableSessions = loadableSessions
+  }
+
+  nonisolated var repositoriesPublisher: AnyPublisher<[SelectedRepository], Never> {
+    Empty<[SelectedRepository], Never>().eraseToAnyPublisher()
+  }
+
+  func addRepository(_ path: String) async -> SelectedRepository? { nil }
+  func removeRepository(_ path: String) async {}
+  func getSelectedRepositories() async -> [SelectedRepository] { skeletonRepositories }
+  func setSelectedRepositories(_ repositories: [SelectedRepository]) async {}
+  func refreshSessions(skipWorktreeRedetection: Bool) async {}
+
+  func restoreRepositoriesSkeleton(_ paths: [String]) async -> [SelectedRepository] {
+    skeletonRepositories
+  }
+
+  func loadSessions(ids: Set<String>) async -> [CLISession] {
+    loadableSessions.filter { ids.contains($0.id) }
+  }
+}
+
+private actor PinnedRetentionStubFileWatcher: SessionFileWatcherProtocol {
+  private nonisolated let subject = PassthroughSubject<SessionFileWatcher.StateUpdate, Never>()
+
+  nonisolated var statePublisher: AnyPublisher<SessionFileWatcher.StateUpdate, Never> {
+    subject.eraseToAnyPublisher()
+  }
+
+  func startMonitoring(sessionId: String, projectPath: String, sessionFilePath: String?) async {}
+  func stopMonitoring(sessionId: String) async {}
+  func getState(sessionId: String) async -> SessionMonitorState? { nil }
+  func refreshState(sessionId: String) async {}
+  func setApprovalTimeout(_ seconds: Int) async {}
+}
+
+@Suite("Pinned session retention")
+@MainActor
+struct PinnedSessionRetentionTests {
+
+  private func makeStore() throws -> SessionMetadataStore {
+    let dbPath = FileManager.default.temporaryDirectory
+      .appending(path: "pinned_retention_\(UUID().uuidString).sqlite")
+      .path
+    return try SessionMetadataStore(path: dbPath)
+  }
+
+  private func makeViewModel(
+    monitorService: PinnedRetentionStubMonitorService,
+    store: SessionMetadataStore
+  ) -> CLISessionsViewModel {
+    CLISessionsViewModel(
+      monitorService: monitorService,
+      fileWatcher: PinnedRetentionStubFileWatcher(),
+      searchService: nil,
+      cliConfiguration: CLICommandConfiguration(command: "claude", mode: .claude),
+      providerKind: .claude,
+      metadataStore: store,
+      approvalNotificationService: NoOpApprovalNotificationService()
+    )
+  }
+
+  @Test("Pinned session in a deleted worktree survives launch restore; unpinned one is dropped")
+  func pinnedSessionInDeletedWorktreeSurvivesRestore() async throws {
+    let base = URL(fileURLWithPath: NSTemporaryDirectory())
+      .appendingPathComponent("PinnedRetention-\(UUID().uuidString)")
+    let repoDir = base.appendingPathComponent("repo")
+    try FileManager.default.createDirectory(at: repoDir, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: base) }
+    let deletedWorktreePath = base.appendingPathComponent("repo-deleted").path
+
+    let store = try makeStore()
+    try await store.saveWorkspaceState(
+      SessionWorkspaceState(
+        selectedRepositoryPaths: [repoDir.path],
+        monitoredSessionIds: ["pinned-gone", "unpinned-gone"],
+        ownedWorktreePaths: []
+      ),
+      for: .claude
+    )
+    try await store.setPinned(true, for: "pinned-gone")
+
+    let monitorService = PinnedRetentionStubMonitorService(
+      skeletonRepositories: [SelectedRepository(path: repoDir.path)],
+      loadableSessions: [
+        CLISession(
+          id: "pinned-gone",
+          projectPath: deletedWorktreePath,
+          branchName: "kept",
+          isWorktree: true,
+          isActive: false,
+          sessionFilePath: "/tmp/pinned-gone.jsonl"
+        ),
+        CLISession(
+          id: "unpinned-gone",
+          projectPath: deletedWorktreePath,
+          branchName: "dropped",
+          isWorktree: true,
+          isActive: false,
+          sessionFilePath: "/tmp/unpinned-gone.jsonl"
+        ),
+      ]
+    )
+
+    let viewModel = makeViewModel(monitorService: monitorService, store: store)
+
+    var persisted: [String] = ["unpinned-gone"]
+    for _ in 0..<400 where persisted.contains("unpinned-gone") || !persisted.contains("pinned-gone") {
+      persisted = store.getWorkspaceStateSync(for: .claude).monitoredSessionIds
+      try await Task.sleep(for: .milliseconds(10))
+    }
+
+    #expect(persisted.contains("pinned-gone"))
+    #expect(!persisted.contains("unpinned-gone"))
+    #expect(viewModel.isMonitoring(sessionId: "pinned-gone"))
+    #expect(!viewModel.isMonitoring(sessionId: "unpinned-gone"))
+  }
+
+  @Test("Pinned session missing from the persisted monitored set is re-monitored at launch")
+  func pinnedSessionMissingFromMonitoredSetIsRestored() async throws {
+    let base = URL(fileURLWithPath: NSTemporaryDirectory())
+      .appendingPathComponent("PinnedRetention-\(UUID().uuidString)")
+    let repoDir = base.appendingPathComponent("repo")
+    try FileManager.default.createDirectory(at: repoDir, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: base) }
+
+    let store = try makeStore()
+    try await store.saveWorkspaceState(
+      SessionWorkspaceState(
+        selectedRepositoryPaths: [repoDir.path],
+        monitoredSessionIds: [],
+        ownedWorktreePaths: []
+      ),
+      for: .claude
+    )
+    try await store.setPinned(true, for: "lost-pin")
+
+    let monitorService = PinnedRetentionStubMonitorService(
+      skeletonRepositories: [SelectedRepository(path: repoDir.path)],
+      loadableSessions: [
+        CLISession(
+          id: "lost-pin",
+          projectPath: repoDir.path,
+          branchName: "main",
+          isWorktree: false,
+          isActive: false,
+          sessionFilePath: "/tmp/lost-pin.jsonl"
+        ),
+      ]
+    )
+
+    let viewModel = makeViewModel(monitorService: monitorService, store: store)
+
+    var persisted: [String] = []
+    for _ in 0..<400 where !persisted.contains("lost-pin") {
+      persisted = store.getWorkspaceStateSync(for: .claude).monitoredSessionIds
+      try await Task.sleep(for: .milliseconds(10))
+    }
+
+    #expect(persisted.contains("lost-pin"))
+    #expect(viewModel.isMonitoring(sessionId: "lost-pin"))
+  }
+
+  @Test("Worktree archive sweep skips pinned sessions")
+  func archiveSweepSkipsPinnedSessions() async throws {
+    let base = URL(fileURLWithPath: NSTemporaryDirectory())
+      .appendingPathComponent("PinnedRetention-\(UUID().uuidString)")
+    let worktreeDir = base.appendingPathComponent("repo-feature")
+    try FileManager.default.createDirectory(at: worktreeDir, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: base) }
+
+    let store = try makeStore()
+    try await store.setPinned(true, for: "pinned-session")
+
+    let monitorService = PinnedRetentionStubMonitorService(
+      skeletonRepositories: [],
+      loadableSessions: []
+    )
+    let viewModel = makeViewModel(monitorService: monitorService, store: store)
+
+    let pinnedSession = CLISession(
+      id: "pinned-session",
+      projectPath: worktreeDir.path,
+      branchName: "feature",
+      isWorktree: true,
+      isActive: false,
+      sessionFilePath: "/tmp/pinned-session.jsonl"
+    )
+    let unpinnedSession = CLISession(
+      id: "unpinned-session",
+      projectPath: worktreeDir.path,
+      branchName: "feature",
+      isWorktree: true,
+      isActive: false,
+      sessionFilePath: "/tmp/unpinned-session.jsonl"
+    )
+    viewModel.startMonitoring(session: pinnedSession)
+    viewModel.startMonitoring(session: unpinnedSession)
+
+    viewModel.archiveMonitoredSessions(inWorktreePath: worktreeDir.path)
+
+    #expect(viewModel.isMonitoring(sessionId: "pinned-session"))
+    #expect(!viewModel.isMonitoring(sessionId: "unpinned-session"))
+  }
+
+  @Test("Explicitly archiving a pinned session clears its pin")
+  func explicitStopMonitoringUnpins() async throws {
+    let base = URL(fileURLWithPath: NSTemporaryDirectory())
+      .appendingPathComponent("PinnedRetention-\(UUID().uuidString)")
+    let repoDir = base.appendingPathComponent("repo")
+    try FileManager.default.createDirectory(at: repoDir, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: base) }
+
+    let store = try makeStore()
+    try await store.setPinned(true, for: "pinned-session")
+
+    let monitorService = PinnedRetentionStubMonitorService(
+      skeletonRepositories: [],
+      loadableSessions: []
+    )
+    let viewModel = makeViewModel(monitorService: monitorService, store: store)
+    #expect(viewModel.pinnedSessionIds.contains("pinned-session"))
+
+    let session = CLISession(
+      id: "pinned-session",
+      projectPath: repoDir.path,
+      branchName: "main",
+      isWorktree: false,
+      isActive: false,
+      sessionFilePath: "/tmp/pinned-session.jsonl"
+    )
+    viewModel.startMonitoring(session: session)
+
+    viewModel.stopMonitoring(sessionId: "pinned-session")
+
+    #expect(!viewModel.isMonitoring(sessionId: "pinned-session"))
+    #expect(!viewModel.pinnedSessionIds.contains("pinned-session"))
+
+    var storedPins: Set<String> = ["pinned-session"]
+    for _ in 0..<400 where storedPins.contains("pinned-session") {
+      storedPins = try await store.getPinnedSessionIds()
+      try await Task.sleep(for: .milliseconds(10))
+    }
+    #expect(!storedPins.contains("pinned-session"))
+  }
+}


### PR DESCRIPTION
## Problem

Pinned sessions could silently disappear after an app relaunch — gone from the pinned section and from the module rows. Investigated against the live metadata DB: 3 pinned, custom-named sessions ("edit-mode-easel", "ahub-perf", "background-session") still had `isPinned=1` and intact transcripts, but had been dropped from the persisted monitored set of both providers.

Two mechanisms caused this:

1. **Launch restore permanently forgot sessions whose project directory was gone.** `restoreLoadedMonitoredSessions` rejects sessions outside tracked project roots, and when the directory no longer exists (deleted worktree) classifies them "confirmed gone" and erases them from persistence — even though the JSONL transcript still exists and the session is pinned.
2. **Bulk sweeps archived pinned sessions.** Worktree deletion, agent-requested deletion, cleanup suggestions, and stop-focusing a module all funnel through `archiveMonitoredSessions(inWorktreePath:)`, which stopped every session in the worktree — pinned included.

Because pin flags live in `session_metadata` while membership lives in workspace state, the pin survived while the session vanished — pinned-but-invisible.

## Fix

Pinned sessions are now durable anchors:

- **Launch restore unions pinned session IDs into the restore set.** A pinned session dropped from the monitored set by any past or future path self-heals on the next launch, as long as its pin flag and transcript exist. IDs that fail to load (other provider, transcript deleted) stay out of the persisted set and retry on a future launch — no pollution.
- **Restore never rejects or forgets a pinned session**, even when its project directory vanished. Restored sets persist immediately instead of only at the 10s launch timeout.
- **`archiveMonitoredSessions(inWorktreePath:)` skips pinned sessions** — bulk sweeps can no longer silently drop them.
- **Explicitly archiving a pinned session clears its pin**, so the durable-anchor restore doesn't resurrect a session the user deliberately let go.

Existing lost pinned sessions recover automatically on first launch with this fix — their pins and transcripts were never deleted, only disconnected.

## Testing

- New `PinnedSessionRetentionTests` (4 tests): pinned session in a deleted worktree survives restore while the unpinned one is dropped; pinned session missing from the persisted monitored set is re-monitored and re-persisted; archive sweep skips pinned; explicit archive unpins.
- Existing `LaunchRestoreSessionRetentionTests` still passes (unpinned drop behavior unchanged).
- Monitored-session lifecycle regression slice green: 44 passed / 0 failed across LazyBrowseSessionsLoading, AgentWorkspaceSessionCoordinator, WorktreeSessionImportCoordinator, sidebar projections, monitor-state model, auxiliary terminals.
- Full `./scripts/test.sh` gate: fast packages green; AgentHubCore suite 1046 passed / 11 failed. Controlled comparison of the 11: the same 5 suites run in isolation pass on **both** clean `main` and this branch (branch: 34/1, main: 33/2) — the timing failures are load-dependent flakes of the full parallel suite, not branch effects.
- The one deterministic failure, `ProjectSimulatorPreferenceTests` "v11 migration preserves existing metadata" (`no such table: project_simulator_preferences`), **fails identically on clean `main`** — pre-existing, unrelated to this PR; should be fixed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)