### PR TITLE
Voice: first-use reliability, HUD polish, and prompt-delivery fixes

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubDefaults.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubDefaults.swift
@@ -214,6 +214,10 @@ public enum AgentHubDefaults {
   /// Type: Bool (default: false)
   public static let voiceOnboardingCompleted = "\(keyPrefix)voice.onboardingCompleted"
 
+  /// Whether the voice HUD shows live transcript text instead of the voice
+  /// visualizer. Type: Bool (default: false)
+  public static let voiceShowTranscript = "\(keyPrefix)voice.showTranscript"
+
   // MARK: - Feature Flags
 
   /// Whether smart mode (AI-powered orchestration planning) is enabled

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/AgentHubVoiceHUDHost.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/AgentHubVoiceHUDHost.swift
@@ -9,23 +9,29 @@
 
 import AgentHubVoice
 import Foundation
+import SwiftUI
 
 extension VoiceHUDConfiguration {
-  public static let agentHub = VoiceHUDConfiguration(
-    productName: "AgentHub",
-    settings: VoiceHUDSettingsKeys(
-      mode: AgentHubDefaults.voiceMode,
-      realtimeModel: AgentHubDefaults.voiceRealtimeModel,
-      voiceName: AgentHubDefaults.voiceName,
-      vadEagerness: AgentHubDefaults.voiceVADEagerness,
-      dictationModel: AgentHubDefaults.voiceDictationModel,
-      language: AgentHubDefaults.voiceLanguage,
-      allowBargeIn: AgentHubDefaults.voiceAllowBargeIn,
-      hudFrame: AgentHubDefaults.voiceHUDFrame,
-      screenCaptureEnabled: AgentHubDefaults.voiceScreenCaptureEnabled,
-      onboardingCompleted: AgentHubDefaults.voiceOnboardingCompleted
+  // Computed (not a stored `let`) so the brand color re-resolves against the
+  // active theme each time a HUD is created.
+  public static var agentHub: VoiceHUDConfiguration {
+    VoiceHUDConfiguration(
+      productName: "AgentHub",
+      settings: VoiceHUDSettingsKeys(
+        mode: AgentHubDefaults.voiceMode,
+        realtimeModel: AgentHubDefaults.voiceRealtimeModel,
+        voiceName: AgentHubDefaults.voiceName,
+        vadEagerness: AgentHubDefaults.voiceVADEagerness,
+        dictationModel: AgentHubDefaults.voiceDictationModel,
+        language: AgentHubDefaults.voiceLanguage,
+        allowBargeIn: AgentHubDefaults.voiceAllowBargeIn,
+        hudFrame: AgentHubDefaults.voiceHUDFrame,
+        screenCaptureEnabled: AgentHubDefaults.voiceScreenCaptureEnabled,
+        onboardingCompleted: AgentHubDefaults.voiceOnboardingCompleted
+      ),
+      accentColor: .brandSecondary
     )
-  )
+  }
 }
 
 @MainActor

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/AgentHubVoiceHUDHost.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/AgentHubVoiceHUDHost.swift
@@ -27,7 +27,8 @@ extension VoiceHUDConfiguration {
         allowBargeIn: AgentHubDefaults.voiceAllowBargeIn,
         hudFrame: AgentHubDefaults.voiceHUDFrame,
         screenCaptureEnabled: AgentHubDefaults.voiceScreenCaptureEnabled,
-        onboardingCompleted: AgentHubDefaults.voiceOnboardingCompleted
+        onboardingCompleted: AgentHubDefaults.voiceOnboardingCompleted,
+        showTranscript: AgentHubDefaults.voiceShowTranscript
       ),
       accentColor: .brandSecondary
     )

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/VoiceBehaviorSettingsSection.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/VoiceBehaviorSettingsSection.swift
@@ -5,6 +5,7 @@ struct VoiceBehaviorSettingsSection: View {
   @Binding var autoSubmitDictation: Bool
   @Binding var screenCaptureEnabled: Bool
   @Binding var allowBargeIn: Bool
+  @Binding var showTranscript: Bool
   let registrationError: String?
   let onShowOnboarding: () -> Void
 
@@ -27,6 +28,15 @@ struct VoiceBehaviorSettingsSection: View {
         VStack(alignment: .leading, spacing: 2) {
           Text("Allow interrupting the assistant")
           Text("Keeps the mic live while the assistant speaks. Without headphones, speaker echo can cut replies short — leave this off on open speakers.")
+            .font(.caption)
+            .foregroundStyle(.secondary)
+        }
+      }
+
+      Toggle(isOn: $showTranscript) {
+        VStack(alignment: .leading, spacing: 2) {
+          Text("Show transcript text")
+          Text("Show live conversation text in the voice panel instead of the voice visualizer")
             .font(.caption)
             .foregroundStyle(.secondary)
         }

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/VoiceSettingsView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/VoiceSettingsView.swift
@@ -36,6 +36,9 @@ public struct VoiceSettingsView: View {
   @AppStorage(AgentHubDefaults.voiceAllowBargeIn)
   private var allowBargeIn = false
 
+  @AppStorage(AgentHubDefaults.voiceShowTranscript)
+  private var showTranscript = false
+
   @State private var showsOnboarding = false
 
   public init() {}
@@ -55,6 +58,7 @@ public struct VoiceSettingsView: View {
         autoSubmitDictation: $autoSubmitDictation,
         screenCaptureEnabled: $screenCaptureEnabled,
         allowBargeIn: $allowBargeIn,
+        showTranscript: $showTranscript,
         registrationError: agentHub?
           .voiceControlCoordinator
           .registrationErrorMessage,

--- a/app/modules/AgentHubVoice/Sources/AgentHubVoice/HUD/VoiceHUDContract.swift
+++ b/app/modules/AgentHubVoice/Sources/AgentHubVoice/HUD/VoiceHUDContract.swift
@@ -93,6 +93,9 @@ public struct VoiceHUDSettingsKeys: Sendable {
   public let hudFrame: String
   public let screenCaptureEnabled: String
   public let onboardingCompleted: String
+  /// Bool key: show live transcript text in the HUD instead of the voice
+  /// visualizer. Off by default.
+  public let showTranscript: String
 
   public init(
     mode: String,
@@ -104,7 +107,8 @@ public struct VoiceHUDSettingsKeys: Sendable {
     allowBargeIn: String,
     hudFrame: String,
     screenCaptureEnabled: String,
-    onboardingCompleted: String
+    onboardingCompleted: String,
+    showTranscript: String = "voice.showTranscript"
   ) {
     self.mode = mode
     self.realtimeModel = realtimeModel
@@ -116,6 +120,7 @@ public struct VoiceHUDSettingsKeys: Sendable {
     self.hudFrame = hudFrame
     self.screenCaptureEnabled = screenCaptureEnabled
     self.onboardingCompleted = onboardingCompleted
+    self.showTranscript = showTranscript
   }
 }
 

--- a/app/modules/AgentHubVoice/Sources/AgentHubVoice/HUD/VoiceHUDContract.swift
+++ b/app/modules/AgentHubVoice/Sources/AgentHubVoice/HUD/VoiceHUDContract.swift
@@ -8,6 +8,7 @@
 //
 
 import Foundation
+import SwiftUI
 
 // MARK: - Presenting
 
@@ -122,9 +123,17 @@ public struct VoiceHUDConfiguration: Sendable {
   /// Product name used in HUD and onboarding copy (e.g. "AgentHub").
   public let productName: String
   public let settings: VoiceHUDSettingsKeys
+  /// Host brand color for selected/emphasized HUD controls. When nil the HUD
+  /// falls back to the system accent color.
+  public let accentColor: Color?
 
-  public init(productName: String, settings: VoiceHUDSettingsKeys) {
+  public init(
+    productName: String,
+    settings: VoiceHUDSettingsKeys,
+    accentColor: Color? = nil
+  ) {
     self.productName = productName
     self.settings = settings
+    self.accentColor = accentColor
   }
 }

--- a/app/modules/AgentHubVoice/Sources/AgentHubVoice/Realtime/RealtimeAudioControllerFactory.swift
+++ b/app/modules/AgentHubVoice/Sources/AgentHubVoice/Realtime/RealtimeAudioControllerFactory.swift
@@ -16,9 +16,17 @@ public enum RealtimeAudioControllerFactory {
   }
 
   static func make(
-    controllerFactory: @escaping SwiftOpenAIAudioControllerFactory
+    controllerFactory: @escaping SwiftOpenAIAudioControllerFactory,
+    liveAudioDeadline: Duration = .seconds(2)
   ) async throws -> any RealtimeAudioControlling {
     let controller = try await controllerFactory([.record, .playback])
-    return LiveRealtimeAudioController(sharedController: controller)
+    // The first voice-processing session after app launch can come up with a
+    // dead capture stream (AUVPAggregate timeout); the wrapper rebuilds the
+    // controller once when the microphone stays digitally silent.
+    return SelfHealingRealtimeAudioController(
+      initialController: controller,
+      rebuildController: { try await controllerFactory([.record, .playback]) },
+      liveAudioDeadline: liveAudioDeadline
+    )
   }
 }

--- a/app/modules/AgentHubVoice/Sources/AgentHubVoice/Realtime/RealtimeSessionConfigurationBuilder.swift
+++ b/app/modules/AgentHubVoice/Sources/AgentHubVoice/Realtime/RealtimeSessionConfigurationBuilder.swift
@@ -2,10 +2,16 @@ import Foundation
 import SwiftOpenAI
 
 public enum RealtimeSessionConfigurationBuilder {
-  public static let instructions = """
+  private static let persona = """
     You are AgentHub's concise voice controller. Keep spoken responses brief and natural.
+    """
+
+  private static let followUserLanguage = """
     Reply in the language the user is currently speaking. If the language is unclear, use English.
     Do not switch languages because of background audio or your own spoken response.
+    """
+
+  private static let sessionDiscipline = """
     Before referring to a session, call list_sessions and use only session IDs returned by tools.
     Never invent or guess a session ID.
     For Claude approval requests, you must call approve_pending_tool without confirmed first,
@@ -16,6 +22,9 @@ public enum RealtimeSessionConfigurationBuilder {
     read_session_response and answer with a concise spoken summary of its content. Never tell
     the user that results are displayed in the panel, workspace, or screen instead of answering.
     """
+
+  public static let instructions = [persona, followUserLanguage, sessionDiscipline]
+    .joined(separator: "\n")
 
   public static let screenCaptureInstructions = """
     When the user asks about something on their screen, call capture_screen and include the
@@ -28,14 +37,19 @@ public enum RealtimeSessionConfigurationBuilder {
     for tools: VoiceToolRegistry,
     language: String? = nil
   ) -> String {
-    var combined = instructions
+    var combined: String
     if let language, let name = languageName(for: language) {
-      // Replaces the follow-the-user's-language behavior: a pinned language
-      // keeps replies stable when echo or noise distorts transcription.
-      combined += """
-        \nAlways speak and respond in \(name), regardless of the language the \
+      // A pinned language must REPLACE the follow-the-user's-language
+      // directive, not join it: sending both contradictory rules lets
+      // background audio or distorted transcription flip the reply language.
+      let pinnedLanguage = """
+        Always speak and respond in \(name), regardless of the language the \
         user's audio appears to be in. Never switch languages mid-conversation.
         """
+      combined = [persona, pinnedLanguage, sessionDiscipline]
+        .joined(separator: "\n")
+    } else {
+      combined = instructions
     }
     let hasScreenCapture = tools.tools.contains { $0.name == "capture_screen" }
     if hasScreenCapture {

--- a/app/modules/AgentHubVoice/Sources/AgentHubVoice/Realtime/RealtimeVoiceEngine.swift
+++ b/app/modules/AgentHubVoice/Sources/AgentHubVoice/Realtime/RealtimeVoiceEngine.swift
@@ -32,6 +32,11 @@ public final class RealtimeVoiceEngine {
   public private(set) var transcripts: [VoiceTranscriptEntry] = []
   public private(set) var microphoneLevel: Float = 0
   public private(set) var assistantLevel: Float = 0
+  /// True while assistant audio is audibly playing. Unlike `assistantLevel`,
+  /// which tracks network delta arrival (OpenAI streams audio much faster
+  /// than realtime), this follows actual playback so UI stays animated for
+  /// the full spoken response.
+  public private(set) var isAssistantSpeaking = false
   public private(set) var errorMessage: String?
   public private(set) var isMicrophoneMuted = false
 
@@ -145,6 +150,7 @@ public final class RealtimeVoiceEngine {
     backgroundUpdates.removeAll()
     microphoneLevel = 0
     assistantLevel = 0
+    isAssistantSpeaking = false
     isMicrophoneMuted = false
   }
 
@@ -181,9 +187,13 @@ public final class RealtimeVoiceEngine {
           // Half-duplex echo gate: while assistant audio is audibly playing,
           // drop mic frames so speaker echo can't trigger turn detection or
           // pollute transcription. Barge-in opts back into full duplex.
-          let gatedByPlayback = !allowBargeIn && audio.isPlaybackActive()
+          let playbackActive = audio.isPlaybackActive()
+          let gatedByPlayback = !allowBargeIn && playbackActive
           let level = gatedByPlayback ? 0 : Self.rms(buffer)
-          let muted = await self?.updateMicrophoneLevel(level) ?? true
+          let muted = await self?.updateAudioActivity(
+            microphoneLevel: level,
+            playbackActive: playbackActive
+          ) ?? true
           if !muted,
              !gatedByPlayback,
              await readyState.get(),
@@ -230,6 +240,7 @@ public final class RealtimeVoiceEngine {
       currentAudioItemID = itemID
       await audio.play(base64Audio: delta, itemID: itemID)
       assistantLevel = Self.pcm16Level(base64: delta)
+      isAssistantSpeaking = true
       state = .speaking
     case .responseAudioDone:
       assistantLevel = 0
@@ -242,6 +253,7 @@ public final class RealtimeVoiceEngine {
       }
       currentAudioItemID = nil
       assistantLevel = 0
+      isAssistantSpeaking = false
       state = .userSpeaking
     case .responseTranscriptDelta(_, _, let delta),
          .responseTextDelta(_, _, let delta):
@@ -337,8 +349,14 @@ public final class RealtimeVoiceEngine {
     transcripts = reducer.entries
   }
 
-  private func updateMicrophoneLevel(_ level: Float) -> Bool {
-    microphoneLevel = level
+  private func updateAudioActivity(
+    microphoneLevel: Float,
+    playbackActive: Bool
+  ) -> Bool {
+    self.microphoneLevel = microphoneLevel
+    // Mic buffers are the heartbeat (~50ms): they keep this true for the
+    // whole audible response and flip it off when the playback queue drains.
+    isAssistantSpeaking = playbackActive
     return isMicrophoneMuted
   }
 

--- a/app/modules/AgentHubVoice/Sources/AgentHubVoice/Realtime/RealtimeVoiceEngine.swift
+++ b/app/modules/AgentHubVoice/Sources/AgentHubVoice/Realtime/RealtimeVoiceEngine.swift
@@ -416,13 +416,23 @@ public final class RealtimeVoiceEngine {
       || lowercase.contains("invalid api key")
   }
 
-  private nonisolated static func rms(_ buffer: AVAudioPCMBuffer) -> Float {
+  nonisolated static func rms(_ buffer: AVAudioPCMBuffer) -> Float {
     let count = Int(buffer.frameLength)
     guard count > 0 else { return 0 }
     if let values = buffer.floatChannelData?[0] {
       var sum: Float = 0
       for index in 0..<count {
         sum += values[index] * values[index]
+      }
+      return min(1, sqrt(sum / Float(count)) * 5)
+    }
+    // The microphone vendor delivers PCM16 buffers, which expose only
+    // int16ChannelData — without this branch the level meter reads 0.
+    if let values = buffer.int16ChannelData?[0] {
+      var sum: Float = 0
+      for index in 0..<count {
+        let sample = Float(values[index]) / Float(Int16.max)
+        sum += sample * sample
       }
       return min(1, sqrt(sum / Float(count)) * 5)
     }

--- a/app/modules/AgentHubVoice/Sources/AgentHubVoice/Realtime/SelfHealingRealtimeAudioController.swift
+++ b/app/modules/AgentHubVoice/Sources/AgentHubVoice/Realtime/SelfHealingRealtimeAudioController.swift
@@ -1,0 +1,165 @@
+@preconcurrency import AVFoundation
+import OSLog
+import SwiftOpenAI
+
+private let logger = Logger(subsystem: "com.agenthub.voice", category: "Audio")
+
+/// Wraps the shared record/playback controller and heals a dead capture graph.
+///
+/// On the first voice session after app launch, enabling voice processing can fail inside
+/// CoreAudio (`AUVPAggregate: Timeout waiting for streams`, `-10877`): the engine reports it
+/// started, but the input HAL stream never runs — macOS shows no microphone indicator and the
+/// tap delivers only digital silence. A second attempt with a fresh engine reliably succeeds
+/// because the voice-processing aggregate device already exists.
+///
+/// A healthy microphone always carries a noise floor, so exact-zero samples across the deadline
+/// window mean capture is dead (or voice processing is gating true silence — rebuilding then is
+/// harmless). When that happens this controller tears the inner controller down and rebuilds it
+/// once, piping the fresh capture into the same outer stream so the session never notices.
+@RealtimeActor
+final class SelfHealingRealtimeAudioController: RealtimeAudioControlling {
+  init(
+    initialController: any SwiftOpenAIAudioControlling,
+    rebuildController: @escaping @RealtimeActor @Sendable () async throws
+      -> any SwiftOpenAIAudioControlling,
+    liveAudioDeadline: Duration = .seconds(2)
+  ) {
+    controller = initialController
+    self.rebuildController = rebuildController
+    self.liveAudioDeadline = liveAudioDeadline
+  }
+
+  func microphoneStream() throws -> AsyncStream<AVAudioPCMBuffer> {
+    let inner = try controller.microphoneStream()
+    let stream = AsyncStream<AVAudioPCMBuffer> { [weak self] continuation in
+      guard let this = self else {
+        continuation.finish()
+        return
+      }
+      this.continuation = continuation
+    }
+    pump(inner)
+    scheduleWatchdog()
+    return stream
+  }
+
+  func play(base64Audio: String, itemID: String?) {
+    controller.playPCM16Audio(base64String: base64Audio, itemID: itemID)
+  }
+
+  func interruptPlayback() async -> Int? {
+    await controller.interruptPlayback()
+  }
+
+  func isPlaybackActive() -> Bool {
+    controller.playbackIsActive()
+  }
+
+  func stop() {
+    isStopped = true
+    watchdogTask?.cancel()
+    watchdogTask = nil
+    pumpTask?.cancel()
+    pumpTask = nil
+    continuation?.finish()
+    continuation = nil
+    controller.stop()
+  }
+
+  private var controller: any SwiftOpenAIAudioControlling
+  private let rebuildController: @RealtimeActor @Sendable () async throws
+    -> any SwiftOpenAIAudioControlling
+  private let liveAudioDeadline: Duration
+  private var continuation: AsyncStream<AVAudioPCMBuffer>.Continuation?
+  private var pumpTask: Task<Void, Never>?
+  private var watchdogTask: Task<Void, Never>?
+  private var hasSeenLiveAudio = false
+  private var hasRebuilt = false
+  private var isStopped = false
+
+  private func pump(_ inner: AsyncStream<AVAudioPCMBuffer>) {
+    pumpTask?.cancel()
+    pumpTask = Task { @RealtimeActor [weak self] in
+      for await buffer in inner {
+        guard let self, !Task.isCancelled else { return }
+        if !hasSeenLiveAudio, Self.containsLiveAudio(buffer) {
+          hasSeenLiveAudio = true
+        }
+        continuation?.yield(buffer)
+      }
+      guard let self, !Task.isCancelled else { return }
+      continuation?.finish()
+      continuation = nil
+    }
+  }
+
+  private func scheduleWatchdog() {
+    watchdogTask?.cancel()
+    watchdogTask = Task { @RealtimeActor [weak self] in
+      guard let deadline = self?.liveAudioDeadline else { return }
+      try? await Task.sleep(for: deadline)
+      guard !Task.isCancelled else { return }
+      await self?.rebuildIfCaptureIsDead()
+    }
+  }
+
+  private func rebuildIfCaptureIsDead() async {
+    guard !isStopped, !hasRebuilt, !hasSeenLiveAudio else { return }
+    // Rebuilding swaps the shared playback graph too — don't cut off audible
+    // assistant audio; check again after another deadline window.
+    guard !controller.playbackIsActive() else {
+      scheduleWatchdog()
+      return
+    }
+    hasRebuilt = true
+    logger.warning(
+      "Microphone capture produced no live audio; rebuilding the voice audio graph"
+    )
+    pumpTask?.cancel()
+    pumpTask = nil
+    // Audio teardown blocks on default-QoS CoreAudio work; keep it at utility
+    // so it doesn't trip the priority-inversion diagnostic.
+    let previous = controller
+    await Task.detached(priority: .utility) {
+      await previous.stop()
+    }.value
+    guard !isStopped else { return }
+    do {
+      let fresh = try await rebuildController()
+      controller = fresh
+      pump(try fresh.microphoneStream())
+      logger.info("Voice audio graph rebuilt after dead capture")
+    } catch {
+      logger.error(
+        "Voice audio graph rebuild failed: \(error.localizedDescription)"
+      )
+      continuation?.finish()
+      continuation = nil
+    }
+  }
+
+  private nonisolated static func containsLiveAudio(
+    _ buffer: AVAudioPCMBuffer
+  ) -> Bool {
+    let frames = Int(buffer.frameLength)
+    guard frames > 0 else { return false }
+    let channels = Int(buffer.format.channelCount)
+    if let int16Data = buffer.int16ChannelData {
+      for channel in 0..<channels {
+        for frame in 0..<frames where int16Data[channel][frame] != 0 {
+          return true
+        }
+      }
+      return false
+    }
+    if let floatData = buffer.floatChannelData {
+      for channel in 0..<channels {
+        for frame in 0..<frames where floatData[channel][frame] != 0 {
+          return true
+        }
+      }
+      return false
+    }
+    return false
+  }
+}

--- a/app/modules/AgentHubVoice/Sources/AgentHubVoicePanel/AppKitVoiceHUDPresenter.swift
+++ b/app/modules/AgentHubVoice/Sources/AgentHubVoicePanel/AppKitVoiceHUDPresenter.swift
@@ -130,7 +130,11 @@ public final class AppKitVoiceHUDPresenter: VoiceHUDPresenting {
     self.viewModel = viewModel
     newPanel.orderFrontRegardless()
     newPanel.makeKey()
-    viewModel.toggleMicrophone()
+    // Deliberately no auto-start: the mic button is the single start/stop
+    // control. Auto-starting here made the user's first tap on the mic button
+    // STOP the just-started session (a ~1s start/teardown cycle that looks
+    // like "voice doesn't work the first time"), and raced the onboarding
+    // sheet's own start button the same way.
     #endif
   }
 

--- a/app/modules/AgentHubVoice/Sources/AgentHubVoicePanel/VoiceActivityVisualizer.swift
+++ b/app/modules/AgentHubVoice/Sources/AgentHubVoicePanel/VoiceActivityVisualizer.swift
@@ -8,6 +8,7 @@ struct VoiceActivityVisualizer: View {
   let voiceId: String
   let realtimeState: VoiceEngineState
   let dictationState: DictationState
+  let isAssistantSpeaking: Bool
   let microphoneLevel: Float
   let assistantLevel: Float
   var accentColor: Color?
@@ -23,6 +24,7 @@ struct VoiceActivityVisualizer: View {
         VoiceConversationOrb(
           voice: voice,
           state: realtimeState,
+          isAssistantSpeaking: isAssistantSpeaking,
           microphoneLevel: microphoneLevel,
           assistantLevel: assistantLevel
         )

--- a/app/modules/AgentHubVoice/Sources/AgentHubVoicePanel/VoiceActivityVisualizer.swift
+++ b/app/modules/AgentHubVoice/Sources/AgentHubVoicePanel/VoiceActivityVisualizer.swift
@@ -1,0 +1,39 @@
+import AgentHubVoice
+import SwiftUI
+
+/// Occupies the transcript area when transcript text is hidden: the selected
+/// voice's orb in converse mode, an animated dictation symbol in dictate mode.
+struct VoiceActivityVisualizer: View {
+  let mode: VoiceHUDMode
+  let voiceId: String
+  let realtimeState: VoiceEngineState
+  let dictationState: DictationState
+  let microphoneLevel: Float
+  let assistantLevel: Float
+  var accentColor: Color?
+
+  private var voice: VoiceOption {
+    VoiceOption.all.first { $0.id == voiceId } ?? VoiceOption.all[0]
+  }
+
+  var body: some View {
+    Group {
+      switch mode {
+      case .converse:
+        VoiceConversationOrb(
+          voice: voice,
+          state: realtimeState,
+          microphoneLevel: microphoneLevel,
+          assistantLevel: assistantLevel
+        )
+      case .dictate:
+        VoiceDictationIndicator(
+          state: dictationState,
+          level: microphoneLevel,
+          accentColor: accentColor
+        )
+      }
+    }
+    .frame(minHeight: 140, maxHeight: .infinity)
+  }
+}

--- a/app/modules/AgentHubVoice/Sources/AgentHubVoicePanel/VoiceConversationOrb.swift
+++ b/app/modules/AgentHubVoice/Sources/AgentHubVoicePanel/VoiceConversationOrb.swift
@@ -1,0 +1,92 @@
+import AgentHubVoice
+import SwiftUI
+
+/// The converse-mode visualizer: an orb in the selected voice's gradient that
+/// swells with whoever is louder (user or assistant), breathes gently while
+/// idle, and dims while disconnected.
+struct VoiceConversationOrb: View {
+  let voice: VoiceOption
+  let state: VoiceEngineState
+  let microphoneLevel: Float
+  let assistantLevel: Float
+
+  @Environment(\.accessibilityReduceMotion) private var reduceMotion
+  @State private var isBreathing = false
+
+  private var level: CGFloat {
+    CGFloat(max(microphoneLevel, assistantLevel))
+  }
+
+  private var isConnected: Bool {
+    switch state {
+    case .disconnected, .failed:
+      false
+    default:
+      true
+    }
+  }
+
+  var body: some View {
+    ZStack {
+      Circle()
+        .fill(
+          RadialGradient(
+            colors: [voice.gradient.first?.opacity(0.45) ?? .clear, .clear],
+            center: .center,
+            startRadius: 10,
+            endRadius: 90
+          )
+        )
+        .frame(width: 180, height: 180)
+        .scaleEffect(haloScale)
+
+      Circle()
+        .fill(
+          LinearGradient(
+            colors: voice.gradient,
+            startPoint: .topLeading,
+            endPoint: .bottomTrailing
+          )
+        )
+        .frame(width: 104, height: 104)
+        .overlay {
+          Circle()
+            .fill(
+              RadialGradient(
+                colors: [Color.white.opacity(0.35), .clear],
+                center: .init(x: 0.3, y: 0.25),
+                startRadius: 2,
+                endRadius: 60
+              )
+            )
+        }
+        .scaleEffect(coreScale)
+        .opacity(isConnected ? 1 : 0.45)
+    }
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+    .animation(.smooth(duration: 0.15), value: level)
+    .animation(.smooth(duration: 0.3), value: isConnected)
+    .onAppear {
+      guard !reduceMotion else { return }
+      withAnimation(.easeInOut(duration: 2.4).repeatForever(autoreverses: true)) {
+        isBreathing = true
+      }
+    }
+    .accessibilityElement()
+    .accessibilityLabel("\(voice.title) voice activity")
+  }
+
+  private var breathScale: CGFloat {
+    isBreathing ? 1.04 : 1.0
+  }
+
+  private var coreScale: CGFloat {
+    guard isConnected else { return 1 }
+    return breathScale + level * 0.22
+  }
+
+  private var haloScale: CGFloat {
+    guard isConnected else { return 0.9 }
+    return breathScale + level * 0.5
+  }
+}

--- a/app/modules/AgentHubVoice/Sources/AgentHubVoicePanel/VoiceConversationOrb.swift
+++ b/app/modules/AgentHubVoice/Sources/AgentHubVoicePanel/VoiceConversationOrb.swift
@@ -7,11 +7,16 @@ import SwiftUI
 struct VoiceConversationOrb: View {
   let voice: VoiceOption
   let state: VoiceEngineState
+  /// True while assistant audio is audibly playing — drives a continuous
+  /// pulse for the whole spoken response, because the levels only track
+  /// network delta arrival and go quiet while audio is still playing.
+  let isAssistantSpeaking: Bool
   let microphoneLevel: Float
   let assistantLevel: Float
 
   @Environment(\.accessibilityReduceMotion) private var reduceMotion
   @State private var isBreathing = false
+  @State private var isSpeakingPulse = false
 
   private var level: CGFloat {
     CGFloat(max(microphoneLevel, assistantLevel))
@@ -71,22 +76,47 @@ struct VoiceConversationOrb: View {
       withAnimation(.easeInOut(duration: 2.4).repeatForever(autoreverses: true)) {
         isBreathing = true
       }
+      updateSpeakingPulse(isAssistantSpeaking)
+    }
+    .onChange(of: isAssistantSpeaking) { _, speaking in
+      updateSpeakingPulse(speaking)
     }
     .accessibilityElement()
     .accessibilityLabel("\(voice.title) voice activity")
+  }
+
+  private func updateSpeakingPulse(_ speaking: Bool) {
+    guard !reduceMotion else { return }
+    if speaking {
+      withAnimation(.easeInOut(duration: 0.45).repeatForever(autoreverses: true)) {
+        isSpeakingPulse = true
+      }
+    } else {
+      withAnimation(.smooth(duration: 0.3)) {
+        isSpeakingPulse = false
+      }
+    }
   }
 
   private var breathScale: CGFloat {
     isBreathing ? 1.04 : 1.0
   }
 
+  private var speakingBoost: CGFloat {
+    // Reduce Motion still gets a static swell so "speaking" stays visible.
+    if reduceMotion {
+      return isAssistantSpeaking ? 0.08 : 0.0
+    }
+    return isSpeakingPulse ? 0.1 : 0.0
+  }
+
   private var coreScale: CGFloat {
     guard isConnected else { return 1 }
-    return breathScale + level * 0.22
+    return breathScale + speakingBoost + level * 0.22
   }
 
   private var haloScale: CGFloat {
     guard isConnected else { return 0.9 }
-    return breathScale + level * 0.5
+    return breathScale + speakingBoost * 1.6 + level * 0.5
   }
 }

--- a/app/modules/AgentHubVoice/Sources/AgentHubVoicePanel/VoiceDictationIndicator.swift
+++ b/app/modules/AgentHubVoice/Sources/AgentHubVoicePanel/VoiceDictationIndicator.swift
@@ -1,0 +1,74 @@
+import AgentHubVoice
+import SwiftUI
+
+/// The dictate-mode visualizer: an animated SF Symbol that ripples while
+/// recording, pulses while transcribing, and rests dimmed when idle.
+struct VoiceDictationIndicator: View {
+  let state: DictationState
+  let level: Float
+  var accentColor: Color?
+
+  @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+  private var isRecording: Bool {
+    state == .recording
+  }
+
+  private var isTranscribing: Bool {
+    state == .transcribing
+  }
+
+  private var symbolName: String {
+    switch state {
+    case .recording:
+      "waveform"
+    case .transcribing:
+      "ellipsis"
+    case .idle, .failed:
+      "mic"
+    }
+  }
+
+  private var caption: String {
+    switch state {
+    case .recording:
+      "Listening…"
+    case .transcribing:
+      "Transcribing…"
+    case .idle, .failed:
+      "Ready to listen"
+    }
+  }
+
+  var body: some View {
+    VStack(spacing: 12) {
+      Image(systemName: symbolName)
+        .font(.system(size: 44, weight: .light))
+        .symbolRenderingMode(.hierarchical)
+        .foregroundStyle(
+          isRecording ? (accentColor ?? .accentColor) : Color.secondary
+        )
+        .symbolEffect(
+          .variableColor.iterative,
+          options: .repeating,
+          isActive: isRecording && !reduceMotion
+        )
+        .symbolEffect(
+          .pulse,
+          options: .repeating,
+          isActive: isTranscribing && !reduceMotion
+        )
+        .scaleEffect(isRecording ? 1 + CGFloat(level) * 0.2 : 1)
+        .animation(.smooth(duration: 0.15), value: level)
+        .contentTransition(.symbolEffect(.replace))
+
+      Text(caption)
+        .font(.caption)
+        .foregroundStyle(.secondary)
+    }
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+    .animation(.smooth(duration: 0.25), value: symbolName)
+    .accessibilityElement()
+    .accessibilityLabel(caption)
+  }
+}

--- a/app/modules/AgentHubVoice/Sources/AgentHubVoicePanel/VoiceHUDChrome.swift
+++ b/app/modules/AgentHubVoice/Sources/AgentHubVoicePanel/VoiceHUDChrome.swift
@@ -1,0 +1,29 @@
+import SwiftUI
+
+/// The HUD panel's window chrome: Liquid Glass on macOS 26+, falling back to a
+/// material card on earlier systems. Glass draws its own edge highlight, so the
+/// manual hairline stroke only exists on the fallback path.
+struct VoiceHUDChrome: ViewModifier {
+  private static let shape = RoundedRectangle(cornerRadius: 18, style: .continuous)
+
+  func body(content: Content) -> some View {
+    if #available(macOS 26.0, *) {
+      content
+        .glassEffect(.regular, in: Self.shape)
+    } else {
+      content
+        .background(.regularMaterial)
+        .clipShape(Self.shape)
+        .overlay {
+          Self.shape
+            .stroke(.secondary.opacity(0.2))
+        }
+    }
+  }
+}
+
+extension View {
+  func voiceHUDChrome() -> some View {
+    modifier(VoiceHUDChrome())
+  }
+}

--- a/app/modules/AgentHubVoice/Sources/AgentHubVoicePanel/VoiceHUDView.swift
+++ b/app/modules/AgentHubVoice/Sources/AgentHubVoicePanel/VoiceHUDView.swift
@@ -22,7 +22,10 @@ public struct VoiceHUDView: View {
         onClose: onClose
       )
 
-      VoiceModeToggle(mode: $viewModel.mode)
+      VoiceModeToggle(
+        mode: $viewModel.mode,
+        accentColor: viewModel.configuration.accentColor
+      )
 
       VoiceTargetChip(
         target: viewModel.target,

--- a/app/modules/AgentHubVoice/Sources/AgentHubVoicePanel/VoiceHUDView.swift
+++ b/app/modules/AgentHubVoice/Sources/AgentHubVoicePanel/VoiceHUDView.swift
@@ -4,6 +4,8 @@ import SwiftUI
 public struct VoiceHUDView: View {
   @State private var viewModel: VoiceHUDViewModel
   @State private var showsOnboarding = false
+  @AppStorage private var showsTranscript: Bool
+  @AppStorage private var selectedVoiceId: String
 
   let onClose: () -> Void
 
@@ -12,6 +14,14 @@ public struct VoiceHUDView: View {
     onClose: @escaping () -> Void = {}
   ) {
     _viewModel = State(initialValue: viewModel)
+    _showsTranscript = AppStorage(
+      wrappedValue: false,
+      viewModel.configuration.settings.showTranscript
+    )
+    _selectedVoiceId = AppStorage(
+      wrappedValue: VoiceOption.all[0].id,
+      viewModel.configuration.settings.voiceName
+    )
     self.onClose = onClose
   }
 
@@ -33,7 +43,19 @@ public struct VoiceHUDView: View {
         onSelect: viewModel.selectTarget
       )
 
-      VoiceTranscriptList(entries: viewModel.transcripts)
+      if showsTranscript {
+        VoiceTranscriptList(entries: viewModel.transcripts)
+      } else {
+        VoiceActivityVisualizer(
+          mode: viewModel.mode,
+          voiceId: selectedVoiceId,
+          realtimeState: viewModel.realtimeState,
+          dictationState: viewModel.dictationState,
+          microphoneLevel: viewModel.microphoneLevel,
+          assistantLevel: viewModel.assistantLevel,
+          accentColor: viewModel.configuration.accentColor
+        )
+      }
 
       if let errorMessage = viewModel.errorMessage {
         VoiceHUDErrorBanner(message: errorMessage)

--- a/app/modules/AgentHubVoice/Sources/AgentHubVoicePanel/VoiceHUDView.swift
+++ b/app/modules/AgentHubVoice/Sources/AgentHubVoicePanel/VoiceHUDView.swift
@@ -51,6 +51,7 @@ public struct VoiceHUDView: View {
           voiceId: selectedVoiceId,
           realtimeState: viewModel.realtimeState,
           dictationState: viewModel.dictationState,
+          isAssistantSpeaking: viewModel.isAssistantSpeaking,
           microphoneLevel: viewModel.microphoneLevel,
           assistantLevel: viewModel.assistantLevel,
           accentColor: viewModel.configuration.accentColor

--- a/app/modules/AgentHubVoice/Sources/AgentHubVoicePanel/VoiceHUDView.swift
+++ b/app/modules/AgentHubVoice/Sources/AgentHubVoicePanel/VoiceHUDView.swift
@@ -46,12 +46,7 @@ public struct VoiceHUDView: View {
     }
     .padding(16)
     .frame(maxWidth: .infinity, maxHeight: .infinity)
-    .background(.regularMaterial)
-    .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
-    .overlay {
-      RoundedRectangle(cornerRadius: 18, style: .continuous)
-        .stroke(.secondary.opacity(0.2))
-    }
+    .voiceHUDChrome()
     .onChange(of: viewModel.mode) { _, _ in
       viewModel.handleModeChange()
     }

--- a/app/modules/AgentHubVoice/Sources/AgentHubVoicePanel/VoiceHUDViewModel.swift
+++ b/app/modules/AgentHubVoice/Sources/AgentHubVoicePanel/VoiceHUDViewModel.swift
@@ -67,6 +67,19 @@ public final class VoiceHUDViewModel {
     }
   }
 
+  public var assistantLevel: Float {
+    switch mode {
+    case .dictate:
+      0
+    case .converse:
+      engine.assistantLevel
+    }
+  }
+
+  public var dictationState: DictationState {
+    dictationController?.state ?? .idle
+  }
+
   public var isActive: Bool {
     switch mode {
     case .dictate:

--- a/app/modules/AgentHubVoice/Sources/AgentHubVoicePanel/VoiceHUDViewModel.swift
+++ b/app/modules/AgentHubVoice/Sources/AgentHubVoicePanel/VoiceHUDViewModel.swift
@@ -76,6 +76,10 @@ public final class VoiceHUDViewModel {
     }
   }
 
+  public var isAssistantSpeaking: Bool {
+    mode == .converse && engine.isAssistantSpeaking
+  }
+
   public var dictationState: DictationState {
     dictationController?.state ?? .idle
   }

--- a/app/modules/AgentHubVoice/Sources/AgentHubVoicePanel/VoiceModeToggle.swift
+++ b/app/modules/AgentHubVoice/Sources/AgentHubVoicePanel/VoiceModeToggle.swift
@@ -1,14 +1,18 @@
+import AgentHubVoice
 import SwiftUI
 
 struct VoiceModeToggle: View {
   @Binding var mode: VoiceHUDMode
+  var accentColor: Color?
 
   var body: some View {
-    Picker("Voice mode", selection: $mode) {
-      ForEach(VoiceHUDMode.allCases, id: \.self) { mode in
-        Text(mode.label).tag(mode)
-      }
-    }
-    .pickerStyle(.segmented)
+    VoicePillSegmentedControl(
+      selection: $mode,
+      items: VoiceHUDMode.allCases.map { mode in
+        VoicePillSegmentedControlItem(value: mode, title: mode.label)
+      },
+      selectedColor: accentColor,
+      accessibilityLabel: "Voice mode"
+    )
   }
 }

--- a/app/modules/AgentHubVoice/Sources/AgentHubVoicePanel/VoicePillSegmentedControl.swift
+++ b/app/modules/AgentHubVoice/Sources/AgentHubVoicePanel/VoicePillSegmentedControl.swift
@@ -1,0 +1,96 @@
+import SwiftUI
+
+struct VoicePillSegmentedControlItem<Value: Hashable>: Identifiable {
+  let value: Value
+  let title: String
+  let helpText: String?
+
+  var id: AnyHashable {
+    AnyHashable(value)
+  }
+
+  init(value: Value, title: String, helpText: String? = nil) {
+    self.value = value
+    self.title = title
+    self.helpText = helpText
+  }
+}
+
+/// The panel-module twin of the app's `CompactPillSegmentedControl` (this
+/// module cannot import it): same track, pill, metrics, and spring selection
+/// animation, with the selected color injected via `VoiceHUDConfiguration`.
+struct VoicePillSegmentedControl<Value: Hashable>: View {
+  private static var controlHeight: CGFloat { 26 }
+  private static var selectedPillVerticalInset: CGFloat { 2 }
+
+  @Binding var selection: Value
+  let items: [VoicePillSegmentedControlItem<Value>]
+  var selectedColor: Color?
+  var accessibilityLabel = "Segmented control"
+
+  @Environment(\.accessibilityReduceMotion) private var reduceMotion
+  @Environment(\.colorScheme) private var colorScheme
+  @Namespace private var selectionNamespace
+
+  var body: some View {
+    HStack(spacing: 2) {
+      ForEach(items) { item in
+        segmentButton(for: item)
+      }
+    }
+    .padding(2)
+    .frame(height: Self.controlHeight)
+    .background(controlFill, in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+    .overlay {
+      RoundedRectangle(cornerRadius: 8, style: .continuous)
+        .strokeBorder(controlBorder, lineWidth: 1)
+    }
+    .fixedSize(horizontal: true, vertical: false)
+    .accessibilityElement(children: .contain)
+    .accessibilityLabel(accessibilityLabel)
+  }
+
+  private func segmentButton(
+    for item: VoicePillSegmentedControlItem<Value>
+  ) -> some View {
+    let isSelected = selection == item.value
+    let pillColor = selectedColor ?? Color.accentColor
+
+    return Button {
+      withAnimation(selectionAnimation) {
+        selection = item.value
+      }
+    } label: {
+      Text(item.title)
+        .font(.system(size: 10))
+        .lineLimit(1)
+        .foregroundStyle(isSelected ? Color.white : Color.secondary)
+        .padding(.horizontal, 14)
+        .frame(height: Self.controlHeight - (Self.selectedPillVerticalInset * 2))
+        .background {
+          if isSelected {
+            RoundedRectangle(cornerRadius: 6, style: .continuous)
+              .fill(pillColor)
+              .matchedGeometryEffect(id: "selected-pill", in: selectionNamespace)
+              .shadow(color: pillColor.opacity(0.18), radius: 6, y: 1)
+          }
+        }
+        .contentShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+    }
+    .buttonStyle(.plain)
+    .help(item.helpText ?? item.title)
+    .accessibilityAddTraits(isSelected ? .isSelected : [])
+  }
+
+  private var selectionAnimation: Animation? {
+    reduceMotion ? nil : .spring(response: 0.28, dampingFraction: 0.86)
+  }
+
+  private var controlFill: Color {
+    colorScheme == .dark ? Color.white.opacity(0.07) : Color.black.opacity(0.06)
+  }
+
+  private var controlBorder: Color {
+    colorScheme == .dark ? Color.white.opacity(0.08) : Color.black.opacity(0.12)
+  }
+}

--- a/app/modules/AgentHubVoice/Tests/AgentHubVoiceTests/RealtimeSessionConfigurationBuilderTests.swift
+++ b/app/modules/AgentHubVoice/Tests/AgentHubVoiceTests/RealtimeSessionConfigurationBuilderTests.swift
@@ -77,6 +77,15 @@ struct RealtimeSessionConfigurationBuilderTests {
     #expect(turnDetection["interrupt_response"] as? Bool == false)
     #expect(instructions.contains("Always speak and respond in Spanish"))
     #expect(instructions.contains("Never switch languages"))
+    // The pin must REPLACE the follow-the-user's-language directive — sending
+    // both contradictory rules lets background audio flip the reply language.
+    #expect(
+      !instructions.contains("Reply in the language the user is currently speaking")
+    )
+    #expect(!instructions.contains("If the language is unclear, use English."))
+    // Pinning must not drop the session/approval discipline rules.
+    #expect(instructions.contains("call list_sessions"))
+    #expect(instructions.contains("explicit confirmation"))
   }
 
   @Test

--- a/app/modules/AgentHubVoice/Tests/AgentHubVoiceTests/RealtimeVoiceEngineLevelTests.swift
+++ b/app/modules/AgentHubVoice/Tests/AgentHubVoiceTests/RealtimeVoiceEngineLevelTests.swift
@@ -1,0 +1,55 @@
+import AVFoundation
+import Testing
+@testable import AgentHubVoice
+
+struct RealtimeVoiceEngineLevelTests {
+  private func makeInt16Buffer(sample: Int16) -> AVAudioPCMBuffer {
+    let format = AVAudioFormat(
+      commonFormat: .pcmFormatInt16,
+      sampleRate: 24000,
+      channels: 1,
+      interleaved: false
+    )!
+    let frames: AVAudioFrameCount = 240
+    let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: frames)!
+    buffer.frameLength = frames
+    if let data = buffer.int16ChannelData {
+      for frame in 0..<Int(frames) {
+        data[0][frame] = sample
+      }
+    }
+    return buffer
+  }
+
+  @Test
+  func rmsReadsPCM16Buffers() {
+    // The microphone vendor delivers Int16 buffers; the level meter must not
+    // silently read 0 for them.
+    let level = RealtimeVoiceEngine.rms(makeInt16Buffer(sample: 8000))
+    #expect(level > 0.5)
+  }
+
+  @Test
+  func rmsIsZeroForDigitalSilence() {
+    #expect(RealtimeVoiceEngine.rms(makeInt16Buffer(sample: 0)) == 0)
+  }
+
+  @Test
+  func rmsReadsFloatBuffers() {
+    let format = AVAudioFormat(
+      commonFormat: .pcmFormatFloat32,
+      sampleRate: 24000,
+      channels: 1,
+      interleaved: false
+    )!
+    let frames: AVAudioFrameCount = 240
+    let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: frames)!
+    buffer.frameLength = frames
+    if let data = buffer.floatChannelData {
+      for frame in 0..<Int(frames) {
+        data[0][frame] = 0.25
+      }
+    }
+    #expect(RealtimeVoiceEngine.rms(buffer) > 0.5)
+  }
+}

--- a/app/modules/AgentHubVoice/Tests/AgentHubVoiceTests/RealtimeVoiceEngineTests.swift
+++ b/app/modules/AgentHubVoice/Tests/AgentHubVoiceTests/RealtimeVoiceEngineTests.swift
@@ -425,6 +425,42 @@ struct RealtimeVoiceEngineTests {
     #expect(sentAfterPlayback)
   }
 
+  @Test
+  func assistantSpeakingFollowsAudiblePlaybackNotDeltaArrival() async {
+    let transport = await FakeRealtimeTransport()
+    let audio = await FakeRealtimeAudioController()
+    let engine = makeEngine(transport: transport, audio: audio)
+
+    await engine.start(
+      service: OpenAIServiceFactory.service(apiKey: "test"),
+      settings: VoiceEngineSettings(),
+      tools: VoiceToolRegistry(tools: [])
+    )
+    transport.yield(.sessionUpdated)
+    await waitUntil { engine.state == .idle }
+
+    // A delta starts speaking immediately, without waiting for a mic tick.
+    await audio.setPlaybackActive(true)
+    transport.yield(
+      .responseAudioDelta(itemID: "item-1", responseID: "resp-1", delta: "")
+    )
+    await waitUntil { engine.isAssistantSpeaking }
+    #expect(engine.isAssistantSpeaking)
+
+    // Deltas stop arriving (network done) while audio is still audibly
+    // playing — the orb must keep animating through the whole response.
+    transport.yield(.responseAudioDone(itemID: "item-1", responseID: "resp-1"))
+    await audio.yieldMicrophoneBuffer()
+    await waitUntil { engine.assistantLevel == 0 }
+    #expect(engine.isAssistantSpeaking)
+
+    // The playback queue drains; the next mic tick flips speaking off.
+    await audio.setPlaybackActive(false)
+    await audio.yieldMicrophoneBuffer()
+    await waitUntil { !engine.isAssistantSpeaking }
+    #expect(!engine.isAssistantSpeaking)
+  }
+
   private func makeEngine(
     transport: FakeRealtimeTransport,
     audio: FakeRealtimeAudioController

--- a/app/modules/AgentHubVoice/Tests/AgentHubVoiceTests/SelfHealingRealtimeAudioControllerTests.swift
+++ b/app/modules/AgentHubVoice/Tests/AgentHubVoiceTests/SelfHealingRealtimeAudioControllerTests.swift
@@ -1,0 +1,227 @@
+import AVFoundation
+import SwiftOpenAI
+import Testing
+@testable import AgentHubVoice
+
+@RealtimeActor
+private final class ScriptedAudioController: SwiftOpenAIAudioControlling {
+  private(set) var microphoneStartCount = 0
+  private(set) var stopCount = 0
+  var playbackActive = false
+  private var micContinuation: AsyncStream<AVAudioPCMBuffer>.Continuation?
+
+  func microphoneStream() throws -> AsyncStream<AVAudioPCMBuffer> {
+    microphoneStartCount += 1
+    return AsyncStream { continuation in
+      self.micContinuation = continuation
+    }
+  }
+
+  func vend(_ buffer: AVAudioPCMBuffer) {
+    micContinuation?.yield(buffer)
+  }
+
+  func playPCM16Audio(base64String _: String, itemID _: String?) {}
+
+  func interruptPlayback() async -> Int? {
+    nil
+  }
+
+  func playbackIsActive() -> Bool {
+    playbackActive
+  }
+
+  func stop() {
+    stopCount += 1
+    micContinuation?.finish()
+    micContinuation = nil
+  }
+}
+
+@RealtimeActor
+private final class RebuildFactorySpy {
+  private let replacements: [ScriptedAudioController]
+  private(set) var rebuildCount = 0
+
+  init(replacements: [ScriptedAudioController]) {
+    self.replacements = replacements
+  }
+
+  func make() throws -> any SwiftOpenAIAudioControlling {
+    let controller = replacements[rebuildCount]
+    rebuildCount += 1
+    return controller
+  }
+}
+
+private func makeBuffer(sample: Int16) -> AVAudioPCMBuffer {
+  let format = AVAudioFormat(
+    commonFormat: .pcmFormatInt16,
+    sampleRate: 24000,
+    channels: 1,
+    interleaved: false
+  )!
+  let frames: AVAudioFrameCount = 240
+  let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: frames)!
+  buffer.frameLength = frames
+  if let data = buffer.int16ChannelData {
+    for frame in 0..<Int(frames) {
+      data[0][frame] = sample
+    }
+  }
+  return buffer
+}
+
+/// Polls until `condition` holds, failing the test after a generous deadline.
+private func waitUntil(
+  _ comment: Comment,
+  condition: @RealtimeActor () -> Bool
+) async {
+  for _ in 0..<400 {
+    if await condition() { return }
+    try? await Task.sleep(for: .milliseconds(5))
+  }
+  let satisfied = await condition()
+  #expect(satisfied, comment)
+}
+
+@RealtimeActor
+struct SelfHealingRealtimeAudioControllerTests {
+  @Test
+  func rebuildsOnceWhenCaptureStaysDigitallySilent() async throws {
+    let deadController = ScriptedAudioController()
+    let healthyController = ScriptedAudioController()
+    let factory = RebuildFactorySpy(replacements: [healthyController])
+    let controller = SelfHealingRealtimeAudioController(
+      initialController: deadController,
+      rebuildController: { try factory.make() },
+      liveAudioDeadline: .milliseconds(20)
+    )
+
+    let stream = try controller.microphoneStream()
+    let received = ReceivedBuffers()
+    let consumer = Task { @RealtimeActor in
+      for await buffer in stream {
+        await received.append(buffer)
+      }
+    }
+
+    deadController.vend(makeBuffer(sample: 0))
+    await waitUntil("the dead controller should be replaced") {
+      factory.rebuildCount == 1
+    }
+    #expect(deadController.stopCount == 1)
+    #expect(healthyController.microphoneStartCount == 1)
+
+    healthyController.vend(makeBuffer(sample: 100))
+    await waitUntilAsync("live buffer reaches the consumer via the same outer stream") {
+      await received.containsLiveBuffer()
+    }
+
+    // A second silent window must not trigger another rebuild.
+    try? await Task.sleep(for: .milliseconds(60))
+    #expect(factory.rebuildCount == 1)
+
+    controller.stop()
+    consumer.cancel()
+  }
+
+  @Test
+  func keepsControllerWhenLiveAudioArrives() async throws {
+    let liveController = ScriptedAudioController()
+    let factory = RebuildFactorySpy(replacements: [])
+    let controller = SelfHealingRealtimeAudioController(
+      initialController: liveController,
+      rebuildController: { try factory.make() },
+      liveAudioDeadline: .milliseconds(20)
+    )
+
+    let stream = try controller.microphoneStream()
+    let consumer = Task { @RealtimeActor in
+      for await _ in stream {}
+    }
+
+    liveController.vend(makeBuffer(sample: 42))
+    try? await Task.sleep(for: .milliseconds(80))
+    #expect(factory.rebuildCount == 0)
+    #expect(liveController.stopCount == 0)
+
+    controller.stop()
+    consumer.cancel()
+  }
+
+  @Test
+  func defersRebuildWhilePlaybackIsAudible() async throws {
+    let deadController = ScriptedAudioController()
+    deadController.playbackActive = true
+    let healthyController = ScriptedAudioController()
+    let factory = RebuildFactorySpy(replacements: [healthyController])
+    let controller = SelfHealingRealtimeAudioController(
+      initialController: deadController,
+      rebuildController: { try factory.make() },
+      liveAudioDeadline: .milliseconds(20)
+    )
+
+    let stream = try controller.microphoneStream()
+    let consumer = Task { @RealtimeActor in
+      for await _ in stream {}
+    }
+
+    try? await Task.sleep(for: .milliseconds(60))
+    #expect(factory.rebuildCount == 0)
+
+    deadController.playbackActive = false
+    await waitUntil("rebuild should run once playback goes quiet") {
+      factory.rebuildCount == 1
+    }
+
+    controller.stop()
+    consumer.cancel()
+  }
+
+  @Test
+  func stopPreventsPendingRebuild() async throws {
+    let deadController = ScriptedAudioController()
+    let factory = RebuildFactorySpy(replacements: [])
+    let controller = SelfHealingRealtimeAudioController(
+      initialController: deadController,
+      rebuildController: { try factory.make() },
+      liveAudioDeadline: .milliseconds(20)
+    )
+
+    _ = try controller.microphoneStream()
+    controller.stop()
+
+    try? await Task.sleep(for: .milliseconds(60))
+    #expect(factory.rebuildCount == 0)
+    #expect(deadController.stopCount == 1)
+  }
+}
+
+private actor ReceivedBuffers {
+  private var buffers = [AVAudioPCMBuffer]()
+
+  func append(_ buffer: AVAudioPCMBuffer) {
+    buffers.append(buffer)
+  }
+
+  func containsLiveBuffer() -> Bool {
+    buffers.contains { buffer in
+      guard let data = buffer.int16ChannelData else { return false }
+      return (0..<Int(buffer.frameLength)).contains { data[0][$0] != 0 }
+    }
+  }
+}
+
+/// Polls an async condition until it holds, failing the test after a deadline.
+private func waitUntilAsync(
+  _ comment: Comment,
+  condition: () async -> Bool
+) async {
+  for _ in 0..<400 {
+    if await condition() { return }
+    try? await Task.sleep(for: .milliseconds(5))
+  }
+  let satisfied = await condition()
+  #expect(satisfied, comment)
+}

--- a/app/modules/Ghostty/Package.resolved
+++ b/app/modules/Ghostty/Package.resolved
@@ -2,6 +2,15 @@
   "originHash" : "82627f6050b7e6b3d4a3960da3abd600295b738ea8bad219444c6eab41b08620",
   "pins" : [
     {
+      "identity" : "async-http-client",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swift-server/async-http-client.git",
+      "state" : {
+        "revision" : "9544287b9416c0bc71e58b9f3aead8dd14b16103",
+        "version" : "1.36.0"
+      }
+    },
+    {
       "identity" : "beautiful-mermaid-swift",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/lukilabs/beautiful-mermaid-swift",
@@ -119,12 +128,57 @@
       }
     },
     {
+      "identity" : "swift-algorithms",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-algorithms.git",
+      "state" : {
+        "revision" : "87e50f483c54e6efd60e885f7f5aa946cee68023",
+        "version" : "1.2.1"
+      }
+    },
+    {
       "identity" : "swift-argument-parser",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-argument-parser",
       "state" : {
         "revision" : "626b5b7b2f45e1b0b1c6f4a309296d1d21d7311b",
         "version" : "1.7.1"
+      }
+    },
+    {
+      "identity" : "swift-asn1",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-asn1.git",
+      "state" : {
+        "revision" : "a9a5efd40eaf558a2bcd48d64b1d1646be686008",
+        "version" : "1.7.1"
+      }
+    },
+    {
+      "identity" : "swift-async-algorithms",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-async-algorithms.git",
+      "state" : {
+        "revision" : "d0b4a06d0f173a2f3be27d3ea21b3c3aa18db440",
+        "version" : "1.1.4"
+      }
+    },
+    {
+      "identity" : "swift-atomics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-atomics.git",
+      "state" : {
+        "revision" : "0442cb5a3f98ab802acb777929fdb446bda11a34",
+        "version" : "1.3.1"
+      }
+    },
+    {
+      "identity" : "swift-certificates",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-certificates.git",
+      "state" : {
+        "revision" : "449dbbecd0f31e82b510ada227ca152caa8b5e98",
+        "version" : "1.19.4"
       }
     },
     {
@@ -146,6 +200,60 @@
       }
     },
     {
+      "identity" : "swift-configuration",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-configuration.git",
+      "state" : {
+        "revision" : "be76c4ad929eb6c4bcaf3351799f2adf9e6848a9",
+        "version" : "1.2.0"
+      }
+    },
+    {
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto.git",
+      "state" : {
+        "revision" : "47d3869a7291f085c1fb9fb1e6d3b97a793f45c6",
+        "version" : "4.5.1"
+      }
+    },
+    {
+      "identity" : "swift-distributed-tracing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-distributed-tracing.git",
+      "state" : {
+        "revision" : "dc4030184203ffafbb2ec614352487235d747fe0",
+        "version" : "1.4.1"
+      }
+    },
+    {
+      "identity" : "swift-http-structured-headers",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-http-structured-headers.git",
+      "state" : {
+        "revision" : "933538faa42c432d385f02e07df0ace7c5ecfc47",
+        "version" : "1.7.0"
+      }
+    },
+    {
+      "identity" : "swift-http-types",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-http-types.git",
+      "state" : {
+        "revision" : "db774a277f60063a32d854f2980299caf06da041",
+        "version" : "1.6.0"
+      }
+    },
+    {
+      "identity" : "swift-log",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-log.git",
+      "state" : {
+        "revision" : "3ffafb9722d5d918c614feb496c8789a3b59d222",
+        "version" : "1.15.0"
+      }
+    },
+    {
       "identity" : "swift-markdown-ui",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/gonzalezreal/swift-markdown-ui",
@@ -155,12 +263,102 @@
       }
     },
     {
+      "identity" : "swift-nio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio.git",
+      "state" : {
+        "revision" : "0b18836bd8b0162e7e17a995a3fbee20ed8f3b2b",
+        "version" : "2.101.3"
+      }
+    },
+    {
+      "identity" : "swift-nio-extras",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-extras.git",
+      "state" : {
+        "revision" : "88a51340f59cf181ebde888bd1b749296b3ec029",
+        "version" : "1.34.3"
+      }
+    },
+    {
+      "identity" : "swift-nio-http2",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-http2.git",
+      "state" : {
+        "revision" : "45bdf670248be5f16ec0340e125dca285536f0fb",
+        "version" : "1.45.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-ssl",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-ssl.git",
+      "state" : {
+        "revision" : "d930168b86f46ca51a4bc09c5ca45c1833db8067",
+        "version" : "2.37.2"
+      }
+    },
+    {
+      "identity" : "swift-nio-transport-services",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-transport-services.git",
+      "state" : {
+        "revision" : "67787bb645a5e67d2edcdfbe48a216cc549222d5",
+        "version" : "1.28.0"
+      }
+    },
+    {
+      "identity" : "swift-numerics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-numerics.git",
+      "state" : {
+        "revision" : "0c0290ff6b24942dadb83a929ffaaa1481df04a2",
+        "version" : "1.1.1"
+      }
+    },
+    {
+      "identity" : "swift-service-context",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-service-context.git",
+      "state" : {
+        "revision" : "d0997351b0c7779017f88e7a93bc30a1878d7f29",
+        "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swift-service-lifecycle",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swift-server/swift-service-lifecycle",
+      "state" : {
+        "revision" : "9829955b385e5bb88128b73f1b8389e9b9c3191a",
+        "version" : "2.11.0"
+      }
+    },
+    {
+      "identity" : "swift-system",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-system",
+      "state" : {
+        "revision" : "704705c5c51156ede21172a38654d522ce487074",
+        "version" : "1.8.0"
+      }
+    },
+    {
       "identity" : "swiftlintplugin",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/lukepistrol/SwiftLintPlugin",
       "state" : {
         "revision" : "a3877065a7d72ee40e1fa64e13b9e33e846c667c",
         "version" : "0.63.1"
+      }
+    },
+    {
+      "identity" : "swiftopenai",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/jamesrochabrun/SwiftOpenAI.git",
+      "state" : {
+        "revision" : "15250281d2b072d27e54405fb40275c83ac354a4",
+        "version" : "4.5.1"
       }
     },
     {

--- a/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyPromptTextAction.swift
+++ b/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyPromptTextAction.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+/// Builds Ghostty `text:` binding actions for prompt submission.
+///
+/// `ghostty_surface_text` is libghostty's IME text-input path and sanitizes
+/// control bytes: the ESC of a bracketed-paste marker is dropped and the
+/// remaining `[200~` / `[201~` are typed into the child app as literal text.
+/// The `text:` binding action instead decodes Zig string-literal escapes and
+/// writes the bytes straight to the pty, so the markers survive intact.
+enum AgentHubGhosttyPromptTextAction {
+  /// The binding action that pastes `text` wrapped in bracketed-paste markers.
+  static func bracketedPaste(_ text: String) -> String {
+    "text:\\x1b[200~" + escaped(text) + "\\x1b[201~"
+  }
+
+  /// Escapes `text` as Zig string-literal content: backslashes, double quotes,
+  /// and control characters become escape sequences; everything else passes
+  /// through as UTF-8. Ghostty evaluates the action's payload as a quoted Zig
+  /// string literal, so an unescaped quote would truncate the prompt.
+  static func escaped(_ text: String) -> String {
+    var out = ""
+    for scalar in text.unicodeScalars {
+      switch scalar {
+      case "\\":
+        out += "\\\\"
+      case "\"":
+        out += "\\\""
+      default:
+        if scalar.value < 0x20 || scalar.value == 0x7F {
+          out += String(format: "\\x%02x", scalar.value)
+        } else {
+          out.unicodeScalars.append(scalar)
+        }
+      }
+    }
+    return out
+  }
+}

--- a/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalSurface.swift
+++ b/app/modules/Ghostty/Sources/Ghostty/AgentHubGhosttyTerminalSurface.swift
@@ -1306,7 +1306,17 @@ public final class AgentHubGhosttyTerminalSurface: NSView, EmbeddedTerminalSurfa
     _ text: String,
     to controller: GhosttyTerminalController?
   ) {
-    controller?.sendBytes(TerminalPromptSubmissionPayload.bracketedPasteTextBytes(prompt: text))
+    guard let controller else { return }
+    // Never send bracketed-paste markers through sendText/sendBytes: that is
+    // the IME text-input path, which drops the ESC byte and types "[200~"
+    // into the child app as literal text (see AgentHubGhosttyPromptTextAction).
+    if controller.performBindingAction(
+      AgentHubGhosttyPromptTextAction.bracketedPaste(text)
+    ) {
+      return
+    }
+    // Degrade to plain typed text without markers.
+    controller.sendText(text)
   }
 
   private func installInteractionMonitorIfNeeded() {

--- a/app/modules/Ghostty/Tests/GhosttyTests/AgentHubGhosttyPromptTextActionTests.swift
+++ b/app/modules/Ghostty/Tests/GhosttyTests/AgentHubGhosttyPromptTextActionTests.swift
@@ -1,0 +1,43 @@
+import Testing
+@testable import Ghostty
+
+struct AgentHubGhosttyPromptTextActionTests {
+  @Test
+  func wrapsPromptInBracketedPasteMarkers() {
+    #expect(
+      AgentHubGhosttyPromptTextAction.bracketedPaste("Hello") ==
+        "text:\\x1b[200~Hello\\x1b[201~"
+    )
+  }
+
+  @Test
+  func escapesBackslashesSoZigLiteralDecodingCannotMangleThePrompt() {
+    #expect(
+      AgentHubGhosttyPromptTextAction.escaped(#"path\to\file and \x1b"#) ==
+        #"path\\to\\file and \\x1b"#
+    )
+  }
+
+  @Test
+  func escapesDoubleQuotesThatWouldTerminateTheLiteral() {
+    #expect(
+      AgentHubGhosttyPromptTextAction.escaped(#"say "hi""#) ==
+        #"say \"hi\""#
+    )
+  }
+
+  @Test
+  func escapesControlCharactersIncludingNewlines() {
+    #expect(
+      AgentHubGhosttyPromptTextAction.escaped("line one\nline two\ttabbed\u{1B}") ==
+        #"line one\x0aline two\x09tabbed\x1b"#
+    )
+  }
+
+  @Test
+  func passesUnicodeThroughUnchanged() {
+    #expect(
+      AgentHubGhosttyPromptTextAction.escaped("café 🚀 日本語") == "café 🚀 日本語"
+    )
+  }
+}


### PR DESCRIPTION
Voice: first-use reliability, HUD polish, and prompt-delivery fixes.

## Fixes

### First voice session looked dead (no mic capsule, agent deaf)
Two stacked causes, diagnosed from the unified log:

1. **Toggle race (primary).** `AppKitVoiceHUDPresenter.show()` auto-called `toggleMicrophone()` when the HUD opened, so the user's first tap on the mic button **stopped** the just-started session (~1s start/teardown cycle — also the source of the priority-inversion runtime warning). Auto-start removed; the mic button is the single start/stop control.
2. **Dead capture on overlapped VP enable.** Enabling voice processing while a previous engine's VP unit tears down can hit `AUVPAggregate: Timeout waiting for streams` / `-10877`: the engine "starts" but delivers only exact-zero buffers. New `SelfHealingRealtimeAudioController` rebuilds the audio graph once when no live (non-zero) mic sample arrives within 2s (a healthy mic always has a noise floor), deferring while assistant audio is audible.

### Ghostty terminals received literal `[200~Hello [201~`
`submitPromptImmediately` pushed bracketed-paste markers through `ghostty_surface_text` — libghostty's IME text-input path, which strips the ESC byte, typing the leftover markers into the agent's input. This affected **every** auto-submitted prompt (voice, web-preview feedback), not just voice. Prompts now ride the `text:` binding action (Zig string-literal escaped via `AgentHubGhosttyPromptTextAction`), which writes raw bytes to the PTY; on rejection, delivery degrades to plain text with no markers. The SwiftTerm surface was never affected (raw bytes + live `bracketedPasteMode` check).

### Pinned language could still flip mid-conversation
The pinned-language instruction was appended to base instructions that still said "Reply in the language the user is currently speaking" — two contradictory rules. The builder now assembles persona / language guidance / session discipline, and a pin **replaces** the follow-the-user directive.

### Mic level meter was always 0 in conversations
`RealtimeVoiceEngine.rms` only read `floatChannelData`, but the mic vendor delivers PCM16 buffers; it now reads `int16ChannelData` too.

### Orb kept still while the assistant was audibly speaking
`assistantLevel` tracks network delta arrival (OpenAI streams faster than realtime), so it went quiet mid-response. New `isAssistantSpeaking` follows actual playback (refreshed from `audio.isPlaybackActive()` on every mic tick); the orb pulses for the whole audible response.

## HUD polish

- **Liquid Glass chrome** on macOS 26+ (`VoiceHUDChrome`), material card fallback on macOS 14–15.
- **Pill segmented control** for Dictate/Converse (`VoicePillSegmentedControl`) matching the app's `CompactPillSegmentedControl`; brand color injected via new `VoiceHUDConfiguration.accentColor` so the panel stays app-agnostic.
- **New setting: "Show transcript text" (off by default).** When off, the transcript area shows a visualizer instead: **Converse** — an orb in the selected voice's gradient that swells with whoever is louder, breathes while idle, dims when disconnected; **Dictate** — animated SF Symbols (variable-color `waveform` while recording, pulsing `ellipsis` while transcribing). Both honor Reduce Motion.

## Tests

- `AgentHubVoice`: 41 tests / 13 suites green (`swift test`), including new suites for the self-healing controller, RMS PCM16 levels, playback-driven speaking state, and the language-pin instruction contract (payload-level JSON assertions).
- `Ghostty`: new `AgentHubGhosttyPromptTextActionTests` (5 tests) green via the `Ghostty` xcodebuild scheme.
- `AgentHubCore`: targeted `VoiceControlCoordinatorTests` / `VoiceToolCatalogTests` green; full `./scripts/test.sh` run before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
