### PR TITLE
Fix file-descriptor exhaustion that made the app lose disk access until relaunch

### DIFF
--- a/app/AgentHub/AgentHubApp.swift
+++ b/app/AgentHub/AgentHubApp.swift
@@ -130,6 +130,12 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
 struct AgentHubApp: App {
   @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
 
+  init() {
+    // Must run before any terminal/watcher/subprocess spawns: Finder-launched
+    // apps inherit a 256 open-file soft limit, which a busy hub exhausts.
+    FileDescriptorLimits.raiseSoftLimit()
+  }
+
   var body: some Scene {
     WindowGroup {
       AgentHubSessionsView()

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/CodexGlobalStatsService.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/CodexGlobalStatsService.swift
@@ -200,6 +200,7 @@ public final class CodexGlobalStatsService: @unchecked Sendable {
   }
 
   private func startWatching() {
+    guard directoryWatcher == nil else { return }
     let fileManager = FileManager.default
 
     // Create directory if it doesn't exist
@@ -234,10 +235,13 @@ public final class CodexGlobalStatsService: @unchecked Sendable {
       DispatchQueue.main.asyncAfter(deadline: .now() + 1.0, execute: workItem)
     }
 
-    source.setCancelHandler { [weak self] in
-      if let fd = self?.fileDescriptor, fd >= 0 {
-        close(fd)
-      }
+    // Capture the fd by value: the handler runs async on the source's queue,
+    // where `self` may already be gone (deinit-driven cancel would leak the
+    // fd) or `fileDescriptor` may already refer to a NEWER descriptor
+    // (closing it would kill an unrelated live fd once the number recycles).
+    let watchedFd = fileDescriptor
+    source.setCancelHandler {
+      close(watchedFd)
     }
 
     source.resume()

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/CodexSessionFileWatcher.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/CodexSessionFileWatcher.swift
@@ -54,7 +54,10 @@ public actor CodexSessionFileWatcher {
 
     let fileDescriptor = open(filePath, O_EVTONLY)
     guard fileDescriptor >= 0 else {
-      AppLogger.watcher.error("[Codex] Could not open file for watching: \(filePath)")
+      let openErrno = errno
+      AppLogger.watcher.error(
+        "[Codex] Could not open file for watching: \(filePath) errno=\(openErrno) (\(String(cString: strerror(openErrno)), privacy: .public))"
+      )
       return
     }
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/DevServerManager.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/DevServerManager.swift
@@ -612,9 +612,15 @@ public final class DevServerManager {
   }
 
   private func cleanupPipeHandlers(for key: String) {
+    // Keep draining after readiness: with no reader the child fills the 64KB
+    // pipe buffer and blocks on write, freezing the dev server. Handlers are
+    // only truly nil-ed in disposeManagedServer when the server stops.
     if let pipes = outputPipes[key] {
-      pipes.stdout.fileHandleForReading.readabilityHandler = nil
-      pipes.stderr.fileHandleForReading.readabilityHandler = nil
+      let drain: @Sendable (FileHandle) -> Void = { handle in
+        _ = handle.availableData
+      }
+      pipes.stdout.fileHandleForReading.readabilityHandler = drain
+      pipes.stderr.fileHandleForReading.readabilityHandler = drain
     }
   }
 }

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/GlobalStatsService.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/GlobalStatsService.swift
@@ -173,6 +173,7 @@ public final class GlobalStatsService: @unchecked Sendable {
   }
 
   private func startWatching() {
+    guard fileWatcher == nil else { return }
     guard FileManager.default.fileExists(atPath: statsFilePath) else {
       // Try again later when file might exist
       DispatchQueue.global().asyncAfter(deadline: .now() + 5) { [weak self] in
@@ -197,10 +198,13 @@ public final class GlobalStatsService: @unchecked Sendable {
       self?.scheduleDebouncedReload()
     }
 
-    source.setCancelHandler { [weak self] in
-      if let fd = self?.fileDescriptor, fd >= 0 {
-        close(fd)
-      }
+    // Capture the fd by value: the handler runs async on the source's queue,
+    // where `self` may already be gone (deinit-driven cancel would leak the
+    // fd) or `fileDescriptor` may already refer to a NEWER descriptor
+    // (closing it would kill an unrelated live fd once the number recycles).
+    let watchedFd = fileDescriptor
+    source.setCancelHandler {
+      close(watchedFd)
     }
 
     source.resume()

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/PendingSessionDirectoryWatcher.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/PendingSessionDirectoryWatcher.swift
@@ -1,0 +1,117 @@
+//
+//  PendingSessionDirectoryWatcher.swift
+//  AgentHub
+//
+
+import Foundation
+
+/// One-shot kqueue watch for a new `.jsonl` session file appearing in a
+/// Claude project directory.
+///
+/// Owns the directory descriptor for the duration of the wait and guarantees
+/// it is closed on every exit path — a new file appearing, `cancel()` (user
+/// dismissed the pending session card, or another resolution path won), or
+/// deallocation. Previously this watch was inlined with no teardown path, so
+/// every abandoned pending session permanently leaked one directory fd.
+public final class PendingSessionDirectoryWatcher: @unchecked Sendable {
+
+  public enum Outcome: Equatable, Sendable {
+    /// A new `.jsonl` file appeared; the associated value is its filename.
+    case found(String)
+    /// `cancel()` won before any file appeared.
+    case cancelled
+    /// The directory could not be opened for watching.
+    case unableToWatch
+  }
+
+  private let queue = DispatchQueue(label: "com.agenthub.pending-session-watcher")
+  private var source: DispatchSourceFileSystemObject?
+  private var isCancelled = false
+  private var didStart = false
+  private var foundFile: String?
+
+  public init() {}
+
+  deinit {
+    queue.sync {
+      isCancelled = true
+      source?.cancel()
+    }
+  }
+
+  /// Suspends until a `.jsonl` file not in `existingFiles` appears in
+  /// `directoryPath`, or `cancel()` is called. Call at most once per instance.
+  public func waitForNewJSONLFile(
+    inDirectory directoryPath: String,
+    excluding existingFiles: Set<String>
+  ) async -> Outcome {
+    let fd = open(directoryPath, O_EVTONLY)
+    guard fd >= 0 else { return .unableToWatch }
+
+    return await withCheckedContinuation { continuation in
+      queue.async {
+        guard !self.isCancelled, !self.didStart else {
+          close(fd)
+          continuation.resume(returning: .cancelled)
+          return
+        }
+        self.didStart = true
+
+        let source = DispatchSource.makeFileSystemObjectSource(
+          fileDescriptor: fd,
+          eventMask: [.write, .link, .attrib],
+          queue: self.queue
+        )
+        self.source = source
+
+        let checkForNewFile: () -> Void = { [weak self] in
+          guard let self, self.foundFile == nil else { return }
+          guard let currentFiles = try? FileManager.default.contentsOfDirectory(atPath: directoryPath) else {
+            return
+          }
+          let newJSONLFiles = Set(currentFiles)
+            .subtracting(existingFiles)
+            .filter { $0.hasSuffix(".jsonl") }
+          if let newFile = newJSONLFiles.first {
+            self.foundFile = newFile
+            source.cancel()
+          }
+        }
+
+        source.setEventHandler(handler: checkForNewFile)
+
+        // Single resume point: the cancel handler runs exactly once whether
+        // the event handler found a file or cancel()/deinit tore the watch
+        // down, so the continuation can never resume twice or never.
+        source.setCancelHandler { [weak self] in
+          close(fd)
+          guard let self else {
+            continuation.resume(returning: .cancelled)
+            return
+          }
+          self.source = nil
+          if let file = self.foundFile {
+            continuation.resume(returning: .found(file))
+          } else {
+            continuation.resume(returning: .cancelled)
+          }
+        }
+
+        source.resume()
+
+        // The file may have appeared between the caller's directory snapshot
+        // and the source arming; kqueue only reports subsequent changes.
+        checkForNewFile()
+      }
+    }
+  }
+
+  /// Ends the wait with `.cancelled` and releases the directory descriptor.
+  /// Safe to call from any thread, before or after the wait starts.
+  public func cancel() {
+    queue.async {
+      self.isCancelled = true
+      self.source?.cancel()
+    }
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/SessionFileWatcher.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/SessionFileWatcher.swift
@@ -26,6 +26,10 @@ public actor SessionFileWatcher {
   // MARK: - Properties
 
   private var watchedSessions: [String: FileWatcherInfo] = [:]
+  /// Sessions whose `startMonitoring` is between its duplicate-guard and its
+  /// `watchedSessions` store (the call suspends in between); used to reject
+  /// concurrent duplicate starts that would orphan the first watcher.
+  private var startingSessions: Set<String> = []
   private var hookCancellables: [String: AnyCancellable] = [:]
   private nonisolated let stateSubject = PassthroughSubject<StateUpdate, Never>()
   private let claudePath: String
@@ -86,6 +90,18 @@ public actor SessionFileWatcher {
       return
     }
 
+    // Reserve before the first suspension point: two concurrent starts for
+    // the same session both pass the guard above (the store into
+    // watchedSessions happens only after several awaits), and the second
+    // store would overwrite — and thereby orphan — the first watcher's
+    // dispatch source, leaking its descriptors and status timer.
+    guard !startingSessions.contains(sessionId) else {
+      AppLogger.watcher.info("[Polling] Start already in flight for: \(sessionId.prefix(8), privacy: .public)")
+      return
+    }
+    startingSessions.insert(sessionId)
+    defer { startingSessions.remove(sessionId) }
+
     // Find session file
     let resolvedFilePath = sessionFilePath ?? findSessionFile(sessionId: sessionId, projectPath: projectPath)
     guard let filePath = resolvedFilePath else {
@@ -117,7 +133,10 @@ public actor SessionFileWatcher {
     // Set up file watching
     let fileDescriptor = open(filePath, O_EVTONLY)
     guard fileDescriptor >= 0 else {
-      AppLogger.watcher.error("Could not open file for watching: \(filePath)")
+      let openErrno = errno
+      AppLogger.watcher.error(
+        "Could not open file for watching: \(filePath) errno=\(openErrno) (\(String(cString: strerror(openErrno)), privacy: .public))"
+      )
       return
     }
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/SimulatorService.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/SimulatorService.swift
@@ -789,8 +789,10 @@ public final class SimulatorService {
     let process = Process()
     process.executableURL = URL(fileURLWithPath: xcrun)
     process.arguments = ["simctl", "bootstatus", udid, "-b"]
-    process.standardOutput = Pipe()
-    process.standardError = Pipe()
+    // bootstatus streams progress nobody reads; an unread Pipe fills its 64KB
+    // buffer on slow boots and wedges the child past the timeout.
+    process.standardOutput = FileHandle.nullDevice
+    process.standardError = FileHandle.nullDevice
     guard (try? process.run()) != nil else { return false }
 
     let timeoutItem = DispatchWorkItem { process.terminate() }
@@ -819,8 +821,8 @@ public final class SimulatorService {
       process.environment = ProcessInfo.processInfo.environment
         .merging(environment) { _, override in override }
     }
-    process.standardOutput = Pipe()
-    process.standardError = Pipe()
+    process.standardOutput = FileHandle.nullDevice
+    process.standardError = FileHandle.nullDevice
     do {
       try process.run()
       process.waitUntilExit()
@@ -852,7 +854,6 @@ public final class SimulatorService {
 
     do {
       try process.run()
-      process.waitUntilExit()
     } catch {
       AppLogger.simulator.error("Failed to run xcrun devicectl: \(error.localizedDescription)")
       return ProcessExecutionResult(
@@ -862,10 +863,23 @@ public final class SimulatorService {
       )
     }
 
+    // Drain both pipes to EOF before waiting: a child that fills either 64KB
+    // pipe buffer would otherwise block on write while we block on wait.
+    var errorData = Data()
+    let errorDrain = DispatchGroup()
+    errorDrain.enter()
+    DispatchQueue.global().async {
+      errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
+      errorDrain.leave()
+    }
+    let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
+    errorDrain.wait()
+    process.waitUntilExit()
+
     return ProcessExecutionResult(
       exitCode: process.terminationStatus,
-      outputText: String(data: outputPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? "",
-      errorText: String(data: errorPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+      outputText: String(data: outputData, encoding: .utf8) ?? "",
+      errorText: String(data: errorData, encoding: .utf8) ?? ""
     )
   }
 
@@ -875,8 +889,8 @@ public final class SimulatorService {
     let process = Process()
     process.executableURL = URL(fileURLWithPath: open)
     process.arguments = ["-a", name]
-    process.standardOutput = Pipe()
-    process.standardError = Pipe()
+    process.standardOutput = FileHandle.nullDevice
+    process.standardError = FileHandle.nullDevice
     try? process.run()
   }
 
@@ -886,8 +900,8 @@ public final class SimulatorService {
     let process = Process()
     process.executableURL = URL(fileURLWithPath: open)
     process.arguments = [path]
-    process.standardOutput = Pipe()
-    process.standardError = Pipe()
+    process.standardOutput = FileHandle.nullDevice
+    process.standardError = FileHandle.nullDevice
     try? process.run()
   }
 
@@ -1381,14 +1395,16 @@ public final class SimulatorService {
     process.arguments = args
     let pipe = Pipe()
     process.standardOutput = pipe
-    process.standardError = Pipe()
+    process.standardError = FileHandle.nullDevice
 
     do {
       try process.run()
-      process.waitUntilExit()
     } catch { return nil }
 
+    // Read to EOF before waiting: output larger than the 64KB pipe buffer
+    // otherwise deadlocks the child against waitUntilExit().
     let data = pipe.fileHandleForReading.readDataToEndOfFile()
+    process.waitUntilExit()
     guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
       return nil
     }
@@ -1616,16 +1632,18 @@ public final class SimulatorService {
 
     let pipe = Pipe()
     process.standardOutput = pipe
-    process.standardError = Pipe()
+    process.standardError = FileHandle.nullDevice
 
     do {
       try process.run()
-      process.waitUntilExit()
     } catch {
       return .failure(error)
     }
 
+    // Read to EOF before waiting: `simctl list --json` routinely exceeds the
+    // 64KB pipe buffer and would deadlock against waitUntilExit().
     let data = pipe.fileHandleForReading.readDataToEndOfFile()
+    process.waitUntilExit()
 
     do {
       let runtimes = try parseDeviceList(from: data)
@@ -1663,19 +1681,23 @@ public final class SimulatorService {
       "--json-output", outputURL.path
     ]
 
-    process.standardOutput = Pipe()
+    process.standardOutput = FileHandle.nullDevice
     let errorPipe = Pipe()
     process.standardError = errorPipe
 
     do {
       try process.run()
-      process.waitUntilExit()
     } catch {
       return .failure(error)
     }
 
+    // Drain stderr to EOF before waiting so a chatty failure can't fill the
+    // 64KB pipe buffer and deadlock against waitUntilExit().
+    let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
+    process.waitUntilExit()
+
     guard process.terminationStatus == 0 else {
-      let errorText = String(data: errorPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+      let errorText = String(data: errorData, encoding: .utf8) ?? ""
       return .failure(NSError(domain: "SimulatorService", code: Int(process.terminationStatus),
                               userInfo: [NSLocalizedDescriptionKey: errorText.isEmpty ? "devicectl list devices failed" : errorText]))
     }
@@ -1700,21 +1722,24 @@ public final class SimulatorService {
 
     let pipe = Pipe()
     process.standardOutput = pipe
-    process.standardError = Pipe()
+    process.standardError = FileHandle.nullDevice
 
     do {
       try process.run()
-      process.waitUntilExit()
     } catch {
       return .failure(error)
     }
+
+    // Read to EOF before waiting: output larger than the 64KB pipe buffer
+    // otherwise deadlocks the child against waitUntilExit().
+    let data = pipe.fileHandleForReading.readDataToEndOfFile()
+    process.waitUntilExit()
 
     guard process.terminationStatus == 0 else {
       return .failure(NSError(domain: "SimulatorService", code: Int(process.terminationStatus),
                               userInfo: [NSLocalizedDescriptionKey: "xcdevice list failed"]))
     }
 
-    let data = pipe.fileHandleForReading.readDataToEndOfFile()
     do {
       return .success(try parsePhysicalDeviceList(from: data))
     } catch {

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/TerminalLauncher.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/TerminalLauncher.swift
@@ -414,14 +414,16 @@ public struct TerminalLauncher {
 
     let pipe = Pipe()
     task.standardOutput = pipe
-    task.standardError = Pipe()
+    task.standardError = FileHandle.nullDevice
 
     do {
       try task.run()
+      // Read to EOF before waiting: output larger than the 64KB pipe buffer
+      // otherwise deadlocks the child against waitUntilExit().
+      let data = pipe.fileHandleForReading.readDataToEndOfFile()
       task.waitUntilExit()
 
       if task.terminationStatus == 0 {
-        let data = pipe.fileHandleForReading.readDataToEndOfFile()
         if let path = String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines),
            !path.isEmpty {
           return path

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/TerminalProcessRegistry.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/TerminalProcessRegistry.swift
@@ -62,12 +62,14 @@ struct DarwinProcessInspector: ProcessInspecting {
 
     let pipe = Pipe()
     task.standardOutput = pipe
-    task.standardError = Pipe()
+    task.standardError = FileHandle.nullDevice
 
     do {
       try task.run()
-      task.waitUntilExit()
+      // Read to EOF before waiting: output larger than the 64KB pipe buffer
+      // otherwise deadlocks the child against waitUntilExit().
       let data = pipe.fileHandleForReading.readDataToEndOfFile()
+      task.waitUntilExit()
       let command = String(data: data, encoding: .utf8)?
         .trimmingCharacters(in: .whitespacesAndNewlines)
       return command?.isEmpty == false ? command : nil

--- a/app/modules/AgentHubCore/Sources/AgentHub/Utils/FileDescriptorLimits.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Utils/FileDescriptorLimits.swift
@@ -1,0 +1,57 @@
+//
+//  FileDescriptorLimits.swift
+//  AgentHub
+//
+
+import Darwin
+import Foundation
+
+/// Raises the process open-file soft limit at launch.
+///
+/// GUI apps launched from Finder inherit launchd's default soft limit of 256
+/// open files. AgentHub holds one descriptor per monitored session JSONL plus
+/// hook sidecars, PTY masters, kqueue watchers, SQLite, and transient
+/// subprocess pipes, so a busy hub can exhaust 256 — after which PTY spawns,
+/// git subprocesses, and file watchers all fail until relaunch. Child shells
+/// inherit the raised limit, so agents inside embedded terminals benefit too.
+public enum FileDescriptorLimits {
+  /// OPEN_MAX (10 240), the historical Darwin per-process ceiling. Kept below
+  /// larger values because C code using select(2) misbehaves once descriptor
+  /// numbers reach FD_SETSIZE-sensitive territory, and 10 240 is ample.
+  public static let targetSoftLimit: rlim_t = 10_240
+
+  /// Raises the RLIMIT_NOFILE soft limit to `targetSoftLimit`, bounded by the
+  /// hard limit. Never lowers an already-higher limit. Returns the resulting
+  /// soft limit, or nil when the current limit could not be read.
+  @discardableResult
+  public static func raiseSoftLimit() -> rlim_t? {
+    var limits = rlimit()
+    guard getrlimit(RLIMIT_NOFILE, &limits) == 0 else {
+      AppLogger.session.error("[FDLimits] getrlimit(RLIMIT_NOFILE) failed errno=\(errno)")
+      return nil
+    }
+
+    let current = limits.rlim_cur
+    guard current < targetSoftLimit else {
+      return current
+    }
+
+    // RLIM_INFINITY (not importable from Swift) is numerically enormous, so
+    // min() against the hard limit covers both the bounded and infinite cases.
+    let ceiling = min(limits.rlim_max, targetSoftLimit)
+    guard ceiling > current else {
+      return current
+    }
+
+    limits.rlim_cur = ceiling
+    guard setrlimit(RLIMIT_NOFILE, &limits) == 0 else {
+      AppLogger.session.error(
+        "[FDLimits] setrlimit(RLIMIT_NOFILE) to \(ceiling) failed errno=\(errno); staying at \(current)"
+      )
+      return current
+    }
+
+    AppLogger.session.info("[FDLimits] raised open-file soft limit \(current) -> \(ceiling)")
+    return ceiling
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/Utils/GitWorktreeDetector.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Utils/GitWorktreeDetector.swift
@@ -89,60 +89,81 @@ public class GitWorktreeDetector {
   /// Gets the current branch name for the given directory
   private static func getCurrentBranch(at path: String) async -> String? {
     AppLogger.git.info("[WorktreeDetector] getCurrentBranch start path=\(path, privacy: .public)")
+    guard let output = await runGitCommand(arguments: ["branch", "--show-current"], at: path) else {
+      return nil
+    }
+    let trimmed = output.trimmingCharacters(in: .whitespacesAndNewlines)
+    return trimmed.isEmpty ? nil : trimmed
+  }
+
+  /// Runs a short git command and returns its stdout, or nil on launch
+  /// failure or timeout.
+  private static func runGitCommand(arguments: [String], at path: String) async -> String? {
     let process = Process()
     process.executableURL = URL(fileURLWithPath: "/usr/bin/git")
-    process.arguments = ["branch", "--show-current"]
+    process.arguments = arguments
     process.currentDirectoryURL = URL(fileURLWithPath: path)
 
-    let pipe = Pipe()
-    process.standardOutput = pipe
-    process.standardError = Pipe()
+    let outputPipe = Pipe()
+    process.standardOutput = outputPipe
+    process.standardError = FileHandle.nullDevice
+
+    // The exit notifier must be wired BEFORE run(): these git commands exit in
+    // milliseconds, and a terminationHandler installed after the exit never
+    // fires, stranding the wait (and the pipe descriptors) forever.
+    let exitNotifier = GitProcessExitNotifier()
+    process.terminationHandler = { process in
+      exitNotifier.complete(status: process.terminationStatus)
+    }
 
     do {
       try process.run()
-
-      // Wait for process with timeout using async terminationHandler (non-blocking)
-      let didTimeout = await withTaskGroup(of: Bool.self) { group in
-        // Task 1: Wait for process completion via terminationHandler
-        group.addTask {
-          await withCheckedContinuation { (continuation: CheckedContinuation<Bool, Never>) in
-            process.terminationHandler = { _ in
-              continuation.resume(returning: false)
-            }
-          }
-        }
-
-        // Task 2: Timeout
-        group.addTask {
-          do {
-            try await Task.sleep(for: .seconds(Self.gitCommandTimeout))
-            if process.isRunning {
-              process.terminate()
-              AppLogger.git.warning("Git branch command timed out")
-            }
-            return true
-          } catch {
-            return false
-          }
-        }
-
-        let result = await group.next() ?? false
-        group.cancelAll()
-        return result
-      }
-
-      // Check if process was terminated due to timeout
-      if didTimeout || process.terminationStatus == SIGTERM {
-        return nil
-      }
-
-      let data = pipe.fileHandleForReading.readDataToEndOfFile()
-      let output = String(data: data, encoding: .utf8)?
-        .trimmingCharacters(in: .whitespacesAndNewlines)
-
-      return output?.isEmpty == false ? output : nil
     } catch {
       return nil
+    }
+
+    // Drain stdout while the process runs so a full pipe can never block exit.
+    async let outputData = readHandleToEnd(outputPipe.fileHandleForReading)
+
+    let timedOut = await withTaskGroup(of: Bool.self) { group in
+      group.addTask {
+        _ = await exitNotifier.wait()
+        return false
+      }
+
+      group.addTask {
+        do {
+          try await Task.sleep(for: .seconds(Self.gitCommandTimeout))
+          if process.isRunning {
+            process.terminate()
+            AppLogger.git.warning(
+              "Git command timed out args=\(arguments.joined(separator: " "), privacy: .public)"
+            )
+          }
+          return true
+        } catch {
+          return false
+        }
+      }
+
+      let result = await group.next() ?? false
+      group.cancelAll()
+      return result
+    }
+
+    let data = await outputData
+    if timedOut {
+      return nil
+    }
+    return String(data: data, encoding: .utf8)
+  }
+
+  private static func readHandleToEnd(_ handle: FileHandle) async -> Data {
+    await withCheckedContinuation { continuation in
+      DispatchQueue.global(qos: .utility).async {
+        let data = handle.readDataToEndOfFile()
+        continuation.resume(returning: data)
+      }
     }
   }
 
@@ -191,71 +212,17 @@ public class GitWorktreeDetector {
   public static func listWorktrees(at repoPath: String) async -> [GitWorktreeInfo] {
     let start = ContinuousClock.now
     AppLogger.git.info("[WorktreeDetector] listWorktrees start path=\(repoPath, privacy: .public)")
-    let process = Process()
-    process.executableURL = URL(fileURLWithPath: "/usr/bin/git")
-    process.arguments = ["worktree", "list", "--porcelain"]
-    process.currentDirectoryURL = URL(fileURLWithPath: repoPath)
 
-    let pipe = Pipe()
-    process.standardOutput = pipe
-    process.standardError = Pipe()
-
-    do {
-      try process.run()
-
-      // Wait for process with timeout using async terminationHandler (non-blocking)
-      let didTimeout = await withTaskGroup(of: Bool.self) { group in
-        // Task 1: Wait for process completion via terminationHandler
-        group.addTask {
-          await withCheckedContinuation { (continuation: CheckedContinuation<Bool, Never>) in
-            process.terminationHandler = { _ in
-              continuation.resume(returning: false)
-            }
-          }
-        }
-
-        // Task 2: Timeout
-        group.addTask {
-          do {
-            try await Task.sleep(for: .seconds(Self.gitCommandTimeout))
-            if process.isRunning {
-              process.terminate()
-              AppLogger.git.warning("Git worktree list command timed out")
-            }
-            return true
-          } catch {
-            return false
-          }
-        }
-
-        let result = await group.next() ?? false
-        group.cancelAll()
-        return result
-      }
-
-      // Check if process was terminated due to timeout
-      if didTimeout || process.terminationStatus == SIGTERM {
-        let elapsed = ContinuousClock.now - start
-        AppLogger.git.info("[WorktreeDetector] listWorktrees end path=\(repoPath, privacy: .public) result=[] (timeout) elapsed=\(elapsed, privacy: .public)")
-        return []
-      }
-
-      let data = pipe.fileHandleForReading.readDataToEndOfFile()
-      guard let output = String(data: data, encoding: .utf8) else {
-        let elapsed = ContinuousClock.now - start
-        AppLogger.git.info("[WorktreeDetector] listWorktrees end path=\(repoPath, privacy: .public) result=[] (no output) elapsed=\(elapsed, privacy: .public)")
-        return []
-      }
-
-      let result = parseWorktreeList(output, mainRepoPath: repoPath)
+    guard let output = await runGitCommand(arguments: ["worktree", "list", "--porcelain"], at: repoPath) else {
       let elapsed = ContinuousClock.now - start
-      AppLogger.git.info("[WorktreeDetector] listWorktrees end path=\(repoPath, privacy: .public) count=\(result.count) elapsed=\(elapsed, privacy: .public)")
-      return result
-    } catch {
-      let elapsed = ContinuousClock.now - start
-      AppLogger.git.info("[WorktreeDetector] listWorktrees end path=\(repoPath, privacy: .public) result=[] (error) elapsed=\(elapsed, privacy: .public)")
+      AppLogger.git.info("[WorktreeDetector] listWorktrees end path=\(repoPath, privacy: .public) result=[] (timeout or error) elapsed=\(elapsed, privacy: .public)")
       return []
     }
+
+    let result = parseWorktreeList(output, mainRepoPath: repoPath)
+    let elapsed = ContinuousClock.now - start
+    AppLogger.git.info("[WorktreeDetector] listWorktrees end path=\(repoPath, privacy: .public) count=\(result.count) elapsed=\(elapsed, privacy: .public)")
+    return result
   }
 
   /// Parses the output of `git worktree list --porcelain`
@@ -316,5 +283,41 @@ public class GitWorktreeDetector {
     let fileManager = FileManager.default
     let gitPath = (path as NSString).appendingPathComponent(".git")
     return fileManager.fileExists(atPath: gitPath)
+  }
+}
+
+/// Latches a process exit so waiters registered before OR after the exit both
+/// resume. A raw terminationHandler-in-continuation cannot make that
+/// guarantee, which previously stranded task groups when git exited quickly.
+private final class GitProcessExitNotifier: @unchecked Sendable {
+  private let lock = NSLock()
+  private var status: Int32?
+  private var continuations: [CheckedContinuation<Int32, Never>] = []
+
+  func complete(status: Int32) {
+    lock.lock()
+    if self.status == nil {
+      self.status = status
+    }
+    let continuations = self.continuations
+    self.continuations = []
+    lock.unlock()
+
+    for continuation in continuations {
+      continuation.resume(returning: status)
+    }
+  }
+
+  func wait() async -> Int32 {
+    await withCheckedContinuation { continuation in
+      lock.lock()
+      if let status {
+        lock.unlock()
+        continuation.resume(returning: status)
+      } else {
+        continuations.append(continuation)
+        lock.unlock()
+      }
+    }
   }
 }

--- a/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/CLISessionsViewModel.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/CLISessionsViewModel.swift
@@ -57,6 +57,14 @@ public final class CLISessionsViewModel {
   @ObservationIgnored private var isRefreshing = false
   @ObservationIgnored private var pendingRefreshRequested = false
   @ObservationIgnored private var accessoryDetectionTasks: [AccessoryDetectionContextKey: Task<Void, Never>] = [:]
+  /// Live kqueue watchers for pending Hub sessions, keyed by pending id, so
+  /// cancellation/resolution can release their directory descriptors.
+  @ObservationIgnored private var pendingSessionWatchers: [UUID: PendingSessionDirectoryWatcher] = [:]
+  /// Per-session FIFO for file-watcher start/stop operations. Unordered
+  /// fire-and-forget Tasks let a stop overtake an in-flight start (the start
+  /// hops through the claim store first), which orphaned a live watcher whose
+  /// session-file and sidecar descriptors were then never released.
+  @ObservationIgnored private var watcherLifecycleTasks: [String: (token: UUID, task: Task<Void, Never>)] = [:]
   @ObservationIgnored private var activeAccessoryDetectionKeysByParent: [String: Set<AccessoryDetectionContextKey>] = [:]
   @ObservationIgnored private var activeAccessoryRelationshipsByParent: [String: Set<AccessoryRelationshipIdentity>] = [:]
   @ObservationIgnored private var pendingResolvedAccessoryRelationships: [String: [SessionRelationshipRecord]] = [:]
@@ -638,6 +646,26 @@ public final class CLISessionsViewModel {
     }
   }
 
+  /// Runs `operation` after every previously enqueued watcher operation for
+  /// the same session has finished, so starts and stops reach the watcher
+  /// actor in the order they were issued.
+  private func enqueueWatcherLifecycleOperation(
+    for sessionId: String,
+    _ operation: @escaping () async -> Void
+  ) {
+    let previous = watcherLifecycleTasks[sessionId]?.task
+    let token = UUID()
+    let task = Task { [weak self] in
+      await previous?.value
+      await operation()
+      guard let self else { return }
+      if self.watcherLifecycleTasks[sessionId]?.token == token {
+        self.watcherLifecycleTasks.removeValue(forKey: sessionId)
+      }
+    }
+    watcherLifecycleTasks[sessionId] = (token, task)
+  }
+
   /// Start polling for a session
   private func startPolling(session: CLISession) {
     AppLogger.session.info("[Polling] startPolling called for session: \(session.id.prefix(8), privacy: .public)")
@@ -668,13 +696,14 @@ public final class CLISessionsViewModel {
     let claimStore = approvalClaimStore
     let sessionId = session.id
     let projectPath = session.projectPath
+    let sessionFilePath = session.sessionFilePath
 
-    Task {
+    enqueueWatcherLifecycleOperation(for: sessionId) { [fileWatcher] in
       await claimStore?.claim(sessionId: sessionId)
       await fileWatcher.startMonitoring(
         sessionId: sessionId,
         projectPath: projectPath,
-        sessionFilePath: session.sessionFilePath
+        sessionFilePath: sessionFilePath
       )
     }
     AppLogger.session.info("[Polling] Started polling for session: \(session.id.prefix(8), privacy: .public)")
@@ -689,7 +718,7 @@ public final class CLISessionsViewModel {
 
     let claimStore = approvalClaimStore
 
-    Task {
+    enqueueWatcherLifecycleOperation(for: sessionId) { [fileWatcher] in
       await fileWatcher.stopMonitoring(sessionId: sessionId)
       await claimStore?.release(sessionId: sessionId)
     }
@@ -3294,6 +3323,7 @@ public final class CLISessionsViewModel {
     let pendingKey = "pending-\(pending.id.uuidString)"
     removeTerminal(forKey: pendingKey)
     removeAuxiliaryShellTerminal(forKey: pendingKey)
+    pendingSessionWatchers.removeValue(forKey: pending.id)?.cancel()
     pendingHubSessions.removeAll { $0.id == pending.id }
     resolvedPendingSessions.removeValue(forKey: pending.id)
   }
@@ -3358,9 +3388,35 @@ public final class CLISessionsViewModel {
       return
     }
 
-    // Open directory for watching
-    let dirFd = open(projectDir, O_EVTONLY)
-    guard dirFd >= 0 else {
+    // Watch the directory for a new session file. The watcher owns the
+    // directory fd and releases it on every exit path; it waits indefinitely
+    // until a file appears or the pending card is cancelled/resolved.
+    let watcher = PendingSessionDirectoryWatcher()
+    pendingSessionWatchers[pending.id] = watcher
+    let outcome = await watcher.waitForNewJSONLFile(
+      inDirectory: projectDir,
+      excluding: existingFiles
+    )
+    if pendingSessionWatchers[pending.id] === watcher {
+      pendingSessionWatchers.removeValue(forKey: pending.id)
+    }
+
+    switch outcome {
+    case .found(let newFile):
+      let sessionId = String(newFile.dropLast(6)) // Remove ".jsonl"
+#if DEBUG
+      AppLogger.watcher.debug(
+        "[WatchNewSession] pendingId=\(pending.id.uuidString, privacy: .public) found new session file \(newFile, privacy: .public)"
+      )
+#endif
+      handleNewSessionFound(sessionId: sessionId, pending: pending, worktree: worktree)
+    case .cancelled:
+#if DEBUG
+      AppLogger.watcher.debug(
+        "[WatchNewSession] pendingId=\(pending.id.uuidString, privacy: .public) watch cancelled"
+      )
+#endif
+    case .unableToWatch:
 #if DEBUG
       AppLogger.watcher.debug(
         "[WatchNewSession] pendingId=\(pending.id.uuidString, privacy: .public) open failed, falling back to poll"
@@ -3368,53 +3424,6 @@ public final class CLISessionsViewModel {
 #endif
       // Directory doesn't exist yet - poll until it does
       await pollForNewClaudeSessionFallback(pending: pending, worktree: worktree)
-      return
-    }
-
-    let source = DispatchSource.makeFileSystemObjectSource(
-      fileDescriptor: dirFd,
-      eventMask: [.write, .link, .attrib],
-      queue: DispatchQueue.global(qos: .utility)
-    )
-
-    await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
-      var didFind = false
-
-      source.setEventHandler { [weak self] in
-        guard !didFind else { return }
-
-        // Check for new .jsonl files
-        guard let currentFiles = try? FileManager.default.contentsOfDirectory(atPath: projectDir) else { return }
-        let newFiles = Set(currentFiles).subtracting(existingFiles)
-        let newJsonlFiles = newFiles.filter { $0.hasSuffix(".jsonl") }
-#if DEBUG
-        if !newFiles.isEmpty {
-          AppLogger.watcher.debug(
-            "[WatchNewSession] pendingId=\(pending.id.uuidString, privacy: .public) event newFiles=\(newFiles.count) newJsonl=\(newJsonlFiles.count)"
-          )
-        }
-#endif
-
-        if let newFile = newJsonlFiles.first {
-          didFind = true
-          let sessionId = String(newFile.dropLast(6)) // Remove ".jsonl"
-
-          Task { @MainActor in
-            self?.handleNewSessionFound(sessionId: sessionId, pending: pending, worktree: worktree)
-          }
-          source.cancel()
-          continuation.resume()
-        }
-      }
-
-      source.setCancelHandler {
-        close(dirFd)
-      }
-
-      source.resume()
-
-      // No timeout: watcher waits indefinitely until user sends a message
-      // or closes the pending session card manually
     }
   }
 
@@ -3455,6 +3464,9 @@ public final class CLISessionsViewModel {
     worktree: WorktreeBranch,
     sessionFilePath: String? = nil
   ) {
+    // A competing resolution path (accessory detection, history polling) can
+    // win while the kqueue watch is still armed; release its directory fd.
+    pendingSessionWatchers.removeValue(forKey: pending.id)?.cancel()
 #if DEBUG
     AppLogger.session.debug(
       "[HandleNewSession] pendingId=\(pending.id.uuidString, privacy: .public) sessionId=\(sessionId, privacy: .public) worktreePath=\(worktree.path, privacy: .public) start"
@@ -3976,7 +3988,7 @@ public final class CLISessionsViewModel {
     syncFocusedSessionIdsToMonitor()
     persistMonitoredSessions()
 
-    Task {
+    enqueueWatcherLifecycleOperation(for: sessionId) { [fileWatcher] in
       await fileWatcher.stopMonitoring(sessionId: sessionId)
     }
   }

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/FileDescriptorLimitsTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/FileDescriptorLimitsTests.swift
@@ -1,0 +1,36 @@
+import Darwin
+import Foundation
+import Testing
+
+@testable import AgentHubCore
+
+@Suite("FileDescriptorLimits")
+struct FileDescriptorLimitsTests {
+
+  @Test("Raising the soft limit reaches the target (bounded by the hard limit)")
+  func raisesSoftLimitToTarget() {
+    let result = FileDescriptorLimits.raiseSoftLimit()
+
+    var limits = rlimit()
+    #expect(getrlimit(RLIMIT_NOFILE, &limits) == 0)
+
+    let expectedFloor = min(limits.rlim_max, FileDescriptorLimits.targetSoftLimit)
+    #expect(limits.rlim_cur >= expectedFloor)
+    #expect(result == limits.rlim_cur)
+  }
+
+  @Test("Raising is idempotent and never lowers an already-higher limit")
+  func neverLowersExistingLimit() {
+    let first = FileDescriptorLimits.raiseSoftLimit()
+    let second = FileDescriptorLimits.raiseSoftLimit()
+    #expect(first != nil)
+    #expect(second != nil)
+    if let first, let second {
+      #expect(second >= first)
+    }
+
+    var limits = rlimit()
+    #expect(getrlimit(RLIMIT_NOFILE, &limits) == 0)
+    #expect(limits.rlim_cur == second)
+  }
+}

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/GitWorktreeDetectorTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/GitWorktreeDetectorTests.swift
@@ -1,0 +1,150 @@
+import Foundation
+import Testing
+
+@testable import AgentHubCore
+
+@Suite("GitWorktreeDetector")
+struct GitWorktreeDetectorTests {
+
+  @Test("Detects a main repository with its current branch")
+  func detectsMainRepository() async throws {
+    let fixture = try Fixture()
+    defer { fixture.teardown() }
+
+    let info = await GitWorktreeDetector.detectWorktreeInfo(for: fixture.repoPath)
+    let unwrapped = try #require(info)
+    #expect(unwrapped.isWorktree == false)
+    #expect(unwrapped.mainRepoPath == nil)
+    #expect(unwrapped.branch == "main")
+  }
+
+  @Test("Returns nil for a directory that is not a git repository")
+  func returnsNilForNonRepository() async throws {
+    let fixture = try Fixture(initializeGit: false)
+    defer { fixture.teardown() }
+
+    let info = await GitWorktreeDetector.detectWorktreeInfo(for: fixture.repoPath)
+    #expect(info == nil)
+  }
+
+  @Test("Detects a linked worktree and resolves its main repository path")
+  func detectsLinkedWorktree() async throws {
+    let fixture = try Fixture()
+    defer { fixture.teardown() }
+    let worktreePath = try fixture.addWorktree(branch: "feature-x")
+
+    let info = await GitWorktreeDetector.detectWorktreeInfo(for: worktreePath)
+    let unwrapped = try #require(info)
+    #expect(unwrapped.isWorktree == true)
+    #expect(unwrapped.branch == "feature-x")
+    #expect(unwrapped.mainRepoPath.map { URL(fileURLWithPath: $0).standardizedFileURL.lastPathComponent }
+      == URL(fileURLWithPath: fixture.repoPath).standardizedFileURL.lastPathComponent)
+  }
+
+  @Test("Lists the main worktree plus linked worktrees")
+  func listsWorktrees() async throws {
+    let fixture = try Fixture()
+    defer { fixture.teardown() }
+    _ = try fixture.addWorktree(branch: "feature-y")
+
+    let worktrees = await GitWorktreeDetector.listWorktrees(at: fixture.repoPath)
+    #expect(worktrees.count == 2)
+    #expect(worktrees.first?.isWorktree == false)
+    #expect(worktrees.last?.isWorktree == true)
+    #expect(worktrees.last?.branch == "feature-y")
+  }
+
+  @Test("Returns an empty list for a non-repository path")
+  func listWorktreesOnNonRepository() async throws {
+    let fixture = try Fixture(initializeGit: false)
+    defer { fixture.teardown() }
+
+    let worktrees = await GitWorktreeDetector.listWorktrees(at: fixture.repoPath)
+    #expect(worktrees.isEmpty)
+  }
+
+  /// Regression guard: git exits in milliseconds, and the previous
+  /// implementation installed its terminationHandler after run(), which could
+  /// miss the exit and strand the call (and its pipe descriptors) forever. A
+  /// concurrent burst makes that race overwhelmingly likely to fire; with
+  /// per-test timeouts enabled a strand fails the suite instead of hanging.
+  @Test("Concurrent detection burst completes without stranding")
+  func concurrentBurstCompletes() async throws {
+    let fixture = try Fixture()
+    defer { fixture.teardown() }
+
+    let results = await withTaskGroup(of: GitWorktreeInfo?.self) { group in
+      for _ in 0..<24 {
+        group.addTask {
+          await GitWorktreeDetector.detectWorktreeInfo(for: fixture.repoPath)
+        }
+      }
+      var collected: [GitWorktreeInfo?] = []
+      for await result in group {
+        collected.append(result)
+      }
+      return collected
+    }
+
+    #expect(results.count == 24)
+    #expect(results.allSatisfy { $0?.branch == "main" })
+  }
+
+  // MARK: - Fixture
+
+  private struct Fixture {
+    let repoPath: String
+
+    init(initializeGit: Bool = true) throws {
+      let root = FileManager.default.temporaryDirectory
+        .appendingPathComponent("GitWorktreeDetectorTests-\(UUID().uuidString)")
+      try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+      repoPath = root.path
+
+      if initializeGit {
+        try Self.runGit(["init", "--initial-branch=main"], in: repoPath)
+        try Self.runGit(
+          ["-c", "user.email=test@agenthub.dev", "-c", "user.name=AgentHub Tests",
+           "commit", "--allow-empty", "-m", "init"],
+          in: repoPath
+        )
+      }
+    }
+
+    func addWorktree(branch: String) throws -> String {
+      let worktreePath = (repoPath as NSString)
+        .deletingLastPathComponent + "/" + (repoPath as NSString).lastPathComponent + "-\(branch)"
+      try Self.runGit(["worktree", "add", "-b", branch, worktreePath], in: repoPath)
+      return worktreePath
+    }
+
+    func teardown() {
+      let mainURL = URL(fileURLWithPath: repoPath)
+      let parent = mainURL.deletingLastPathComponent()
+      let prefix = mainURL.lastPathComponent
+      if let siblings = try? FileManager.default.contentsOfDirectory(atPath: parent.path) {
+        for name in siblings where name.hasPrefix(prefix) {
+          try? FileManager.default.removeItem(at: parent.appendingPathComponent(name))
+        }
+      }
+    }
+
+    private static func runGit(_ arguments: [String], in directory: String) throws {
+      let process = Process()
+      process.executableURL = URL(fileURLWithPath: "/usr/bin/git")
+      process.arguments = arguments
+      process.currentDirectoryURL = URL(fileURLWithPath: directory)
+      process.standardOutput = FileHandle.nullDevice
+      process.standardError = FileHandle.nullDevice
+      try process.run()
+      process.waitUntilExit()
+      guard process.terminationStatus == 0 else {
+        throw FixtureError.gitCommandFailed(arguments)
+      }
+    }
+  }
+
+  private enum FixtureError: Error {
+    case gitCommandFailed([String])
+  }
+}

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/PendingSessionDirectoryWatcherTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/PendingSessionDirectoryWatcherTests.swift
@@ -1,0 +1,149 @@
+import Foundation
+import Testing
+
+@testable import AgentHubCore
+
+@Suite("PendingSessionDirectoryWatcher", .serialized)
+struct PendingSessionDirectoryWatcherTests {
+
+  @Test("Resolves when a new .jsonl file appears")
+  func resolvesWhenNewJSONLAppears() async throws {
+    let directory = try makeTempDirectory()
+    defer { try? FileManager.default.removeItem(at: directory) }
+
+    let watcher = PendingSessionDirectoryWatcher()
+    async let outcome = watcher.waitForNewJSONLFile(inDirectory: directory.path, excluding: [])
+
+    try await Task.sleep(for: .milliseconds(100))
+    FileManager.default.createFile(
+      atPath: directory.appendingPathComponent("session-a.jsonl").path,
+      contents: Data("{}".utf8)
+    )
+
+    #expect(await outcome == .found("session-a.jsonl"))
+  }
+
+  @Test("Ignores excluded pre-existing files and non-jsonl files")
+  func ignoresExcludedAndNonJSONLFiles() async throws {
+    let directory = try makeTempDirectory()
+    defer { try? FileManager.default.removeItem(at: directory) }
+    FileManager.default.createFile(
+      atPath: directory.appendingPathComponent("existing.jsonl").path,
+      contents: Data()
+    )
+
+    let watcher = PendingSessionDirectoryWatcher()
+    async let outcome = watcher.waitForNewJSONLFile(
+      inDirectory: directory.path,
+      excluding: ["existing.jsonl"]
+    )
+
+    try await Task.sleep(for: .milliseconds(100))
+    FileManager.default.createFile(
+      atPath: directory.appendingPathComponent("notes.txt").path,
+      contents: Data()
+    )
+    try await Task.sleep(for: .milliseconds(100))
+    FileManager.default.createFile(
+      atPath: directory.appendingPathComponent("session-b.jsonl").path,
+      contents: Data()
+    )
+
+    #expect(await outcome == .found("session-b.jsonl"))
+  }
+
+  @Test("Resolves a file that appeared before the watch armed")
+  func resolvesFileCreatedBeforeArming() async throws {
+    let directory = try makeTempDirectory()
+    defer { try? FileManager.default.removeItem(at: directory) }
+    // Simulates the race where the session file lands between the caller's
+    // directory snapshot and the kqueue source arming: no further directory
+    // writes will occur, so only the initial check can catch it.
+    FileManager.default.createFile(
+      atPath: directory.appendingPathComponent("early.jsonl").path,
+      contents: Data()
+    )
+
+    let watcher = PendingSessionDirectoryWatcher()
+    let outcome = await watcher.waitForNewJSONLFile(inDirectory: directory.path, excluding: [])
+    #expect(outcome == .found("early.jsonl"))
+  }
+
+  @Test("cancel() resolves the wait as cancelled")
+  func cancelResolvesWait() async throws {
+    let directory = try makeTempDirectory()
+    defer { try? FileManager.default.removeItem(at: directory) }
+
+    let watcher = PendingSessionDirectoryWatcher()
+    async let outcome = watcher.waitForNewJSONLFile(inDirectory: directory.path, excluding: [])
+    try await Task.sleep(for: .milliseconds(100))
+    watcher.cancel()
+
+    #expect(await outcome == .cancelled)
+  }
+
+  @Test("cancel() before the wait starts resolves immediately")
+  func cancelBeforeStart() async throws {
+    let directory = try makeTempDirectory()
+    defer { try? FileManager.default.removeItem(at: directory) }
+
+    let watcher = PendingSessionDirectoryWatcher()
+    watcher.cancel()
+    let outcome = await watcher.waitForNewJSONLFile(inDirectory: directory.path, excluding: [])
+    #expect(outcome == .cancelled)
+  }
+
+  @Test("Unwatchable directory reports unableToWatch")
+  func unwatchableDirectory() async {
+    let watcher = PendingSessionDirectoryWatcher()
+    let outcome = await watcher.waitForNewJSONLFile(
+      inDirectory: "/nonexistent/agenthub-test-\(UUID().uuidString)",
+      excluding: []
+    )
+    #expect(outcome == .unableToWatch)
+  }
+
+  /// Regression guard for the original leak: cancelled/abandoned watches must
+  /// release their directory descriptor. Runs many cycles and asserts the
+  /// process open-fd count does not grow with them.
+  @Test("Cancelled watches release their directory descriptors")
+  func cancelReleasesDirectoryDescriptors() async throws {
+    let directory = try makeTempDirectory()
+    defer { try? FileManager.default.removeItem(at: directory) }
+
+    let baseline = openFileDescriptorCount()
+    for cycle in 0..<20 {
+      let watcher = PendingSessionDirectoryWatcher()
+      async let outcome = watcher.waitForNewJSONLFile(inDirectory: directory.path, excluding: [])
+      if cycle.isMultiple(of: 2) {
+        try await Task.sleep(for: .milliseconds(20))
+      }
+      watcher.cancel()
+      _ = await outcome
+    }
+
+    // Other suites run in the same process and open fds transiently; sample a
+    // few times and take the minimum so only a real (persistent) leak fails.
+    var after = Int.max
+    for _ in 0..<5 {
+      after = min(after, openFileDescriptorCount())
+      try await Task.sleep(for: .milliseconds(50))
+    }
+
+    #expect(baseline > 0)
+    #expect(after <= baseline + 5)
+  }
+
+  // MARK: - Helpers
+
+  private func makeTempDirectory() throws -> URL {
+    let url = FileManager.default.temporaryDirectory
+      .appendingPathComponent("PendingSessionDirectoryWatcherTests-\(UUID().uuidString)")
+    try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+    return url
+  }
+
+  private func openFileDescriptorCount() -> Int {
+    (try? FileManager.default.contentsOfDirectory(atPath: "/dev/fd"))?.count ?? -1
+  }
+}

--- a/app/modules/SimulatorPreview/Sources/SimulatorPreview/HotReload/HotReloadBuildLogSynthesizer.swift
+++ b/app/modules/SimulatorPreview/Sources/SimulatorPreview/HotReload/HotReloadBuildLogSynthesizer.swift
@@ -54,8 +54,13 @@ public enum HotReloadBuildLogSynthesizer {
     process.standardOutput = output
     try process.run()
 
-    input.fileHandleForWriting.write(data)
-    try input.fileHandleForWriting.close()
+    // Feed stdin on a background queue while draining stdout here: writing
+    // the whole input first deadlocks once gzip's output fills the 64KB pipe
+    // buffer with no reader on the other end.
+    DispatchQueue.global().async {
+      input.fileHandleForWriting.write(data)
+      try? input.fileHandleForWriting.close()
+    }
     let compressed = output.fileHandleForReading.readDataToEndOfFile()
     process.waitUntilExit()
 

--- a/app/modules/SimulatorPreview/Sources/SimulatorPreview/ScreenshotPoller.swift
+++ b/app/modules/SimulatorPreview/Sources/SimulatorPreview/ScreenshotPoller.swift
@@ -45,8 +45,8 @@ final class ScreenshotPoller {
     let process = Process()
     process.executableURL = URL(fileURLWithPath: "/usr/bin/xcrun")
     process.arguments = ["simctl", "io", udid, "screenshot", "--type=png", tempURL.path]
-    process.standardOutput = Pipe()
-    process.standardError = Pipe()
+    process.standardOutput = FileHandle.nullDevice
+    process.standardError = FileHandle.nullDevice
     do {
       try process.run()
     } catch {

--- a/app/modules/SimulatorPreview/Sources/SimulatorPreview/SimulatorScreenshotCapture.swift
+++ b/app/modules/SimulatorPreview/Sources/SimulatorPreview/SimulatorScreenshotCapture.swift
@@ -56,8 +56,8 @@ public enum SimulatorScreenshotCapture {
     let process = Process()
     process.executableURL = URL(fileURLWithPath: "/usr/bin/xcrun")
     process.arguments = ["simctl", "io", udid, "screenshot", "--type=png", tempURL.path]
-    process.standardOutput = Pipe()
-    process.standardError = Pipe()
+    process.standardOutput = FileHandle.nullDevice
+    process.standardError = FileHandle.nullDevice
     do {
       try process.run()
     } catch {


### PR DESCRIPTION
## Problem

Users reported that after running for a while, AgentHub randomly "loses access to the file system" — embedded terminals (both SwiftTerm and Ghostty) can no longer make local changes or create PRs — and only relaunching the app fixes it.

## Root cause

Not TCC/sandbox (the app is unsandboxed and uses no security-scoped APIs). The app runs at launchd's default **256 open-file soft limit** and both leaks and wedges descriptors over time:

- Steady state is already ~2 fds per monitored session (JSONL + hook sidecar), with no idle eviction.
- The pending-session kqueue watch had **no teardown path** — one directory fd leaked forever per cancelled/abandoned Start-in-Hub launch.
- `GitWorktreeDetector` installed its `terminationHandler` *after* `run()`; fast-exiting git stranded the task group forever, leaking 4 pipe fds per occurrence on the hottest git path (every repo refresh).
- A stop could overtake an in-flight start in the watcher plumbing, orphaning live watchers (2 fds + a forever-firing timer each).
- Several subprocess sites called `waitUntilExit()` before draining pipes (`simctl list --json` always exceeds the 64KB pipe buffer → permanent deadlock, 4 fds + a wedged thread per call).
- Stats services' cancel handlers resolved the fd through `weak self` — leaking on deinit and able to close a *newer, unrelated* live fd after a restart.

Once the table fills, PTY spawns, git subprocesses, and watchers all fail — "file access is gone." Child shells inherit the 256 limit too, so agents inside terminals hit `EMFILE` mid-session and report it as I/O failures. Relaunch resets the fd table, which is why it "fixed" it.

## Fixes (safe tier)

- **Raise `RLIMIT_NOFILE` to 10,240 at launch** (`FileDescriptorLimits`, called from `AgentHubApp.init`). Child shells inherit the raised limit. Capped at `OPEN_MAX` to stay clear of `select(2)`/`FD_SETSIZE` territory.
- **`GitWorktreeDetector`**: exit notifier wired before `run()` (the proven `FileIndexService` pattern), stdout drained concurrently, stderr to null.
- **`PendingSessionDirectoryWatcher`** (new, extracted + tested): owns the directory fd with a single-resume-point cancel handler; torn down from `cancelPendingSession`, from `handleNewSessionFound` when a competing resolution path wins, and by a `deinit` backstop. Also catches files that land between the directory snapshot and the kqueue arming.
- **Watcher lifecycle FIFO**: start/stop ops are serialized per session; plus a `startingSessions` reservation inside the `SessionFileWatcher` actor closes the duplicate-start re-entrancy window.
- **Stats services**: cancel handlers capture the fd by value; double-start guards added.
- **EMFILE observability**: watcher `open()` failures now log errno.
- **Pipe hygiene**: read-before-wait or `FileHandle.nullDevice` across `SimulatorService`, `ScreenshotPoller` (2 Hz), `SimulatorScreenshotCapture`, `TerminalProcessRegistry`, `TerminalLauncher`; background stdin write for the gzip build-log helper; `DevServerManager` keeps draining dev-server output after readiness (fixes vite/storybook silently freezing after ~64KB of post-ready output).

## Deliberately deferred (higher-risk, tracked separately)

Closing SwiftTerm PTY masters + `FD_CLOEXEC` in the fork, and freeing Ghostty surfaces on shell exit. With the raised limit these are resource-waste bugs rather than app-breaking ones; they need manual terminal-flow testing and a lifecycle design decision.

## Testing

- App target: `BUILD SUCCEEDED`.
- 39 tests across 8 targeted `AgentHubCore` suites passed, including three new suites: `FileDescriptorLimitsTests`, `GitWorktreeDetectorTests` (with a 24-way concurrent-detection burst regression test that hangs on the old code), `PendingSessionDirectoryWatcherTests` (with an fd-release regression test counting `/dev/fd`).
- `SimulatorServiceTests` + `DevServerManagerTests` passed.
- `SimulatorPreview` module: all 73 tests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)