### PR TITLE
Add the Measurements panel: agent-recorded numbers with their query

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,6 +127,19 @@ AgentHub has MCP UI support wired through the reusable `AgentHubMCPUI` Swift mod
 
 AgentHub renders MCP app UIs an agent produces during a Claude or Codex session in a dedicated side panel, driven by the agent's tool calls (no proactive server discovery). Read **`MCPApps.md`** before editing MCP app detection (`detectedMCPAppInvocations`/`detectedMCPAppResources` in the parsers), resolution (`CLISessionsViewModel.ensureMCPAppRenderItems`), rendering (`MCPAppSidePanelView`), the on-demand gateway (`MCPAppDiscoveryService`), or the bridge push in `AgentHubMCPUIResourceView`. `MCPApps.md` documents the current state and remaining gaps.
 
+### Measurements (agent-recorded measurements)
+
+Measurements an agent produced during a session render in a dedicated side panel. Read **`Measurements.md`** before editing anything named `Measurement*`, the `SidePanelContent.measurements` case, `agenthub_record_measurement` / `agenthub_list_measurements`, or the `session_measurements` table.
+
+- **The agent sends data, never markup.** `agenthub_record_measurement` takes a chart *specification*; AgentHub draws it with Swift Charts. Never add an HTML/SVG/image passthrough.
+- **A measurement needs numbers.** The tool rejects a call with neither `chart` nor `table`.
+- **Scoped to the project, never to a session.** `sessionId` is provenance only and must not decide what the panel shows; worktrees roll up to their parent repo via `MeasurementProjectScope`.
+- **Re-run goes through the agent, never through AgentHub.** `↻` sends the stored query back into the session terminal; AgentHub must never execute a stored query itself.
+- **Re-run accumulates.** `replacing(_:)` pushes superseded values onto `history` (capped) rather than overwriting them.
+- **Every run records its branch**, stamped by the app from the session. The trend splits one series per branch — measurements roll up to the repo, so unsplit runs from `main` and a worktree interleave and a stable metric reads as thrashing.
+- **Never colour the delta red/green** — nothing tells AgentHub whether up is good.
+- The CLI reads measurements through a JSON index the app republishes (`MeasurementIndexStore`); it must not open the app's SQLite database.
+
 ### Storybook Mode
 
 Storybook-enabled projects swap the Preview button for a Storybook button (never both). `WebPreviewMode { .app, .storybook }` routes the preview pane; the storybook server runs at compound key `"{sessionId}:storybook"` in `DevServerManager` so it coexists with the primary app server. Read **Storybook** in `README.md` before editing this area.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -274,6 +274,14 @@ Agent sessions use XcodeBuildMCP for simulator build/run, screenshots, and UI au
 [InjectionLite]: https://github.com/johnno1962/InjectionLite
 [SnapshotPreviews]: https://github.com/getsentry/SnapshotPreviews
 
+### Measurements Panel
+
+Measurements an agent produced during a session (a claim, the chart/table behind it, the query, and caveats) render in a dedicated side panel. The agent files them with the bundled `agenthub_record_measurement` MCP tool and discovers existing ones with `agenthub_list_measurements`; AgentHub draws the chart from a data spec with Swift Charts — agent-authored markup never reaches the panel.
+
+Measurements are scoped to the **project**, not the session: they outlive the conversation that produced them and are shared across every session and both providers, with worktrees rolling up to their parent repo. `↻` re-runs a measurement's stored query *through the agent* (AgentHub never executes it) and accumulates each run into a capped history so a tracked metric shows its trend. The CLI reads measurements through a JSON index the app republishes (`MeasurementIndexStore`) and must not open the app's SQLite database.
+
+Read **`Measurements.md`** before editing anything named `Measurement*`, the `SidePanelContent.measurements` case, `agenthub_record_measurement` / `agenthub_list_measurements`, or the `session_measurements` table.
+
 ### Command Palette
 
 `CommandPaletteView` — Cmd+K for quick session/repository/action access.

--- a/Measurements.md
+++ b/Measurements.md
@@ -1,0 +1,120 @@
+# Measurements Panel
+
+AgentHub renders **measurements** an agent produced during a session — a claim, the numbers behind it, and the query that produced them — in a dedicated side panel. The guiding principle:
+
+> **A number a PM will decide on must arrive with its query and its caveats attached. The agent supplies data; AgentHub draws it.**
+
+This is the data-analysis counterpart to the web/simulator preview panels: those exist to build, this exists to decide.
+
+## On the name
+
+Called **Measurements** deliberately, after trying "Evidence" and "Findings". The test a name has to pass here is covering *both* kinds of card: a one-off answer ("which files churn most" — a ranking, not a metric) and a metric tracked over time ("clean build time"). "Metrics" only fits the second and implies a live dashboard that does not exist; "Insights" promises interpretation and fights the show-the-query principle; "Snapshots" collides with snapshot testing (SnapshotPreviews is a dependency). Measurements is the plainest word that fits every card.
+
+## User behavior
+
+- A session's monitoring card shows an **Measurements** button only after the agent has filed at least one measurement (no proactive UI, same rule as the MCP button).
+- Clicking it opens a side panel listing cards newest-first: title, the claim in plain English, a chart, an optional table, caveats, and the query collapsed underneath.
+- Cards persist across relaunch and are scoped to the session that produced them.
+- The panel never auto-opens — it is button-only (`isAutoOpenableContent` returns `false` for `.measurements`).
+
+## Data flow
+
+```
+agent calls agenthub_record_measurement(title, claim, chart|table, query, caveats, source)
+   │
+   ├─ AgentHubMCPServer validates + enqueues                                ①
+   │     recordMeasurement() → MeasurementRecordQueue (JSON file, atomic write)
+   │     ~/Library/Application Support/AgentHub/measurement-records/
+   │
+   ├─ App drains the queue                                                  ②
+   │     MeasurementRecordMonitor (poll) → MeasurementRecordHandler
+   │     resolves AGENTHUB_SESSION_ID, else process→session mapping
+   │
+   ├─ ViewModel stores it                                                   ③
+   │     CLISessionsViewModel.storeMeasurement(): in-memory first (card appears
+   │     immediately), then SessionMetadataStore.saveMeasurement()
+   │
+   └─ Panel renders                                                         ④
+         MonitoringCardView gates the button on measurementCount
+         → SidePanelContent.measurements → MeasurementsSidePanelView
+         → MeasurementCardView → MeasurementChartView (Swift Charts)
+```
+
+## Key files
+
+| Area | File |
+|---|---|
+| Record/chart/table models + limits | `AgentHubCLI/Sources/AgentHubCLIKit/MeasurementModels.swift` |
+| CLI→app file queue | `AgentHubCLI/Sources/AgentHubCLIKit/MeasurementRecordQueue.swift` |
+| Tool schema, validation, enqueue | `AgentHubCLI/Sources/AgentHubCLI/AgentHubMCPServer.swift` (`recordMeasurement`, `recordMeasurementToolSchema`) |
+| Queue drain | `AgentHubCore/.../Services/MeasurementRecordMonitor.swift` |
+| Session resolution | `AgentHubCore/.../Services/MeasurementRecordHandler.swift` |
+| SQLite record (blob payload) | `AgentHubCore/.../Models/SessionMeasurementRecord.swift` |
+| `v14_create_session_measurements` + CRUD | `AgentHubCore/.../Services/SessionMetadataStore.swift` |
+| In-memory state, merge, load/delete | `AgentHubCore/.../ViewModels/CLISessionsViewModel.swift` |
+| Panel, card, chart | `AgentHubCore/.../UI/MeasurementsSidePanelView.swift`, `MeasurementCardView.swift`, `MeasurementChartView.swift` |
+| Panel case + routing | `AgentHubCore/.../UI/MultiProviderMonitoringPanelView.swift` |
+| Button gating | `AgentHubCore/.../UI/MonitoringCardView.swift` |
+| Re-run prompt | `AgentHubCore/.../Services/MeasurementRerunPromptBuilder.swift` |
+| Project bucket + worktree rollup | `AgentHubCore/.../Services/MeasurementProjectScope.swift` |
+| Branch-split trend | `AgentHubCore/.../Services/MeasurementTrendBuilder.swift` |
+| Agent-readable index (list tool) | `AgentHubCLI/Sources/AgentHubCLIKit/MeasurementIndexStore.swift` |
+| Axis label rule | `MeasurementAxisLabelLayout` in `MeasurementChartView.swift` |
+
+## Invariants (preserve when editing)
+
+- **The agent sends data, never markup.** `agenthub_record_measurement` accepts a chart *specification* (series of `{x, y}` points) and AgentHub draws it with Swift Charts. Do not add an HTML/SVG/image passthrough: it would put agent-authored markup in the panel, break theming, and make cards unre-runnable.
+- **A measurement needs numbers.** The tool rejects a call with neither `chart` nor `table`. A text-only "measurement" is an assertion, not evidence of anything.
+- **Caveats are not small print.** They render as their own visually distinct block. The panel exists so a number arrives with the reasons it might mislead attached; do not demote them to a tooltip or a footer.
+- **Payload limits are enforced at the tool boundary** (`MeasurementRecord.Limits`), not in the UI. Exceeding one is a tool-level error the agent can correct by aggregating — never a silent truncation, which would make a card lie about its own coverage.
+- **Never store measurements against a `pending-` session id.** That id is replaced when the session becomes real, stranding the card. Unresolvable records stay queued and are retried for 30s (`MeasurementRecordMonitor.shouldRetry`).
+- **The record is stored as an encoded blob** with `payloadVersion` — the one sanctioned per-table version column, because the card's shape evolves independently of the schema. Only queried-on columns are denormalized.
+- **Measurements are scoped to a project, never to a session.** A measurement about a repo or a database outlives the conversation that produced it; session scoping would hide last month's number from this month's work, which is exactly when it matters. `sessionId` is retained as provenance only and must not be used to decide what the panel shows. Worktrees roll up to their parent repo via `MeasurementProjectScope`, so a worktree's runs join the repo's history instead of forming an isolated set.
+- **Re-run accumulates, it does not overwrite.** `replacing(_:)` pushes the superseded values onto `history` (capped at `Limits.maxHistoryRuns`). Losing the old numbers would destroy the only thing that makes a re-run worth doing.
+- **Never colour the delta red/green.** Whether "up" is good depends on the metric — down is good for build time, bad for weekly actives — and AgentHub is not told which. The sign alone is unambiguous; a colour would confidently mislead half the time.
+- **The CLI never opens the app's database.** `agenthub_list_measurements` reads a JSON index the app republishes on every change (`CLISessionsViewModel.publishMeasurementIndex`). Opening SQLite from the helper would couple it to the app's schema and its single-process assumptions. The index is mirrored to every session path that resolves to the project, so a worktree session finds it from `AGENTHUB_PROJECT_PATH` alone.
+- **Index file names are percent-encoded, not separator-substituted.** Turning `/` into `-` makes `/a/b-c` and `/a-b/c` collide, silently merging two projects' measurements.
+- **Every run records the branch it measured.** Measurements roll up to the repository, so a `main` run and a feature-worktree run land on the same card. Plotted as one series they interleave — 214, 163, 211, 160 — and two perfectly stable branches read as a metric thrashing. The branch is stamped by the app from the recording session (never by the CLI shelling out to `git`, which is wrong in a detached or mid-rebase checkout), carried into history with the values it measured, and split into one trend series per branch. The delta likewise compares against the previous run *on the same branch*.
+- **A category axis needs an explicit order when series cover different categories.** Swift Charts derives the axis from first-appearance order, which groups one branch's dates before the other's and renders them out of chronology. `MeasurementChart.xOrder` states the order; the trend builder sorts it by run date.
+- **No auto-open.** The panel is button-only.
+- **Re-run goes through the agent, never through AgentHub.** `↻` sends `MeasurementRerunPromptBuilder.prompt(for:)` into the session terminal and the agent re-files the measurement. AgentHub must not execute a stored query itself: the query is arbitrary shell/SQL an agent wrote, and running it from a click would turn a saved card into a code-execution surface. Clicking `↻` can do nothing the session could not already do.
+- **A re-run must re-file under the same `id`.** That is what upserts the card in place instead of stacking a near-duplicate. `resolvingRerun` then keeps the original `createdAt` (so the refreshed card holds its position and does not jump under the user's cursor) and stamps `updatedAt`.
+- **The re-run prompt forbids rewriting the query**, because the whole point is that the measurement stays comparable across runs, and forbids recording anything if the command fails — a card silently holding stale numbers is worse than one visibly out of date.
+- **The pending spinner must have a terminal state.** The agent can simply never call back; `CLISessionsViewModel.rerunTimeout` clears it after 180s so "re-running…" never becomes permanent.
+- **Migration-preservation tests must anchor on an identifier**, via `seedMigrationBaseline(before:in:)` — never a positional `dropLast(n)`, which silently breaks the moment a `vN_` migration is appended (this is exactly how v14 broke `ProjectSimulatorPreferenceTests`).
+
+## Current state — works
+
+- `agenthub_record_measurement` on the bundled MCP server, available in every AgentHub-managed Claude/Codex session with no configuration (it rides the existing `AGENTHUB_*` env bootstrap).
+- Validated chart (bar/line/area/point, multi-series) and table specs; queue round trip; session resolution by explicit id or process group.
+- SQLite persistence with the v14 migration; cards survive relaunch; per-card delete.
+- Panel with claim, chart, table, caveats block, collapsible query with copy, source footer.
+- Project scoping with worktree rollup, cross-provider sharing, and a v15 backfill for pre-existing rows.
+- Branch-aware runs: history rows name their branch (only when runs actually span branches), and the trend splits into one series per branch so a branch comparison reads as a comparison.
+- Run history per card (capped), with a trend chart for scalar metrics and every earlier claim retained.
+- `agenthub_list_measurements`, so an agent can refresh an existing measurement by name instead of filing a near-duplicate.
+- Tests: `MeasurementRecordQueueTests` and `MeasurementIndexStoreTests` (CLI package), `SessionMeasurementStoreTests`, `MeasurementRunHistoryTests`, `MeasurementProjectScopeTests`, `MeasurementsMergeTests`, `MeasurementRerunTests`, `MeasurementAxisLabelLayoutTests`, `MeasurementRecordHandlerTests`.
+
+## Remaining work / gaps
+
+- [ ] **Re-run needs a live session.** `↻` is hidden when the session has no active terminal, so a measurement from a closed session cannot be refreshed. Reopening the session restores it.
+- [ ] **Nothing verifies the agent actually re-ran the query.** It is asked to run it verbatim; a lazy agent could re-derive it. Detecting that would mean hashing the executed command.
+- [ ] **Branch names are not reconciled.** A renamed or deleted branch keeps its old name in history, and two unrelated repos' branches sharing a name is not a concern here only because measurements are already project-scoped.
+- [ ] **No scheduled refresh.** Re-running is manual: if nobody opens the panel and clicks `↻`, a tracked metric silently goes stale. Automatic refresh would make a card a real tracked metric, and needs a scheduler plus a policy for when it may run.
+- [x] **Data connectors — solved by MCP, not by us.** External data arrives through whatever MCP servers the user has configured in their own agent (`~/.claude.json`, `~/.codex/config.toml`). AgentHub builds and maintains no connectors, never sees credentials, and never moves rows: it reads a JSON file off disk and draws a chart. The privacy claim narrows accordingly and should be stated plainly — *AgentHub sends nothing; what a user's own MCP servers send is their configuration and their call.*
+- [ ] **No provenance/semantic layer.** `source` is free text. A `.agenthub/metrics.yml` that the agent must resolve named metrics through is what turns a card from "trust me" into "checkable".
+- [ ] **No skeptic pass.** Nothing checks sample size, null rate, join fan-out, or partial windows automatically — the caveats are only as good as the agent's honesty.
+- [ ] **No segment decomposition.** The "who's under this average?" action is not built.
+- [ ] **No export.** Cards can't be exported as a shareable report.
+- [ ] **Chart x axis is categorical only.** Dates are labels, so spacing is even regardless of real gaps. Fine for cohorts/buckets, wrong for irregular time series.
+- [ ] **Single-number measurements render badly.** "Build time is 163s" draws as one lone bar, and with history the card then shows that same number twice — once as a bar, once as the trend. A scalar wants a big-number layout plus the trend, not a bar chart.
+- [ ] **Direction-of-good is unknown.** The delta is uncoloured because nothing tells AgentHub whether up is good. A `higherIsBetter` flag on the tool would let the card say so safely.
+- [ ] **Measurements are not deleted when a project is removed.** `deleteAllMeasurements(forProjectPath:)` and `deleteUnscopedMeasurements()` exist but nothing calls them — deliberately, since removing a repo from the sidebar is reversible and should not destroy its history. Needs an explicit user-facing action instead.
+- [ ] **No panel-level tests.** UI is covered indirectly (view model + store); `MeasurementsSidePanelView` itself has no snapshot/behavior test.
+
+## Verification
+
+- CLI: `cd app/modules/AgentHubCLI && swift test --filter MeasurementRecordQueue`
+- Core: `cd app/modules/AgentHubCore && xcodebuild test -scheme AgentHubCore-Tests -destination 'platform=macOS' -test-timeouts-enabled YES -skipPackagePluginValidation -only-testing:AgentHubTests/SessionMeasurementStoreTests -only-testing:AgentHubTests/MeasurementRecordHandlerTests -only-testing:AgentHubTests/MeasurementsMergeTests`
+- End-to-end: in a monitored session, ask the agent to analyze a local CSV and record the result. The Measurements button should appear on the card; the panel should render the chart with the query collapsed underneath.
+- Tool only: pipe JSON-RPC into the built CLI with `AGENTHUB_PROVIDER`/`AGENTHUB_SESSION_ID` set and inspect `~/Library/Application Support/AgentHub/measurement-records/`.

--- a/Measurements.md
+++ b/Measurements.md
@@ -58,6 +58,7 @@ agent calls agenthub_record_measurement(title, claim, chart|table, query, caveat
 | Re-run prompt | `AgentHubCore/.../Services/MeasurementRerunPromptBuilder.swift` |
 | Project bucket + worktree rollup | `AgentHubCore/.../Services/MeasurementProjectScope.swift` |
 | Branch-split trend | `AgentHubCore/.../Services/MeasurementTrendBuilder.swift` |
+| Settings management tab | `AgentHubCore/.../UI/MeasurementsSettingsView.swift`, `ViewModels/MeasurementsSettingsViewModel.swift` |
 | Agent-readable index (list tool) | `AgentHubCLI/Sources/AgentHubCLIKit/MeasurementIndexStore.swift` |
 | Axis label rule | `MeasurementAxisLabelLayout` in `MeasurementChartView.swift` |
 
@@ -76,6 +77,7 @@ agent calls agenthub_record_measurement(title, claim, chart|table, query, caveat
 - **Index file names are percent-encoded, not separator-substituted.** Turning `/` into `-` makes `/a/b-c` and `/a-b/c` collide, silently merging two projects' measurements.
 - **Every run records the branch it measured.** Measurements roll up to the repository, so a `main` run and a feature-worktree run land on the same card. Plotted as one series they interleave — 214, 163, 211, 160 — and two perfectly stable branches read as a metric thrashing. The branch is stamped by the app from the recording session (never by the CLI shelling out to `git`, which is wrong in a detached or mid-rebase checkout), carried into history with the values it measured, and split into one trend series per branch. The delta likewise compares against the previous run *on the same branch*.
 - **A category axis needs an explicit order when series cover different categories.** Swift Charts derives the axis from first-appearance order, which groups one branch's dates before the other's and renders them out of chronology. `MeasurementChart.xOrder` states the order; the trend builder sorts it by run date.
+- **Management UI groups by project, never by worktree.** Worktrees roll up to their parent repo, so there is no per-worktree set to delete; offering one would let a user delete a worktree's measurements and still find the card there. Settings exists for what the panel cannot reach — the panel only shows the project of a session you currently have open, so measurements for a deleted repository are otherwise permanent and invisible.
 - **No auto-open.** The panel is button-only.
 - **Re-run goes through the agent, never through AgentHub.** `↻` sends `MeasurementRerunPromptBuilder.prompt(for:)` into the session terminal and the agent re-files the measurement. AgentHub must not execute a stored query itself: the query is arbitrary shell/SQL an agent wrote, and running it from a click would turn a saved card into a code-execution surface. Clicking `↻` can do nothing the session could not already do.
 - **A re-run must re-file under the same `id`.** That is what upserts the card in place instead of stacking a near-duplicate. `resolvingRerun` then keeps the original `createdAt` (so the refreshed card holds its position and does not jump under the user's cursor) and stamps `updatedAt`.
@@ -90,6 +92,7 @@ agent calls agenthub_record_measurement(title, claim, chart|table, query, caveat
 - SQLite persistence with the v14 migration; cards survive relaunch; per-card delete.
 - Panel with claim, chart, table, caveats block, collapsible query with copy, source footer.
 - Project scoping with worktree rollup, cross-provider sharing, and a v15 backfill for pre-existing rows.
+- Settings tab for reviewing and deleting stored measurements, including those from projects no longer open.
 - Branch-aware runs: history rows name their branch (only when runs actually span branches), and the trend splits into one series per branch so a branch comparison reads as a comparison.
 - Run history per card (capped), with a trend chart for scalar metrics and every earlier claim retained.
 - `agenthub_list_measurements`, so an agent can refresh an existing measurement by name instead of filing a near-duplicate.
@@ -109,7 +112,7 @@ agent calls agenthub_record_measurement(title, claim, chart|table, query, caveat
 - [ ] **Chart x axis is categorical only.** Dates are labels, so spacing is even regardless of real gaps. Fine for cohorts/buckets, wrong for irregular time series.
 - [ ] **Single-number measurements render badly.** "Build time is 163s" draws as one lone bar, and with history the card then shows that same number twice — once as a bar, once as the trend. A scalar wants a big-number layout plus the trend, not a bar chart.
 - [ ] **Direction-of-good is unknown.** The delta is uncoloured because nothing tells AgentHub whether up is good. A `higherIsBetter` flag on the tool would let the card say so safely.
-- [ ] **Measurements are not deleted when a project is removed.** `deleteAllMeasurements(forProjectPath:)` and `deleteUnscopedMeasurements()` exist but nothing calls them — deliberately, since removing a repo from the sidebar is reversible and should not destroy its history. Needs an explicit user-facing action instead.
+- [x] **Manual deletion.** Settings › Measurements lists every stored measurement grouped by project, with per-measurement delete, per-project delete (confirmed, and the dialog says how many recorded runs go with it), and a sweep for unscoped rows. Removing a repo from the sidebar still never deletes anything on its own — that is reversible and must not destroy history.
 - [ ] **No panel-level tests.** UI is covered indirectly (view model + store); `MeasurementsSidePanelView` itself has no snapshot/behavior test.
 
 ## Verification

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ rom session rows, and send GitHub context back into a session
 - **Git worktree management** — Create and delete sibling worktrees from the UI, launch sessions on new branches, and choose whether AgentHub-owned worktree sessions appear under the parent module or as separate modules
 - **Remix with provider picker** — Branch any session into an isolated git worktree and continue it in Claude or Codex; the original session's transcript is passed as context to the new session
 - **Multi-session launcher** — Launch parallel sessions across Claude and Codex with manual prompts or AI-planned orchestration (Smart mode)
+- **Measurements** — Agents record measurements they produce (a claim, the chart behind it, the query, and caveats) into a per-project panel; re-run any of them later to refresh the numbers and build up a history
 - **Mermaid diagrams** — Detects Mermaid diagram syntax in session output and renders it natively; diagrams can be exported as images
 - **Web preview** — Prefers agent-started localhost servers, recovers recent localhost URLs from session files when needed, and falls back to static HTML (`index.html` first) when no live preview is available
 - **Web preview batch updates** — Inspect elements or crop regions in the live web preview, queue multiple requested updates with structured context, and attach the batch to your next terminal message — no copy-paste needed
@@ -96,6 +97,21 @@ Notes & current limitations:
 - Codex host rendering requires the MCP server to be in `~/.codex/config.toml` (capture works regardless).
 
 See **[`MCPApps.md`](MCPApps.md)** for the architecture, data flow, key files, invariants, current state, and the tracked list of remaining work. The known-good build path is `xcodebuild -workspace app/AgentHub.xcodeproj/project.xcworkspace -scheme AgentHub build`.
+
+## Measurements
+
+When an agent finishes an analysis that produces numbers — a `git log` aggregation, a test-timing run, a SQL query through an MCP server — it records the result with the bundled `agenthub_record_measurement` tool, and AgentHub renders it as a card in a dedicated side panel. A session-card **Measurements** button appears once the project has at least one.
+
+Each card carries the claim in plain English, the chart, an optional table, the caveats, and the query that produced it. **The agent sends data, never markup**: it supplies a chart specification (series of `{x, y}` points) and AgentHub draws it with Swift Charts, so no agent-authored HTML reaches the panel and every card follows the app theme. A measurement with no numbers behind it is rejected outright.
+
+- **Scoped to the project, not the session.** Measurements outlive the conversation that produced them and are shared by every session in that project — Claude and Codex alike. Worktrees roll up to their parent repo.
+- **Re-runnable.** `↻` on a card asks the session to run the stored query again, verbatim, and re-file it under the same id. AgentHub never executes the query itself; it goes back through the agent, which is already the thing allowed to run commands.
+- **Accumulates history.** Each re-run pushes the previous numbers onto the card instead of overwriting them, so a metric tracked weekly shows its trend and every earlier claim.
+- **Agent-addressable.** `agenthub_list_measurements` lets a session see what is already tracked, so "re-run the build-time measurement" refreshes the existing card rather than creating a near-duplicate computed a slightly different way.
+
+Data sources are whatever the agent can already reach — local files, a CLI, or any MCP server configured in the user's own agent. AgentHub builds no connectors, never sees credentials, and never moves rows: it reads a JSON file written by the CLI helper and draws a chart.
+
+See **[`Measurements.md`](Measurements.md)** for the architecture, data flow, key files, invariants, and remaining work.
 
 ## Storybook
 

--- a/app/modules/AgentHubCLI/Sources/AgentHubCLI/AgentHubMCPServer.swift
+++ b/app/modules/AgentHubCLI/Sources/AgentHubCLI/AgentHubMCPServer.swift
@@ -8,6 +8,8 @@ struct AgentHubMCPServer {
   private let deletionQueue = WorktreeDeletionRequestQueue()
   private let sessionNameQueue = SessionNameRequestQueue()
   private let progressQueue = WorktreeProgressQueue()
+  private let measurementQueue = MeasurementRecordQueue()
+  private let measurementIndex = MeasurementIndexStore()
 
   /// Hard ceiling on any single `tools/call`. Worktree creation normally
   /// completes in seconds and each underlying `git` invocation has its own
@@ -66,6 +68,8 @@ struct AgentHubMCPServer {
             deleteWorktreeToolSchema(),
             planningToolSchema(),
             nameSessionToolSchema(),
+            recordMeasurementToolSchema(),
+            listMeasurementsToolSchema(),
           ],
         ])
 
@@ -164,6 +168,12 @@ struct AgentHubMCPServer {
     case "agenthub_name_session":
       return try nameSession(arguments: arguments)
 
+    case "agenthub_record_measurement":
+      return try recordMeasurement(arguments: arguments)
+
+    case "agenthub_list_measurements":
+      return listMeasurements(arguments: arguments)
+
     default:
       throw MCPError.invalidRequest("Unknown AgentHub tool: \(name).")
     }
@@ -208,6 +218,236 @@ struct AgentHubMCPServer {
         "provider": provider.commandLineValue,
       ]
     )
+  }
+
+  /// Files one measurement into the session's Measurements panel.
+  ///
+  /// Requires a chart or a table: the point of the panel is that a claim arrives
+  /// with the numbers behind it, so a text-only "measurement" is rejected rather
+  /// than rendered as an unfalsifiable assertion.
+  private func recordMeasurement(arguments: [String: Any]) throws -> [String: Any] {
+    guard let provider = ProcessInfo.processInfo.environment["AGENTHUB_PROVIDER"]
+      .flatMap(WorktreeLaunchProvider.init(commandLineValue:))
+    else {
+      throw MCPError.invalidRequest(
+        "agenthub_record_measurement is only available inside an AgentHub-managed Claude or Codex session."
+      )
+    }
+
+    let title = try requiredString("title", in: arguments)
+    let claim = try requiredString("claim", in: arguments)
+    let chart = try parseMeasurementChart(arguments["chart"])
+    let table = try parseMeasurementTable(arguments["table"])
+
+    guard chart != nil || table != nil else {
+      throw MCPError.invalidRequest(
+        "agenthub_record_measurement needs a chart or a table. A claim with no numbers behind it is an assertion, not a measurement — pass the aggregated result you derived the claim from."
+      )
+    }
+
+    let caveats = Array(
+      (try optionalStringArray("caveats", in: arguments) ?? [])
+        .prefix(MeasurementRecord.Limits.maxCaveats)
+    )
+
+    // An explicit id means this is a re-run of a card that already exists: the
+    // app upserts on id, so the existing card refreshes in place instead of a
+    // near-duplicate piling up beneath it.
+    let record = MeasurementRecord(
+      id: optionalString("id", in: arguments).flatMap { $0.isEmpty ? nil : $0 } ?? UUID().uuidString,
+      title: title,
+      claim: claim,
+      question: optionalString("question", in: arguments),
+      query: optionalString("query", in: arguments),
+      source: optionalString("source", in: arguments),
+      caveats: caveats,
+      chart: chart,
+      table: table,
+      sourceProvider: provider,
+      sourceSessionId: ProcessInfo.processInfo.environment["AGENTHUB_SESSION_ID"],
+      sourceProjectPath: ProcessInfo.processInfo.environment["AGENTHUB_PROJECT_PATH"],
+      sourceProcessId: getppid()
+    )
+    try measurementQueue.enqueue(record)
+
+    return toolResult(
+      text: "AgentHub recorded the measurement \"\(title)\". It appears in this session's Measurements panel momentarily.",
+      structuredContent: [
+        "queued": true,
+        "id": record.id,
+        "title": title,
+        "hasChart": chart != nil,
+        "hasTable": table != nil,
+      ]
+    )
+  }
+
+  /// Lists the measurements already tracked for this project.
+  ///
+  /// Without this, an agent asked to "refresh the build-time measurement" has no
+  /// way to learn that measurement's id or its stored query, so it files a fresh
+  /// card computed a slightly different way — the exact drift the panel exists
+  /// to prevent.
+  private func listMeasurements(arguments: [String: Any]) -> [String: Any] {
+    let projectPath = optionalString("projectPath", in: arguments)
+      ?? ProcessInfo.processInfo.environment["AGENTHUB_PROJECT_PATH"]
+      ?? FileManager.default.currentDirectoryPath
+
+    guard let index = measurementIndex.read(projectPath: projectPath) else {
+      return toolResult(
+        text: "No measurements recorded for this project yet.",
+        structuredContent: ["projectPath": projectPath, "measurements": []]
+      )
+    }
+
+    let entries = index.measurements.map { entry -> [String: Any] in
+      var object: [String: Any] = [
+        "id": entry.id,
+        "title": entry.title,
+        "latestClaim": entry.latestClaim,
+        "lastRunAt": ISO8601DateFormatter().string(from: entry.lastRunAt),
+        "runCount": entry.runCount,
+      ]
+      if let question = entry.question { object["question"] = question }
+      if let query = entry.query { object["query"] = query }
+      if let source = entry.source { object["source"] = source }
+      return object
+    }
+
+    let summary = index.measurements.isEmpty
+      ? "No measurements recorded for this project yet."
+      : index.measurements
+        .map { "• \($0.title) — \($0.latestClaim) (\($0.runCount) run(s), id \($0.id))" }
+        .joined(separator: "\n")
+
+    return toolResult(
+      text: summary,
+      structuredContent: ["projectPath": index.projectPath, "measurements": entries]
+    )
+  }
+
+  private func parseMeasurementChart(_ raw: Any?) throws -> MeasurementChart? {
+    guard let raw, !(raw is NSNull) else { return nil }
+    guard let object = raw as? [String: Any] else {
+      throw MCPError.invalidRequest("Expected chart to be an object.")
+    }
+
+    let rawKind = (object["kind"] as? String)?
+      .trimmingCharacters(in: .whitespacesAndNewlines)
+      .lowercased() ?? MeasurementChart.Kind.bar.rawValue
+    guard let kind = MeasurementChart.Kind(rawValue: rawKind) else {
+      let supported = MeasurementChart.Kind.allCases.map(\.rawValue).joined(separator: ", ")
+      throw MCPError.invalidRequest("Unsupported chart kind '\(rawKind)'. Use one of: \(supported).")
+    }
+
+    guard let rawSeries = object["series"] as? [[String: Any]], !rawSeries.isEmpty else {
+      throw MCPError.invalidRequest(
+        "chart.series must be a non-empty array of { name, points } objects."
+      )
+    }
+    guard rawSeries.count <= MeasurementRecord.Limits.maxSeries else {
+      throw MCPError.invalidRequest(
+        "chart.series has \(rawSeries.count) series but the limit is \(MeasurementRecord.Limits.maxSeries). Aggregate to fewer groups before charting."
+      )
+    }
+
+    let series = try rawSeries.map { entry -> MeasurementSeries in
+      guard let name = (entry["name"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines),
+            !name.isEmpty
+      else {
+        throw MCPError.invalidRequest("Every chart series needs a non-empty name.")
+      }
+      guard let rawPoints = entry["points"] as? [[String: Any]], !rawPoints.isEmpty else {
+        throw MCPError.invalidRequest("Series '\(name)' needs a non-empty points array.")
+      }
+      guard rawPoints.count <= MeasurementRecord.Limits.maxPointsPerSeries else {
+        throw MCPError.invalidRequest(
+          "Series '\(name)' has \(rawPoints.count) points but the limit is \(MeasurementRecord.Limits.maxPointsPerSeries). Bucket the data before charting."
+        )
+      }
+
+      let points = try rawPoints.map { point -> MeasurementPoint in
+        guard let x = measurementLabel(point["x"]), !x.isEmpty else {
+          throw MCPError.invalidRequest("Every point in series '\(name)' needs an x label.")
+        }
+        guard let y = measurementNumber(point["y"]) else {
+          throw MCPError.invalidRequest("Point '\(x)' in series '\(name)' needs a numeric y value.")
+        }
+        return MeasurementPoint(x: x, y: y)
+      }
+      return MeasurementSeries(name: name, points: points)
+    }
+
+    return MeasurementChart(
+      kind: kind,
+      xLabel: optionalString("xLabel", in: object),
+      yLabel: optionalString("yLabel", in: object),
+      series: series
+    )
+  }
+
+  private func parseMeasurementTable(_ raw: Any?) throws -> MeasurementTable? {
+    guard let raw, !(raw is NSNull) else { return nil }
+    guard let object = raw as? [String: Any] else {
+      throw MCPError.invalidRequest("Expected table to be an object.")
+    }
+    guard let columns = (object["columns"] as? [String])?
+      .map({ $0.trimmingCharacters(in: .whitespacesAndNewlines) }),
+      !columns.isEmpty
+    else {
+      throw MCPError.invalidRequest("table.columns must be a non-empty array of strings.")
+    }
+    guard columns.count <= MeasurementRecord.Limits.maxTableColumns else {
+      throw MCPError.invalidRequest(
+        "table.columns has \(columns.count) columns but the limit is \(MeasurementRecord.Limits.maxTableColumns)."
+      )
+    }
+
+    let rawRows = object["rows"] as? [[Any]] ?? []
+    guard rawRows.count <= MeasurementRecord.Limits.maxTableRows else {
+      throw MCPError.invalidRequest(
+        "table.rows has \(rawRows.count) rows but the limit is \(MeasurementRecord.Limits.maxTableRows). Aggregate or take a top-N slice, and say which in caveats."
+      )
+    }
+
+    let rows = try rawRows.map { row -> [String] in
+      guard row.count == columns.count else {
+        throw MCPError.invalidRequest(
+          "Every table row must have \(columns.count) cells to match table.columns; found a row with \(row.count)."
+        )
+      }
+      return row.map { measurementLabel($0) ?? "" }
+    }
+
+    return MeasurementTable(columns: columns, rows: rows)
+  }
+
+  /// Coerces a JSON scalar to a display label. Numbers arrive as `NSNumber`
+  /// from `JSONSerialization`, and integral values must not render as "5.0".
+  private func measurementLabel(_ raw: Any?) -> String? {
+    switch raw {
+    case let value as String:
+      return value.trimmingCharacters(in: .whitespacesAndNewlines)
+    case let value as NSNumber:
+      let doubleValue = value.doubleValue
+      if doubleValue == doubleValue.rounded(), abs(doubleValue) < 1e15 {
+        return String(value.int64Value)
+      }
+      return String(doubleValue)
+    default:
+      return nil
+    }
+  }
+
+  private func measurementNumber(_ raw: Any?) -> Double? {
+    switch raw {
+    case let value as NSNumber:
+      return value.doubleValue
+    case let value as String:
+      return Double(value.trimmingCharacters(in: .whitespacesAndNewlines))
+    default:
+      return nil
+    }
   }
 
   private func createWorktreeSession(arguments: [String: Any]) async throws -> MCPWorktreeLaunchResult {
@@ -823,6 +1063,152 @@ struct AgentHubMCPServer {
           ],
         ],
         "required": ["name"],
+        "additionalProperties": false,
+      ],
+    ]
+  }
+
+  private func recordMeasurementToolSchema() -> [String: Any] {
+    [
+      "name": "agenthub_record_measurement",
+      "description": """
+        Files a measurement into this session's Measurements panel in AgentHub, where it renders as a \
+        chart or table with the query behind it. Call this whenever you finish an analysis that \
+        produces numbers the user will make a decision on — querying a database, aggregating a \
+        CSV or log file, counting events, comparing cohorts, sizing an opportunity — including \
+        when the user did not explicitly ask you to record anything. One call per distinct \
+        measurement; do not batch unrelated results into one card. Write `claim` the way you would \
+        say it out loud to a product review: the conclusion and its size, not a description of \
+        what you did. Always pass `query` when a query or script produced the numbers, so the \
+        claim can be checked rather than trusted. Use `caveats` for anything that would change \
+        how the number should be read — partial time windows, excluded rows, small samples, \
+        top-N truncation, a metric you defined yourself rather than one that already existed. \
+        Prefer a chart; add a table only when exact values matter. Do not call this for code \
+        changes, file edits, or work that produced no measurement. Before filing a new measurement, \
+        call agenthub_list_measurements: if one already measures this, run its stored query instead \
+        of writing a fresh one and pass its id here, so the card updates and its history builds \
+        up rather than a near-duplicate appearing next to it.
+        """,
+      "inputSchema": [
+        "type": "object",
+        "properties": [
+          "id": [
+            "type": "string",
+            "description": "Only when re-running an existing measurement: pass that measurement's id so its card refreshes in place. Omit for a new measurement.",
+          ],
+          "title": [
+            "type": "string",
+            "minLength": 1,
+            "description": "Short headline for the card, e.g. 'Week-2 retention by signup channel'.",
+          ],
+          "claim": [
+            "type": "string",
+            "minLength": 1,
+            "description": "The measurement in plain English, stated as a conclusion with its magnitude. Example: 'Referral signups retain at 41% in week 2 versus 22% for paid — roughly double, on 3.1k users.'",
+          ],
+          "question": [
+            "type": "string",
+            "description": "The question this analysis set out to answer, if there was an explicit one.",
+          ],
+          "query": [
+            "type": "string",
+            "description": "The SQL, script, or command that produced these numbers. Shown collapsed under the chart.",
+          ],
+          "source": [
+            "type": "string",
+            "description": "Where the data came from — table name, file path, or endpoint.",
+          ],
+          "caveats": [
+            "type": "array",
+            "items": ["type": "string"],
+            "description": "Limitations that change how the number should be read (partial windows, excluded segments, small samples, self-defined metrics).",
+          ],
+          "chart": [
+            "type": "object",
+            "description": "The data to plot. AgentHub draws the chart — send values, never HTML or image markup.",
+            "properties": [
+              "kind": [
+                "type": "string",
+                "enum": MeasurementChart.Kind.allCases.map(\.rawValue),
+                "description": "bar for comparisons across categories, line/area for a value over time, point for correlation.",
+              ],
+              "xLabel": ["type": "string", "description": "Label for the x axis."],
+              "yLabel": ["type": "string", "description": "Label for the y axis."],
+              "series": [
+                "type": "array",
+                "minItems": 1,
+                "maxItems": MeasurementRecord.Limits.maxSeries,
+                "description": "One entry per plotted group. Use several series to compare segments on the same axes.",
+                "items": [
+                  "type": "object",
+                  "properties": [
+                    "name": ["type": "string", "description": "Series name, shown in the legend."],
+                    "points": [
+                      "type": "array",
+                      "minItems": 1,
+                      "maxItems": MeasurementRecord.Limits.maxPointsPerSeries,
+                      "items": [
+                        "type": "object",
+                        "properties": [
+                          "x": ["type": "string", "description": "Category, bucket, or date label. Send points already sorted."],
+                          "y": ["type": "number", "description": "The measured value."],
+                        ],
+                        "required": ["x", "y"],
+                      ],
+                    ],
+                  ],
+                  "required": ["name", "points"],
+                ],
+              ],
+            ],
+            "required": ["kind", "series"],
+          ],
+          "table": [
+            "type": "object",
+            "description": "Optional exact values, aggregated or top-N — not a raw row dump.",
+            "properties": [
+              "columns": [
+                "type": "array",
+                "items": ["type": "string"],
+                "maxItems": MeasurementRecord.Limits.maxTableColumns,
+              ],
+              "rows": [
+                "type": "array",
+                "maxItems": MeasurementRecord.Limits.maxTableRows,
+                "items": ["type": "array", "description": "One cell per column, in column order."],
+              ],
+            ],
+            "required": ["columns", "rows"],
+          ],
+        ],
+        "required": ["title", "claim"],
+        "additionalProperties": false,
+      ],
+    ]
+  }
+
+  private func listMeasurementsToolSchema() -> [String: Any] {
+    [
+      "name": "agenthub_list_measurements",
+      "description": """
+        Lists the measurements already recorded for this project in AgentHub, with each one's id, \
+        title, latest claim, and the query that produced it. Call this before recording a new \
+        measurement, so an existing measurement gets refreshed instead of a near-duplicate card \
+        appearing beside it. Also call it whenever the user asks to re-run, refresh, or update \
+        a measurement, or asks what is already being tracked or measured: match their words against \
+        the titles, run that measurement's stored query exactly as written, then call \
+        agenthub_record_measurement with its id. Measurements are shared across every session in the \
+        project, Claude and Codex alike, so this will list work done in conversations other \
+        than this one.
+        """,
+      "inputSchema": [
+        "type": "object",
+        "properties": [
+          "projectPath": [
+            "type": "string",
+            "description": "Project to list measurements for. Defaults to the current AgentHub session's project, which is almost always what you want.",
+          ],
+        ],
         "additionalProperties": false,
       ],
     ]

--- a/app/modules/AgentHubCLI/Sources/AgentHubCLIKit/MeasurementIndexStore.swift
+++ b/app/modules/AgentHubCLI/Sources/AgentHubCLIKit/MeasurementIndexStore.swift
@@ -1,0 +1,141 @@
+import Foundation
+
+/// A compact, agent-readable summary of one measurement.
+public struct MeasurementIndexEntry: Codable, Equatable, Sendable, Identifiable {
+  public let id: String
+  public let title: String
+  public let question: String?
+  /// The command that produced it. Present so an agent asked to refresh can run
+  /// the original measurement rather than writing a new one that happens to
+  /// answer the same question differently.
+  public let query: String?
+  public let source: String?
+  public let lastRunAt: Date
+  public let runCount: Int
+  public let latestClaim: String
+
+  public init(
+    id: String,
+    title: String,
+    question: String?,
+    query: String?,
+    source: String?,
+    lastRunAt: Date,
+    runCount: Int,
+    latestClaim: String
+  ) {
+    self.id = id
+    self.title = title
+    self.question = question
+    self.query = query
+    self.source = source
+    self.lastRunAt = lastRunAt
+    self.runCount = runCount
+    self.latestClaim = latestClaim
+  }
+
+  public init(measurement: MeasurementRecord) {
+    self.init(
+      id: measurement.id,
+      title: measurement.title,
+      question: measurement.question,
+      query: measurement.query,
+      source: measurement.source,
+      lastRunAt: measurement.displayDate,
+      runCount: measurement.runs.count,
+      latestClaim: measurement.claim
+    )
+  }
+}
+
+public struct MeasurementIndex: Codable, Equatable, Sendable {
+  public let projectPath: String
+  public let updatedAt: Date
+  public let measurements: [MeasurementIndexEntry]
+
+  public init(projectPath: String, updatedAt: Date, measurements: [MeasurementIndexEntry]) {
+    self.projectPath = projectPath
+    self.updatedAt = updatedAt
+    self.measurements = measurements
+  }
+}
+
+/// A read-only view of a project's measurements, for the `agenthub` CLI.
+///
+/// The CLI runs as a separate process and deliberately does not open the app's
+/// SQLite database — that would couple the helper to the app's schema and its
+/// single-process assumptions. Instead the app republishes a small JSON index
+/// whenever a project's measurements change, and the CLI only ever reads it.
+///
+/// The app writes the index under the project's canonical key *and* under every
+/// session path that resolves to it (a worktree, say), so the CLI can look it
+/// up from `AGENTHUB_PROJECT_PATH` alone without knowing about worktree rollup.
+public struct MeasurementIndexStore: Sendable {
+  public let directoryURL: URL
+
+  public init(directoryURL: URL = MeasurementIndexStore.defaultDirectoryURL()) {
+    self.directoryURL = directoryURL
+  }
+
+  public static func defaultDirectoryURL(fileManager: FileManager = .default) -> URL {
+    let appSupportURL = fileManager.urls(
+      for: .applicationSupportDirectory,
+      in: .userDomainMask
+    ).first ?? URL(fileURLWithPath: NSHomeDirectory()).appendingPathComponent("Library/Application Support")
+
+    return appSupportURL
+      .appendingPathComponent("AgentHub", isDirectory: true)
+      .appendingPathComponent("measurement-index", isDirectory: true)
+  }
+
+  /// Filesystem-safe, collision-free file name for a project path.
+  ///
+  /// Percent-encoding rather than substituting separators: turning `/` into `-`
+  /// makes `/a/b-c` and `/a-b/c` collide, which would silently merge two
+  /// projects' measurements.
+  public static func fileName(forProjectPath projectPath: String) -> String {
+    let allowed = CharacterSet.alphanumerics
+    let encoded = projectPath.addingPercentEncoding(withAllowedCharacters: allowed)
+      ?? projectPath
+    return "\(encoded).json"
+  }
+
+  public func fileURL(forProjectPath projectPath: String) -> URL {
+    directoryURL.appendingPathComponent(
+      Self.fileName(forProjectPath: projectPath),
+      isDirectory: false
+    )
+  }
+
+  public func read(projectPath: String) -> MeasurementIndex? {
+    let url = fileURL(forProjectPath: projectPath)
+    guard let data = try? Data(contentsOf: url) else { return nil }
+    let decoder = JSONDecoder()
+    decoder.dateDecodingStrategy = .iso8601
+    return try? decoder.decode(MeasurementIndex.self, from: data)
+  }
+
+  /// Publishes an index, mirroring it to every alias path so a worktree session
+  /// finds the same list its parent repo sees.
+  public func write(_ index: MeasurementIndex, aliasPaths: [String] = []) throws {
+    try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+    encoder.dateEncodingStrategy = .iso8601
+    let data = try encoder.encode(index)
+
+    for path in Set([index.projectPath] + aliasPaths) where !path.isEmpty {
+      let finalURL = fileURL(forProjectPath: path)
+      let temporaryURL = directoryURL.appendingPathComponent(
+        ".\(UUID().uuidString).tmp",
+        isDirectory: false
+      )
+      try data.write(to: temporaryURL, options: [.atomic])
+      if FileManager.default.fileExists(atPath: finalURL.path) {
+        try FileManager.default.removeItem(at: finalURL)
+      }
+      try FileManager.default.moveItem(at: temporaryURL, to: finalURL)
+    }
+  }
+}

--- a/app/modules/AgentHubCLI/Sources/AgentHubCLIKit/MeasurementModels.swift
+++ b/app/modules/AgentHubCLI/Sources/AgentHubCLIKit/MeasurementModels.swift
@@ -1,0 +1,329 @@
+import Foundation
+
+/// A single measurement an agent filed from a session — the unit the Measurements panel
+/// renders.
+///
+/// Deliberately a *data spec*, never markup: the agent supplies the claim and the
+/// numbers, AgentHub draws the chart. That keeps every card on the app's theme,
+/// keeps agent-authored HTML out of the panel, and leaves the card structured
+/// enough to re-run later.
+public struct MeasurementRecord: Codable, Equatable, Identifiable, Sendable {
+  /// Caps on how much a single card may carry.
+  ///
+  /// These are guardrails, not preferences: the record is persisted to the
+  /// session database, so an agent that dumps a 100k-row export would bloat the
+  /// store and stall the panel. Exceeding a cap is a tool-level validation
+  /// error, which the agent can see and correct by aggregating first — which is
+  /// what a chart wants anyway.
+  public enum Limits {
+    public static let maxSeries = 12
+    public static let maxPointsPerSeries = 200
+    public static let maxTableRows = 200
+    public static let maxTableColumns = 12
+    public static let maxCaveats = 10
+    /// How many previous runs a card keeps. A measurement re-run weekly holds
+    /// several months of history; past that the oldest run is dropped rather
+    /// than letting one card grow without bound.
+    public static let maxHistoryRuns = 20
+  }
+
+  public let id: String
+  /// When this measurement was first filed. Preserved across re-runs so a refreshed
+  /// card keeps its place in the panel instead of jumping to the top.
+  public let createdAt: Date
+  /// When the numbers were last refreshed. `nil` for a measurement that has never
+  /// been re-run — decoding older payloads relies on that, so keep it optional.
+  public let updatedAt: Date?
+  /// Short headline for the card ("Weekly actives by signup cohort").
+  public let title: String
+  /// The measurement in plain English — what a PM would paste into a review.
+  public let claim: String
+  /// The question this analysis set out to answer, when the agent states one.
+  public let question: String?
+  /// The SQL/code that produced the numbers. Collapsed in the UI, but present:
+  /// a claim whose query cannot be inspected is an assertion, not a measurement.
+  public let query: String?
+  /// Where the data came from (table, file, endpoint) — free text for now, and
+  /// the seam a future metrics/semantic layer plugs into.
+  public let source: String?
+  /// Known limitations: partial windows, excluded segments, small samples.
+  public let caveats: [String]
+  public let chart: MeasurementChart?
+  public let table: MeasurementTable?
+
+  /// Earlier runs of this same measurement, oldest first — the point of re-running
+  /// is watching a number move, which requires not throwing the old one away.
+  /// `nil` on a measurement that has never been re-run, which is also what lets
+  /// payloads written before history existed still decode.
+  public let history: [MeasurementRun]?
+
+  /// The branch the current values were measured on, stamped by the app from
+  /// the recording session. Measurements roll up to the repo, so without this a
+  /// `main` run and a feature-branch run would be indistinguishable in history.
+  public let branchName: String?
+  /// The worktree the current values were measured in, when not the repo root.
+  public let worktreePath: String?
+
+  public let sourceProvider: WorktreeLaunchProvider
+  public let sourceSessionId: String?
+  public let sourceProjectPath: String?
+  public let sourceProcessId: Int32
+
+  /// The timestamp to show on the card: when the numbers were last refreshed.
+  public var displayDate: Date {
+    updatedAt ?? createdAt
+  }
+
+  public var hasBeenRerun: Bool {
+    updatedAt != nil
+  }
+
+  /// Re-anchors an incoming re-run onto the card it replaces.
+  ///
+  /// The original filing date is kept (so the refreshed card holds its place),
+  /// the incoming timestamp becomes the update time, and the values being
+  /// replaced are pushed onto the history rather than discarded.
+  public func replacing(_ previous: MeasurementRecord) -> MeasurementRecord {
+    let carried = (previous.history ?? []) + [MeasurementRun(supersededBy: previous)]
+
+    return MeasurementRecord(
+      id: previous.id,
+      createdAt: previous.createdAt,
+      updatedAt: createdAt,
+      title: title,
+      claim: claim,
+      question: question,
+      query: query,
+      source: source,
+      caveats: caveats,
+      chart: chart,
+      table: table,
+      history: Array(carried.suffix(Limits.maxHistoryRuns)),
+      branchName: branchName,
+      worktreePath: worktreePath,
+      sourceProvider: sourceProvider,
+      sourceSessionId: sourceSessionId,
+      sourceProjectPath: sourceProjectPath,
+      sourceProcessId: sourceProcessId
+    )
+  }
+
+  /// Records which branch and worktree produced the current values.
+  ///
+  /// Stamped by the app rather than the CLI: the app already knows the session's
+  /// branch, and asking the helper to shell out to `git` would be both slower
+  /// and wrong inside a detached or mid-rebase checkout.
+  public func stamped(branchName: String?, worktreePath: String?) -> MeasurementRecord {
+    MeasurementRecord(
+      id: id,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      title: title,
+      claim: claim,
+      question: question,
+      query: query,
+      source: source,
+      caveats: caveats,
+      chart: chart,
+      table: table,
+      history: history,
+      branchName: branchName,
+      worktreePath: worktreePath,
+      sourceProvider: sourceProvider,
+      sourceSessionId: sourceSessionId,
+      sourceProjectPath: sourceProjectPath,
+      sourceProcessId: sourceProcessId
+    )
+  }
+
+  /// Every run of this measurement, oldest first, with the current values last.
+  public var runs: [MeasurementRun] {
+    (history ?? []) + [MeasurementRun(supersededBy: self)]
+  }
+
+  /// The single number this measurement measures, when it measures exactly one —
+  /// a scalar like "build time" or "row count". `nil` for anything with more
+  /// than one series or one point, where "the value" is not a single number.
+  public var scalarValue: Double? {
+    guard let chart,
+          chart.series.count == 1,
+          let series = chart.series.first,
+          series.points.count == 1
+    else {
+      return nil
+    }
+    return series.points[0].y
+  }
+
+  public init(
+    id: String = UUID().uuidString,
+    createdAt: Date = .now,
+    updatedAt: Date? = nil,
+    title: String,
+    claim: String,
+    question: String? = nil,
+    query: String? = nil,
+    source: String? = nil,
+    caveats: [String] = [],
+    chart: MeasurementChart? = nil,
+    table: MeasurementTable? = nil,
+    history: [MeasurementRun]? = nil,
+    branchName: String? = nil,
+    worktreePath: String? = nil,
+    sourceProvider: WorktreeLaunchProvider,
+    sourceSessionId: String?,
+    sourceProjectPath: String? = nil,
+    sourceProcessId: Int32
+  ) {
+    self.id = id
+    self.createdAt = createdAt
+    self.updatedAt = updatedAt
+    self.title = title
+    self.claim = claim
+    self.question = question
+    self.query = query
+    self.source = source
+    self.caveats = caveats
+    self.chart = chart
+    self.table = table
+    self.history = history
+    self.branchName = branchName
+    self.worktreePath = worktreePath
+    self.sourceProvider = sourceProvider
+    self.sourceSessionId = sourceSessionId
+    self.sourceProjectPath = sourceProjectPath
+    self.sourceProcessId = sourceProcessId
+  }
+}
+
+/// One execution of a measurement's query — the values as they stood at that moment.
+///
+/// Kept so a card can answer "what was this last month, and what did we say
+/// about it then", which a card that only holds its latest values cannot.
+public struct MeasurementRun: Codable, Equatable, Sendable, Identifiable {
+  public var id: Date { runAt }
+
+  public let runAt: Date
+  public let claim: String
+  public let chart: MeasurementChart?
+  public let table: MeasurementTable?
+  /// The branch this run measured. Without it, runs from different branches
+  /// interleave into one series and a stable metric reads as thrashing.
+  /// `nil` for runs recorded before branches were tracked.
+  public let branchName: String?
+
+  public init(
+    runAt: Date,
+    claim: String,
+    chart: MeasurementChart?,
+    table: MeasurementTable?,
+    branchName: String? = nil
+  ) {
+    self.runAt = runAt
+    self.claim = claim
+    self.chart = chart
+    self.table = table
+    self.branchName = branchName
+  }
+
+  /// Snapshots the values a record held before being refreshed.
+  public init(supersededBy record: MeasurementRecord) {
+    self.init(
+      runAt: record.displayDate,
+      claim: record.claim,
+      chart: record.chart,
+      table: record.table,
+      branchName: record.branchName
+    )
+  }
+
+  /// See `MeasurementRecord.scalarValue`.
+  public var scalarValue: Double? {
+    guard let chart,
+          chart.series.count == 1,
+          let series = chart.series.first,
+          series.points.count == 1
+    else {
+      return nil
+    }
+    return series.points[0].y
+  }
+}
+
+/// A chart specification: what to draw, not how it looks.
+public struct MeasurementChart: Codable, Equatable, Sendable {
+  public enum Kind: String, Codable, Sendable, CaseIterable {
+    case bar
+    case line
+    case area
+    case point
+  }
+
+  public let kind: Kind
+  public let xLabel: String?
+  public let yLabel: String?
+  public let series: [MeasurementSeries]
+  /// Explicit left-to-right order for the category axis.
+  ///
+  /// Needed whenever series cover different categories: Swift Charts otherwise
+  /// derives the axis from the order categories first appear, which for a
+  /// branch-split trend groups all of one branch's dates before the other's and
+  /// renders them out of chronological order. `nil` keeps the derived order.
+  public let xOrder: [String]?
+
+  public init(
+    kind: Kind,
+    xLabel: String? = nil,
+    yLabel: String? = nil,
+    series: [MeasurementSeries],
+    xOrder: [String]? = nil
+  ) {
+    self.kind = kind
+    self.xLabel = xLabel
+    self.yLabel = yLabel
+    self.series = series
+    self.xOrder = xOrder
+  }
+
+  /// Total plotted points, used for limit checks.
+  public var pointCount: Int {
+    series.reduce(0) { $0 + $1.points.count }
+  }
+}
+
+public struct MeasurementSeries: Codable, Equatable, Sendable, Identifiable {
+  public var id: String { name }
+  public let name: String
+  public let points: [MeasurementPoint]
+
+  public init(name: String, points: [MeasurementPoint]) {
+    self.name = name
+    self.points = points
+  }
+}
+
+/// One plotted value.
+///
+/// `x` stays a string on purpose: cohort names, dates and buckets all arrive as
+/// labels from a `GROUP BY`, and a single category axis renders every one of
+/// them without asking the agent to declare an axis type it would often get
+/// wrong.
+public struct MeasurementPoint: Codable, Equatable, Sendable {
+  public let x: String
+  public let y: Double
+
+  public init(x: String, y: Double) {
+    self.x = x
+    self.y = y
+  }
+}
+
+public struct MeasurementTable: Codable, Equatable, Sendable {
+  public let columns: [String]
+  public let rows: [[String]]
+
+  public init(columns: [String], rows: [[String]]) {
+    self.columns = columns
+    self.rows = rows
+  }
+}

--- a/app/modules/AgentHubCLI/Sources/AgentHubCLIKit/MeasurementRecordQueue.swift
+++ b/app/modules/AgentHubCLI/Sources/AgentHubCLIKit/MeasurementRecordQueue.swift
@@ -1,0 +1,106 @@
+import Foundation
+
+public struct QueuedMeasurementRecord: Equatable, Sendable {
+  public let record: MeasurementRecord
+  public let fileURL: URL
+
+  public init(record: MeasurementRecord, fileURL: URL) {
+    self.record = record
+    self.fileURL = fileURL
+  }
+}
+
+/// File-backed handoff from the `agenthub` CLI's MCP server to the app.
+///
+/// The CLI runs as a separate process, so it cannot write the app's SQLite store
+/// directly; it drops a JSON file here and the app drains it (same shape as
+/// `SessionNameRequestQueue`). Writes are atomic-then-move so the app never
+/// reads a half-written record.
+public struct MeasurementRecordQueue: Sendable {
+  public let directoryURL: URL
+
+  public init(directoryURL: URL = MeasurementRecordQueue.defaultDirectoryURL()) {
+    self.directoryURL = directoryURL
+  }
+
+  public static func defaultDirectoryURL(fileManager: FileManager = .default) -> URL {
+    let appSupportURL = fileManager.urls(
+      for: .applicationSupportDirectory,
+      in: .userDomainMask
+    ).first ?? URL(fileURLWithPath: NSHomeDirectory()).appendingPathComponent("Library/Application Support")
+
+    return appSupportURL
+      .appendingPathComponent("AgentHub", isDirectory: true)
+      .appendingPathComponent("measurement-records", isDirectory: true)
+  }
+
+  @discardableResult
+  public func enqueue(_ record: MeasurementRecord) throws -> QueuedMeasurementRecord {
+    try FileManager.default.createDirectory(
+      at: directoryURL,
+      withIntermediateDirectories: true
+    )
+
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+    encoder.dateEncodingStrategy = .iso8601
+    let data = try encoder.encode(record)
+
+    let finalURL = directoryURL.appendingPathComponent("\(record.id).json", isDirectory: false)
+    let temporaryURL = directoryURL.appendingPathComponent(".\(record.id).tmp", isDirectory: false)
+
+    try data.write(to: temporaryURL, options: [.atomic])
+    if FileManager.default.fileExists(atPath: finalURL.path) {
+      try FileManager.default.removeItem(at: finalURL)
+    }
+    try FileManager.default.moveItem(at: temporaryURL, to: finalURL)
+
+    return QueuedMeasurementRecord(record: record, fileURL: finalURL)
+  }
+
+  public func pendingRecords() throws -> [QueuedMeasurementRecord] {
+    guard FileManager.default.fileExists(atPath: directoryURL.path) else {
+      return []
+    }
+
+    let files = try FileManager.default.contentsOfDirectory(
+      at: directoryURL,
+      includingPropertiesForKeys: nil
+    )
+
+    let decoder = JSONDecoder()
+    decoder.dateDecodingStrategy = .iso8601
+    return files
+      .filter { $0.pathExtension == "json" && !$0.lastPathComponent.hasPrefix(".") }
+      .compactMap { url in
+        guard let data = try? Data(contentsOf: url),
+              let record = try? decoder.decode(MeasurementRecord.self, from: data)
+        else {
+          return nil
+        }
+        return QueuedMeasurementRecord(record: record, fileURL: url)
+      }
+      .sorted {
+        if $0.record.createdAt == $1.record.createdAt {
+          return $0.record.id < $1.record.id
+        }
+        return $0.record.createdAt < $1.record.createdAt
+      }
+  }
+
+  public func remove(_ queued: QueuedMeasurementRecord) throws {
+    guard FileManager.default.fileExists(atPath: queued.fileURL.path) else { return }
+    try FileManager.default.removeItem(at: queued.fileURL)
+  }
+
+  public func markFailed(_ queued: QueuedMeasurementRecord) throws {
+    guard FileManager.default.fileExists(atPath: queued.fileURL.path) else { return }
+    let failedURL = queued.fileURL
+      .deletingPathExtension()
+      .appendingPathExtension("failed")
+    if FileManager.default.fileExists(atPath: failedURL.path) {
+      try FileManager.default.removeItem(at: failedURL)
+    }
+    try FileManager.default.moveItem(at: queued.fileURL, to: failedURL)
+  }
+}

--- a/app/modules/AgentHubCLI/Tests/AgentHubCLIKitTests/MeasurementIndexStoreTests.swift
+++ b/app/modules/AgentHubCLI/Tests/AgentHubCLIKitTests/MeasurementIndexStoreTests.swift
@@ -1,0 +1,121 @@
+import Foundation
+import Testing
+
+@testable import AgentHubCLIKit
+
+@Suite("MeasurementIndexStore")
+struct MeasurementIndexStoreTests {
+  @Test("An index round-trips with the query the agent needs to re-run")
+  func indexRoundTrips() throws {
+    let directory = try temporaryIndexDirectory()
+    defer { try? FileManager.default.removeItem(at: directory.deletingLastPathComponent()) }
+
+    let store = MeasurementIndexStore(directoryURL: directory)
+    try store.write(makeIndex(projectPath: "/tmp/project"))
+
+    let read = try #require(store.read(projectPath: "/tmp/project"))
+    #expect(read.measurements.map(\.id) == ["measurement-1"])
+    #expect(read.measurements.first?.query == "xcodebuild build")
+    #expect(read.measurements.first?.runCount == 3)
+  }
+
+  /// The CLI only knows `AGENTHUB_PROJECT_PATH`, which for a worktree session is
+  /// the worktree — not the repo the measurements are filed under. Mirroring to
+  /// aliases is what lets it find the list anyway.
+  @Test("Aliases resolve a worktree path to the parent repo's index")
+  func aliasesResolveWorktreePaths() throws {
+    let directory = try temporaryIndexDirectory()
+    defer { try? FileManager.default.removeItem(at: directory.deletingLastPathComponent()) }
+
+    let store = MeasurementIndexStore(directoryURL: directory)
+    try store.write(
+      makeIndex(projectPath: "/Users/me/code/app"),
+      aliasPaths: ["/Users/me/code/app-feature"]
+    )
+
+    #expect(store.read(projectPath: "/Users/me/code/app-feature")?.measurements.count == 1)
+    #expect(store.read(projectPath: "/Users/me/code/app-feature")?.projectPath == "/Users/me/code/app")
+  }
+
+  @Test("An unknown project reads back as nothing rather than failing")
+  func unknownProjectReadsBackNil() throws {
+    let directory = try temporaryIndexDirectory()
+    defer { try? FileManager.default.removeItem(at: directory.deletingLastPathComponent()) }
+
+    #expect(MeasurementIndexStore(directoryURL: directory).read(projectPath: "/tmp/nothing") == nil)
+  }
+
+  @Test("Rewriting replaces the previous index rather than appending")
+  func rewritingReplaces() throws {
+    let directory = try temporaryIndexDirectory()
+    defer { try? FileManager.default.removeItem(at: directory.deletingLastPathComponent()) }
+
+    let store = MeasurementIndexStore(directoryURL: directory)
+    try store.write(makeIndex(projectPath: "/tmp/project"))
+    try store.write(MeasurementIndex(projectPath: "/tmp/project", updatedAt: .now, measurements: []))
+
+    #expect(store.read(projectPath: "/tmp/project")?.measurements.isEmpty == true)
+  }
+
+  /// Substituting separators (`/` → `-`) would make these two collide and
+  /// silently merge two projects' measurements.
+  @Test("Similar paths do not collide on disk")
+  func similarPathsDoNotCollide() {
+    let first = MeasurementIndexStore.fileName(forProjectPath: "/a/b-c")
+    let second = MeasurementIndexStore.fileName(forProjectPath: "/a-b/c")
+    #expect(first != second)
+  }
+
+  @Test("An index entry summarizes a measurement including its run count")
+  func entrySummarizesMeasurement() {
+    let first = makeMeasurement(claim: "214s")
+    let second = makeMeasurement(claim: "163s").replacing(first)
+    let entry = MeasurementIndexEntry(measurement: second)
+
+    #expect(entry.latestClaim == "163s")
+    #expect(entry.runCount == 2)
+    #expect(entry.query == "xcodebuild build")
+  }
+}
+
+private func makeIndex(projectPath: String) -> MeasurementIndex {
+  MeasurementIndex(
+    projectPath: projectPath,
+    updatedAt: Date(timeIntervalSince1970: 5_000),
+    measurements: [
+      MeasurementIndexEntry(
+        id: "measurement-1",
+        title: "Clean build time",
+        question: "Is the build getting slower?",
+        query: "xcodebuild build",
+        source: "xcodebuild",
+        lastRunAt: Date(timeIntervalSince1970: 4_000),
+        runCount: 3,
+        latestClaim: "Clean build is 163s."
+      )
+    ]
+  )
+}
+
+private func makeMeasurement(claim: String) -> MeasurementRecord {
+  MeasurementRecord(
+    id: "measurement-1",
+    title: "Clean build time",
+    claim: claim,
+    query: "xcodebuild build",
+    chart: MeasurementChart(
+      kind: .bar,
+      series: [MeasurementSeries(name: "Build", points: [MeasurementPoint(x: "core", y: 163)])]
+    ),
+    sourceProvider: .claude,
+    sourceSessionId: "session-1",
+    sourceProcessId: 1
+  )
+}
+
+private func temporaryIndexDirectory() throws -> URL {
+  let root = FileManager.default.temporaryDirectory
+    .appendingPathComponent("agenthub-measurement-index-tests-\(UUID().uuidString)", isDirectory: true)
+  try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+  return root.appendingPathComponent("index", isDirectory: true)
+}

--- a/app/modules/AgentHubCLI/Tests/AgentHubCLIKitTests/MeasurementRecordQueueTests.swift
+++ b/app/modules/AgentHubCLI/Tests/AgentHubCLIKitTests/MeasurementRecordQueueTests.swift
@@ -1,0 +1,126 @@
+import Foundation
+import Testing
+
+@testable import AgentHubCLIKit
+
+@Suite("MeasurementRecordQueue")
+struct MeasurementRecordQueueTests {
+  @Test("Enqueue writes the record and preserves the full payload")
+  func enqueuePreservesPayload() throws {
+    let directory = try temporaryMeasurementDirectory()
+    defer { try? FileManager.default.removeItem(at: directory.deletingLastPathComponent()) }
+
+    let queue = MeasurementRecordQueue(directoryURL: directory)
+    let record = makeRecord(id: "measurement-1")
+
+    let queued = try queue.enqueue(record)
+    let pending = try queue.pendingRecords()
+
+    #expect(FileManager.default.fileExists(atPath: queued.fileURL.path))
+    #expect(pending.map(\.record) == [record])
+  }
+
+  @Test("Chart, table and caveats survive the round trip")
+  func chartAndTableSurviveRoundTrip() throws {
+    let directory = try temporaryMeasurementDirectory()
+    defer { try? FileManager.default.removeItem(at: directory.deletingLastPathComponent()) }
+
+    let queue = MeasurementRecordQueue(directoryURL: directory)
+    try queue.enqueue(makeRecord(id: "measurement-1"))
+
+    let decoded = try #require(try queue.pendingRecords().first?.record)
+    #expect(decoded.chart?.kind == .bar)
+    #expect(decoded.chart?.series.count == 2)
+    #expect(decoded.chart?.series.first?.points == [
+      MeasurementPoint(x: "referral", y: 41),
+      MeasurementPoint(x: "paid", y: 22),
+    ])
+    #expect(decoded.table?.columns == ["channel", "users"])
+    #expect(decoded.table?.rows == [["referral", "3100"]])
+    #expect(decoded.caveats == ["Excludes trial accounts"])
+  }
+
+  @Test("Pending records are ordered oldest first")
+  func pendingRecordsAreOrderedOldestFirst() throws {
+    let directory = try temporaryMeasurementDirectory()
+    defer { try? FileManager.default.removeItem(at: directory.deletingLastPathComponent()) }
+
+    let queue = MeasurementRecordQueue(directoryURL: directory)
+    try queue.enqueue(makeRecord(id: "newer", createdAt: Date(timeIntervalSince1970: 9_000)))
+    try queue.enqueue(makeRecord(id: "older", createdAt: Date(timeIntervalSince1970: 1_000)))
+
+    #expect(try queue.pendingRecords().map(\.record.id) == ["older", "newer"])
+  }
+
+  @Test("Remove deletes a handled record")
+  func removeDeletesHandledRecord() throws {
+    let directory = try temporaryMeasurementDirectory()
+    defer { try? FileManager.default.removeItem(at: directory.deletingLastPathComponent()) }
+
+    let queue = MeasurementRecordQueue(directoryURL: directory)
+    let queued = try queue.enqueue(makeRecord(id: "measurement-1"))
+
+    try queue.remove(queued)
+
+    #expect(try queue.pendingRecords().isEmpty)
+    #expect(!FileManager.default.fileExists(atPath: queued.fileURL.path))
+  }
+
+  @Test("Mark failed moves the record out of the pending queue")
+  func markFailedMovesRecordOut() throws {
+    let directory = try temporaryMeasurementDirectory()
+    defer { try? FileManager.default.removeItem(at: directory.deletingLastPathComponent()) }
+
+    let queue = MeasurementRecordQueue(directoryURL: directory)
+    let queued = try queue.enqueue(makeRecord(id: "measurement-1"))
+
+    try queue.markFailed(queued)
+
+    let failedURL = queued.fileURL.deletingPathExtension().appendingPathExtension("failed")
+    #expect(try queue.pendingRecords().isEmpty)
+    #expect(FileManager.default.fileExists(atPath: failedURL.path))
+  }
+}
+
+private func makeRecord(
+  id: String,
+  createdAt: Date = Date(timeIntervalSince1970: 3_000)
+) -> MeasurementRecord {
+  MeasurementRecord(
+    id: id,
+    createdAt: createdAt,
+    title: "Week-2 retention by channel",
+    claim: "Referral retains at 41% versus 22% for paid.",
+    question: "Which acquisition channel retains best?",
+    query: "select channel, count(*) from signups group by 1",
+    source: "analytics.signups",
+    caveats: ["Excludes trial accounts"],
+    chart: MeasurementChart(
+      kind: .bar,
+      xLabel: "Channel",
+      yLabel: "Retention %",
+      series: [
+        MeasurementSeries(name: "Week 2", points: [
+          MeasurementPoint(x: "referral", y: 41),
+          MeasurementPoint(x: "paid", y: 22),
+        ]),
+        MeasurementSeries(name: "Week 4", points: [
+          MeasurementPoint(x: "referral", y: 33),
+          MeasurementPoint(x: "paid", y: 15),
+        ]),
+      ]
+    ),
+    table: MeasurementTable(columns: ["channel", "users"], rows: [["referral", "3100"]]),
+    sourceProvider: .claude,
+    sourceSessionId: "session-1",
+    sourceProjectPath: "/tmp/project",
+    sourceProcessId: 42
+  )
+}
+
+private func temporaryMeasurementDirectory() throws -> URL {
+  let root = FileManager.default.temporaryDirectory
+    .appendingPathComponent("agenthub-measurement-record-tests-\(UUID().uuidString)", isDirectory: true)
+  try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+  return root.appendingPathComponent("records", isDirectory: true)
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubProvider.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubProvider.swift
@@ -52,6 +52,7 @@ public final class AgentHubProvider {
   private let worktreeLaunchRequestMonitorOverride: (any WorktreeLaunchRequestMonitorProtocol)?
   private let worktreeDeletionRequestMonitorOverride: (any WorktreeDeletionRequestMonitorProtocol)?
   private let sessionNameRequestMonitorOverride: (any SessionNameRequestMonitorProtocol)?
+  private let measurementRecordMonitorOverride: (any MeasurementRecordMonitorProtocol)?
 
   // MARK: - Lazy Services
 
@@ -181,6 +182,14 @@ public final class AgentHubProvider {
     codexTarget: codexSessionsViewModel
   )
 
+  /// Watches measurement records written by the bundled `agenthub` MCP server.
+  public private(set) lazy var measurementRecordMonitor: any MeasurementRecordMonitorProtocol = measurementRecordMonitorOverride ?? MeasurementRecordMonitor()
+
+  public private(set) lazy var measurementRecordHandler: any MeasurementRecordHandlingProtocol = MeasurementRecordHandler(
+    claudeTarget: claudeSessionsViewModel,
+    codexTarget: codexSessionsViewModel
+  )
+
   /// Watches the worktree-progress sidecar directory the `agenthub` CLI writes
   /// during MCP-initiated creations, so the app can surface live git progress.
   public private(set) lazy var worktreeProgressSidecarWatcher: any WorktreeProgressSidecarWatcherProtocol = WorktreeProgressSidecarWatcher()
@@ -198,6 +207,7 @@ public final class AgentHubProvider {
   private var isWorktreeLaunchRequestMonitoringStarted = false
   private var isWorktreeDeletionRequestMonitoringStarted = false
   private var isSessionNameRequestMonitoringStarted = false
+  private var isMeasurementRecordMonitoringStarted = false
   private var isWorktreeProgressMonitoringStarted = false
 
   // MARK: - GitHub Integration
@@ -289,7 +299,8 @@ public final class AgentHubProvider {
     metadataStore: SessionMetadataStore? = nil,
     worktreeLaunchRequestMonitor: (any WorktreeLaunchRequestMonitorProtocol)? = nil,
     worktreeDeletionRequestMonitor: (any WorktreeDeletionRequestMonitorProtocol)? = nil,
-    sessionNameRequestMonitor: (any SessionNameRequestMonitorProtocol)? = nil
+    sessionNameRequestMonitor: (any SessionNameRequestMonitorProtocol)? = nil,
+    measurementRecordMonitor: (any MeasurementRecordMonitorProtocol)? = nil
   ) {
     self.configuration = configuration
     terminalBackend = .storedPreference
@@ -299,6 +310,7 @@ public final class AgentHubProvider {
     worktreeLaunchRequestMonitorOverride = worktreeLaunchRequestMonitor
     worktreeDeletionRequestMonitorOverride = worktreeDeletionRequestMonitor
     sessionNameRequestMonitorOverride = sessionNameRequestMonitor
+    measurementRecordMonitorOverride = measurementRecordMonitor
     if let metadataStore {
       Task {
         await TerminalProcessRegistry.shared.configure(store: metadataStore)
@@ -477,6 +489,7 @@ public final class AgentHubProvider {
     startWorktreeLaunchQueueMonitoring()
     startWorktreeDeletionQueueMonitoring()
     startSessionNameQueueMonitoring()
+    startMeasurementRecordMonitoring()
     startWorktreeProgressMonitoring()
   }
 
@@ -542,6 +555,21 @@ public final class AgentHubProvider {
     }
   }
 
+  private func startMeasurementRecordMonitoring() {
+    guard !isMeasurementRecordMonitoringStarted else { return }
+    isMeasurementRecordMonitoringStarted = true
+
+    let monitor = measurementRecordMonitor
+    Task {
+      await monitor.start { [weak self] queued in
+        guard let self else {
+          throw MeasurementRecordHandlingError.sessionUnavailable
+        }
+        try await self.measurementRecordHandler.handle(queued.record)
+      }
+    }
+  }
+
   public func stopWorktreeLaunchRequestMonitoring() {
     if isWorktreeLaunchRequestMonitoringStarted {
       isWorktreeLaunchRequestMonitoringStarted = false
@@ -565,6 +593,15 @@ public final class AgentHubProvider {
       isSessionNameRequestMonitoringStarted = false
 
       let monitor = sessionNameRequestMonitor
+      Task {
+        await monitor.stop()
+      }
+    }
+
+    if isMeasurementRecordMonitoringStarted {
+      isMeasurementRecordMonitoringStarted = false
+
+      let monitor = measurementRecordMonitor
       Task {
         await monitor.stop()
       }

--- a/app/modules/AgentHubCore/Sources/AgentHub/Models/SessionMeasurementRecord.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Models/SessionMeasurementRecord.swift
@@ -1,0 +1,86 @@
+//
+//  SessionMeasurementRecord.swift
+//  AgentHub
+//
+//  SQLite record for one measurement an agent filed into a session's Measurements panel.
+//
+
+import AgentHubCLIKit
+import Foundation
+import GRDB
+
+/// Persisted measurement card.
+///
+/// The measurement itself is stored as an encoded `MeasurementRecord` blob rather than
+/// a column per field: the card's shape (chart kinds, caveats, future provenance)
+/// evolves with the feature, and a blob keeps that evolution out of the migration
+/// list. `payloadVersion` is the table-specific version for that encoded payload —
+/// the one case the schema rules allow a per-table version column. Only the
+/// columns the app actually queries on are denormalized.
+public struct SessionMeasurementRecord: Codable, Equatable, Identifiable, Sendable, FetchableRecord, PersistableRecord {
+  public static let currentPayloadVersion = 1
+
+  public var id: String
+  /// The project this measurement belongs to — the storage scope. Worktrees roll
+  /// up to their parent repo (see `MeasurementProjectScope`).
+  public var projectPath: String
+  /// Which session filed it. Provenance only: measurements are *not* scoped to a
+  /// session, so this is never used to decide what the panel shows.
+  public var sessionId: String
+  public var provider: String
+  public var createdAt: Date
+  public var payloadVersion: Int
+  public var payloadData: Data
+
+  public static var databaseTableName: String { "session_measurements" }
+
+  /// Coders pinned to ISO-8601 so a payload written by one build always decodes
+  /// in the next one.
+  private static var payloadEncoder: JSONEncoder {
+    let encoder = JSONEncoder()
+    encoder.dateEncodingStrategy = .iso8601
+    return encoder
+  }
+
+  private static var payloadDecoder: JSONDecoder {
+    let decoder = JSONDecoder()
+    decoder.dateDecodingStrategy = .iso8601
+    return decoder
+  }
+
+  public init(
+    id: String,
+    projectPath: String,
+    sessionId: String,
+    provider: String,
+    createdAt: Date,
+    payloadVersion: Int,
+    payloadData: Data
+  ) {
+    self.id = id
+    self.projectPath = projectPath
+    self.sessionId = sessionId
+    self.provider = provider
+    self.createdAt = createdAt
+    self.payloadVersion = payloadVersion
+    self.payloadData = payloadData
+  }
+
+  /// Wraps a measurement filed by the CLI. A measurement with no resolvable project is
+  /// dropped upstream rather than stored where nothing would ever show it.
+  public init(measurement: MeasurementRecord, projectPath: String, sessionId: String) throws {
+    self.init(
+      id: measurement.id,
+      projectPath: projectPath,
+      sessionId: sessionId,
+      provider: measurement.sourceProvider.commandLineValue,
+      createdAt: measurement.createdAt,
+      payloadVersion: Self.currentPayloadVersion,
+      payloadData: try Self.payloadEncoder.encode(measurement)
+    )
+  }
+
+  public func decodedMeasurement() throws -> MeasurementRecord {
+    try Self.payloadDecoder.decode(MeasurementRecord.self, from: payloadData)
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/MeasurementProjectScope.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/MeasurementProjectScope.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+/// Resolves which project a measurement belongs to.
+///
+/// Measurements are keyed by project, not by session. A measurement about a repo,
+/// a CSV, or a database is about *the data* — the session is only who asked.
+/// Scoping to a session would hide last month's number from this month's
+/// conversation, which is precisely when comparing it matters.
+enum MeasurementProjectScope {
+  /// The storage key for a measurement filed from a session.
+  ///
+  /// A worktree rolls up to its parent repository: an agent working in a
+  /// sibling worktree is working on the same project, and splitting its
+  /// measurements into a separate bucket would fragment the history the feature
+  /// exists to accumulate.
+  static func key(projectPath: String, parentRepoPath: String?) -> String {
+    let preferred = parentRepoPath.flatMap { path -> String? in
+      let trimmed = path.trimmingCharacters(in: .whitespacesAndNewlines)
+      return trimmed.isEmpty ? nil : trimmed
+    } ?? projectPath
+
+    return normalized(preferred)
+  }
+
+  /// Expands `~`, resolves `..`, and drops a trailing slash so the same
+  /// directory written three ways lands in one bucket.
+  static func normalized(_ path: String) -> String {
+    let expanded = NSString(string: path.trimmingCharacters(in: .whitespacesAndNewlines))
+      .expandingTildeInPath
+    let standardized = (expanded as NSString).standardizingPath
+    guard standardized.count > 1, standardized.hasSuffix("/") else {
+      return standardized
+    }
+    return String(standardized.dropLast())
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/MeasurementRecordHandler.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/MeasurementRecordHandler.swift
@@ -1,0 +1,67 @@
+import AgentHubCLIKit
+import Foundation
+
+@MainActor
+public protocol MeasurementRecordTarget: AnyObject {
+  func activeSessionId(forProcessId processId: Int32) -> String?
+  func storeMeasurement(_ measurement: MeasurementRecord, forSessionId sessionId: String)
+}
+
+@MainActor
+public protocol MeasurementRecordHandlingProtocol: AnyObject {
+  func handle(_ record: MeasurementRecord) async throws
+}
+
+enum MeasurementRecordHandlingError: LocalizedError {
+  case sessionUnavailable
+
+  var errorDescription: String? {
+    switch self {
+    case .sessionUnavailable:
+      return "The AgentHub session that recorded this measurement could not be found."
+    }
+  }
+}
+
+/// Routes a filed measurement to the session it came from.
+///
+/// Resolution mirrors `SessionNameRequestHandler`: trust `AGENTHUB_SESSION_ID`
+/// when it names a real session, otherwise map the calling process back to a
+/// session. Measurement is never stored against a `pending-` id — that id is
+/// replaced once the session is real, which would strand the card.
+@MainActor
+public final class MeasurementRecordHandler: MeasurementRecordHandlingProtocol {
+  private let claudeTarget: any MeasurementRecordTarget
+  private let codexTarget: any MeasurementRecordTarget
+
+  public init(
+    claudeTarget: any MeasurementRecordTarget,
+    codexTarget: any MeasurementRecordTarget
+  ) {
+    self.claudeTarget = claudeTarget
+    self.codexTarget = codexTarget
+  }
+
+  public func handle(_ record: MeasurementRecord) async throws {
+    let target: any MeasurementRecordTarget
+    switch record.sourceProvider {
+    case .claude:
+      target = claudeTarget
+    case .codex:
+      target = codexTarget
+    }
+
+    let explicitSessionId = record.sourceSessionId.flatMap { sessionId in
+      sessionId.hasPrefix("pending-") ? nil : sessionId
+    }
+    let sessionId = explicitSessionId
+      ?? target.activeSessionId(forProcessId: record.sourceProcessId)
+    guard let sessionId, !sessionId.hasPrefix("pending-") else {
+      throw MeasurementRecordHandlingError.sessionUnavailable
+    }
+
+    target.storeMeasurement(record, forSessionId: sessionId)
+  }
+}
+
+extension CLISessionsViewModel: MeasurementRecordTarget {}

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/MeasurementRecordMonitor.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/MeasurementRecordMonitor.swift
@@ -1,0 +1,92 @@
+import AgentHubCLIKit
+import Foundation
+
+public protocol MeasurementRecordMonitorProtocol: AnyObject, Sendable {
+  func start(handler: @escaping @MainActor @Sendable (QueuedMeasurementRecord) async throws -> Void) async
+  func stop() async
+}
+
+/// Drains measurements the `agenthub` CLI queued on disk into the app.
+///
+/// Same shape as `SessionNameRequestMonitor`: poll the queue directory, hand
+/// each record to the app, and only delete the file once the app has taken it.
+/// A record whose session cannot be resolved yet is left in place and retried,
+/// because the CLI can file a measurement a moment before AgentHub has bound the
+/// session id.
+public actor MeasurementRecordMonitor: MeasurementRecordMonitorProtocol {
+  private let queue: MeasurementRecordQueue
+  private let pollInterval: Duration
+  private var task: Task<Void, Never>?
+  private var activeRecordIds: Set<String> = []
+
+  public init(
+    queue: MeasurementRecordQueue = MeasurementRecordQueue(),
+    pollInterval: Duration = .milliseconds(400)
+  ) {
+    self.queue = queue
+    self.pollInterval = pollInterval
+  }
+
+  public func start(
+    handler: @escaping @MainActor @Sendable (QueuedMeasurementRecord) async throws -> Void
+  ) async {
+    guard task == nil else { return }
+
+    task = Task { [queue, pollInterval] in
+      while !Task.isCancelled {
+        await self.processPendingRecords(queue: queue, handler: handler)
+        try? await Task.sleep(for: pollInterval)
+      }
+    }
+  }
+
+  public func stop() async {
+    task?.cancel()
+    task = nil
+    activeRecordIds.removeAll()
+  }
+
+  private func processPendingRecords(
+    queue: MeasurementRecordQueue,
+    handler: @escaping @MainActor @Sendable (QueuedMeasurementRecord) async throws -> Void
+  ) async {
+    let queuedRecords: [QueuedMeasurementRecord]
+    do {
+      queuedRecords = try queue.pendingRecords()
+    } catch {
+      AppLogger.session.error("Failed to read AgentHub measurement records: \(error.localizedDescription)")
+      return
+    }
+
+    for queued in queuedRecords {
+      guard activeRecordIds.insert(queued.record.id).inserted else { continue }
+      defer { activeRecordIds.remove(queued.record.id) }
+
+      do {
+        try await handler(queued)
+        try queue.remove(queued)
+      } catch {
+        if shouldRetry(error, record: queued.record) {
+          continue
+        }
+        AppLogger.session.error("Failed to handle AgentHub measurement record: \(error.localizedDescription)")
+        do {
+          try queue.markFailed(queued)
+        } catch {
+          AppLogger.session.error("Failed to mark AgentHub measurement record failed: \(error.localizedDescription)")
+        }
+      }
+    }
+  }
+
+  /// A session that is not bound yet is a timing problem, not a bad record —
+  /// keep retrying briefly before giving up on it.
+  private func shouldRetry(_ error: Error, record: MeasurementRecord) -> Bool {
+    guard let handlingError = error as? MeasurementRecordHandlingError,
+          case .sessionUnavailable = handlingError
+    else {
+      return false
+    }
+    return Date.now.timeIntervalSince(record.createdAt) < 30
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/MeasurementRerunPromptBuilder.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/MeasurementRerunPromptBuilder.swift
@@ -1,0 +1,48 @@
+import AgentHubCLIKit
+import Foundation
+
+/// Builds the prompt that asks a session to re-run one of its own measurements.
+///
+/// Re-running goes back through the agent rather than executing the stored
+/// query directly: the query is arbitrary shell/SQL the agent wrote, and the
+/// agent is already the thing allowed to run commands in this session. That
+/// keeps AgentHub out of the code-execution business entirely — clicking ↻
+/// can do nothing the session could not already do on its own.
+enum MeasurementRerunPromptBuilder {
+  /// Measurements without a stored query cannot be refreshed — there is nothing to
+  /// re-execute, and asking the agent to reconstruct one would silently change
+  /// the measurement, which defeats the point of re-running.
+  static func canRerun(_ record: MeasurementRecord) -> Bool {
+    guard let query = record.query else { return false }
+    return !query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+  }
+
+  static func prompt(for record: MeasurementRecord) -> String? {
+    guard canRerun(record), let query = record.query else { return nil }
+
+    return """
+      Re-run a measurement you recorded earlier in this session and refresh its card in AgentHub.
+
+      Measurement id: \(record.id)
+      Title: \(record.title)
+
+      Run this exactly as written — do not rewrite, "improve", or re-derive it, because the \
+      point of re-running is that the measurement stays comparable to the earlier one:
+
+      ```
+      \(query.trimmingCharacters(in: .whitespacesAndNewlines))
+      ```
+
+      Then call agenthub_record_measurement with:
+      - id: "\(record.id)" — required, so the existing card refreshes instead of a duplicate appearing
+      - title: "\(record.title)" — unchanged
+      - chart/table built from the new numbers
+      - claim rewritten to state what the new numbers say, including how they moved since the \
+      previous run if the difference matters
+      - caveats that still apply
+
+      If the command fails or its output no longer parses, say so plainly and do not record a \
+      measurement — a card that silently keeps stale numbers is worse than one that is obviously out of date.
+      """
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/MeasurementTrendBuilder.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/MeasurementTrendBuilder.swift
@@ -1,0 +1,73 @@
+import AgentHubCLIKit
+import Foundation
+
+/// Builds the "over time" chart shown under a measurement's history.
+///
+/// Splits by branch. Measurements roll up to the repository, so runs from
+/// `main` and from a feature worktree land on the same card; plotted as one
+/// series they interleave — 214, 163, 211, 160 — and a pair of perfectly stable
+/// branches reads as a metric thrashing. One series per branch makes that the
+/// comparison it actually is.
+enum MeasurementTrendBuilder {
+  /// A trend needs at least two runs, and every run has to measure the same
+  /// single number — there is no meaningful "value over time" for a multi-series
+  /// breakdown.
+  static func chart(for runs: [MeasurementRun], title: String) -> MeasurementChart? {
+    guard runs.count >= 2 else { return nil }
+
+    let scalars = runs.compactMap { run -> (run: MeasurementRun, value: Double)? in
+      guard let value = run.scalarValue else { return nil }
+      return (run, value)
+    }
+    guard scalars.count == runs.count else { return nil }
+
+    let grouped = Dictionary(grouping: scalars) { $0.run.branchName ?? title }
+    // Stable order: whichever branch was measured first leads the legend.
+    let branchOrder = scalars.reduce(into: [String]()) { order, entry in
+      let key = entry.run.branchName ?? title
+      if !order.contains(key) { order.append(key) }
+    }
+
+    let series = branchOrder.compactMap { branch -> MeasurementSeries? in
+      guard let entries = grouped[branch] else { return nil }
+      let points = entries.map {
+        MeasurementPoint(x: label(for: $0.run.runAt), y: $0.value)
+      }
+      return MeasurementSeries(name: branch, points: points)
+    }
+    guard !series.isEmpty else { return nil }
+
+    // Order the axis by when each run happened, across every branch — grouping
+    // by series would put one branch's dates before the other's regardless of
+    // chronology.
+    let xOrder = scalars
+      .sorted { $0.run.runAt < $1.run.runAt }
+      .map { label(for: $0.run.runAt) }
+      .reduce(into: [String]()) { order, label in
+        if !order.contains(label) { order.append(label) }
+      }
+
+    return MeasurementChart(
+      kind: .line,
+      yLabel: "Over time",
+      series: series,
+      xOrder: xOrder
+    )
+  }
+
+  /// Whether the runs span more than one branch, and so whether naming the
+  /// branch on each history row is informative or just noise.
+  static func spansMultipleBranches(_ runs: [MeasurementRun]) -> Bool {
+    Set(runs.compactMap(\.branchName)).count > 1
+  }
+
+  static func label(for date: Date) -> String {
+    dateFormatter.string(from: date)
+  }
+
+  private static let dateFormatter: DateFormatter = {
+    let formatter = DateFormatter()
+    formatter.dateFormat = "d MMM"
+    return formatter
+  }()
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/SessionMetadataStore.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/SessionMetadataStore.swift
@@ -28,6 +28,8 @@ public actor SessionMetadataStore: TerminalWorkspaceStoreProtocol, AgentWorkspac
     static let createProjectSimulatorPreferences = "v11_create_project_simulator_preferences"
     static let createAgentWorkspaces = "v12_create_agent_workspaces"
     static let createPinnedSessionOrder = "v13_create_pinned_session_order"
+    static let createSessionMeasurements = "v14_create_session_measurements"
+    static let addMeasurementProjectPath = "v15_add_measurement_project_path"
   }
 
   static let migrationIdentifiers = [
@@ -43,7 +45,9 @@ public actor SessionMetadataStore: TerminalWorkspaceStoreProtocol, AgentWorkspac
     MigrationID.createSessionRelationships,
     MigrationID.createProjectSimulatorPreferences,
     MigrationID.createAgentWorkspaces,
-    MigrationID.createPinnedSessionOrder
+    MigrationID.createPinnedSessionOrder,
+    MigrationID.createSessionMeasurements,
+    MigrationID.addMeasurementProjectPath
   ]
 
   private let dbQueue: DatabaseQueue
@@ -247,6 +251,52 @@ public actor SessionMetadataStore: TerminalWorkspaceStoreProtocol, AgentWorkspac
       }
     }
 
+    // Measurements an agent filed into a session's Measurements panel. Keyed by the
+    // measurement id the CLI generated so a queue entry drained twice (app restart
+    // mid-drain) replaces rather than duplicates.
+    migrator.registerMigration(MigrationID.createSessionMeasurements) { db in
+      try db.create(table: "session_measurements") { t in
+        t.column("id", .text).primaryKey(onConflict: .replace)
+        t.column("sessionId", .text).notNull().indexed()
+        t.column("provider", .text).notNull()
+        t.column("createdAt", .datetime).notNull()
+        t.column("payloadVersion", .integer).notNull()
+        t.column("payloadData", .blob).notNull()
+      }
+    }
+
+    // Measurements are scoped to a project, not a session: a measurement about a
+    // repo or a database outlives the conversation that produced it, and
+    // keying it to a session hides last month's number from this month's work.
+    // Existing rows are backfilled from the payload they already carry, so no
+    // measurement is lost.
+    migrator.registerMigration(MigrationID.addMeasurementProjectPath) { db in
+      try db.alter(table: "session_measurements") { t in
+        t.add(column: "projectPath", .text).notNull().defaults(to: "")
+      }
+
+      let rows = try Row.fetchAll(db, sql: "SELECT id, payloadData FROM session_measurements")
+      for row in rows {
+        guard let payload: Data = row["payloadData"],
+              let object = try? JSONSerialization.jsonObject(with: payload) as? [String: Any],
+              let sourceProjectPath = object["sourceProjectPath"] as? String,
+              !sourceProjectPath.isEmpty
+        else {
+          continue
+        }
+        try db.execute(
+          sql: "UPDATE session_measurements SET projectPath = ? WHERE id = ?",
+          arguments: [MeasurementProjectScope.normalized(sourceProjectPath), row["id"] as String?]
+        )
+      }
+
+      try db.create(
+        index: "idx_session_measurements_project",
+        on: "session_measurements",
+        columns: ["projectPath"]
+      )
+    }
+
     return migrator
   }
 
@@ -417,6 +467,7 @@ public actor SessionMetadataStore: TerminalWorkspaceStoreProtocol, AgentWorkspac
       _ = try AIConfigRecord.deleteAll(db)
       _ = try SessionRepoMapping.deleteAll(db)
       _ = try PinnedSessionOrderRecord.deleteAll(db)
+      _ = try SessionMeasurementRecord.deleteAll(db)
       _ = try SessionMetadata.deleteAll(db)
     }
   }
@@ -735,6 +786,70 @@ extension SessionMetadataStore: SessionRelationshipStoreProtocol {
   public func deleteProjectSimulatorPreference(projectPath: String) throws {
     try dbQueue.write { db in
       _ = try ProjectSimulatorPreference.deleteOne(db, key: projectPath)
+    }
+  }
+}
+
+// MARK: - Session Measurement
+
+extension SessionMetadataStore {
+  /// Stores one measurement card. `save` (upsert) rather than `insert` so a queue
+  /// entry drained twice is idempotent.
+  public func saveMeasurement(_ record: SessionMeasurementRecord) throws {
+    try dbQueue.write { db in
+      try record.save(db)
+    }
+  }
+
+  /// Measurements for a project, newest first — the order the panel renders.
+  ///
+  /// Spans every session and both providers: Claude and Codex sessions in the
+  /// same repo contribute to one shared set.
+  public func getMeasurements(forProjectPath projectPath: String) throws -> [SessionMeasurementRecord] {
+    let key = MeasurementProjectScope.normalized(projectPath)
+    return try dbQueue.read { db in
+      try SessionMeasurementRecord
+        .filter(Column("projectPath") == key)
+        .order(Column("createdAt").desc, Column("id").desc)
+        .fetchAll(db)
+    }
+  }
+
+  /// Projects that have at least one card, so the card button can gate without
+  /// loading every payload.
+  public func getProjectPathsWithMeasurements() throws -> Set<String> {
+    try dbQueue.read { db in
+      let paths = try String.fetchAll(
+        db,
+        sql: "SELECT DISTINCT projectPath FROM \(SessionMeasurementRecord.databaseTableName)"
+      )
+      return Set(paths.filter { !$0.isEmpty })
+    }
+  }
+
+  public func deleteMeasurement(id: String) throws {
+    _ = try dbQueue.write { db in
+      try SessionMeasurementRecord.deleteOne(db, key: id)
+    }
+  }
+
+  public func deleteAllMeasurements(forProjectPath projectPath: String) throws {
+    let key = MeasurementProjectScope.normalized(projectPath)
+    _ = try dbQueue.write { db in
+      try SessionMeasurementRecord
+        .filter(Column("projectPath") == key)
+        .deleteAll(db)
+    }
+  }
+
+  /// Drops rows that could never be shown again — measurements whose project was
+  /// never resolved. Without this they accumulate invisibly forever.
+  @discardableResult
+  public func deleteUnscopedMeasurements() throws -> Int {
+    try dbQueue.write { db in
+      try SessionMeasurementRecord
+        .filter(Column("projectPath") == "")
+        .deleteAll(db)
     }
   }
 }

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/SessionMetadataStore.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/SessionMetadataStore.swift
@@ -815,6 +815,20 @@ extension SessionMetadataStore {
     }
   }
 
+  /// Every stored measurement, for the Settings management view.
+  ///
+  /// Loads whole payloads rather than a summary query because the counts here
+  /// are small (tens per project) and the view needs each card's title and last
+  /// run — deriving those from a `GROUP BY` would mean a second round trip per
+  /// project anyway.
+  public func getAllMeasurements() throws -> [SessionMeasurementRecord] {
+    try dbQueue.read { db in
+      try SessionMeasurementRecord
+        .order(Column("createdAt").desc, Column("id").desc)
+        .fetchAll(db)
+    }
+  }
+
   /// Projects that have at least one card, so the card button can gate without
   /// loading every payload.
   public func getProjectPathsWithMeasurements() throws -> Set<String> {

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MeasurementCardView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MeasurementCardView.swift
@@ -1,0 +1,418 @@
+//
+//  MeasurementCardView.swift
+//  AgentHub
+//
+//  One measurement: the claim, the numbers behind it, and the query that produced them.
+//
+
+import AgentHubCLIKit
+import AppKit
+import SwiftUI
+
+struct MeasurementCardView: View {
+  let record: MeasurementRecord
+  var canRerun: Bool = false
+  var isRerunning: Bool = false
+  var onRerun: (() -> Void)? = nil
+  let onDelete: () -> Void
+
+  @State private var isQueryExpanded = false
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 10) {
+      MeasurementCardHeader(
+        record: record,
+        canRerun: canRerun,
+        isRerunning: isRerunning,
+        onRerun: onRerun,
+        onDelete: onDelete
+      )
+
+      Text(record.claim)
+        .font(.body)
+        .textSelection(.enabled)
+        .fixedSize(horizontal: false, vertical: true)
+
+      if let chart = record.chart {
+        MeasurementChartView(chart: chart)
+      }
+
+      if let table = record.table, !table.rows.isEmpty {
+        MeasurementTableView(table: table)
+      }
+
+      if let history = record.history, !history.isEmpty {
+        MeasurementHistoryView(record: record, history: history)
+      }
+
+      if !record.caveats.isEmpty {
+        MeasurementCaveatsView(caveats: record.caveats)
+      }
+
+      if let query = record.query, !query.isEmpty {
+        MeasurementQueryDisclosure(query: query, isExpanded: $isQueryExpanded)
+      }
+
+      if let source = record.source, !source.isEmpty {
+        MeasurementSourceFooter(source: source)
+      }
+    }
+    .padding(14)
+    .background(Color(NSColor.textBackgroundColor))
+    .clipShape(RoundedRectangle(cornerRadius: 10))
+    .overlay(
+      RoundedRectangle(cornerRadius: 10)
+        .stroke(Color.secondary.opacity(0.2), lineWidth: 1)
+    )
+  }
+}
+
+// MARK: - Header
+
+private struct MeasurementCardHeader: View {
+  let record: MeasurementRecord
+  let canRerun: Bool
+  let isRerunning: Bool
+  let onRerun: (() -> Void)?
+  let onDelete: () -> Void
+
+  var body: some View {
+    HStack(alignment: .firstTextBaseline, spacing: 8) {
+      VStack(alignment: .leading, spacing: 2) {
+        Text(record.title)
+          .font(.headline)
+          .textSelection(.enabled)
+          .fixedSize(horizontal: false, vertical: true)
+
+        if let question = record.question, !question.isEmpty {
+          Text(question)
+            .font(.caption)
+            .foregroundStyle(.secondary)
+            .fixedSize(horizontal: false, vertical: true)
+        }
+      }
+
+      Spacer(minLength: 8)
+
+      if isRerunning {
+        ProgressView()
+          .controlSize(.mini)
+      } else if canRerun {
+        Button { onRerun?() } label: {
+          Image(systemName: "arrow.clockwise")
+            .font(.caption)
+        }
+        .buttonStyle(.plain)
+        .foregroundStyle(.secondary)
+        .help("Re-run this query and refresh the numbers")
+        .accessibilityLabel("Re-run this measurement")
+      }
+
+      Text(timestampLabel)
+        .font(.caption2)
+        .foregroundStyle(.tertiary)
+        .fixedSize()
+
+      Menu {
+        Button("Copy Claim") {
+          MeasurementPasteboard.copy(record.claim)
+        }
+        if let query = record.query, !query.isEmpty {
+          Button("Copy Query") {
+            MeasurementPasteboard.copy(query)
+          }
+        }
+        Divider()
+        Button("Remove Card", role: .destructive, action: onDelete)
+      } label: {
+        Image(systemName: "ellipsis")
+          .font(.caption)
+      }
+      .menuStyle(.borderlessButton)
+      .menuIndicator(.hidden)
+      .frame(width: 20)
+      .accessibilityLabel("Card actions")
+    }
+  }
+
+  /// "updated" only appears once a card has actually been refreshed — saying it
+  /// on a first-time measurement would imply a re-run that never happened.
+  private var timestampLabel: String {
+    let relative = record.displayDate.formatted(.relative(presentation: .numeric))
+    if isRerunning {
+      return "re-running…"
+    }
+    return record.hasBeenRerun ? "updated \(relative)" : relative
+  }
+}
+
+// MARK: - Table
+
+/// Renders the table with a `Grid` so columns size to their content.
+///
+/// Fixed-width columns truncated long file paths to `CLISessio…odel.swift`
+/// while numeric columns wasted half their width; the grid gives every column
+/// exactly what it needs and only scrolls when the total genuinely overflows.
+private struct MeasurementTableView: View {
+  let table: MeasurementTable
+
+  var body: some View {
+    ScrollView(.horizontal, showsIndicators: true) {
+      Grid(alignment: .leading, horizontalSpacing: 14, verticalSpacing: 0) {
+        GridRow {
+          ForEach(Array(table.columns.enumerated()), id: \.offset) { _, column in
+            cell(column, isHeader: true)
+          }
+        }
+
+        Divider()
+          .gridCellUnsizedAxes(.horizontal)
+
+        ForEach(Array(table.rows.enumerated()), id: \.offset) { _, cells in
+          GridRow {
+            ForEach(Array(cells.enumerated()), id: \.offset) { _, value in
+              cell(value, isHeader: false)
+            }
+          }
+        }
+      }
+      .padding(.horizontal, 8)
+      .padding(.vertical, 6)
+    }
+    .frame(maxHeight: 220)
+    .background(Color(NSColor.controlBackgroundColor).opacity(0.5))
+    .clipShape(RoundedRectangle(cornerRadius: 6))
+  }
+
+  private func cell(_ value: String, isHeader: Bool) -> some View {
+    Text(value)
+      .font(.caption)
+      .fontWeight(isHeader ? .semibold : .regular)
+      .monospacedDigit()
+      .foregroundStyle(isHeader ? .secondary : .primary)
+      .lineLimit(1)
+      .padding(.vertical, 3)
+  }
+}
+
+// MARK: - History
+
+/// Earlier runs of the same measurement.
+///
+/// This is what turns a card from a snapshot into a tracked metric: when the
+/// measurement measures a single number, the runs plot as a trend; otherwise each
+/// run is listed with what was claimed at the time, so a month-old reading is
+/// still readable rather than silently overwritten.
+private struct MeasurementHistoryView: View {
+  let record: MeasurementRecord
+  let history: [MeasurementRun]
+
+  @State private var isExpanded = false
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      Button {
+        withAnimation(.easeInOut(duration: 0.15)) {
+          isExpanded.toggle()
+        }
+      } label: {
+        HStack(spacing: 4) {
+          Image(systemName: "chevron.right")
+            .font(.caption2)
+            .rotationEffect(.degrees(isExpanded ? 90 : 0))
+          Text(history.count == 1 ? "1 earlier run" : "\(history.count) earlier runs")
+            .font(.caption.weight(.medium))
+          if let delta = deltaLabel {
+            Text(delta)
+              .font(.caption2.weight(.semibold))
+          }
+        }
+        .foregroundStyle(.secondary)
+      }
+      .buttonStyle(.plain)
+
+      if isExpanded {
+        if let trend {
+          MeasurementChartView(chart: trend)
+        }
+
+        VStack(alignment: .leading, spacing: 6) {
+          ForEach(record.runs.reversed()) { run in
+            MeasurementHistoryRow(
+              run: run,
+              isCurrent: run.runAt == record.displayDate,
+              showsBranch: showsBranch
+            )
+          }
+        }
+      }
+    }
+  }
+
+  /// A trend across runs, split by branch — see `MeasurementTrendBuilder`.
+  private var trend: MeasurementChart? {
+    MeasurementTrendBuilder.chart(for: record.runs, title: record.title)
+  }
+
+  /// Naming the branch on every row is noise when they all ran on the same one.
+  private var showsBranch: Bool {
+    MeasurementTrendBuilder.spansMultipleBranches(record.runs)
+  }
+
+  /// Change against the previous run **on the same branch**. Comparing across
+  /// branches would report a branch difference as movement over time.
+  private var deltaLabel: String? {
+    let previousOnSameBranch = history.last { $0.branchName == record.branchName }
+    guard let current = record.scalarValue,
+          let previous = previousOnSameBranch?.scalarValue,
+          previous != 0
+    else {
+      return nil
+    }
+    let change = (current - previous) / abs(previous) * 100
+    guard abs(change) >= 0.5 else { return "unchanged" }
+    return String(format: "%@%.0f%%", change > 0 ? "+" : "", change)
+  }
+
+  // Deliberately no red/green on the delta. Whether a number going up is good
+  // depends on the metric — down is good for build time and bad for weekly
+  // actives — and AgentHub is not told which. Colouring it would confidently
+  // mislead half the time; the sign alone is unambiguous.
+
+}
+
+private struct MeasurementHistoryRow: View {
+  let run: MeasurementRun
+  let isCurrent: Bool
+  let showsBranch: Bool
+
+  var body: some View {
+    HStack(alignment: .top, spacing: 8) {
+      VStack(alignment: .leading, spacing: 2) {
+        Text(run.runAt.formatted(date: .abbreviated, time: .shortened))
+          .font(.caption2.monospacedDigit())
+          .foregroundStyle(.tertiary)
+
+        if showsBranch, let branch = run.branchName {
+          Text(branch)
+            .font(.caption2)
+            .foregroundStyle(.secondary)
+            .lineLimit(1)
+            .truncationMode(.middle)
+        }
+      }
+      .frame(width: 108, alignment: .leading)
+
+      Text(run.claim)
+        .font(.caption)
+        .foregroundStyle(isCurrent ? .primary : .secondary)
+        .fixedSize(horizontal: false, vertical: true)
+    }
+  }
+}
+
+// MARK: - Caveats
+
+/// Caveats get their own visually distinct block rather than small print.
+/// The whole point of the panel is that a number arrives with the reasons it
+/// might mislead attached to it, so they must survive a skim.
+private struct MeasurementCaveatsView: View {
+  let caveats: [String]
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 4) {
+      Label("Read with care", systemImage: "exclamationmark.triangle.fill")
+        .font(.caption.weight(.semibold))
+        .foregroundStyle(.orange)
+
+      ForEach(Array(caveats.enumerated()), id: \.offset) { _, caveat in
+        HStack(alignment: .top, spacing: 6) {
+          Text("•")
+          Text(caveat)
+            .fixedSize(horizontal: false, vertical: true)
+        }
+        .font(.caption)
+        .foregroundStyle(.secondary)
+      }
+    }
+    .frame(maxWidth: .infinity, alignment: .leading)
+    .padding(8)
+    .background(Color.orange.opacity(0.08))
+    .clipShape(RoundedRectangle(cornerRadius: 6))
+  }
+}
+
+// MARK: - Query
+
+private struct MeasurementQueryDisclosure: View {
+  let query: String
+  @Binding var isExpanded: Bool
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 6) {
+      HStack(spacing: 6) {
+        Button {
+          withAnimation(.easeInOut(duration: 0.15)) {
+            isExpanded.toggle()
+          }
+        } label: {
+          HStack(spacing: 4) {
+            Image(systemName: "chevron.right")
+              .font(.caption2)
+              .rotationEffect(.degrees(isExpanded ? 90 : 0))
+            Text("Query")
+              .font(.caption.weight(.medium))
+          }
+          .foregroundStyle(.secondary)
+        }
+        .buttonStyle(.plain)
+
+        Spacer()
+
+        if isExpanded {
+          Button("Copy") {
+            MeasurementPasteboard.copy(query)
+          }
+          .buttonStyle(.plain)
+          .font(.caption2)
+          .foregroundStyle(.secondary)
+        }
+      }
+
+      if isExpanded {
+        ScrollView(.horizontal, showsIndicators: true) {
+          Text(query)
+            .font(.system(.caption, design: .monospaced))
+            .textSelection(.enabled)
+            .padding(8)
+        }
+        .frame(maxHeight: 160)
+        .background(Color(NSColor.controlBackgroundColor).opacity(0.6))
+        .clipShape(RoundedRectangle(cornerRadius: 6))
+      }
+    }
+  }
+}
+
+// MARK: - Source
+
+private struct MeasurementSourceFooter: View {
+  let source: String
+
+  var body: some View {
+    Label(source, systemImage: "cylinder.split.1x2")
+      .font(.caption2)
+      .foregroundStyle(.tertiary)
+      .lineLimit(1)
+      .truncationMode(.middle)
+  }
+}
+
+// MARK: - Pasteboard
+
+enum MeasurementPasteboard {
+  static func copy(_ text: String) {
+    NSPasteboard.general.clearContents()
+    NSPasteboard.general.setString(text, forType: .string)
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MeasurementChartView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MeasurementChartView.swift
@@ -1,0 +1,184 @@
+//
+//  MeasurementChartView.swift
+//  AgentHub
+//
+//  Draws an agent-supplied chart specification with Swift Charts.
+//
+
+import AgentHubCLIKit
+import Charts
+import SwiftUI
+
+/// Renders an `MeasurementChart`.
+///
+/// The agent sends values only; every visual decision is made here so cards stay
+/// on the app's theme and no agent-authored markup reaches the panel.
+struct MeasurementChartView: View {
+  let chart: MeasurementChart
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 4) {
+      // The y unit reads as a caption above the plot rather than a rotated axis
+      // title. In a ~440pt side panel a vertical title crowds the plot area and
+      // collides with the tick labels for no readability gain.
+      if let yLabel = chart.yLabel, !yLabel.isEmpty {
+        Text(yLabel)
+          .font(.caption2)
+          .foregroundStyle(.secondary)
+      }
+
+      plot
+    }
+  }
+
+  private var plot: some View {
+    Chart {
+      ForEach(chart.series) { series in
+        ForEach(Array(series.points.enumerated()), id: \.offset) { _, point in
+          mark(for: point, seriesName: series.name)
+        }
+      }
+    }
+    .chartLegend(chart.series.count > 1 ? .visible : .hidden)
+    .chartXAxis {
+      AxisMarks { value in
+        AxisGridLine()
+        AxisTick()
+        AxisValueLabel(orientation: labelOrientation) {
+          if let label = value.as(String.self) {
+            Text(label)
+              .font(.caption2)
+          }
+        }
+      }
+    }
+    .chartYAxis {
+      AxisMarks { value in
+        AxisGridLine()
+        AxisValueLabel {
+          if let number = value.as(Double.self) {
+            Text(MeasurementNumberFormat.axis(number))
+              .font(.caption2)
+          }
+        }
+      }
+    }
+    .chartXScale(domain: chart.xOrder ?? derivedCategoryOrder)
+    .chartXAxisLabel(position: .bottom, alignment: .center) {
+      if let xLabel = chart.xLabel, !xLabel.isEmpty {
+        Text(xLabel).font(.caption2).foregroundStyle(.secondary)
+      }
+    }
+    .frame(height: 200)
+  }
+
+  @ChartContentBuilder
+  private func mark(for point: MeasurementPoint, seriesName: String) -> some ChartContent {
+    switch chart.kind {
+    case .bar:
+      BarMark(
+        x: .value(chart.xLabel ?? "Category", point.x),
+        y: .value(chart.yLabel ?? "Value", point.y)
+      )
+      .foregroundStyle(by: .value("Series", seriesName))
+      .position(by: .value("Series", seriesName))
+    case .line:
+      LineMark(
+        x: .value(chart.xLabel ?? "Category", point.x),
+        y: .value(chart.yLabel ?? "Value", point.y)
+      )
+      .foregroundStyle(by: .value("Series", seriesName))
+      .symbol(by: .value("Series", seriesName))
+    case .area:
+      AreaMark(
+        x: .value(chart.xLabel ?? "Category", point.x),
+        y: .value(chart.yLabel ?? "Value", point.y)
+      )
+      .foregroundStyle(by: .value("Series", seriesName))
+      .opacity(0.7)
+    case .point:
+      PointMark(
+        x: .value(chart.xLabel ?? "Category", point.x),
+        y: .value(chart.yLabel ?? "Value", point.y)
+      )
+      .foregroundStyle(by: .value("Series", seriesName))
+    }
+  }
+
+  /// Categories in order of first appearance — the same order Swift Charts
+  /// would derive on its own, stated explicitly so the scale is always set.
+  private var derivedCategoryOrder: [String] {
+    chart.series
+      .flatMap { $0.points.map(\.x) }
+      .reduce(into: [String]()) { order, category in
+        if !order.contains(category) { order.append(category) }
+      }
+  }
+
+  private var labelOrientation: AxisValueLabelOrientation {
+    switch MeasurementAxisLabelLayout.orientation(
+      forCategories: chart.series.flatMap { $0.points.map(\.x) }
+    ) {
+    case .horizontal: .horizontal
+    case .rotated: .verticalReversed
+    }
+  }
+}
+
+/// Decides whether category labels have to rotate.
+///
+/// Keyed on how much text has to fit, not how many points there are: seven
+/// "Mon"/"Tue" labels sit comfortably side by side, while four file names do
+/// not. Counting points alone rotated the days-of-week case for no reason.
+enum MeasurementAxisLabelLayout {
+  /// Framework-independent so the rule can be tested directly — Swift Charts'
+  /// own `AxisValueLabelOrientation` is not `Equatable`.
+  enum Orientation: Equatable {
+    case horizontal
+    case rotated
+  }
+
+  /// Rough usable plot width in the side panel, minus the y-axis gutter.
+  static let assumedPlotWidth = 360.0
+  /// Rough width of one character at `.caption2`, plus per-label breathing room.
+  static let approximateCharacterWidth = 5.5
+  static let perLabelPadding = 8.0
+
+  static func orientation(forCategories categories: [String]) -> Orientation {
+    // Series share an x axis, so the same category appearing in several series
+    // is still one column.
+    let distinct = Set(categories)
+    guard !distinct.isEmpty else { return .horizontal }
+
+    let widestLabel = distinct.map(\.count).max() ?? 0
+    let requiredWidth =
+      Double(distinct.count) * (Double(widestLabel) * approximateCharacterWidth + perLabelPadding)
+
+    return requiredWidth > assumedPlotWidth ? .rotated : .horizontal
+  }
+}
+
+/// Number formatting shared by the chart axis and the table.
+enum MeasurementNumberFormat {
+  /// Compact form for axis ticks: 12.5K, 3.2M.
+  static func axis(_ value: Double) -> String {
+    let magnitude = abs(value)
+    switch magnitude {
+    case 1_000_000_000...:
+      return trimmed(value / 1_000_000_000) + "B"
+    case 1_000_000...:
+      return trimmed(value / 1_000_000) + "M"
+    case 1_000...:
+      return trimmed(value / 1_000) + "K"
+    default:
+      return trimmed(value)
+    }
+  }
+
+  private static func trimmed(_ value: Double) -> String {
+    if value == value.rounded(), abs(value) < 1e15 {
+      return String(Int64(value))
+    }
+    return String(format: "%.1f", value)
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MeasurementsSettingsView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MeasurementsSettingsView.swift
@@ -1,0 +1,232 @@
+//
+//  MeasurementsSettingsView.swift
+//  AgentHub
+//
+//  Settings tab for reviewing and deleting stored measurements.
+//
+
+import AgentHubCLIKit
+import SwiftUI
+
+/// Lists stored measurements by project and deletes them.
+///
+/// Grouped by project, never by worktree — see `MeasurementsSettingsViewModel`.
+public struct MeasurementsSettingsView: View {
+  @Environment(\.agentHub) private var agentHub
+  @State private var viewModel: MeasurementsSettingsViewModel?
+  @State private var expandedProjectPaths: Set<String> = []
+  @State private var projectPendingDeletion: MeasurementProjectGroup?
+
+  public init() {}
+
+  public var body: some View {
+    Form {
+      if let viewModel {
+        if viewModel.isEmpty, !viewModel.isLoading {
+          Section {
+            MeasurementsSettingsEmptyState()
+          }
+        } else {
+          Section("Stored measurements") {
+            ForEach(viewModel.groups) { group in
+              MeasurementProjectRow(
+                group: group,
+                isExpanded: expandedProjectPaths.contains(group.projectPath),
+                onToggle: { toggle(group) },
+                onDeleteProject: { projectPendingDeletion = group },
+                onDeleteMeasurement: { id in
+                  Task { await viewModel.deleteMeasurement(id: id) }
+                }
+              )
+            }
+          }
+
+          if viewModel.unscopedCount > 0 {
+            Section("Unreachable") {
+              MeasurementsUnscopedRow(count: viewModel.unscopedCount) {
+                Task { await viewModel.sweepUnscoped() }
+              }
+            }
+          }
+        }
+      }
+    }
+    .formStyle(.grouped)
+    .task {
+      if viewModel == nil {
+        viewModel = MeasurementsSettingsViewModel(store: agentHub?.metadataStore)
+      }
+      await viewModel?.load()
+    }
+    .confirmationDialog(
+      "Delete measurements?",
+      isPresented: Binding(
+        get: { projectPendingDeletion != nil },
+        set: { if !$0 { projectPendingDeletion = nil } }
+      ),
+      presenting: projectPendingDeletion
+    ) { group in
+      Button("Delete \(group.measurements.count)", role: .destructive) {
+        let path = group.projectPath
+        projectPendingDeletion = nil
+        Task { await viewModel?.deleteAll(inProjectPath: path) }
+      }
+      Button("Cancel", role: .cancel) { projectPendingDeletion = nil }
+    } message: { group in
+      // Deleting takes the history with it, which is the part that cannot be
+      // recovered by re-running — say so before they confirm.
+      Text("This removes \(group.measurements.count) measurement(s) from \(group.displayName), including \(group.runCount) recorded run(s). Re-running later starts a fresh history.")
+    }
+  }
+
+  private func toggle(_ group: MeasurementProjectGroup) {
+    if expandedProjectPaths.contains(group.projectPath) {
+      expandedProjectPaths.remove(group.projectPath)
+    } else {
+      expandedProjectPaths.insert(group.projectPath)
+    }
+  }
+}
+
+// MARK: - Project row
+
+private struct MeasurementProjectRow: View {
+  let group: MeasurementProjectGroup
+  let isExpanded: Bool
+  let onToggle: () -> Void
+  let onDeleteProject: () -> Void
+  let onDeleteMeasurement: (String) -> Void
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      HStack(spacing: 8) {
+        Button(action: onToggle) {
+          HStack(spacing: 6) {
+            Image(systemName: "chevron.right")
+              .font(.caption2)
+              .rotationEffect(.degrees(isExpanded ? 90 : 0))
+
+            VStack(alignment: .leading, spacing: 2) {
+              Text(group.displayName)
+                .font(.body)
+              Text(group.projectPath)
+                .font(.caption2)
+                .foregroundStyle(.tertiary)
+                .lineLimit(1)
+                .truncationMode(.head)
+            }
+          }
+        }
+        .buttonStyle(.plain)
+
+        Spacer(minLength: 8)
+
+        Text(subtitle)
+          .font(.caption)
+          .foregroundStyle(.secondary)
+          .fixedSize()
+
+        Button("Delete All", role: .destructive, action: onDeleteProject)
+          .buttonStyle(.link)
+      }
+
+      if isExpanded {
+        VStack(alignment: .leading, spacing: 4) {
+          ForEach(group.measurements) { measurement in
+            MeasurementSettingsRow(measurement: measurement) {
+              onDeleteMeasurement(measurement.id)
+            }
+          }
+        }
+        .padding(.leading, 18)
+      }
+    }
+    .padding(.vertical, 2)
+  }
+
+  private var subtitle: String {
+    let count = group.measurements.count
+    let noun = count == 1 ? "measurement" : "measurements"
+    guard let last = group.lastActivityAt else { return "\(count) \(noun)" }
+    return "\(count) \(noun) · \(last.formatted(.relative(presentation: .numeric)))"
+  }
+}
+
+// MARK: - Measurement row
+
+private struct MeasurementSettingsRow: View {
+  let measurement: MeasurementRecord
+  let onDelete: () -> Void
+
+  var body: some View {
+    HStack(alignment: .firstTextBaseline, spacing: 8) {
+      VStack(alignment: .leading, spacing: 1) {
+        Text(measurement.title)
+          .font(.caption)
+        Text(detail)
+          .font(.caption2)
+          .foregroundStyle(.tertiary)
+      }
+
+      Spacer(minLength: 8)
+
+      Button(role: .destructive, action: onDelete) {
+        Image(systemName: "trash")
+          .font(.caption)
+      }
+      .buttonStyle(.plain)
+      .foregroundStyle(.secondary)
+      .accessibilityLabel("Delete \(measurement.title)")
+    }
+    .padding(.vertical, 1)
+  }
+
+  private var detail: String {
+    let runs = measurement.runs.count
+    let runLabel = runs == 1 ? "1 run" : "\(runs) runs"
+    let when = measurement.displayDate.formatted(.relative(presentation: .numeric))
+    guard let branch = measurement.branchName else { return "\(runLabel) · \(when)" }
+    return "\(runLabel) · \(branch) · \(when)"
+  }
+}
+
+// MARK: - Unscoped
+
+private struct MeasurementsUnscopedRow: View {
+  let count: Int
+  let onSweep: () -> Void
+
+  var body: some View {
+    HStack(alignment: .firstTextBaseline, spacing: 8) {
+      VStack(alignment: .leading, spacing: 2) {
+        Text(count == 1 ? "1 measurement with no project" : "\(count) measurements with no project")
+          .font(.body)
+        Text("These were recorded before AgentHub could resolve their project, so no panel can show them.")
+          .font(.caption)
+          .foregroundStyle(.secondary)
+          .fixedSize(horizontal: false, vertical: true)
+      }
+
+      Spacer(minLength: 8)
+
+      Button("Remove", role: .destructive, action: onSweep)
+        .buttonStyle(.link)
+    }
+  }
+}
+
+// MARK: - Empty state
+
+private struct MeasurementsSettingsEmptyState: View {
+  var body: some View {
+    VStack(alignment: .leading, spacing: 6) {
+      Text("No measurements recorded")
+        .font(.body)
+      Text("When a session analyzes something — a git aggregation, a test-timing run, a query — it records the result here and in that project's Measurements panel.")
+        .font(.caption)
+        .foregroundStyle(.secondary)
+        .fixedSize(horizontal: false, vertical: true)
+    }
+    .padding(.vertical, 4)
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MeasurementsSidePanelView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MeasurementsSidePanelView.swift
@@ -1,0 +1,126 @@
+//
+//  MeasurementsSidePanelView.swift
+//  AgentHub
+//
+//  Side panel listing the measurements an agent filed during a session.
+//
+
+import AgentHubCLIKit
+import SwiftUI
+
+/// Renders a session's measurement thread, newest measurement first.
+///
+/// Cards arrive from `agenthub_record_measurement` (see `MeasurementRecordMonitor`),
+/// so this view only reads state — it never contacts an agent or a data source.
+public struct MeasurementsSidePanelView: View {
+  let session: CLISession
+  let viewModel: CLISessionsViewModel
+  let onDismiss: () -> Void
+  var isEmbedded: Bool = false
+
+  public init(
+    session: CLISession,
+    viewModel: CLISessionsViewModel,
+    onDismiss: @escaping () -> Void,
+    isEmbedded: Bool = false
+  ) {
+    self.session = session
+    self.viewModel = viewModel
+    self.onDismiss = onDismiss
+    self.isEmbedded = isEmbedded
+  }
+
+  private var records: [MeasurementRecord] {
+    viewModel.measurements(for: session)
+  }
+
+  public var body: some View {
+    VStack(spacing: 0) {
+      header
+
+      Divider()
+
+      if records.isEmpty {
+        MeasurementEmptyState()
+      } else {
+        cardList
+      }
+    }
+    .frame(
+      minWidth: isEmbedded ? 320 : 620, idealWidth: isEmbedded ? .infinity : 760, maxWidth: .infinity,
+      minHeight: isEmbedded ? 300 : 520, idealHeight: isEmbedded ? .infinity : 720, maxHeight: .infinity
+    )
+    .onKeyPress(.escape) {
+      guard !isEmbedded else { return .handled }
+      onDismiss()
+      return .handled
+    }
+    .task(id: session.id) {
+      viewModel.loadMeasurements(for: session)
+    }
+  }
+
+  private var header: some View {
+    HStack(spacing: 8) {
+      Label("Measurements", systemImage: "chart.bar.doc.horizontal")
+        .font(.headline)
+
+      if !records.isEmpty {
+        Text("\(records.count)")
+          .font(.caption2.monospacedDigit())
+          .padding(.horizontal, 6)
+          .padding(.vertical, 2)
+          .background(Color.secondary.opacity(0.15))
+          .clipShape(Capsule())
+      }
+
+      Spacer()
+
+      Button("Close", action: onDismiss)
+    }
+    .padding(.horizontal, 12)
+    .padding(.vertical, 8)
+  }
+
+  private var cardList: some View {
+    ScrollView {
+      LazyVStack(spacing: 14) {
+        ForEach(records) { record in
+          MeasurementCardView(
+            record: record,
+            canRerun: viewModel.canRerunMeasurement(record, sessionId: session.id),
+            isRerunning: viewModel.isRerunning(measurementId: record.id),
+            onRerun: { viewModel.rerunMeasurement(id: record.id, in: session) }
+          ) {
+            viewModel.deleteMeasurement(id: record.id, in: session)
+          }
+        }
+      }
+      .padding(14)
+    }
+  }
+}
+
+/// Shown once every card has been removed. Names the tool explicitly so the
+/// path back to a populated panel is obvious to someone who has never used it.
+private struct MeasurementEmptyState: View {
+  var body: some View {
+    VStack(spacing: 10) {
+      Image(systemName: "chart.bar.doc.horizontal")
+        .font(.title2)
+        .foregroundStyle(.secondary)
+
+      Text("No measurements yet")
+        .font(.callout.weight(.medium))
+
+      Text("Ask this session to analyze something — query a database, aggregate a CSV, count events — and the result lands here as a chart with the query behind it.")
+        .font(.caption)
+        .foregroundStyle(.secondary)
+        .multilineTextAlignment(.center)
+        .fixedSize(horizontal: false, vertical: true)
+        .frame(maxWidth: 320)
+    }
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+    .padding(24)
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringCardView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringCardView.swift
@@ -41,6 +41,7 @@ public struct MonitoringCardView: View {
   let onShowGitHub: ((CLISession, String) -> Void)?
   let onShowPendingChanges: ((CLISession, PendingToolUse) -> Void)?
   let onShowMCPApp: ((CLISession, String) -> Void)?
+  let onShowMeasurement: ((CLISession) -> Void)?
   let onShowSimulatorPreview: ((CLISession, String) -> Void)?
   let onFork: ((CLISession, SessionProviderKind) -> Void)?
   let onPromptConsumed: (() -> Void)?
@@ -95,6 +96,7 @@ public struct MonitoringCardView: View {
     onShowGitHub: ((CLISession, String) -> Void)? = nil,
     onShowPendingChanges: ((CLISession, PendingToolUse) -> Void)? = nil,
     onShowMCPApp: ((CLISession, String) -> Void)? = nil,
+    onShowMeasurement: ((CLISession) -> Void)? = nil,
     onShowSimulatorPreview: ((CLISession, String) -> Void)? = nil,
     onFork: ((CLISession, SessionProviderKind) -> Void)? = nil,
     onPromptConsumed: (() -> Void)? = nil,
@@ -133,6 +135,7 @@ public struct MonitoringCardView: View {
     self.onShowGitHub = onShowGitHub
     self.onShowPendingChanges = onShowPendingChanges
     self.onShowMCPApp = onShowMCPApp
+    self.onShowMeasurement = onShowMeasurement
     self.onShowSimulatorPreview = onShowSimulatorPreview
     self.onFork = onFork
     self.onPromptConsumed = onPromptConsumed
@@ -212,6 +215,14 @@ public struct MonitoringCardView: View {
 
   /// Key that changes when the set of detected MCP tool invocations changes, so
   /// host-app resolution re-runs only when the agent makes a new app-bearing call.
+  private var measurementCount: Int {
+    viewModel?.measurements(for: session).count ?? 0
+  }
+
+  private var measurementButtonAccessibilityLabel: String {
+    measurementCount == 1 ? "Open 1 recorded measurement" : "Open \(measurementCount) recorded measurements"
+  }
+
   private var mcpAppInvocationResolutionKey: String {
     (state?.detectedMCPAppInvocations ?? []).map(\.id).joined(separator: ",")
   }
@@ -315,6 +326,11 @@ public struct MonitoringCardView: View {
     }
     .task(id: mcpAppInvocationResolutionKey) {
       await viewModel?.ensureMCPAppRenderItems(for: session, state: state)
+    }
+    // Measurements outlive the session that filed them, so the button has to reflect
+    // what this project already holds — not just what this session produced.
+    .task(id: session.projectPath) {
+      viewModel?.loadMeasurements(for: session)
     }
     .task(id: gitHubObservationTaskID) {
       if linkedPullRequests.isEmpty {
@@ -763,6 +779,26 @@ public struct MonitoringCardView: View {
           .buttonStyle(.agentHubOutlined)
           .help("Open MCP app resources")
           .accessibilityLabel(mcpAppButtonAccessibilityLabel)
+        }
+
+        // Measurements button — appears only once the agent has actually filed a
+        // measurement, so a session that never analyzed anything stays uncluttered.
+        if measurementCount > 0 {
+          Button(action: {
+            onShowMeasurement?(session)
+          }) {
+            HStack(spacing: 4) {
+              Image(systemName: "chart.bar.doc.horizontal")
+                .font(.caption2)
+              Text("Measurements")
+              Text("\(measurementCount)")
+                .font(.system(.caption2, design: .monospaced))
+                .foregroundStyle(.secondary)
+            }
+          }
+          .buttonStyle(.agentHubOutlined)
+          .help("Open measurements recorded in this session")
+          .accessibilityLabel(measurementButtonAccessibilityLabel)
         }
 
         // Mermaid diagram button (only visible when mermaid content is detected)

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderMonitoringPanelView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderMonitoringPanelView.swift
@@ -22,6 +22,7 @@ enum SidePanelContent: Equatable {
   case edits(sessionId: String, session: CLISession)
   case mcpApp(sessionId: String, session: CLISession, projectPath: String)
   case simulator(sessionId: String, session: CLISession, projectPath: String)
+  case measurements(sessionId: String, session: CLISession)
 
   static func == (lhs: SidePanelContent, rhs: SidePanelContent) -> Bool {
     switch (lhs, rhs) {
@@ -41,6 +42,8 @@ enum SidePanelContent: Equatable {
       return id1 == id2 && p1 == p2
     case (.simulator(let id1, _, let p1), .simulator(let id2, _, let p2)):
       return id1 == id2 && p1 == p2
+    case (.measurements(let id1, _), .measurements(let id2, _)):
+      return id1 == id2
     default: return false
     }
   }
@@ -596,6 +599,12 @@ public struct MultiProviderMonitoringPanelView: View {
                 forItemID: item.id
               )
             },
+            onShowMeasurement: { session in
+              toggleSidePanel(
+                .measurements(sessionId: session.id, session: session),
+                forItemID: item.id
+              )
+            },
             onShowSimulatorPreview: { session, projectPath in
               toggleSidePanel(
                 .simulator(sessionId: session.id, session: session, projectPath: projectPath),
@@ -687,6 +696,12 @@ public struct MultiProviderMonitoringPanelView: View {
             onShowMCPApp: { session, projectPath in
               toggleSidePanel(
                 .mcpApp(sessionId: session.id, session: session, projectPath: projectPath),
+                forItemID: item.id
+              )
+            },
+            onShowMeasurement: { session in
+              toggleSidePanel(
+                .measurements(sessionId: session.id, session: session),
                 forItemID: item.id
               )
             },
@@ -879,7 +894,7 @@ public struct MultiProviderMonitoringPanelView: View {
     switch content {
     case .edits, .plan:
       return true
-    case .diff, .webPreview, .mermaid, .gitHub, .mcpApp, .simulator:
+    case .diff, .webPreview, .mermaid, .gitHub, .mcpApp, .simulator, .measurements:
       return false
     }
   }
@@ -1118,6 +1133,13 @@ public struct MultiProviderMonitoringPanelView: View {
         openEditorFilePath: editorStates[payload.itemID]?.selectedFilePath
       )
       .id("\(sessionId)|\(projectPath)")
+    case .measurements(_, let session):
+      MeasurementsSidePanelView(
+        session: session,
+        viewModel: viewModel,
+        onDismiss: closeEmbeddedSidePanel,
+        isEmbedded: true
+      )
     }
   }
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/SettingsView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/SettingsView.swift
@@ -157,6 +157,11 @@ public struct SettingsView: View {
           Label("Worktrees", systemImage: "arrow.triangle.branch")
         }
 
+      MeasurementsSettingsView()
+        .tabItem {
+          Label("Measurements", systemImage: "chart.bar.doc.horizontal")
+        }
+
       appearanceSettingsForm
         .tabItem {
           Label("Appearance", systemImage: "paintpalette")

--- a/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/CLISessionsViewModel.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/CLISessionsViewModel.swift
@@ -5,6 +5,7 @@
 //  Created by Assistant on 1/9/26.
 //
 
+import AgentHubCLIKit
 import AgentHubGitDiff
 import AgentHubGitHub
 import AgentHubMCPUI
@@ -75,6 +76,8 @@ public final class CLISessionsViewModel {
   // MARK: - State
 
   public private(set) var selectedRepositories: [SelectedRepository] = []
+  public private(set) var lastFocusedSessionId: String?
+  public private(set) var lastFocusedSessionAt: Date?
   public private(set) var loadingState: CLILoadingState = .idle
   public private(set) var browseSessionsLoadState: BrowseSessionsLoadState = .notLoaded
   public private(set) var error: Error?
@@ -730,6 +733,7 @@ public final class CLISessionsViewModel {
   /// Stores the prompt temporarily so that when the terminal view renders,
   /// it can pass the prompt to EmbeddedTerminalView for the resume command.
   public func showTerminalWithPrompt(for session: CLISession, prompt: String) {
+    markSessionFocused(session.id)
     // Start monitoring if not already
     if !monitoredSessionIds.contains(session.id) {
       startMonitoring(session: session)
@@ -768,7 +772,22 @@ public final class CLISessionsViewModel {
     guard let terminal = activeTerminals[key] else {
       return false
     }
-    return terminal.submitPromptImmediately(prompt)
+    let didSubmit = terminal.submitPromptImmediately(prompt)
+    if didSubmit {
+      markSessionFocused(key)
+    }
+    return didSubmit
+  }
+
+  /// Types text into an already-mounted session terminal without submitting it.
+  @discardableResult
+  public func typeTextInActiveTerminal(forKey key: String, text: String) -> Bool {
+    guard !text.isEmpty, let terminal = activeTerminals[key] else {
+      return false
+    }
+    terminal.typeText(text)
+    markSessionFocused(key)
+    return true
   }
 
   public func queueWebPreviewContext(_ element: ElementInspectorData, for sessionID: String) {
@@ -1642,6 +1661,7 @@ public final class CLISessionsViewModel {
   /// Focuses the terminal for a given key so it receives keyboard input.
   /// Uses a short delay to let SwiftUI layout settle before requesting AppKit first responder.
   public func focusTerminal(forKey key: String) {
+    markSessionFocused(key)
     guard activeTerminals[key] != nil else { return }
     guard scheduledTerminalFocusKeys.insert(key).inserted else { return }
     Task { @MainActor in
@@ -1649,6 +1669,11 @@ public final class CLISessionsViewModel {
       scheduledTerminalFocusKeys.remove(key)
       activeTerminals[key]?.focus()
     }
+  }
+
+  private func markSessionFocused(_ sessionId: String) {
+    lastFocusedSessionId = sessionId
+    lastFocusedSessionAt = Date()
   }
 
   /// Focuses the auxiliary shell terminal for a given key so it receives keyboard input.
@@ -1909,6 +1934,254 @@ public final class CLISessionsViewModel {
         return groupId > 0 ? groupId : nil
       }
     )
+  }
+
+  // MARK: - Measurement
+
+  /// Measurements keyed by **project**, newest first — the Measurements panel's model.
+  ///
+  /// Not keyed by session: a measurement about a repo or a database outlives
+  /// the conversation that produced it, and every session working on that
+  /// project sees the same set (including across Claude and Codex).
+  public private(set) var measurementCards: [String: [MeasurementRecord]] = [:]
+
+  /// Resolved project key per session, so views can look up measurements
+  /// synchronously without touching the database on every redraw.
+  private var measurementProjectKeys: [String: String] = [:]
+
+  /// Projects whose persisted measurements have already been read back from SQLite,
+  /// so reopening the panel doesn't re-query on every appearance.
+  private var loadedMeasurementProjectKeys: Set<String> = []
+
+  /// The project bucket a session's measurements live in.
+  ///
+  /// Falls back to the raw project path until the repo mapping has been read;
+  /// the cached value takes over once `loadMeasurements` has resolved it.
+  public func measurementProjectKey(for session: CLISession) -> String {
+    measurementProjectKeys[session.id]
+      ?? MeasurementProjectScope.key(projectPath: session.projectPath, parentRepoPath: nil)
+  }
+
+  public func measurements(for session: CLISession) -> [MeasurementRecord] {
+    measurementCards[measurementProjectKey(for: session)] ?? []
+  }
+
+  public func hasMeasurements(for session: CLISession) -> Bool {
+    !measurements(for: session).isEmpty
+  }
+
+  /// Resolves a session's project bucket, rolling worktrees up to their parent
+  /// repository so a worktree's measurements join the repo's history rather than
+  /// forming an isolated set.
+  private func resolveMeasurementProjectKey(for sessionId: String, projectPath: String) async -> String {
+    if let cached = measurementProjectKeys[sessionId] {
+      return cached
+    }
+
+    var parentRepoPath: String?
+    if let store = metadataStore {
+      parentRepoPath = try? await store.getRepoMapping(for: sessionId)?.parentRepoPath
+    }
+
+    let key = MeasurementProjectScope.key(projectPath: projectPath, parentRepoPath: parentRepoPath)
+    measurementProjectKeys[sessionId] = key
+    return key
+  }
+
+  /// Takes a measurement filed by the CLI.
+  ///
+  /// The project bucket is resolved first — a card shown under the wrong key
+  /// for even a moment would split a metric's history in two, which is the one
+  /// thing this feature exists to prevent.
+  public func storeMeasurement(_ measurement: MeasurementRecord, forSessionId sessionId: String) {
+    let session = monitoredSession(withId: sessionId)
+    let projectPath = session?.projectPath
+      ?? measurement.sourceProjectPath
+      ?? ""
+    guard !projectPath.isEmpty else {
+      AppLogger.session.error("Dropping measurement \(measurement.id): no project path to file it under.")
+      return
+    }
+
+    Task {
+      let key = await resolveMeasurementProjectKey(for: sessionId, projectPath: projectPath)
+
+      // Stamp the branch before merging, so the values being superseded carry
+      // the branch they were measured on into the history. Measurements roll up
+      // to the repo, so without this a `main` run and a feature-worktree run are
+      // indistinguishable and the trend reads as one thrashing series.
+      let stamped = measurement.stamped(
+        branchName: session?.branchName,
+        worktreePath: session?.isWorktree == true ? session?.projectPath : nil
+      )
+
+      // A measurement filed under an id we already hold is a re-run: keep the
+      // original filing date so the refreshed card holds its position, push the
+      // superseded values onto its history, and stamp it as updated.
+      let existing = measurementCards[key] ?? []
+      let resolved = Self.resolvingRerun(incoming: stamped, against: existing)
+
+      measurementCards[key] = Self.mergedMeasurements(existing: existing, incoming: [resolved])
+      rerunningMeasurementIds.remove(resolved.id)
+      publishMeasurementIndex(forKey: key)
+
+      guard let store = metadataStore else { return }
+      do {
+        let record = try SessionMeasurementRecord(
+          measurement: resolved,
+          projectPath: key,
+          sessionId: sessionId
+        )
+        try await store.saveMeasurement(record)
+      } catch {
+        AppLogger.session.error("Failed to save measurement record: \(error.localizedDescription)")
+      }
+    }
+  }
+
+  /// The monitored session with this id, across whichever provider owns it.
+  private func monitoredSession(withId sessionId: String) -> CLISession? {
+    monitoredSessions.first { $0.session.id == sessionId }?.session
+  }
+
+  /// Republishes the agent-readable index for a project.
+  ///
+  /// This is how `agenthub_list_measurements` sees anything: the CLI is a separate
+  /// process that deliberately never opens the app's database, so the app keeps
+  /// a small JSON summary in sync instead. Mirrored to every session path that
+  /// resolves to this project (worktrees included) so the CLI can find it from
+  /// `AGENTHUB_PROJECT_PATH` without knowing about rollup.
+  private func publishMeasurementIndex(forKey key: String) {
+    let entries = (measurementCards[key] ?? []).map(MeasurementIndexEntry.init(measurement:))
+    let aliases = measurementProjectKeys
+      .filter { $0.value == key }
+      .compactMap { monitoredSession(withId: $0.key)?.projectPath }
+      .map(MeasurementProjectScope.normalized)
+
+    let index = MeasurementIndex(projectPath: key, updatedAt: .now, measurements: entries)
+    Task.detached(priority: .utility) {
+      do {
+        try MeasurementIndexStore().write(index, aliasPaths: aliases)
+      } catch {
+        AppLogger.session.error("Failed to publish measurement index: \(error.localizedDescription)")
+      }
+    }
+  }
+
+  // MARK: Re-running a measurement
+
+  /// Measurements whose refresh has been handed to a session and not yet come back.
+  public private(set) var rerunningMeasurementIds: Set<String> = []
+
+  /// How long a refresh may stay pending before the spinner gives up.
+  ///
+  /// The agent may simply never call the tool back — it can decide the command
+  /// failed, or get distracted by other work — and a spinner with no terminal
+  /// state would misreport that as "still working" forever.
+  static let rerunTimeout: Duration = .seconds(180)
+
+  public func isRerunning(measurementId: String) -> Bool {
+    rerunningMeasurementIds.contains(measurementId)
+  }
+
+  /// Whether ↻ can do anything: the measurement needs a stored query, and the
+  /// session needs a live terminal to run it in.
+  ///
+  /// Note this is the *viewing* session, not the one that filed the measurement —
+  /// a card from last month can be refreshed by whatever session is open in
+  /// that project today, which is the point of scoping by project.
+  public func canRerunMeasurement(_ measurement: MeasurementRecord, sessionId: String) -> Bool {
+    MeasurementRerunPromptBuilder.canRerun(measurement) && activeTerminals[sessionId] != nil
+  }
+
+  /// Asks the session to re-run a measurement and re-file it under the same id.
+  @discardableResult
+  public func rerunMeasurement(id: String, in session: CLISession) -> Bool {
+    let key = measurementProjectKey(for: session)
+    guard let measurement = measurementCards[key]?.first(where: { $0.id == id }),
+          let prompt = MeasurementRerunPromptBuilder.prompt(for: measurement),
+          sendPromptToActiveTerminal(forKey: session.id, prompt: prompt)
+    else {
+      return false
+    }
+
+    rerunningMeasurementIds.insert(id)
+    Task { [weak self] in
+      try? await Task.sleep(for: Self.rerunTimeout)
+      self?.rerunningMeasurementIds.remove(id)
+    }
+    return true
+  }
+
+  /// Reads a session's persisted measurement back once.
+  ///
+  /// Merges rather than replaces: a record can arrive from the CLI queue before
+  /// this load completes, and the newly filed card must not be dropped by the
+  /// older snapshot landing second.
+  public func loadMeasurements(for session: CLISession) {
+    guard let store = metadataStore, !session.id.hasPrefix("pending-") else { return }
+
+    Task {
+      let key = await resolveMeasurementProjectKey(for: session.id, projectPath: session.projectPath)
+      guard loadedMeasurementProjectKeys.insert(key).inserted else { return }
+
+      do {
+        let records = try await store.getMeasurements(forProjectPath: key)
+        let decoded = records.compactMap { try? $0.decodedMeasurement() }
+        guard !decoded.isEmpty else { return }
+        measurementCards[key] = Self.mergedMeasurements(
+          existing: measurementCards[key] ?? [],
+          incoming: decoded
+        )
+        publishMeasurementIndex(forKey: key)
+      } catch {
+        loadedMeasurementProjectKeys.remove(key)
+        AppLogger.session.error("Failed to load measurement records: \(error.localizedDescription)")
+      }
+    }
+  }
+
+  public func deleteMeasurement(id: String, in session: CLISession) {
+    let key = measurementProjectKey(for: session)
+    measurementCards[key]?.removeAll { $0.id == id }
+    if measurementCards[key]?.isEmpty == true {
+      measurementCards.removeValue(forKey: key)
+    }
+    publishMeasurementIndex(forKey: key)
+
+    guard let store = metadataStore else { return }
+    Task {
+      do {
+        try await store.deleteMeasurement(id: id)
+      } catch {
+        AppLogger.session.error("Failed to delete measurement record: \(error.localizedDescription)")
+      }
+    }
+  }
+
+  /// Re-anchors a measurement onto the card it replaces, if one exists.
+  static func resolvingRerun(
+    incoming: MeasurementRecord,
+    against existing: [MeasurementRecord]
+  ) -> MeasurementRecord {
+    existing.first { $0.id == incoming.id }
+      .map { incoming.replacing($0) } ?? incoming
+  }
+
+  /// Union by id, newest first. Incoming wins on collision so a re-filed card
+  /// reflects the latest version.
+  static func mergedMeasurements(
+    existing: [MeasurementRecord],
+    incoming: [MeasurementRecord]
+  ) -> [MeasurementRecord] {
+    let incomingIds = Set(incoming.map(\.id))
+    return (incoming + existing.filter { !incomingIds.contains($0.id) })
+      .sorted {
+        if $0.createdAt == $1.createdAt {
+          return $0.id > $1.id
+        }
+        return $0.createdAt > $1.createdAt
+      }
   }
 
   /// Loads custom names for all monitored sessions

--- a/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/MeasurementsSettingsViewModel.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/MeasurementsSettingsViewModel.swift
@@ -1,0 +1,138 @@
+//
+//  MeasurementsSettingsViewModel.swift
+//  AgentHub
+//
+//  Backs the Settings tab for reviewing and deleting stored measurements.
+//
+
+import AgentHubCLIKit
+import Foundation
+
+/// One project's stored measurements, as the Settings list shows them.
+public struct MeasurementProjectGroup: Identifiable, Equatable, Sendable {
+  public var id: String { projectPath }
+
+  public let projectPath: String
+  public let measurements: [MeasurementRecord]
+
+  public init(projectPath: String, measurements: [MeasurementRecord]) {
+    self.projectPath = projectPath
+    self.measurements = measurements
+  }
+
+  /// Last directory component, for a readable row title.
+  public var displayName: String {
+    let name = (projectPath as NSString).lastPathComponent
+    return name.isEmpty ? projectPath : name
+  }
+
+  /// Most recent activity across the group — a re-run counts, which is why this
+  /// uses `displayDate` rather than the stored creation column.
+  public var lastActivityAt: Date? {
+    measurements.map(\.displayDate).max()
+  }
+
+  public var runCount: Int {
+    measurements.reduce(0) { $0 + $1.runs.count }
+  }
+}
+
+/// Lists and deletes stored measurements.
+///
+/// Settings exists for the measurements the panel cannot reach: the panel only
+/// shows the project of a session you currently have open, so measurements for
+/// a repository you have since deleted — exactly the ones worth clearing — are
+/// otherwise invisible and permanent.
+///
+/// Grouped by project and never by worktree: worktrees roll up to their parent
+/// repository, so there is no per-worktree set to delete, and offering one would
+/// mean deleting a worktree's measurements and finding the card still there.
+@MainActor
+@Observable
+public final class MeasurementsSettingsViewModel {
+  public private(set) var groups: [MeasurementProjectGroup] = []
+  /// Rows whose project resolved to nothing and which no panel can ever show.
+  public private(set) var unscopedCount = 0
+  public private(set) var isLoading = false
+
+  private let store: SessionMetadataStore?
+
+  public init(store: SessionMetadataStore?) {
+    self.store = store
+  }
+
+  public var isEmpty: Bool {
+    groups.isEmpty && unscopedCount == 0
+  }
+
+  public var totalCount: Int {
+    groups.reduce(0) { $0 + $1.measurements.count } + unscopedCount
+  }
+
+  public func load() async {
+    guard let store else { return }
+    isLoading = true
+    defer { isLoading = false }
+
+    do {
+      let records = try await store.getAllMeasurements()
+      let decoded = records.compactMap { record -> (String, MeasurementRecord)? in
+        guard let measurement = try? record.decodedMeasurement() else { return nil }
+        return (record.projectPath, measurement)
+      }
+
+      unscopedCount = decoded.filter { $0.0.isEmpty }.count
+      groups = Self.grouped(decoded.filter { !$0.0.isEmpty })
+    } catch {
+      AppLogger.session.error("Failed to load measurements for settings: \(error.localizedDescription)")
+    }
+  }
+
+  public func deleteMeasurement(id: String) async {
+    guard let store else { return }
+    do {
+      try await store.deleteMeasurement(id: id)
+      await load()
+    } catch {
+      AppLogger.session.error("Failed to delete measurement: \(error.localizedDescription)")
+    }
+  }
+
+  public func deleteAll(inProjectPath projectPath: String) async {
+    guard let store else { return }
+    do {
+      try await store.deleteAllMeasurements(forProjectPath: projectPath)
+      await load()
+    } catch {
+      AppLogger.session.error("Failed to delete project measurements: \(error.localizedDescription)")
+    }
+  }
+
+  public func sweepUnscoped() async {
+    guard let store else { return }
+    do {
+      try await store.deleteUnscopedMeasurements()
+      await load()
+    } catch {
+      AppLogger.session.error("Failed to sweep unscoped measurements: \(error.localizedDescription)")
+    }
+  }
+
+  /// Groups by project, most recently active project first, and newest
+  /// measurement first within each.
+  static func grouped(_ decoded: [(String, MeasurementRecord)]) -> [MeasurementProjectGroup] {
+    Dictionary(grouping: decoded, by: \.0)
+      .map { projectPath, entries in
+        MeasurementProjectGroup(
+          projectPath: projectPath,
+          measurements: entries.map(\.1).sorted { $0.displayDate > $1.displayDate }
+        )
+      }
+      .sorted {
+        switch ($0.lastActivityAt, $1.lastActivityAt) {
+        case let (lhs?, rhs?) where lhs != rhs: return lhs > rhs
+        default: return $0.projectPath < $1.projectPath
+        }
+      }
+  }
+}

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/MeasurementRecordHandlerTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/MeasurementRecordHandlerTests.swift
@@ -1,0 +1,122 @@
+import AgentHubCLIKit
+import Foundation
+import Testing
+
+@testable import AgentHubCore
+
+@MainActor
+@Suite("MeasurementRecordHandler")
+struct MeasurementRecordHandlerTests {
+  @Test("Routes to the recording provider using the explicit session id")
+  func routesUsingExplicitSessionId() async throws {
+    let claude = MeasurementRecordTargetMock()
+    let codex = MeasurementRecordTargetMock()
+    let handler = MeasurementRecordHandler(claudeTarget: claude, codexTarget: codex)
+
+    try await handler.handle(makeMeasurement(
+      id: "measurement-1",
+      sourceProvider: .codex,
+      sourceSessionId: "codex-session",
+      sourceProcessId: 42
+    ))
+
+    #expect(claude.stored.isEmpty)
+    #expect(codex.stored.map(\.sessionId) == ["codex-session"])
+    #expect(codex.stored.first?.measurementId == "measurement-1")
+  }
+
+  @Test("Resolves the session by process id when the environment had none")
+  func resolvesSessionByProcessId() async throws {
+    let claude = MeasurementRecordTargetMock(sessionIdsByProcessId: [84: "resolved-session"])
+    let codex = MeasurementRecordTargetMock()
+    let handler = MeasurementRecordHandler(claudeTarget: claude, codexTarget: codex)
+
+    try await handler.handle(makeMeasurement(
+      id: "measurement-1",
+      sourceProvider: .claude,
+      sourceSessionId: nil,
+      sourceProcessId: 84
+    ))
+
+    #expect(claude.stored.map(\.sessionId) == ["resolved-session"])
+    #expect(codex.stored.isEmpty)
+  }
+
+  /// A `pending-` id is replaced once the session becomes real, so storing
+  /// against it would strand the card under an id nothing renders.
+  @Test("Falls back from a pending session id to process resolution")
+  func fallsBackFromPendingSessionId() async throws {
+    let claude = MeasurementRecordTargetMock(sessionIdsByProcessId: [84: "resolved-session"])
+    let handler = MeasurementRecordHandler(claudeTarget: claude, codexTarget: MeasurementRecordTargetMock())
+
+    try await handler.handle(makeMeasurement(
+      id: "measurement-1",
+      sourceProvider: .claude,
+      sourceSessionId: "pending-123",
+      sourceProcessId: 84
+    ))
+
+    #expect(claude.stored.map(\.sessionId) == ["resolved-session"])
+  }
+
+  @Test("Throws when no session can be resolved, so the record stays queued")
+  func throwsWhenSessionUnresolved() async {
+    let target = MeasurementRecordTargetMock()
+    let handler = MeasurementRecordHandler(claudeTarget: target, codexTarget: target)
+
+    await #expect(throws: MeasurementRecordHandlingError.self) {
+      try await handler.handle(makeMeasurement(
+        id: "measurement-1",
+        sourceProvider: .claude,
+        sourceSessionId: nil,
+        sourceProcessId: 1
+      ))
+    }
+    #expect(target.stored.isEmpty)
+  }
+}
+
+@MainActor
+private final class MeasurementRecordTargetMock: MeasurementRecordTarget {
+  struct Stored: Equatable {
+    let measurementId: String
+    let sessionId: String
+  }
+
+  let sessionIdsByProcessId: [Int32: String]
+  private(set) var stored: [Stored] = []
+
+  init(sessionIdsByProcessId: [Int32: String] = [:]) {
+    self.sessionIdsByProcessId = sessionIdsByProcessId
+  }
+
+  func activeSessionId(forProcessId processId: Int32) -> String? {
+    sessionIdsByProcessId[processId]
+  }
+
+  func storeMeasurement(_ measurement: MeasurementRecord, forSessionId sessionId: String) {
+    stored.append(Stored(measurementId: measurement.id, sessionId: sessionId))
+  }
+}
+
+private func makeMeasurement(
+  id: String,
+  sourceProvider: WorktreeLaunchProvider,
+  sourceSessionId: String?,
+  sourceProcessId: Int32
+) -> MeasurementRecord {
+  MeasurementRecord(
+    id: id,
+    title: "Week-2 retention by channel",
+    claim: "Referral retains at 41% versus 22% for paid.",
+    chart: MeasurementChart(
+      kind: .bar,
+      series: [
+        MeasurementSeries(name: "Week 2", points: [MeasurementPoint(x: "referral", y: 41)])
+      ]
+    ),
+    sourceProvider: sourceProvider,
+    sourceSessionId: sourceSessionId,
+    sourceProcessId: sourceProcessId
+  )
+}

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/MeasurementRerunTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/MeasurementRerunTests.swift
@@ -1,0 +1,143 @@
+import AgentHubCLIKit
+import Foundation
+import Testing
+
+@testable import AgentHubCore
+
+@MainActor
+@Suite("Measurement re-run")
+struct MeasurementRerunTests {
+  @Test("A measurement without a query cannot be re-run")
+  func measurementWithoutQueryCannotBeRerun() {
+    #expect(!MeasurementRerunPromptBuilder.canRerun(makeMeasurement(query: nil)))
+    #expect(!MeasurementRerunPromptBuilder.canRerun(makeMeasurement(query: "   \n  ")))
+    #expect(MeasurementRerunPromptBuilder.canRerun(makeMeasurement(query: "git log --oneline")))
+    #expect(MeasurementRerunPromptBuilder.prompt(for: makeMeasurement(query: nil)) == nil)
+  }
+
+  /// The id is what makes a re-run refresh the card instead of stacking a
+  /// near-duplicate under it, so it has to survive into the prompt.
+  @Test("The prompt carries the id, title and query verbatim")
+  func promptCarriesIdentityAndQuery() throws {
+    let measurement = makeMeasurement(query: "git log --since='12 months ago' --name-only")
+    let prompt = try #require(MeasurementRerunPromptBuilder.prompt(for: measurement))
+
+    #expect(prompt.contains(measurement.id))
+    #expect(prompt.contains(measurement.title))
+    #expect(prompt.contains("git log --since='12 months ago' --name-only"))
+    #expect(prompt.contains("agenthub_record_measurement"))
+  }
+
+  @Test("The prompt forbids rewriting the query and forbids recording on failure")
+  func promptPinsTheMeasurement() throws {
+    let prompt = try #require(MeasurementRerunPromptBuilder.prompt(for: makeMeasurement(query: "echo 1")))
+
+    #expect(prompt.contains("exactly as written"))
+    #expect(prompt.contains("do not record a measurement"))
+  }
+
+  @Test("Re-filing under a known id keeps the original creation date")
+  func rerunPreservesCreationDate() {
+    let original = makeMeasurement(
+      id: "measurement-1",
+      createdAt: Date(timeIntervalSince1970: 1_000),
+      claim: "41s"
+    )
+    let refreshed = makeMeasurement(
+      id: "measurement-1",
+      createdAt: Date(timeIntervalSince1970: 9_000),
+      claim: "22s"
+    )
+
+    let resolved = CLISessionsViewModel.resolvingRerun(incoming: refreshed, against: [original])
+
+    #expect(resolved.createdAt == Date(timeIntervalSince1970: 1_000))
+    #expect(resolved.updatedAt == Date(timeIntervalSince1970: 9_000))
+    #expect(resolved.displayDate == Date(timeIntervalSince1970: 9_000))
+    #expect(resolved.claim == "22s")
+    #expect(resolved.hasBeenRerun)
+  }
+
+  /// Sorting is by creation date, so a preserved date is what stops a refreshed
+  /// card from jumping to the top of the panel under the user's cursor.
+  @Test("A refreshed card holds its position in the panel")
+  func refreshedCardHoldsItsPosition() {
+    let older = makeMeasurement(id: "older", createdAt: Date(timeIntervalSince1970: 1_000))
+    let newer = makeMeasurement(id: "newer", createdAt: Date(timeIntervalSince1970: 5_000))
+    let existing = [newer, older]
+
+    let refreshedOlder = makeMeasurement(id: "older", createdAt: Date(timeIntervalSince1970: 9_000))
+    let resolved = CLISessionsViewModel.resolvingRerun(incoming: refreshedOlder, against: existing)
+    let merged = CLISessionsViewModel.mergedMeasurements(existing: existing, incoming: [resolved])
+
+    #expect(merged.map(\.id) == ["newer", "older"])
+  }
+
+  @Test("A first-time measurement is not marked as updated")
+  func firstFilingIsNotMarkedUpdated() {
+    let measurement = makeMeasurement(id: "fresh", createdAt: Date(timeIntervalSince1970: 1_000))
+    let resolved = CLISessionsViewModel.resolvingRerun(incoming: measurement, against: [])
+
+    #expect(resolved.updatedAt == nil)
+    #expect(!resolved.hasBeenRerun)
+    #expect(resolved.displayDate == Date(timeIntervalSince1970: 1_000))
+  }
+}
+
+@Suite("Measurement axis label layout")
+struct MeasurementAxisLabelLayoutTests {
+  /// The bug this replaced rotated seven three-letter labels purely because
+  /// there were more than six of them.
+  @Test("Short labels stay horizontal even when there are many")
+  func shortLabelsStayHorizontal() {
+    let days = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
+    #expect(MeasurementAxisLabelLayout.orientation(forCategories: days) == .horizontal)
+  }
+
+  @Test("Long labels rotate even when there are few")
+  func longLabelsRotate() {
+    let files = [
+      "CLISessionsViewModel.swift",
+      "MonitoringCardView.swift",
+      "MultiProviderPanel.swift",
+      "GitDiffView.swift"
+    ]
+    #expect(MeasurementAxisLabelLayout.orientation(forCategories: files) == .rotated)
+  }
+
+  @Test("Repeated categories across series are not double counted")
+  func repeatedCategoriesAreDeduplicated() {
+    // Two series over the same seven days must not read as fourteen columns.
+    let days = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
+    #expect(MeasurementAxisLabelLayout.orientation(forCategories: days + days) == .horizontal)
+  }
+
+  @Test("No categories is handled without rotating")
+  func emptyCategoriesStayHorizontal() {
+    #expect(MeasurementAxisLabelLayout.orientation(forCategories: []) == .horizontal)
+  }
+}
+
+// MARK: - Helpers
+
+private func makeMeasurement(
+  id: String = "measurement-1",
+  createdAt: Date = Date(timeIntervalSince1970: 3_000),
+  claim: String = "GitDiffServiceTests alone is 41s.",
+  query: String? = "xcodebuild test -scheme AgentHubCore-Tests"
+) -> MeasurementRecord {
+  MeasurementRecord(
+    id: id,
+    createdAt: createdAt,
+    title: "Slowest test suites",
+    claim: claim,
+    query: query,
+    chart: MeasurementChart(
+      kind: .bar,
+      series: [MeasurementSeries(name: "Duration", points: [MeasurementPoint(x: "GitDiff", y: 41)])]
+    ),
+    sourceProvider: .claude,
+    sourceSessionId: "session-1",
+    sourceProcessId: 42
+  )
+}

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/MeasurementTrendBuilderTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/MeasurementTrendBuilderTests.swift
@@ -1,0 +1,192 @@
+import AgentHubCLIKit
+import Foundation
+import Testing
+
+@testable import AgentHubCore
+
+@Suite("Measurement trend by branch")
+struct MeasurementTrendBuilderTests {
+  /// The bug this exists to prevent: `main` and a feature branch are each
+  /// perfectly stable, but interleaved into one series they read 214 → 163 →
+  /// 211 → 160, which looks like a metric thrashing.
+  @Test("Runs from different branches plot as separate series")
+  func branchesPlotAsSeparateSeries() throws {
+    let runs = [
+      makeRun(day: 1, value: 214, branch: "main"),
+      makeRun(day: 2, value: 163, branch: "refactor"),
+      makeRun(day: 3, value: 211, branch: "main"),
+      makeRun(day: 4, value: 160, branch: "refactor")
+    ]
+
+    let chart = try #require(MeasurementTrendBuilder.chart(for: runs, title: "Build time"))
+
+    #expect(chart.series.map(\.name) == ["main", "refactor"])
+    #expect(chart.series[0].points.map(\.y) == [214, 211])
+    #expect(chart.series[1].points.map(\.y) == [163, 160])
+  }
+
+  /// Swift Charts derives a category axis from first-appearance order, which
+  /// for a branch split groups one branch's dates before the other's — the axis
+  /// then read 12 Jul, 26 Jul, 19 Jul, 7 Aug.
+  @Test("The axis is ordered by date across every branch")
+  func axisIsChronologicalAcrossBranches() throws {
+    let runs = [
+      makeRun(day: 1, value: 214, branch: "main"),
+      makeRun(day: 8, value: 163, branch: "refactor"),
+      makeRun(day: 15, value: 211, branch: "main"),
+      makeRun(day: 22, value: 160, branch: "refactor")
+    ]
+
+    let chart = try #require(MeasurementTrendBuilder.chart(for: runs, title: "Build time"))
+    let expected = runs
+      .sorted { $0.runAt < $1.runAt }
+      .map { MeasurementTrendBuilder.label(for: $0.runAt) }
+
+    #expect(chart.xOrder == expected)
+  }
+
+  @Test("Two branches measured on the same day share one axis slot")
+  func sameDayRunsShareAnAxisSlot() throws {
+    let runs = [
+      makeRun(day: 1, value: 214, branch: "main"),
+      makeRun(day: 1, value: 163, branch: "refactor")
+    ]
+
+    let chart = try #require(MeasurementTrendBuilder.chart(for: runs, title: "Build time"))
+    #expect(chart.xOrder?.count == 1)
+    #expect(chart.series.count == 2)
+  }
+
+  @Test("A single branch stays one series named for the branch")
+  func singleBranchStaysOneSeries() throws {
+    let runs = [
+      makeRun(day: 1, value: 214, branch: "main"),
+      makeRun(day: 2, value: 198, branch: "main")
+    ]
+
+    let chart = try #require(MeasurementTrendBuilder.chart(for: runs, title: "Build time"))
+
+    #expect(chart.series.count == 1)
+    #expect(chart.series[0].name == "main")
+  }
+
+  /// Runs recorded before branches were tracked have no branch; they must still
+  /// plot rather than being silently dropped.
+  @Test("Runs without a branch fall back to the measurement title")
+  func runsWithoutBranchFallBackToTitle() throws {
+    let runs = [
+      makeRun(day: 1, value: 214, branch: nil),
+      makeRun(day: 2, value: 198, branch: nil)
+    ]
+
+    let chart = try #require(MeasurementTrendBuilder.chart(for: runs, title: "Build time"))
+
+    #expect(chart.series.map(\.name) == ["Build time"])
+    #expect(chart.series[0].points.count == 2)
+  }
+
+  @Test("Legend order follows whichever branch was measured first")
+  func legendOrderFollowsFirstMeasurement() throws {
+    let runs = [
+      makeRun(day: 1, value: 163, branch: "refactor"),
+      makeRun(day: 2, value: 214, branch: "main")
+    ]
+
+    let chart = try #require(MeasurementTrendBuilder.chart(for: runs, title: "Build time"))
+    #expect(chart.series.map(\.name) == ["refactor", "main"])
+  }
+
+  @Test("A single run is not a trend")
+  func singleRunIsNotATrend() {
+    #expect(MeasurementTrendBuilder.chart(for: [makeRun(day: 1, value: 1, branch: "main")], title: "t") == nil)
+  }
+
+  @Test("A multi-series measurement has no scalar trend")
+  func multiSeriesHasNoTrend() {
+    let breakdown = MeasurementRun(
+      runAt: Date(timeIntervalSince1970: 1_000),
+      claim: "c",
+      chart: MeasurementChart(kind: .bar, series: [
+        MeasurementSeries(name: "s", points: [
+          MeasurementPoint(x: "a", y: 1),
+          MeasurementPoint(x: "b", y: 2)
+        ])
+      ]),
+      table: nil,
+      branchName: "main"
+    )
+
+    #expect(MeasurementTrendBuilder.chart(for: [breakdown, breakdown], title: "t") == nil)
+  }
+
+  @Test("Branch labels only show once runs actually span branches")
+  func branchLabelsOnlyWhenTheySpanBranches() {
+    let sameBranch = [makeRun(day: 1, value: 1, branch: "main"), makeRun(day: 2, value: 2, branch: "main")]
+    let twoBranches = [makeRun(day: 1, value: 1, branch: "main"), makeRun(day: 2, value: 2, branch: "dev")]
+
+    #expect(!MeasurementTrendBuilder.spansMultipleBranches(sameBranch))
+    #expect(MeasurementTrendBuilder.spansMultipleBranches(twoBranches))
+  }
+}
+
+@Suite("Measurement branch stamping")
+struct MeasurementBranchStampingTests {
+  /// The branch has to travel into history with the values it measured,
+  /// otherwise every earlier run looks like it happened on today's branch.
+  @Test("A superseded run carries the branch it was measured on")
+  func supersededRunCarriesItsBranch() {
+    let onMain = makeMeasurement(value: 214).stamped(branchName: "main", worktreePath: nil)
+    let onRefactor = makeMeasurement(value: 163)
+      .stamped(branchName: "refactor", worktreePath: "/tmp/wt")
+      .replacing(onMain)
+
+    #expect(onRefactor.branchName == "refactor")
+    #expect(onRefactor.worktreePath == "/tmp/wt")
+    #expect(onRefactor.history?.first?.branchName == "main")
+    #expect(onRefactor.runs.map(\.branchName) == ["main", "refactor"])
+  }
+
+  @Test("Stamping preserves everything else about the record")
+  func stampingPreservesTheRest() {
+    let original = makeMeasurement(value: 214)
+    let stamped = original.stamped(branchName: "main", worktreePath: nil)
+
+    #expect(stamped.id == original.id)
+    #expect(stamped.createdAt == original.createdAt)
+    #expect(stamped.claim == original.claim)
+    #expect(stamped.query == original.query)
+    #expect(stamped.chart == original.chart)
+  }
+}
+
+// MARK: - Helpers
+
+private func makeRun(day: Int, value: Double, branch: String?) -> MeasurementRun {
+  MeasurementRun(
+    runAt: Date(timeIntervalSince1970: TimeInterval(day) * 86_400),
+    claim: "\(Int(value))s",
+    chart: MeasurementChart(
+      kind: .bar,
+      series: [MeasurementSeries(name: "Build", points: [MeasurementPoint(x: "core", y: value)])]
+    ),
+    table: nil,
+    branchName: branch
+  )
+}
+
+private func makeMeasurement(value: Double) -> MeasurementRecord {
+  MeasurementRecord(
+    id: "build-time",
+    createdAt: Date(timeIntervalSince1970: 1_000),
+    title: "Clean build time",
+    claim: "\(Int(value))s",
+    query: "xcodebuild build",
+    chart: MeasurementChart(
+      kind: .bar,
+      series: [MeasurementSeries(name: "Build", points: [MeasurementPoint(x: "core", y: value)])]
+    ),
+    sourceProvider: .claude,
+    sourceSessionId: "session-1",
+    sourceProcessId: 1
+  )
+}

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/MeasurementsSettingsViewModelTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/MeasurementsSettingsViewModelTests.swift
@@ -1,0 +1,85 @@
+import AgentHubCLIKit
+import Foundation
+import Testing
+
+@testable import AgentHubCore
+
+@MainActor
+@Suite("Measurements settings")
+struct MeasurementsSettingsViewModelTests {
+  /// Grouping is by project. Worktrees roll up to their parent repo, so there
+  /// is deliberately no per-worktree group to delete — offering one would mean
+  /// deleting a worktree's measurements and finding the card still there.
+  @Test("Measurements group by project, most recently active first")
+  func groupsByProjectMostRecentFirst() {
+    let decoded = [
+      ("/tmp/alpha", makeMeasurement(id: "a1", at: 1_000)),
+      ("/tmp/beta", makeMeasurement(id: "b1", at: 9_000)),
+      ("/tmp/alpha", makeMeasurement(id: "a2", at: 5_000))
+    ]
+
+    let groups = MeasurementsSettingsViewModel.grouped(decoded)
+
+    #expect(groups.map(\.projectPath) == ["/tmp/beta", "/tmp/alpha"])
+    #expect(groups[1].measurements.map(\.id) == ["a2", "a1"])
+  }
+
+  @Test("A group reports its display name, count and run total")
+  func groupSummarizesItself() {
+    let first = makeMeasurement(id: "a", at: 1_000)
+    let rerun = makeMeasurement(id: "b", at: 2_000).replacing(makeMeasurement(id: "b", at: 1_500))
+
+    let group = MeasurementProjectGroup(
+      projectPath: "/Users/me/code/AgentHub",
+      measurements: [first, rerun]
+    )
+
+    #expect(group.displayName == "AgentHub")
+    #expect(group.measurements.count == 2)
+    // One run for the first, two for the one that has been re-run.
+    #expect(group.runCount == 3)
+    #expect(group.lastActivityAt == Date(timeIntervalSince1970: 2_000))
+  }
+
+  /// A re-run does not change the stored creation date, so ordering on it would
+  /// make an actively-refreshed project look stale.
+  @Test("Last activity follows the latest run, not the original filing")
+  func lastActivityFollowsLatestRun() {
+    let old = makeMeasurement(id: "a", at: 1_000)
+    let refreshed = makeMeasurement(id: "a", at: 9_000).replacing(old)
+
+    let group = MeasurementProjectGroup(projectPath: "/tmp/p", measurements: [refreshed])
+
+    #expect(group.createdAtForTesting == Date(timeIntervalSince1970: 1_000))
+    #expect(group.lastActivityAt == Date(timeIntervalSince1970: 9_000))
+  }
+
+  @Test("A project path with a trailing component still yields a readable name")
+  func displayNameFallsBackToPath() {
+    #expect(MeasurementProjectGroup(projectPath: "/", measurements: []).displayName == "/")
+    #expect(MeasurementProjectGroup(projectPath: "/tmp/x", measurements: []).displayName == "x")
+  }
+}
+
+private extension MeasurementProjectGroup {
+  var createdAtForTesting: Date? {
+    measurements.map(\.createdAt).min()
+  }
+}
+
+private func makeMeasurement(id: String, at seconds: TimeInterval) -> MeasurementRecord {
+  MeasurementRecord(
+    id: id,
+    createdAt: Date(timeIntervalSince1970: seconds),
+    title: "Clean build time",
+    claim: "163s",
+    query: "xcodebuild build",
+    chart: MeasurementChart(
+      kind: .bar,
+      series: [MeasurementSeries(name: "Build", points: [MeasurementPoint(x: "core", y: 163)])]
+    ),
+    sourceProvider: .claude,
+    sourceSessionId: "session-1",
+    sourceProcessId: 1
+  )
+}

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/MigrationBaselineSupport.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/MigrationBaselineSupport.swift
@@ -1,0 +1,24 @@
+import Foundation
+import GRDB
+
+@testable import AgentHubCore
+
+/// Seeds `grdb_migrations` with every migration that ran *before* `identifier`,
+/// so opening the store applies `identifier` and everything after it.
+///
+/// Migration-preservation tests must anchor on the identifier they are testing,
+/// never on a positional `dropLast(n)`: the moment a new `vN_` migration is
+/// appended, a positional drop silently starts marking the migration under test
+/// as already-applied, and the test then exercises a schema it never created.
+func seedMigrationBaseline(before identifier: String, in db: Database) throws {
+  try db.execute(sql: "CREATE TABLE grdb_migrations (identifier TEXT NOT NULL PRIMARY KEY)")
+
+  let identifiers = SessionMetadataStore.migrationIdentifiers
+  guard let index = identifiers.firstIndex(of: identifier) else {
+    fatalError("Unknown migration identifier: \(identifier)")
+  }
+
+  for applied in identifiers[..<index] {
+    try db.execute(sql: "INSERT INTO grdb_migrations (identifier) VALUES (?)", arguments: [applied])
+  }
+}

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/SessionMeasurementStoreTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/SessionMeasurementStoreTests.swift
@@ -1,0 +1,442 @@
+import AgentHubCLIKit
+import Foundation
+import GRDB
+import Testing
+
+@testable import AgentHubCore
+
+@Suite("Session measurements store")
+struct SessionMeasurementStoreTests {
+  @Test("A measurement round-trips through SQLite with its chart intact")
+  func measurementRoundTrips() async throws {
+    let store = try SessionMetadataStore(path: temporaryMeasurementDatabasePath())
+    let measurement = makeMeasurement(id: "measurement-1")
+
+    try await store.saveMeasurement(
+      SessionMeasurementRecord(measurement: measurement, projectPath: "/tmp/project", sessionId: "session-1")
+    )
+
+    let stored = try await store.getMeasurements(forProjectPath: "/tmp/project")
+    #expect(stored.count == 1)
+    #expect(try stored.first?.decodedMeasurement() == measurement)
+  }
+
+  @Test("Measurements read back newest first")
+  func measurementsReadBackNewestFirst() async throws {
+    let store = try SessionMetadataStore(path: temporaryMeasurementDatabasePath())
+
+    for (id, timestamp) in [("older", 1_000.0), ("newer", 9_000.0)] {
+      let measurement = makeMeasurement(id: id, createdAt: Date(timeIntervalSince1970: timestamp))
+      try await store.saveMeasurement(
+        SessionMeasurementRecord(measurement: measurement, projectPath: "/tmp/project", sessionId: "session-1")
+      )
+    }
+
+    #expect(try await store.getMeasurements(forProjectPath: "/tmp/project").map(\.id) == ["newer", "older"])
+  }
+
+  @Test("Re-saving the same id replaces rather than duplicates")
+  func resavingReplacesRatherThanDuplicates() async throws {
+    let store = try SessionMetadataStore(path: temporaryMeasurementDatabasePath())
+    try await store.saveMeasurement(SessionMeasurementRecord(
+      measurement: makeMeasurement(id: "measurement-1", claim: "First reading."),
+      projectPath: "/tmp/project",
+      sessionId: "session-1"
+    ))
+    try await store.saveMeasurement(SessionMeasurementRecord(
+      measurement: makeMeasurement(id: "measurement-1", claim: "Corrected reading."),
+      projectPath: "/tmp/project",
+      sessionId: "session-1"
+    ))
+
+    let stored = try await store.getMeasurements(forProjectPath: "/tmp/project")
+    #expect(stored.count == 1)
+    #expect(try stored.first?.decodedMeasurement().claim == "Corrected reading.")
+  }
+
+  /// The whole reason measurements moved off session scope: two sessions working on
+  /// the same project must see one shared set, or last month's number is
+  /// invisible exactly when you want to compare against it.
+  @Test("Measurements are shared across sessions and providers in the same project")
+  func measurementsAreSharedAcrossSessionsAndProviders() async throws {
+    let store = try SessionMetadataStore(path: temporaryMeasurementDatabasePath())
+
+    try await store.saveMeasurement(SessionMeasurementRecord(
+      measurement: makeMeasurement(id: "from-claude", provider: .claude),
+      projectPath: "/tmp/project",
+      sessionId: "claude-session"
+    ))
+    try await store.saveMeasurement(SessionMeasurementRecord(
+      measurement: makeMeasurement(id: "from-codex", provider: .codex),
+      projectPath: "/tmp/project",
+      sessionId: "codex-session"
+    ))
+
+    let stored = try await store.getMeasurements(forProjectPath: "/tmp/project")
+    #expect(Set(stored.map(\.id)) == ["from-claude", "from-codex"])
+    #expect(Set(stored.map(\.sessionId)) == ["claude-session", "codex-session"])
+  }
+
+  @Test("Measurements are scoped to their own project")
+  func measurementsAreScopedToProject() async throws {
+    let store = try SessionMetadataStore(path: temporaryMeasurementDatabasePath())
+    try await store.saveMeasurement(
+      SessionMeasurementRecord(measurement: makeMeasurement(id: "a"), projectPath: "/tmp/alpha", sessionId: "s1")
+    )
+    try await store.saveMeasurement(
+      SessionMeasurementRecord(measurement: makeMeasurement(id: "b"), projectPath: "/tmp/beta", sessionId: "s2")
+    )
+
+    #expect(try await store.getMeasurements(forProjectPath: "/tmp/alpha").map(\.id) == ["a"])
+    #expect(try await store.getProjectPathsWithMeasurements() == ["/tmp/alpha", "/tmp/beta"])
+  }
+
+  @Test("Project lookup normalizes the path")
+  func projectLookupNormalizesPath() async throws {
+    let store = try SessionMetadataStore(path: temporaryMeasurementDatabasePath())
+    try await store.saveMeasurement(
+      SessionMeasurementRecord(measurement: makeMeasurement(id: "a"), projectPath: "/tmp/project", sessionId: "s1")
+    )
+
+    #expect(try await store.getMeasurements(forProjectPath: "/tmp/project/").map(\.id) == ["a"])
+    #expect(try await store.getMeasurements(forProjectPath: "/tmp/nested/../project").map(\.id) == ["a"])
+  }
+
+  @Test("Deleting one card leaves the rest of the project's measurements")
+  func deletingOneCardLeavesTheRest() async throws {
+    let store = try SessionMetadataStore(path: temporaryMeasurementDatabasePath())
+    for id in ["a", "b"] {
+      try await store.saveMeasurement(
+        SessionMeasurementRecord(measurement: makeMeasurement(id: id), projectPath: "/tmp/project", sessionId: "s1")
+      )
+    }
+
+    try await store.deleteMeasurement(id: "a")
+
+    #expect(try await store.getMeasurements(forProjectPath: "/tmp/project").map(\.id) == ["b"])
+  }
+
+  /// Rows with no resolved project can never be shown again, so they must be
+  /// collectable rather than accumulating invisibly forever.
+  @Test("Unscoped measurements can be swept")
+  func unscopedMeasurementsCanBeSwept() async throws {
+    let path = temporaryMeasurementDatabasePath()
+    let store = try SessionMetadataStore(path: path)
+    try await store.saveMeasurement(
+      SessionMeasurementRecord(measurement: makeMeasurement(id: "orphan"), projectPath: "", sessionId: "s1")
+    )
+    try await store.saveMeasurement(
+      SessionMeasurementRecord(measurement: makeMeasurement(id: "kept"), projectPath: "/tmp/project", sessionId: "s1")
+    )
+
+    #expect(try await store.deleteUnscopedMeasurements() == 1)
+    #expect(try await store.getMeasurements(forProjectPath: "/tmp/project").map(\.id) == ["kept"])
+  }
+
+  @Test("Measurements survive reopening the database")
+  func measurementsSurviveReopen() async throws {
+    let path = temporaryMeasurementDatabasePath()
+    let store = try SessionMetadataStore(path: path)
+    try await store.saveMeasurement(
+      SessionMeasurementRecord(measurement: makeMeasurement(id: "measurement-1"), projectPath: "/tmp/project", sessionId: "s1")
+    )
+
+    let reopened = try SessionMetadataStore(path: path)
+    #expect(try await reopened.getMeasurements(forProjectPath: "/tmp/project").map(\.id) == ["measurement-1"])
+  }
+
+  @Test("v14 migration preserves existing metadata")
+  func v14MigrationPreservesExistingMetadata() async throws {
+    let path = temporaryMeasurementDatabasePath()
+    let dbQueue = try DatabaseQueue(path: path)
+
+    try await dbQueue.write { db in
+      try seedMigrationBaseline(
+        before: SessionMetadataStore.MigrationID.createSessionMeasurements,
+        in: db
+      )
+      try seedLegacySessionMetadata(in: db)
+    }
+
+    let store = try SessionMetadataStore(path: path)
+
+    #expect(try await store.getCustomName(for: "legacy-session") == "legacy-name")
+    #expect(try await store.getPinnedSessionIds() == ["legacy-session"])
+    #expect(try await store.getMeasurements(forProjectPath: "/tmp/project").isEmpty)
+  }
+
+  /// v15 adds the project column to a table that already has rows; every one of
+  /// them has to be backfilled from the payload it already carries, or existing
+  /// measurements would silently vanish from the panel.
+  @Test("v15 migration backfills the project path from existing payloads")
+  func v15MigrationBackfillsProjectPath() async throws {
+    let path = temporaryMeasurementDatabasePath()
+    let dbQueue = try DatabaseQueue(path: path)
+    let legacy = makeMeasurement(id: "legacy-measurement", projectPath: "/tmp/project/")
+    let payload = try JSONEncoder.iso8601.encode(legacy)
+
+    try await dbQueue.write { db in
+      try seedMigrationBaseline(
+        before: SessionMetadataStore.MigrationID.addMeasurementProjectPath,
+        in: db
+      )
+      try seedLegacySessionMetadata(in: db)
+
+      // The v14 shape: no projectPath column at all.
+      try db.create(table: "session_measurements") { t in
+        t.column("id", .text).primaryKey(onConflict: .replace)
+        t.column("sessionId", .text).notNull().indexed()
+        t.column("provider", .text).notNull()
+        t.column("createdAt", .datetime).notNull()
+        t.column("payloadVersion", .integer).notNull()
+        t.column("payloadData", .blob).notNull()
+      }
+      try db.execute(
+        sql: """
+        INSERT INTO session_measurements (id, sessionId, provider, createdAt, payloadVersion, payloadData)
+        VALUES (?, ?, ?, ?, ?, ?)
+        """,
+        arguments: ["legacy-measurement", "legacy-session", "claude", Date(timeIntervalSince1970: 1_000), 1, payload]
+      )
+    }
+
+    let store = try SessionMetadataStore(path: path)
+
+    // Backfilled, normalized, and still readable — plus the older data intact.
+    #expect(try await store.getMeasurements(forProjectPath: "/tmp/project").map(\.id) == ["legacy-measurement"])
+    #expect(try await store.getCustomName(for: "legacy-session") == "legacy-name")
+  }
+}
+
+// MARK: - History
+
+@Suite("Measurement run history")
+struct MeasurementRunHistoryTests {
+  @Test("A first filing has no history and one run")
+  func firstFilingHasNoHistory() {
+    let measurement = makeMeasurement(id: "a")
+
+    #expect(measurement.history == nil)
+    #expect(measurement.runs.count == 1)
+  }
+
+  /// The compare use case: today's numbers must not erase last week's.
+  @Test("Re-running pushes the superseded values onto the history")
+  func rerunPushesSupersededValuesOntoHistory() {
+    let first = makeMeasurement(id: "a", claim: "41s", value: 41, createdAt: Date(timeIntervalSince1970: 1_000))
+    let second = makeMeasurement(id: "a", claim: "82s", value: 82, createdAt: Date(timeIntervalSince1970: 2_000))
+
+    let merged = second.replacing(first)
+
+    #expect(merged.claim == "82s")
+    #expect(merged.history?.count == 1)
+    #expect(merged.history?.first?.claim == "41s")
+    #expect(merged.history?.first?.scalarValue == 41)
+    #expect(merged.runs.map(\.scalarValue) == [41, 82])
+  }
+
+  @Test("History accumulates across several runs, oldest first")
+  func historyAccumulatesAcrossRuns() {
+    var record = makeMeasurement(id: "a", claim: "run-0", value: 0, createdAt: Date(timeIntervalSince1970: 0))
+    for index in 1...4 {
+      let next = makeMeasurement(
+        id: "a",
+        claim: "run-\(index)",
+        value: Double(index),
+        createdAt: Date(timeIntervalSince1970: TimeInterval(index) * 1_000)
+      )
+      record = next.replacing(record)
+    }
+
+    #expect(record.runs.map(\.claim) == ["run-0", "run-1", "run-2", "run-3", "run-4"])
+    #expect(record.history?.count == 4)
+  }
+
+  /// One card must not grow without bound just because it is re-run often.
+  @Test("History is capped, dropping the oldest runs")
+  func historyIsCapped() {
+    var record = makeMeasurement(id: "a", claim: "run-0", value: 0, createdAt: Date(timeIntervalSince1970: 0))
+    for index in 1...(MeasurementRecord.Limits.maxHistoryRuns + 5) {
+      let next = makeMeasurement(
+        id: "a",
+        claim: "run-\(index)",
+        value: Double(index),
+        createdAt: Date(timeIntervalSince1970: TimeInterval(index) * 1_000)
+      )
+      record = next.replacing(record)
+    }
+
+    #expect(record.history?.count == MeasurementRecord.Limits.maxHistoryRuns)
+    #expect(record.history?.first?.claim != "run-0")
+    #expect(record.claim == "run-\(MeasurementRecord.Limits.maxHistoryRuns + 5)")
+  }
+
+  @Test("History survives the SQLite round trip")
+  func historySurvivesRoundTrip() async throws {
+    let store = try SessionMetadataStore(path: temporaryMeasurementDatabasePath())
+    let first = makeMeasurement(id: "a", claim: "41s", value: 41)
+    let second = makeMeasurement(id: "a", claim: "82s", value: 82).replacing(first)
+
+    try await store.saveMeasurement(
+      SessionMeasurementRecord(measurement: second, projectPath: "/tmp/project", sessionId: "s1")
+    )
+
+    let decoded = try #require(
+      try await store.getMeasurements(forProjectPath: "/tmp/project").first?.decodedMeasurement()
+    )
+    #expect(decoded.runs.map(\.scalarValue) == [41, 82])
+  }
+
+  @Test("Only single-series single-point measurements expose a scalar")
+  func onlyScalarMeasurementsExposeAValue() {
+    #expect(makeMeasurement(id: "a", value: 41).scalarValue == 41)
+
+    let multiPoint = MeasurementRecord(
+      id: "b",
+      title: "t",
+      claim: "c",
+      chart: MeasurementChart(kind: .line, series: [
+        MeasurementSeries(name: "s", points: [MeasurementPoint(x: "1", y: 1), MeasurementPoint(x: "2", y: 2)])
+      ]),
+      sourceProvider: .claude,
+      sourceSessionId: nil,
+      sourceProcessId: 1
+    )
+    #expect(multiPoint.scalarValue == nil)
+  }
+}
+
+// MARK: - Merge ordering
+
+@MainActor
+@Suite("Measurements merge ordering")
+struct MeasurementsMergeTests {
+  @Test("Merging keeps one card per id and orders newest first")
+  func mergeDeduplicatesAndOrders() {
+    let existing = [
+      makeMeasurement(id: "a", createdAt: Date(timeIntervalSince1970: 1_000)),
+      makeMeasurement(id: "b", createdAt: Date(timeIntervalSince1970: 3_000))
+    ]
+    let incoming = [makeMeasurement(id: "c", createdAt: Date(timeIntervalSince1970: 2_000))]
+
+    let merged = CLISessionsViewModel.mergedMeasurements(existing: existing, incoming: incoming)
+
+    #expect(merged.map(\.id) == ["b", "c", "a"])
+  }
+
+  /// A record arriving from the CLI queue can race the database read that
+  /// backfills history; the newer copy must win rather than be replaced by the
+  /// older snapshot landing second.
+  @Test("Incoming wins on an id collision")
+  func incomingWinsOnCollision() {
+    let existing = [makeMeasurement(id: "a", claim: "Stale claim.")]
+    let incoming = [makeMeasurement(id: "a", claim: "Fresh claim.")]
+
+    let merged = CLISessionsViewModel.mergedMeasurements(existing: existing, incoming: incoming)
+
+    #expect(merged.count == 1)
+    #expect(merged.first?.claim == "Fresh claim.")
+  }
+}
+
+// MARK: - Project scope
+
+@Suite("Measurement project scope")
+struct MeasurementProjectScopeTests {
+  /// A worktree is the same project — splitting its measurements into their own
+  /// bucket would fragment the very history the feature accumulates.
+  @Test("A worktree rolls up to its parent repository")
+  func worktreeRollsUpToParentRepo() {
+    let key = MeasurementProjectScope.key(
+      projectPath: "/Users/me/code/app-feature-branch",
+      parentRepoPath: "/Users/me/code/app"
+    )
+    #expect(key == "/Users/me/code/app")
+  }
+
+  @Test("Without a parent repo the project path is used")
+  func fallsBackToProjectPath() {
+    #expect(MeasurementProjectScope.key(projectPath: "/Users/me/code/app", parentRepoPath: nil) == "/Users/me/code/app")
+    #expect(MeasurementProjectScope.key(projectPath: "/Users/me/code/app", parentRepoPath: "  ") == "/Users/me/code/app")
+  }
+
+  @Test("The same directory written several ways lands in one bucket")
+  func equivalentPathsNormalizeTogether() {
+    let canonical = MeasurementProjectScope.normalized("/tmp/project")
+    #expect(MeasurementProjectScope.normalized("/tmp/project/") == canonical)
+    #expect(MeasurementProjectScope.normalized("/tmp/nested/../project") == canonical)
+    #expect(MeasurementProjectScope.normalized("  /tmp/project  ") == canonical)
+  }
+
+  @Test("Root is not mangled by trailing-slash trimming")
+  func rootSurvivesNormalization() {
+    #expect(MeasurementProjectScope.normalized("/") == "/")
+  }
+}
+
+// MARK: - Helpers
+
+private extension JSONEncoder {
+  static var iso8601: JSONEncoder {
+    let encoder = JSONEncoder()
+    encoder.dateEncodingStrategy = .iso8601
+    return encoder
+  }
+}
+
+private func seedLegacySessionMetadata(in db: Database) throws {
+  try db.create(table: "session_metadata") { t in
+    t.column("sessionId", .text).primaryKey()
+    t.column("customName", .text)
+    t.column("createdAt", .datetime).notNull()
+    t.column("updatedAt", .datetime).notNull()
+    t.column("isPinned", .boolean).notNull().defaults(to: false)
+  }
+  try db.execute(
+    sql: """
+    INSERT INTO session_metadata (sessionId, customName, createdAt, updatedAt, isPinned)
+    VALUES (?, ?, ?, ?, ?)
+    """,
+    arguments: [
+      "legacy-session",
+      "legacy-name",
+      Date(timeIntervalSince1970: 1_000),
+      Date(timeIntervalSince1970: 2_000),
+      true
+    ]
+  )
+}
+
+private func makeMeasurement(
+  id: String,
+  claim: String = "GitDiffServiceTests alone is 41s.",
+  value: Double = 41,
+  createdAt: Date = Date(timeIntervalSince1970: 3_000),
+  provider: WorktreeLaunchProvider = .claude,
+  projectPath: String = "/tmp/project"
+) -> MeasurementRecord {
+  MeasurementRecord(
+    id: id,
+    createdAt: createdAt,
+    title: "Slowest test suites",
+    claim: claim,
+    query: "xcodebuild test -scheme AgentHubCore-Tests",
+    source: "AgentHubCore-Tests",
+    caveats: ["Single run, no warm cache"],
+    chart: MeasurementChart(
+      kind: .bar,
+      yLabel: "Seconds",
+      series: [MeasurementSeries(name: "Duration", points: [MeasurementPoint(x: "GitDiff", y: value)])]
+    ),
+    sourceProvider: provider,
+    sourceSessionId: "session-1",
+    sourceProjectPath: projectPath,
+    sourceProcessId: 42
+  )
+}
+
+private func temporaryMeasurementDatabasePath() -> String {
+  FileManager.default.temporaryDirectory
+    .appending(path: "session_measurements_\(UUID().uuidString).sqlite")
+    .path
+}


### PR DESCRIPTION
## Why

An agent computes something, it scrolls out of the terminal, and next week the same question gets answered by a differently-written query — so the two numbers cannot honestly be compared. This keeps the number together with the method that produced it, and makes that method repeatable.

## What

Agents file a measurement with the bundled `agenthub_record_measurement` tool and discover existing ones with `agenthub_list_measurements`. A **Measurements** button appears on a session card once its project has any; the panel shows each card's claim in plain English, a chart, an optional table, its caveats, and the query behind it.

**The agent sends a data specification, never markup.** AgentHub draws the chart with Swift Charts, so no agent-authored HTML reaches the panel, every card follows the app theme, and a card stays structured enough to re-run. A claim with no numbers behind it is rejected outright.

Settings › Measurements lists everything stored, grouped by project, with per-measurement and per-project deletion.

## Design decisions worth reviewing

- **Scoped to the project, not the session.** A measurement about a repo or a database outlives the conversation that produced it. Session scoping would hide last month's number from this month's work — precisely when you want it. Worktrees roll up to their parent repo.
- **Re-run goes back through the agent, not through AgentHub.** The stored query is arbitrary shell an agent wrote; executing it on a button click would turn a saved card into a code-execution surface. `↻` can do nothing the session could not already do.
- **Re-run accumulates rather than overwrites.** Discarding yesterday's numbers would remove the only reason to re-run.
- **Every run records its branch.** Measurements roll up to the repo, so runs from `main` and from a feature worktree land on one card; plotted as a single series they interleave (214, 163, 211, 160) and two perfectly stable branches read as a metric thrashing. The trend splits one series per branch, and the delta compares within a branch.
- **The delta is never coloured red/green.** Whether "up" is good depends on the metric — down is good for build time, bad for weekly actives — and nothing tells AgentHub which.
- **The CLI never opens the app's SQLite.** It reads a JSON index the app republishes, mirrored to worktree paths so `AGENTHUB_PROJECT_PATH` alone resolves it.
- **External data arrives through MCP.** AgentHub builds no connectors and never sees credentials; it reads a file off disk and draws a chart.

## Also fixed

Two pre-existing hazards surfaced along the way:

- Migration-preservation tests anchored on a positional `dropLast(n)`, which silently breaks whenever a `vN_` migration is appended — adding v14 broke `ProjectSimulatorPreferenceTests` exactly this way. Replaced with `seedMigrationBaseline(before:in:)`.
- A category axis that ordered itself by first appearance rather than by the data's own order, which is latent for any multi-series chart whose series cover different categories.

## Testing

- 6 new CLI suites and 9 new core suites; all measurement suites pass from a **clean checkout of each commit**, verified in a scratch worktree rather than only in the working tree.
- v14 and v15 migration-preservation tests seed a real prior-shaped database and assert existing rows survive, including the v15 backfill of `projectPath` from payloads already written.
- The wider `AgentHubCore` suite is red on this machine for pre-existing reasons (different tests fail on each run of identical code, all timing-sensitive, none in Measurements) — see `TestQuarantine.md`.

## Known gaps (tracked in `Measurements.md`)

- Scalar measurements render the number twice — once as a lone bar, once as the trend. Wants a big-number layout.
- No scheduled refresh: re-running is manual, so a tracked metric goes stale unless someone clicks.
- Nothing verifies the agent actually re-ran the query verbatim rather than re-deriving it.
- Branch names are not reconciled after a rename.

🤖 Generated with [Claude Code](https://claude.com/claude-code)