### PR TITLE
Voice: worktree tools (list/create tasks) and liquid-tech conversation orb

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/Models/VoiceAgentModels.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Models/VoiceAgentModels.swift
@@ -166,6 +166,127 @@ public struct VoiceLatestResponse: Codable, Equatable, Sendable {
   }
 }
 
+public struct VoiceWorktreeSummary: Codable, Equatable, Sendable {
+  public let name: String
+  public let path: String
+  public let isWorktree: Bool
+  public let sessionCount: Int
+
+  public init(
+    name: String,
+    path: String,
+    isWorktree: Bool,
+    sessionCount: Int
+  ) {
+    self.name = name
+    self.path = path
+    self.isWorktree = isWorktree
+    self.sessionCount = sessionCount
+  }
+}
+
+public struct VoiceRepositorySummary: Codable, Equatable, Sendable {
+  public let name: String
+  public let path: String
+  public let worktrees: [VoiceWorktreeSummary]
+
+  public init(name: String, path: String, worktrees: [VoiceWorktreeSummary]) {
+    self.name = name
+    self.path = path
+    self.worktrees = worktrees
+  }
+}
+
+public struct VoiceWorktreeInventory: Codable, Equatable, Sendable {
+  public let repositories: [VoiceRepositorySummary]
+
+  public init(repositories: [VoiceRepositorySummary]) {
+    self.repositories = repositories
+  }
+}
+
+public struct VoiceWorktreeTaskSpec: Equatable, Sendable {
+  public let branch: String
+  public let prompt: String
+  public let provider: SessionProviderKind
+
+  public init(branch: String, prompt: String, provider: SessionProviderKind) {
+    self.branch = branch
+    self.prompt = prompt
+    self.provider = provider
+  }
+}
+
+public struct VoiceCreatedWorktree: Equatable, Sendable {
+  public let repositoryPath: String
+  public let branchName: String
+  public let worktreePath: String
+  public let launchPath: String?
+
+  public init(
+    repositoryPath: String,
+    branchName: String,
+    worktreePath: String,
+    launchPath: String?
+  ) {
+    self.repositoryPath = repositoryPath
+    self.branchName = branchName
+    self.worktreePath = worktreePath
+    self.launchPath = launchPath
+  }
+}
+
+public struct VoiceWorktreeTaskLaunch: Codable, Equatable, Sendable {
+  public let branch: String
+  public let provider: SessionProviderKind
+  public let worktreePath: String
+  public let pendingSessionId: String?
+
+  public init(
+    branch: String,
+    provider: SessionProviderKind,
+    worktreePath: String,
+    pendingSessionId: String?
+  ) {
+    self.branch = branch
+    self.provider = provider
+    self.worktreePath = worktreePath
+    self.pendingSessionId = pendingSessionId
+  }
+}
+
+public struct VoiceWorktreeTaskFailure: Codable, Equatable, Sendable {
+  public let branch: String
+  public let message: String
+
+  public init(branch: String, message: String) {
+    self.branch = branch
+    self.message = message
+  }
+}
+
+public struct VoiceWorktreeTaskBatchResult: Codable, Equatable, Sendable {
+  public let status: String
+  public let message: String?
+  public let repositoryPath: String
+  public let launched: [VoiceWorktreeTaskLaunch]
+  public let failures: [VoiceWorktreeTaskFailure]
+
+  public init(
+    status: String,
+    message: String?,
+    repositoryPath: String,
+    launched: [VoiceWorktreeTaskLaunch],
+    failures: [VoiceWorktreeTaskFailure]
+  ) {
+    self.status = status
+    self.message = message
+    self.repositoryPath = repositoryPath
+    self.launched = launched
+    self.failures = failures
+  }
+}
+
 public struct VoiceSessionTarget: Codable, Equatable, Sendable, Identifiable {
   public let sessionId: String
   public let provider: SessionProviderKind

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/VoiceAgentToolExecutor.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/VoiceAgentToolExecutor.swift
@@ -1,3 +1,4 @@
+import AgentHubCLIKit
 import Foundation
 
 @MainActor
@@ -50,6 +51,11 @@ public protocol VoiceAgentToolExecuting: AnyObject {
     provider: SessionProviderKind,
     prompt: String?
   ) -> VoiceLaunchResult
+  func listWorktrees() -> VoiceWorktreeInventory
+  func createWorktreeTasks(
+    repositoryPath: String?,
+    tasks: [VoiceWorktreeTaskSpec]
+  ) async -> VoiceWorktreeTaskBatchResult
   func pendingApproval(sessionId: String) -> VoicePendingApproval?
   func respondToApproval(
     sessionId: String,
@@ -66,6 +72,8 @@ public final class VoiceAgentToolExecutor: VoiceAgentToolExecuting {
   private let selectionRouter: GlobalSessionSelectionRouter
   private let targetResolver: any VoiceSessionTargetResolving
   private let transcriptReader: any VoiceSessionTranscriptReading
+  private let worktreeCreator: (any VoiceWorktreeCreating)?
+  private let launchRequestHandler: (any WorktreeLaunchRequestHandlingProtocol)?
   private let snapshotProvider: (@MainActor () -> SessionInvestigationSnapshot)?
 
   public init(
@@ -73,13 +81,20 @@ public final class VoiceAgentToolExecutor: VoiceAgentToolExecuting {
     codexViewModel: CLISessionsViewModel,
     selectionRouter: GlobalSessionSelectionRouter,
     targetResolver: any VoiceSessionTargetResolving,
-    transcriptReader: any VoiceSessionTranscriptReading = VoiceSessionTranscriptReader()
+    transcriptReader: any VoiceSessionTranscriptReading = VoiceSessionTranscriptReader(),
+    worktreeCreator: (any VoiceWorktreeCreating)? = nil,
+    launchRequestHandler: (any WorktreeLaunchRequestHandlingProtocol)? = nil
   ) {
     self.claudeViewModel = claudeViewModel
     self.codexViewModel = codexViewModel
     self.selectionRouter = selectionRouter
     self.targetResolver = targetResolver
     self.transcriptReader = transcriptReader
+    self.worktreeCreator = worktreeCreator ?? VoiceWorktreeCreator()
+    self.launchRequestHandler = launchRequestHandler ?? WorktreeLaunchRequestHandler(
+      claudeViewModel: claudeViewModel,
+      codexViewModel: codexViewModel
+    )
     snapshotProvider = {
       SessionInvestigationSnapshotBuilder.make(
         claudeViewModel: claudeViewModel,
@@ -93,13 +108,17 @@ public final class VoiceAgentToolExecutor: VoiceAgentToolExecuting {
     codexViewModel: any VoiceSessionManaging,
     selectionRouter: GlobalSessionSelectionRouter,
     targetResolver: any VoiceSessionTargetResolving,
-    transcriptReader: any VoiceSessionTranscriptReading = VoiceSessionTranscriptReader()
+    transcriptReader: any VoiceSessionTranscriptReading = VoiceSessionTranscriptReader(),
+    worktreeCreator: (any VoiceWorktreeCreating)? = nil,
+    launchRequestHandler: (any WorktreeLaunchRequestHandlingProtocol)? = nil
   ) {
     self.claudeViewModel = claudeViewModel
     self.codexViewModel = codexViewModel
     self.selectionRouter = selectionRouter
     self.targetResolver = targetResolver
     self.transcriptReader = transcriptReader
+    self.worktreeCreator = worktreeCreator
+    self.launchRequestHandler = launchRequestHandler
     snapshotProvider = nil
   }
 
@@ -249,6 +268,114 @@ public final class VoiceAgentToolExecutor: VoiceAgentToolExecuting {
     )
   }
 
+  public func listWorktrees() -> VoiceWorktreeInventory {
+    var repositories: [VoiceRepositorySummary] = []
+    var seenRepositoryPaths = Set<String>()
+    for viewModel in [claudeViewModel, codexViewModel] {
+      for repository in viewModel.selectedRepositories
+        where seenRepositoryPaths.insert(repository.path).inserted {
+        var worktrees: [VoiceWorktreeSummary] = []
+        var seenWorktreePaths = Set<String>()
+        if !repository.worktrees.contains(where: { $0.path == repository.path }) {
+          seenWorktreePaths.insert(repository.path)
+          worktrees.append(VoiceWorktreeSummary(
+            name: repository.name,
+            path: repository.path,
+            isWorktree: false,
+            sessionCount: sessionCount(forPath: repository.path)
+          ))
+        }
+        for worktree in repository.worktrees
+          where seenWorktreePaths.insert(worktree.path).inserted {
+          worktrees.append(VoiceWorktreeSummary(
+            name: worktree.name,
+            path: worktree.path,
+            isWorktree: worktree.isWorktree,
+            sessionCount: sessionCount(forPath: worktree.path)
+          ))
+        }
+        repositories.append(VoiceRepositorySummary(
+          name: repository.name,
+          path: repository.path,
+          worktrees: worktrees
+        ))
+      }
+    }
+    return VoiceWorktreeInventory(repositories: repositories)
+  }
+
+  public func createWorktreeTasks(
+    repositoryPath: String?,
+    tasks: [VoiceWorktreeTaskSpec]
+  ) async -> VoiceWorktreeTaskBatchResult {
+    guard let worktreeCreator, let launchRequestHandler else {
+      return VoiceWorktreeTaskBatchResult(
+        status: "unavailable",
+        message: "Worktree task creation is unavailable.",
+        repositoryPath: repositoryPath ?? "",
+        launched: [],
+        failures: []
+      )
+    }
+    guard let requestedPath = repositoryPath
+      ?? targetResolver.resolve(manualSessionId: nil)?.projectPath else {
+      return VoiceWorktreeTaskBatchResult(
+        status: "not_found",
+        message: "There is no focused session to infer the repository from. Say which repository to use, or call list_worktrees.",
+        repositoryPath: "",
+        launched: [],
+        failures: []
+      )
+    }
+    guard let repository = registeredRepository(containing: requestedPath) else {
+      return VoiceWorktreeTaskBatchResult(
+        status: "not_found",
+        message: "No registered repository matches that path. Call list_worktrees for exact paths.",
+        repositoryPath: requestedPath,
+        launched: [],
+        failures: []
+      )
+    }
+
+    var launched: [VoiceWorktreeTaskLaunch] = []
+    var failures: [VoiceWorktreeTaskFailure] = []
+    for task in tasks {
+      do {
+        let created = try await worktreeCreator.createWorktree(
+          repositoryPath: repository.path,
+          branch: task.branch
+        )
+        try await launchRequestHandler.handle(WorktreeLaunchRequest(
+          provider: task.provider == .claude ? .claude : .codex,
+          repositoryPath: created.repositoryPath,
+          worktreePath: created.worktreePath,
+          launchPath: created.launchPath,
+          branchName: created.branchName,
+          prompt: task.prompt
+        ))
+        launched.append(VoiceWorktreeTaskLaunch(
+          branch: created.branchName,
+          provider: task.provider,
+          worktreePath: created.worktreePath,
+          pendingSessionId: viewModel(for: task.provider)
+            .lastCreatedPendingId?.uuidString
+        ))
+      } catch {
+        failures.append(VoiceWorktreeTaskFailure(
+          branch: task.branch,
+          message: error.localizedDescription
+        ))
+      }
+    }
+    return VoiceWorktreeTaskBatchResult(
+      status: "accepted",
+      message: nil,
+      repositoryPath: repository.path,
+      launched: launched,
+      failures: failures
+    )
+  }
+
   public func pendingApproval(sessionId: String) -> VoicePendingApproval? {
     guard let record = record(sessionId: sessionId),
           record.provider == .claude,
@@ -387,6 +514,26 @@ public final class VoiceAgentToolExecutor: VoiceAgentToolExecuting {
         || viewModel.resolvedPendingSessions[pendingID] != nil
         || viewModel.lastCreatedPendingId == pendingID
     }
+  }
+
+  private func sessionCount(forPath path: String) -> Int {
+    [claudeViewModel, codexViewModel].reduce(0) { count, viewModel in
+      count + viewModel.voiceSessions.filter { $0.projectPath == path }.count
+    }
+  }
+
+  private func registeredRepository(
+    containing path: String
+  ) -> SelectedRepository? {
+    for viewModel in [claudeViewModel, codexViewModel] {
+      if let match = WorktreeModuleResolver.bestMatch(
+        for: path,
+        repositories: viewModel.selectedRepositories
+      ) {
+        return match.repository
+      }
+    }
+    return nil
   }
 
   private func resolveWorktree(

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/VoiceToolCatalog.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/VoiceToolCatalog.swift
@@ -46,7 +46,9 @@ public final class VoiceToolCatalog: VoiceToolCataloging {
       readResponseTool(),
       sendPromptTool(),
       focusSessionTool(),
+      listWorktreesTool(),
       launchSessionTool(),
+      createWorktreeTasksTool(),
       approvalTool(),
     ]
     if isScreenCaptureEnabled() {
@@ -236,10 +238,127 @@ public final class VoiceToolCatalog: VoiceToolCataloging {
     }
   }
 
+  private func listWorktreesTool() -> VoiceTool {
+    VoiceTool(
+      name: "list_worktrees",
+      description: """
+        List registered repositories and their worktrees with exact paths and
+        session counts. Call this before launch_session or
+        create_worktree_tasks so you pass an exact registered path.
+        """,
+      parameters: objectSchema(properties: [:])
+    ) { [weak self] _ in
+      guard let self else { return Self.unavailableJSON }
+      return Self.encode(executor.listWorktrees())
+    }
+  }
+
+  private func createWorktreeTasksTool() -> VoiceTool {
+    VoiceTool(
+      name: "create_worktree_tasks",
+      description: """
+        Create NEW git worktrees — one per task, a single task is fine — and
+        launch an agent session in each with its prompt. Use this whenever the
+        user asks to create a worktree, spin up worktree tasks, or run work in
+        parallel; never launch_session for those requests. Omit
+        repository_path to use the current target session's repository. Read
+        the task list back to the user before calling. Branch names are
+        adjusted automatically when they collide.
+        """,
+      parameters: objectSchema(
+        properties: [
+          "repository_path": [
+            "type": "string",
+            "description": """
+              Only pass this when the user explicitly names a repository or
+              path; use the exact registered path from list_worktrees. When
+              the user does not name one, OMIT this field entirely — it
+              defaults to the repository of the session the user is working
+              in. Never guess.
+              """,
+          ],
+          "provider": [
+            "type": "string",
+            "enum": ["claude", "codex"],
+            "description": "Provider for tasks that do not set one. Defaults to claude.",
+          ],
+          "tasks": .object([
+            "type": "array",
+            "minItems": 1,
+            "items": .object([
+              "type": "object",
+              "properties": .object([
+                "branch": [
+                  "type": "string",
+                  "description": "Short kebab-case branch name for the task.",
+                ],
+                "prompt": [
+                  "type": "string",
+                  "description": "Prompt for the agent launched in this task's worktree.",
+                ],
+                "provider": [
+                  "type": "string",
+                  "enum": ["claude", "codex"],
+                ],
+              ]),
+              "required": .array(["branch", "prompt"]),
+              "additionalProperties": false,
+            ]),
+          ]),
+        ],
+        required: ["tasks"]
+      ),
+      allowsAutomaticRetry: false
+    ) { [weak self] data in
+      guard let self else { return Self.unavailableJSON }
+      guard let arguments = Self.decode(
+        CreateWorktreeTasksArguments.self,
+        from: data
+      ), !arguments.tasks.isEmpty else {
+        return Self.invalidArgumentsJSON
+      }
+      var specs: [VoiceWorktreeTaskSpec] = []
+      for task in arguments.tasks {
+        let provider: SessionProviderKind
+        if let rawProvider = task.provider ?? arguments.provider {
+          guard let kind = Self.providerKind(rawProvider) else {
+            return Self.invalidArgumentsJSON
+          }
+          provider = kind
+        } else {
+          provider = .claude
+        }
+        let branch = task.branch.trimmingCharacters(in: .whitespacesAndNewlines)
+        let prompt = task.prompt.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !branch.isEmpty, !prompt.isEmpty else {
+          return Self.invalidArgumentsJSON
+        }
+        specs.append(VoiceWorktreeTaskSpec(
+          branch: branch,
+          prompt: prompt,
+          provider: provider
+        ))
+      }
+      let result = await executor.createWorktreeTasks(
+        repositoryPath: arguments.repositoryPath,
+        tasks: specs
+      )
+      for launch in result.launched {
+        guard let pendingSessionId = launch.pendingSessionId else { continue }
+        completionWatcher.watch(sessionId: pendingSessionId, name: launch.branch)
+      }
+      return Self.encode(result)
+    }
+  }
+
   private func launchSessionTool() -> VoiceTool {
     VoiceTool(
       name: "launch_session",
-      description: "Launch a new Claude or Codex session in a registered worktree.",
+      description: """
+        Start a new agent session in an EXISTING registered repository or
+        worktree path, without creating anything on disk. Never use this when
+        the user asks to create a worktree — that is create_worktree_tasks.
+        """,
       parameters: objectSchema(
         properties: [
           "worktree_path": [
@@ -448,6 +567,18 @@ private struct LaunchArguments: Decodable {
   let worktreePath: String
   let provider: String
   let prompt: String?
+}
+
+private struct CreateWorktreeTasksArguments: Decodable {
+  struct TaskArgument: Decodable {
+    let branch: String
+    let prompt: String
+    let provider: String?
+  }
+
+  let repositoryPath: String?
+  let provider: String?
+  let tasks: [TaskArgument]
 }
 
 private struct ApprovalArguments: Decodable {

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/VoiceWorktreeCreator.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/VoiceWorktreeCreator.swift
@@ -1,0 +1,73 @@
+import AgentHubCLIKit
+import Foundation
+
+/// Creates an AgentHub-managed git worktree for a voice-initiated task.
+public protocol VoiceWorktreeCreating: Sendable {
+  func createWorktree(
+    repositoryPath: String,
+    branch: String
+  ) async throws -> VoiceCreatedWorktree
+}
+
+/// In-process twin of the MCP server's worktree creation path: resolves the
+/// main repository root, avoids branch/directory collisions, and creates a
+/// repo-root worktree (full checkout, per the worktree contract).
+public struct VoiceWorktreeCreator: VoiceWorktreeCreating {
+  private let service: WorktreeManagementService
+
+  public init(service: WorktreeManagementService = WorktreeManagementService()) {
+    self.service = service
+  }
+
+  public func createWorktree(
+    repositoryPath: String,
+    branch: String
+  ) async throws -> VoiceCreatedWorktree {
+    let mainRepositoryPath = try await service.findMainRepositoryRoot(
+      at: repositoryPath
+    )
+    let requested = WorktreeNaming.sanitizeBranchName(branch)
+    let resolvedBranch = await availableBranchName(
+      requested,
+      at: mainRepositoryPath
+    )
+    let creation = try await service.createAgentWorktreeWithNewBranch(
+      at: mainRepositoryPath,
+      startPath: nil,
+      newBranchName: resolvedBranch,
+      directoryName: WorktreeNaming.worktreeDirectoryName(for: resolvedBranch),
+      sparseProfile: nil,
+      fullCheckout: false
+    )
+    return VoiceCreatedWorktree(
+      repositoryPath: mainRepositoryPath,
+      branchName: resolvedBranch,
+      worktreePath: creation.worktreePath,
+      launchPath: creation.launchPath == creation.worktreePath
+        ? nil
+        : creation.launchPath
+    )
+  }
+
+  private func availableBranchName(
+    _ requested: String,
+    at repositoryPath: String
+  ) async -> String {
+    var takenBranches: Set<String> = []
+    var takenDirectoryNames: Set<String> = []
+    if let branches = try? await service.getLocalBranches(at: repositoryPath) {
+      takenBranches.formUnion(branches.map(\.name))
+    }
+    if let worktrees = try? await service.listWorktrees(at: repositoryPath) {
+      takenBranches.formUnion(worktrees.compactMap(\.branch))
+      takenDirectoryNames.formUnion(
+        worktrees.map { URL(fileURLWithPath: $0.path).lastPathComponent }
+      )
+    }
+    return WorktreeNaming.availableBranchName(
+      for: requested,
+      takenBranches: takenBranches,
+      takenDirectoryNames: takenDirectoryNames
+    )
+  }
+}

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/VoiceAgentToolExecutorTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/VoiceAgentToolExecutorTests.swift
@@ -1,3 +1,4 @@
+import AgentHubCLIKit
 import Foundation
 import Observation
 import Testing
@@ -60,6 +61,32 @@ private struct StubTranscriptReader: VoiceSessionTranscriptReading {
     provider: SessionProviderKind
   ) async -> String? {
     textsByPath[path]
+  }
+}
+
+private enum TestWorktreeError: Error {
+  case creationFailed
+}
+
+private struct MockWorktreeCreator: VoiceWorktreeCreating {
+  let onCreate: @Sendable (String, String) async throws -> VoiceCreatedWorktree
+
+  func createWorktree(
+    repositoryPath: String,
+    branch: String
+  ) async throws -> VoiceCreatedWorktree {
+    try await onCreate(repositoryPath, branch)
+  }
+}
+
+@MainActor
+private final class MockLaunchRequestHandler: WorktreeLaunchRequestHandlingProtocol {
+  var onHandle: (@MainActor (WorktreeLaunchRequest) throws -> Void)?
+  private(set) var requests: [WorktreeLaunchRequest] = []
+
+  func handle(_ request: WorktreeLaunchRequest) async throws {
+    requests.append(request)
+    try onHandle?(request)
   }
 }
 
@@ -285,6 +312,231 @@ struct VoiceAgentToolExecutorTests {
     #expect(await executor.latestResponse(sessionId: nil) == nil)
   }
 
+  @Test
+  func listWorktreesMergesRepositoriesAndSynthesizesRootEntry() throws {
+    let (executor, claude, codex) = makeExecutor()
+    claude.selectedRepositories = [
+      SelectedRepository(
+        path: "/repo",
+        name: "Repo",
+        worktrees: [
+          WorktreeBranch(
+            name: "feature-a",
+            path: "/repo-feature-a",
+            isWorktree: true
+          ),
+        ]
+      ),
+    ]
+    codex.selectedRepositories = [
+      SelectedRepository(path: "/repo", name: "Repo"),
+      SelectedRepository(path: "/other", name: "Other"),
+    ]
+    claude.voiceSessions = [session(id: "s1")]
+    codex.voiceSessions = [session(id: "s2")]
+
+    let inventory = executor.listWorktrees()
+    let encoded = try JSONEncoder().encode(inventory)
+    let decoded = try JSONDecoder().decode(
+      VoiceWorktreeInventory.self,
+      from: encoded
+    )
+
+    #expect(decoded == inventory)
+    #expect(inventory.repositories.map(\.path) == ["/repo", "/other"])
+    let repo = try #require(inventory.repositories.first)
+    #expect(repo.worktrees.map(\.path) == ["/repo", "/repo-feature-a"])
+    #expect(repo.worktrees.first?.isWorktree == false)
+    #expect(repo.worktrees.first?.sessionCount == 2)
+    #expect(repo.worktrees.last?.sessionCount == 0)
+  }
+
+  @Test
+  func createWorktreeTasksCreatesLaunchesAndIsolatesFailures() async throws {
+    let creator = MockWorktreeCreator { repositoryPath, branch in
+      guard branch != "boom" else {
+        throw TestWorktreeError.creationFailed
+      }
+      return VoiceCreatedWorktree(
+        repositoryPath: repositoryPath,
+        branchName: "\(branch)-2",
+        worktreePath: "\(repositoryPath)-\(branch)",
+        launchPath: nil
+      )
+    }
+    let handler = MockLaunchRequestHandler()
+    let (executor, claude, _) = makeExecutor(
+      target: nil,
+      worktreeCreator: creator,
+      launchRequestHandler: handler
+    )
+    claude.selectedRepositories = [
+      SelectedRepository(path: "/repo", name: "Repo"),
+    ]
+    handler.onHandle = { request in
+      claude.voiceStartNewSessionInHub(
+        WorktreeBranch(
+          name: request.branchName,
+          path: request.worktreePath,
+          isWorktree: true
+        ),
+        initialPrompt: request.prompt
+      )
+    }
+
+    let result = await executor.createWorktreeTasks(
+      repositoryPath: "/repo",
+      tasks: [
+        VoiceWorktreeTaskSpec(branch: "task-a", prompt: "Do A", provider: .claude),
+        VoiceWorktreeTaskSpec(branch: "boom", prompt: "Do B", provider: .claude),
+      ]
+    )
+
+    #expect(result.status == "accepted")
+    #expect(result.repositoryPath == "/repo")
+    let launch = try #require(result.launched.first)
+    #expect(result.launched.count == 1)
+    #expect(launch.branch == "task-a-2")
+    #expect(launch.worktreePath == "/repo-task-a")
+    #expect(launch.pendingSessionId == claude.lastCreatedPendingId?.uuidString)
+    #expect(result.failures.map(\.branch) == ["boom"])
+    #expect(handler.requests.count == 1)
+    #expect(handler.requests.first?.branchName == "task-a-2")
+    #expect(handler.requests.first?.prompt == "Do A")
+  }
+
+  @Test
+  func createWorktreeTasksDefaultsToTargetSessionParentRepository() async throws {
+    let creator = MockWorktreeCreator { repositoryPath, branch in
+      VoiceCreatedWorktree(
+        repositoryPath: repositoryPath,
+        branchName: branch,
+        worktreePath: "\(repositoryPath)-\(branch)",
+        launchPath: nil
+      )
+    }
+    let handler = MockLaunchRequestHandler()
+    let target = VoiceSessionTarget(
+      sessionId: "s1",
+      provider: .claude,
+      name: "Focused",
+      projectPath: "/repo-feature-a/ios/app",
+      lastActivityAt: Date()
+    )
+    let (executor, claude, _) = makeExecutor(
+      target: target,
+      worktreeCreator: creator,
+      launchRequestHandler: handler
+    )
+    claude.selectedRepositories = [
+      SelectedRepository(
+        path: "/repo",
+        name: "Repo",
+        worktrees: [
+          WorktreeBranch(
+            name: "feature-a",
+            path: "/repo-feature-a",
+            isWorktree: true
+          ),
+        ]
+      ),
+    ]
+
+    let result = await executor.createWorktreeTasks(
+      repositoryPath: nil,
+      tasks: [
+        VoiceWorktreeTaskSpec(branch: "task-a", prompt: "Do A", provider: .claude),
+      ]
+    )
+
+    #expect(result.status == "accepted")
+    #expect(result.repositoryPath == "/repo")
+    #expect(handler.requests.count == 1)
+    let created = try #require(result.launched.first)
+    #expect(created.worktreePath == "/repo-task-a")
+  }
+
+  @Test
+  func createWorktreeTasksWithoutRepositoryOrTargetIsNotFound() async {
+    let creator = MockWorktreeCreator { repositoryPath, branch in
+      VoiceCreatedWorktree(
+        repositoryPath: repositoryPath,
+        branchName: branch,
+        worktreePath: "\(repositoryPath)-\(branch)",
+        launchPath: nil
+      )
+    }
+    let handler = MockLaunchRequestHandler()
+    let (executor, claude, _) = makeExecutor(
+      target: nil,
+      worktreeCreator: creator,
+      launchRequestHandler: handler
+    )
+    claude.selectedRepositories = [
+      SelectedRepository(path: "/repo", name: "Repo"),
+    ]
+
+    let result = await executor.createWorktreeTasks(
+      repositoryPath: nil,
+      tasks: [
+        VoiceWorktreeTaskSpec(branch: "task-a", prompt: "Do A", provider: .claude),
+      ]
+    )
+
+    #expect(result.status == "not_found")
+    #expect(handler.requests.isEmpty)
+  }
+
+  @Test
+  func createWorktreeTasksRejectsUnregisteredRepository() async {
+    let creator = MockWorktreeCreator { repositoryPath, branch in
+      VoiceCreatedWorktree(
+        repositoryPath: repositoryPath,
+        branchName: branch,
+        worktreePath: "\(repositoryPath)-\(branch)",
+        launchPath: nil
+      )
+    }
+    let handler = MockLaunchRequestHandler()
+    let (executor, claude, _) = makeExecutor(
+      target: nil,
+      worktreeCreator: creator,
+      launchRequestHandler: handler
+    )
+    claude.selectedRepositories = [
+      SelectedRepository(path: "/repo", name: "Repo"),
+    ]
+
+    let result = await executor.createWorktreeTasks(
+      repositoryPath: "/nope",
+      tasks: [
+        VoiceWorktreeTaskSpec(branch: "task-a", prompt: "Do A", provider: .claude),
+      ]
+    )
+
+    #expect(result.status == "not_found")
+    #expect(result.launched.isEmpty)
+    #expect(handler.requests.isEmpty)
+  }
+
+  @Test
+  func createWorktreeTasksIsUnavailableWithoutDependencies() async {
+    let (executor, claude, _) = makeExecutor()
+    claude.selectedRepositories = [
+      SelectedRepository(path: "/repo", name: "Repo"),
+    ]
+
+    let result = await executor.createWorktreeTasks(
+      repositoryPath: "/repo",
+      tasks: [
+        VoiceWorktreeTaskSpec(branch: "task-a", prompt: "Do A", provider: .claude),
+      ]
+    )
+
+    #expect(result.status == "unavailable")
+    #expect(result.launched.isEmpty)
+  }
+
   private func makeExecutor() -> (
     VoiceAgentToolExecutor,
     MockVoiceSessionManager,
@@ -296,7 +548,9 @@ struct VoiceAgentToolExecutorTests {
   private func makeExecutor(
     target: VoiceSessionTarget?,
     transcriptReader: any VoiceSessionTranscriptReading =
-      StubTranscriptReader(textsByPath: [:])
+      StubTranscriptReader(textsByPath: [:]),
+    worktreeCreator: (any VoiceWorktreeCreating)? = nil,
+    launchRequestHandler: (any WorktreeLaunchRequestHandlingProtocol)? = nil
   ) -> (
     VoiceAgentToolExecutor,
     MockVoiceSessionManager,
@@ -312,7 +566,9 @@ struct VoiceAgentToolExecutorTests {
         codexViewModel: codex,
         selectionRouter: GlobalSessionSelectionRouter(),
         targetResolver: resolver,
-        transcriptReader: transcriptReader
+        transcriptReader: transcriptReader,
+        worktreeCreator: worktreeCreator,
+        launchRequestHandler: launchRequestHandler
       ),
       claude,
       codex

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/VoiceSessionCompletionWatcherTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/VoiceSessionCompletionWatcherTests.swift
@@ -59,6 +59,23 @@ private final class CompletionWatcherExecutor: VoiceAgentToolExecuting {
     )
   }
 
+  func listWorktrees() -> VoiceWorktreeInventory {
+    .init(repositories: [])
+  }
+
+  func createWorktreeTasks(
+    repositoryPath: String?,
+    tasks: [VoiceWorktreeTaskSpec]
+  ) async -> VoiceWorktreeTaskBatchResult {
+    .init(
+      status: "accepted",
+      message: nil,
+      repositoryPath: repositoryPath ?? "",
+      launched: [],
+      failures: []
+    )
+  }
+
   func pendingApproval(sessionId: String) -> VoicePendingApproval? {
     nil
   }

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/VoiceToolCatalogTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/VoiceToolCatalogTests.swift
@@ -43,6 +43,29 @@ private final class MockVoiceToolExecutor: VoiceAgentToolExecuting {
     )
   }
 
+  var inventory = VoiceWorktreeInventory(repositories: [])
+
+  func listWorktrees() -> VoiceWorktreeInventory {
+    inventory
+  }
+
+  var taskBatchResult = VoiceWorktreeTaskBatchResult(
+    status: "accepted",
+    message: nil,
+    repositoryPath: "/repo",
+    launched: [],
+    failures: []
+  )
+  private(set) var createdTaskRequests: [(String?, [VoiceWorktreeTaskSpec])] = []
+
+  func createWorktreeTasks(
+    repositoryPath: String?,
+    tasks: [VoiceWorktreeTaskSpec]
+  ) async -> VoiceWorktreeTaskBatchResult {
+    createdTaskRequests.append((repositoryPath, tasks))
+    return taskBatchResult
+  }
+
   func pendingApproval(sessionId: String) -> VoicePendingApproval? {
     pending[sessionId]
   }
@@ -117,7 +140,9 @@ struct VoiceToolCatalogTests {
         "read_session_response",
         "send_prompt",
         "focus_session",
+        "list_worktrees",
         "launch_session",
+        "create_worktree_tasks",
         "approve_pending_tool",
         "list_displays",
         "capture_screen",
@@ -125,6 +150,10 @@ struct VoiceToolCatalogTests {
     )
     #expect(
       tools.first(where: { $0.name == "approve_pending_tool" })?
+        .allowsAutomaticRetry == false
+    )
+    #expect(
+      tools.first(where: { $0.name == "create_worktree_tasks" })?
         .allowsAutomaticRetry == false
     )
     #expect(tools.allSatisfy { $0.parameters["type"] != nil })
@@ -315,6 +344,132 @@ struct VoiceToolCatalogTests {
       arguments: #"{"session_id":"codex-1","decision":"approve"}"#
     )
     #expect(try status(codex) == "rejected")
+  }
+
+  @Test
+  func listWorktreesEncodesInventory() async {
+    let executor = MockVoiceToolExecutor()
+    executor.inventory = VoiceWorktreeInventory(repositories: [
+      VoiceRepositorySummary(
+        name: "Repo",
+        path: "/repo",
+        worktrees: [
+          VoiceWorktreeSummary(
+            name: "main",
+            path: "/repo",
+            isWorktree: false,
+            sessionCount: 2
+          ),
+        ]
+      ),
+    ])
+    let catalog = VoiceToolCatalog(
+      executor: executor,
+      onBackgroundUpdate: { _ in }
+    )
+    let registry = VoiceToolRegistry(tools: catalog.makeTools())
+
+    let result = await registry.execute(
+      name: "list_worktrees",
+      arguments: "{}"
+    )
+    #expect(result.contains(#""path":"\/repo""#) || result.contains(#""path":"/repo""#))
+    #expect(result.contains(#""session_count":2"#))
+  }
+
+  @Test
+  func createWorktreeTasksAppliesDefaultProviderAndWatchesLaunches() async throws {
+    let executor = MockVoiceToolExecutor()
+    executor.taskBatchResult = VoiceWorktreeTaskBatchResult(
+      status: "accepted",
+      message: nil,
+      repositoryPath: "/repo",
+      launched: [
+        VoiceWorktreeTaskLaunch(
+          branch: "task-a",
+          provider: .codex,
+          worktreePath: "/repo-task-a",
+          pendingSessionId: "pending-1"
+        ),
+        VoiceWorktreeTaskLaunch(
+          branch: "task-b",
+          provider: .claude,
+          worktreePath: "/repo-task-b",
+          pendingSessionId: nil
+        ),
+      ],
+      failures: []
+    )
+    let catalog = VoiceToolCatalog(
+      executor: executor,
+      onBackgroundUpdate: { _ in }
+    )
+    let registry = VoiceToolRegistry(tools: catalog.makeTools())
+
+    let result = await registry.execute(
+      name: "create_worktree_tasks",
+      arguments: """
+        {"repository_path":"/repo","provider":"codex","tasks":[\
+        {"branch":"task-a","prompt":"Do A"},\
+        {"branch":"task-b","prompt":"Do B","provider":"claude"}]}
+        """
+    )
+
+    #expect(try status(result) == "accepted")
+    let request = try #require(executor.createdTaskRequests.first)
+    #expect(request.0 == "/repo")
+    #expect(request.1.map(\.branch) == ["task-a", "task-b"])
+    #expect(request.1.map(\.provider) == [.codex, .claude])
+    #expect(executor.completionStreamSessionIds == ["pending-1"])
+  }
+
+  @Test
+  func createWorktreeTasksOmittedRepositoryDefaultsToTargetSession() async throws {
+    let executor = MockVoiceToolExecutor()
+    let catalog = VoiceToolCatalog(
+      executor: executor,
+      onBackgroundUpdate: { _ in }
+    )
+    let registry = VoiceToolRegistry(tools: catalog.makeTools())
+
+    let result = await registry.execute(
+      name: "create_worktree_tasks",
+      arguments: #"{"tasks":[{"branch":"task-a","prompt":"Do A"}]}"#
+    )
+
+    #expect(try status(result) == "accepted")
+    let request = try #require(executor.createdTaskRequests.first)
+    #expect(request.0 == nil)
+    #expect(request.1.map(\.provider) == [.claude])
+  }
+
+  @Test
+  func createWorktreeTasksRejectsInvalidArguments() async throws {
+    let executor = MockVoiceToolExecutor()
+    let catalog = VoiceToolCatalog(
+      executor: executor,
+      onBackgroundUpdate: { _ in }
+    )
+    let registry = VoiceToolRegistry(tools: catalog.makeTools())
+
+    let emptyTasks = await registry.execute(
+      name: "create_worktree_tasks",
+      arguments: #"{"repository_path":"/repo","tasks":[]}"#
+    )
+    #expect(try status(emptyTasks) == "error")
+
+    let blankPrompt = await registry.execute(
+      name: "create_worktree_tasks",
+      arguments: #"{"repository_path":"/repo","tasks":[{"branch":"a","prompt":"  "}]}"#
+    )
+    #expect(try status(blankPrompt) == "error")
+
+    let badProvider = await registry.execute(
+      name: "create_worktree_tasks",
+      arguments: #"{"repository_path":"/repo","tasks":[{"branch":"a","prompt":"Do","provider":"gpt"}]}"#
+    )
+    #expect(try status(badProvider) == "error")
+    #expect(executor.createdTaskRequests.isEmpty)
   }
 
   @Test

--- a/app/modules/AgentHubVoice/Package.swift
+++ b/app/modules/AgentHubVoice/Package.swift
@@ -41,6 +41,9 @@ let package = Package(
       name: "AgentHubVoicePanel",
       dependencies: ["AgentHubVoice"],
       path: "Sources/AgentHubVoicePanel",
+      resources: [
+        .process("Shaders")
+      ],
       swiftSettings: [
         .swiftLanguageMode(.v5)
       ]

--- a/app/modules/AgentHubVoice/Sources/AgentHubVoice/Realtime/RealtimeSessionConfigurationBuilder.swift
+++ b/app/modules/AgentHubVoice/Sources/AgentHubVoice/Realtime/RealtimeSessionConfigurationBuilder.swift
@@ -33,6 +33,16 @@ public enum RealtimeSessionConfigurationBuilder {
     display_index. Use the region parameter when they point at a specific area.
     """
 
+  public static let worktreeTaskInstructions = """
+    When the user asks to create a worktree, create worktree tasks, or run tasks in parallel —
+    even a single one — call create_worktree_tasks. launch_session never creates a worktree;
+    only use it when the user asks to start a session in an existing repository or worktree.
+    When calling create_worktree_tasks, omit repository_path unless the user explicitly names
+    a repository or path — omitted, it defaults to the repository of the session the user is
+    working in, which is what they usually mean. Never guess a repository or reuse one from an
+    earlier answer. After the tool returns, tell the user which repository was used.
+    """
+
   public static func instructions(
     for tools: VoiceToolRegistry,
     language: String? = nil
@@ -54,6 +64,10 @@ public enum RealtimeSessionConfigurationBuilder {
     let hasScreenCapture = tools.tools.contains { $0.name == "capture_screen" }
     if hasScreenCapture {
       combined += "\n" + screenCaptureInstructions
+    }
+    let hasWorktreeTasks = tools.tools.contains { $0.name == "create_worktree_tasks" }
+    if hasWorktreeTasks {
+      combined += "\n" + worktreeTaskInstructions
     }
     return combined
   }

--- a/app/modules/AgentHubVoice/Sources/AgentHubVoicePanel/LiquidVoiceOrb.swift
+++ b/app/modules/AgentHubVoice/Sources/AgentHubVoicePanel/LiquidVoiceOrb.swift
@@ -1,0 +1,130 @@
+import AgentHubVoice
+import SwiftUI
+
+/// Shader drive parameters for the liquid voice orb: how bright the liquid
+/// field burns and how fast it flows. Resolved purely from engine activity so
+/// the mapping is unit-testable.
+struct LiquidOrbActivity: Equatable {
+  var intensity: Double
+  var speed: Double
+
+  static func resolve(
+    state: VoiceEngineState,
+    isAssistantSpeaking: Bool,
+    microphoneLevel: Float,
+    assistantLevel: Float
+  ) -> LiquidOrbActivity {
+    // Audible playback outlasts the engine's speaking state (levels track
+    // network delta arrival), so the flag wins over the state machine.
+    if isAssistantSpeaking {
+      return LiquidOrbActivity(
+        intensity: clamped(0.78 + Double(assistantLevel) * 0.22),
+        speed: 1.7
+      )
+    }
+    switch state {
+    case .disconnected, .failed:
+      return LiquidOrbActivity(intensity: 0.16, speed: 0.35)
+    case .connecting:
+      return LiquidOrbActivity(intensity: 0.3, speed: 0.6)
+    case .idle:
+      return LiquidOrbActivity(
+        intensity: clamped(0.42 + Double(microphoneLevel) * 0.15),
+        speed: 0.8
+      )
+    case .userSpeaking:
+      // The user's own voice should read as a gentle glow, not a light show —
+      // the orb's opacity dip is the primary listening cue.
+      return LiquidOrbActivity(
+        intensity: clamped(0.6 + Double(microphoneLevel) * 0.15),
+        speed: 1.05
+      )
+    case .thinking:
+      return LiquidOrbActivity(intensity: 0.55, speed: 1.5)
+    case .speaking:
+      return LiquidOrbActivity(
+        intensity: clamped(0.78 + Double(assistantLevel) * 0.22),
+        speed: 1.7
+      )
+    case .executingTool:
+      return LiquidOrbActivity(intensity: 0.5, speed: 1.2)
+    }
+  }
+
+  private static func clamped(_ value: Double) -> Double {
+    min(max(value, 0), 1)
+  }
+}
+
+/// Accumulates shader phase across frames so speed changes never jump the
+/// pattern: `time * speed` with a large absolute time hard-cuts the visual on
+/// every speed change, while integrated phase stays continuous. Intensity and
+/// speed are low-pass filtered toward their targets for the same reason.
+/// Mutated from `TimelineView` render passes; deliberately not observable.
+final class LiquidOrbClock {
+  private var lastDate: Date?
+  private(set) var phase: Double = 0
+  private(set) var smoothedIntensity: Double = 0
+  private(set) var smoothedSpeed: Double = 0
+
+  /// Time constant ~0.16s: fast enough to feel live, slow enough to glide.
+  private let smoothingRate: Double = 6
+
+  func advance(
+    to date: Date,
+    target: LiquidOrbActivity
+  ) -> (time: Double, intensity: Double) {
+    let elapsed = lastDate.map { date.timeIntervalSince($0) } ?? 0
+    lastDate = date
+    // Frame gaps (window hidden, debugger pauses) must not fast-forward the
+    // pattern or snap the smoothing.
+    let dt = min(max(elapsed, 0), 1.0 / 15.0)
+    let alpha = 1 - exp(-dt * smoothingRate)
+    smoothedIntensity += (target.intensity - smoothedIntensity) * alpha
+    smoothedSpeed += (target.speed - smoothedSpeed) * alpha
+    phase += dt * smoothedSpeed
+    return (phase, smoothedIntensity)
+  }
+}
+
+/// The liquid core of the conversation orb: a dark disc with ShaderKit's
+/// liquid-tech field flowing through it, tinted with the selected voice's
+/// gradient and burning brighter while the user or assistant is speaking.
+struct LiquidVoiceOrb: View {
+  let activity: LiquidOrbActivity
+  let colors: [Color]
+  let diameter: CGFloat
+
+  @State private var clock = LiquidOrbClock()
+
+  private var colorA: Color { colors.first ?? .blue }
+  private var colorB: Color { colors.count > 1 ? colors[1] : colorA }
+
+  var body: some View {
+    TimelineView(.animation(minimumInterval: nil, paused: activity.speed == 0)) { context in
+      let sample = clock.advance(to: context.date, target: activity)
+      Circle()
+        .fill(
+          LinearGradient(
+            colors: [
+              Color(red: 0.06, green: 0.07, blue: 0.10),
+              Color(red: 0.03, green: 0.04, blue: 0.06),
+            ],
+            startPoint: .topLeading,
+            endPoint: .bottomTrailing
+          )
+        )
+        .layerEffect(
+          ShaderLibrary.bundle(.module).liquidVoiceOrb(
+            .float2(diameter, diameter),
+            .float(sample.time),
+            .float(sample.intensity),
+            .color(colorA),
+            .color(colorB)
+          ),
+          maxSampleOffset: .zero
+        )
+    }
+    .frame(width: diameter, height: diameter)
+  }
+}

--- a/app/modules/AgentHubVoice/Sources/AgentHubVoicePanel/Shaders/LiquidVoiceOrb.metal
+++ b/app/modules/AgentHubVoice/Sources/AgentHubVoicePanel/Shaders/LiquidVoiceOrb.metal
@@ -1,0 +1,78 @@
+//
+//  LiquidVoiceOrb.metal
+//  AgentHubVoicePanel
+//
+//  Voice-orb adaptation of ShaderKit's Liquid Tech [234] shader (Twigl GLSL
+//  inspired). The raymarched field is kept, but the rainbow wave coloring is
+//  replaced by a two-color tint (the selected voice's gradient), and the
+//  effect is masked by the sampled layer's alpha so it stays inside the orb.
+//
+
+#include <metal_stdlib>
+#include <SwiftUI/SwiftUI_Metal.h>
+using namespace metal;
+
+static float2x2 orbRotate2D(float angle) {
+  float s = sin(angle);
+  float c = cos(angle);
+  return float2x2(c, -s, s, c);
+}
+
+[[stitchable]] half4 liquidVoiceOrb(
+  float2 position,
+  SwiftUI::Layer layer,
+  float2 size,
+  float time,
+  float intensity,
+  half4 colorA,
+  half4 colorB
+) {
+  float2 r = size;
+
+  float2 uv = (position * 2.0 - r) / r.y;
+  // Tint span uses disc-space coordinates, captured before the zoom below.
+  float radial = clamp(length(uv), 0.0, 1.0);
+  // Zoom the field so the liquid sphere fills the disc edge-to-edge instead
+  // of leaving a dark ring of base circle around it.
+  uv /= 1.5;
+
+  float d = 0.0;
+  float s = 0.0;
+  float4 o = float4(0.0);
+
+  float2x2 rot = orbRotate2D(time * 0.5);
+
+  for (int i = 0; i < 100; i++) {
+    float fi = float(i);
+    float2 v = rot * (uv * d);
+    float3 p = float3(v.x, v.y, d - 8.0);
+
+    float2 xz = rot * p.xz;
+    p.x = xz.x;
+    p.z = xz.y;
+
+    float dp = dot(p.yzx, p) / 0.7;
+    float m = max(sin(dp), length(p) - 4.0);
+    s = 0.012 + 0.08 * abs(m - fi / 100.0);
+    d += s;
+
+    float4 wave = 1.3 * sin(float4(3.0, 2.0, 1.0, 1.0) + fi * 0.3) / s;
+    float lenPP = length(p * p);
+    o += max(wave, float4(-lenPP));
+  }
+
+  o = tanh(o * o / 800000.0);
+
+  // Voice tint: colorA at the center flowing to colorB at the rim, driven by
+  // the field's luminance, with a whisper of the original chroma so the
+  // highlights keep their liquid sparkle.
+  float lum = dot(o.rgb, float3(0.299, 0.587, 0.114));
+  half3 tint = mix(colorA.rgb, colorB.rgb, half(radial));
+  half3 effect = tint * half(lum) * 1.6h + half3(o.rgb) * 0.15h;
+
+  half4 sampled = layer.sample(position);
+  half3 added = min(sampled.rgb + effect * sampled.a, half3(1.0));
+  half3 blended = mix(sampled.rgb, added, half(intensity));
+
+  return half4(blended, sampled.a);
+}

--- a/app/modules/AgentHubVoice/Sources/AgentHubVoicePanel/VoiceConversationOrb.swift
+++ b/app/modules/AgentHubVoice/Sources/AgentHubVoicePanel/VoiceConversationOrb.swift
@@ -18,8 +18,29 @@ struct VoiceConversationOrb: View {
   @State private var isBreathing = false
   @State private var isSpeakingPulse = false
 
+  /// Only assistant audio swells the orb — user speech should not bounce it;
+  /// listening is communicated by a subtle opacity dip instead.
   private var level: CGFloat {
-    CGFloat(max(microphoneLevel, assistantLevel))
+    CGFloat(assistantLevel)
+  }
+
+  private var isListening: Bool {
+    state == .userSpeaking
+  }
+
+  private var orbActivity: LiquidOrbActivity {
+    var activity = LiquidOrbActivity.resolve(
+      state: state,
+      isAssistantSpeaking: isAssistantSpeaking,
+      microphoneLevel: microphoneLevel,
+      assistantLevel: assistantLevel
+    )
+    // Reduce Motion: freeze the liquid flow; intensity still communicates
+    // listening/speaking as a static brightness change.
+    if reduceMotion {
+      activity.speed = 0
+    }
+    return activity
   }
 
   private var isConnected: Bool {
@@ -39,38 +60,36 @@ struct VoiceConversationOrb: View {
             colors: [voice.gradient.first?.opacity(0.45) ?? .clear, .clear],
             center: .center,
             startRadius: 10,
-            endRadius: 90
+            endRadius: 101
           )
         )
-        .frame(width: 180, height: 180)
+        .frame(width: 202, height: 202)
         .scaleEffect(haloScale)
 
-      Circle()
-        .fill(
-          LinearGradient(
-            colors: voice.gradient,
-            startPoint: .topLeading,
-            endPoint: .bottomTrailing
-          )
-        )
-        .frame(width: 104, height: 104)
-        .overlay {
-          Circle()
-            .fill(
-              RadialGradient(
-                colors: [Color.white.opacity(0.35), .clear],
-                center: .init(x: 0.3, y: 0.25),
-                startRadius: 2,
-                endRadius: 60
-              )
+      LiquidVoiceOrb(
+        activity: orbActivity,
+        colors: voice.gradient,
+        diameter: 124
+      )
+      .overlay {
+        Circle()
+          .fill(
+            RadialGradient(
+              colors: [Color.white.opacity(0.2), .clear],
+              center: .init(x: 0.3, y: 0.25),
+              startRadius: 2,
+              endRadius: 70
             )
-        }
-        .scaleEffect(coreScale)
-        .opacity(isConnected ? 1 : 0.45)
+          )
+      }
+      .shadow(color: .black.opacity(0.45), radius: 8, x: 0, y: 3)
+      .scaleEffect(coreScale)
+      .opacity(coreOpacity)
     }
     .frame(maxWidth: .infinity, maxHeight: .infinity)
     .animation(.smooth(duration: 0.15), value: level)
     .animation(.smooth(duration: 0.3), value: isConnected)
+    .animation(.smooth(duration: 0.25), value: isListening)
     .onAppear {
       guard !reduceMotion else { return }
       withAnimation(.easeInOut(duration: 2.4).repeatForever(autoreverses: true)) {
@@ -108,6 +127,11 @@ struct VoiceConversationOrb: View {
       return isAssistantSpeaking ? 0.08 : 0.0
     }
     return isSpeakingPulse ? 0.1 : 0.0
+  }
+
+  private var coreOpacity: Double {
+    guard isConnected else { return 0.45 }
+    return isListening ? 0.82 : 1
   }
 
   private var coreScale: CGFloat {

--- a/app/modules/AgentHubVoice/Tests/AgentHubVoicePanelTests/LiquidVoiceOrbTests.swift
+++ b/app/modules/AgentHubVoice/Tests/AgentHubVoicePanelTests/LiquidVoiceOrbTests.swift
@@ -1,0 +1,161 @@
+import AgentHubVoice
+import Foundation
+import Testing
+@testable import AgentHubVoicePanel
+
+struct LiquidOrbActivityTests {
+  @Test
+  func intensityRisesFromIdleToListeningToSpeaking() {
+    let disconnected = LiquidOrbActivity.resolve(
+      state: .disconnected,
+      isAssistantSpeaking: false,
+      microphoneLevel: 0,
+      assistantLevel: 0
+    )
+    let idle = LiquidOrbActivity.resolve(
+      state: .idle,
+      isAssistantSpeaking: false,
+      microphoneLevel: 0,
+      assistantLevel: 0
+    )
+    let listening = LiquidOrbActivity.resolve(
+      state: .userSpeaking,
+      isAssistantSpeaking: false,
+      microphoneLevel: 0.5,
+      assistantLevel: 0
+    )
+    let speaking = LiquidOrbActivity.resolve(
+      state: .speaking,
+      isAssistantSpeaking: false,
+      microphoneLevel: 0,
+      assistantLevel: 0.5
+    )
+
+    #expect(disconnected.intensity < idle.intensity)
+    #expect(idle.intensity < listening.intensity)
+    #expect(listening.intensity < speaking.intensity)
+    #expect(disconnected.speed < idle.speed)
+    #expect(idle.speed < speaking.speed)
+  }
+
+  @Test
+  func microphoneLevelBoostsListeningIntensity() {
+    let quiet = LiquidOrbActivity.resolve(
+      state: .userSpeaking,
+      isAssistantSpeaking: false,
+      microphoneLevel: 0,
+      assistantLevel: 0
+    )
+    let loud = LiquidOrbActivity.resolve(
+      state: .userSpeaking,
+      isAssistantSpeaking: false,
+      microphoneLevel: 1,
+      assistantLevel: 0
+    )
+
+    #expect(loud.intensity > quiet.intensity)
+    #expect(loud.intensity <= 1)
+  }
+
+  @Test
+  func assistantSpeakingFlagOverridesLaggingState() {
+    let playback = LiquidOrbActivity.resolve(
+      state: .idle,
+      isAssistantSpeaking: true,
+      microphoneLevel: 0,
+      assistantLevel: 1
+    )
+    let spoken = LiquidOrbActivity.resolve(
+      state: .speaking,
+      isAssistantSpeaking: false,
+      microphoneLevel: 0,
+      assistantLevel: 1
+    )
+
+    #expect(playback == spoken)
+    #expect(playback.intensity <= 1)
+  }
+
+  @Test
+  func failedMatchesDisconnected() {
+    let failed = LiquidOrbActivity.resolve(
+      state: .failed("boom"),
+      isAssistantSpeaking: false,
+      microphoneLevel: 0,
+      assistantLevel: 0
+    )
+    let disconnected = LiquidOrbActivity.resolve(
+      state: .disconnected,
+      isAssistantSpeaking: false,
+      microphoneLevel: 0,
+      assistantLevel: 0
+    )
+
+    #expect(failed == disconnected)
+  }
+}
+
+struct LiquidOrbClockTests {
+  @Test
+  func phaseAdvancesContinuouslyAndConvergesToTarget() {
+    let clock = LiquidOrbClock()
+    let target = LiquidOrbActivity(intensity: 0.8, speed: 1.0)
+    var date = Date(timeIntervalSinceReferenceDate: 0)
+
+    var previousPhase = clock.advance(to: date, target: target).time
+    var lastIntensity = 0.0
+    for _ in 0..<300 {
+      date = date.addingTimeInterval(1.0 / 60.0)
+      let sample = clock.advance(to: date, target: target)
+      #expect(sample.time >= previousPhase)
+      previousPhase = sample.time
+      lastIntensity = sample.intensity
+    }
+
+    #expect(abs(lastIntensity - target.intensity) < 0.01)
+    #expect(abs(clock.smoothedSpeed - target.speed) < 0.01)
+  }
+
+  @Test
+  func frameGapsAreClampedInsteadOfFastForwarding() {
+    let clock = LiquidOrbClock()
+    let target = LiquidOrbActivity(intensity: 1.0, speed: 1.0)
+    let start = Date(timeIntervalSinceReferenceDate: 0)
+    _ = clock.advance(to: start, target: target)
+    let beforeGap = clock.phase
+
+    // A 10-second stall (hidden window, debugger) must advance at most one
+    // clamped frame, not ten seconds of phase.
+    let afterGap = clock.advance(
+      to: start.addingTimeInterval(10),
+      target: target
+    ).time
+
+    #expect(afterGap - beforeGap <= (1.0 / 15.0) * target.speed + 0.0001)
+  }
+
+  @Test
+  func speedChangeGlidesWithoutPhaseJump() {
+    let clock = LiquidOrbClock()
+    var date = Date(timeIntervalSinceReferenceDate: 0)
+    let slow = LiquidOrbActivity(intensity: 0.4, speed: 0.5)
+    let fast = LiquidOrbActivity(intensity: 0.9, speed: 1.7)
+
+    _ = clock.advance(to: date, target: slow)
+    for _ in 0..<60 {
+      date = date.addingTimeInterval(1.0 / 60.0)
+      _ = clock.advance(to: date, target: slow)
+    }
+
+    // Switching targets must never move phase faster than the max speed in a
+    // single frame — continuity is the whole point of the clock.
+    var previous = clock.phase
+    for _ in 0..<120 {
+      date = date.addingTimeInterval(1.0 / 60.0)
+      let sample = clock.advance(to: date, target: fast)
+      #expect(sample.time - previous <= (1.0 / 60.0) * fast.speed + 0.0001)
+      previous = sample.time
+    }
+    #expect(abs(clock.smoothedSpeed - fast.speed) < 0.01)
+  }
+}

--- a/app/modules/AgentHubVoice/Tests/AgentHubVoiceTests/RealtimeSessionConfigurationBuilderTests.swift
+++ b/app/modules/AgentHubVoice/Tests/AgentHubVoiceTests/RealtimeSessionConfigurationBuilderTests.swift
@@ -127,4 +127,35 @@ struct RealtimeSessionConfigurationBuilderTests {
     )
     #expect(!withoutCapture.contains("capture_screen"))
   }
+
+  @Test
+  func worktreeTaskInstructionsOnlyAppearWithTheTaskTool() {
+    let taskTool = VoiceTool(
+      name: "create_worktree_tasks",
+      description: "Creates worktree tasks",
+      parameters: ["type": "object"]
+    ) { _ in
+      "{}"
+    }
+    let otherTool = VoiceTool(
+      name: "list_sessions",
+      description: "Lists sessions",
+      parameters: ["type": "object"]
+    ) { _ in
+      "{}"
+    }
+
+    let withTasks = RealtimeSessionConfigurationBuilder.instructions(
+      for: VoiceToolRegistry(tools: [otherTool, taskTool])
+    )
+    #expect(withTasks.contains("call create_worktree_tasks"))
+    #expect(withTasks.contains("launch_session never creates a worktree"))
+    #expect(withTasks.contains("omit repository_path"))
+    #expect(withTasks.contains("Never guess a repository"))
+
+    let withoutTasks = RealtimeSessionConfigurationBuilder.instructions(
+      for: VoiceToolRegistry(tools: [otherTool])
+    )
+    #expect(!withoutTasks.contains("repository_path"))
+  }
 }


### PR DESCRIPTION
## Voice worktree tools

The voice agent gains two orchestration tools — in-process twins of the MCP server's worktree path, reusing `WorktreeManagementService` and `WorktreeLaunchRequestHandler` rather than bridging JSON-RPC:

- **`list_worktrees`** — registered repositories and their worktrees with exact paths and session counts, so the agent stops guessing paths for `launch_session` / task creation.
- **`create_worktree_tasks`** — creates one repo-root git worktree per task (a single task is fine) and launches an agent session in each with its prompt. Per-task failure isolation, branch-collision auto-rename (`WorktreeNaming`), completion watching per launched session, and `allowsAutomaticRetry: false` so a retry can't multiply worktrees.

**Repository defaulting:** `repository_path` is optional. Omitted, it resolves from the focused session (`VoiceSessionTargetResolver`) and rolls nested paths up to the parent repository via `WorktreeModuleResolver.bestMatch`, per the worktree contract.

**Model steering:** realtime session instructions and tool descriptions route "create a worktree" to `create_worktree_tasks` (never `launch_session`, whose description previously mentioned "worktree" and stole those requests), and tell the model to omit `repository_path` unless the user names one — the wrong-repo failure mode was the model guessing a path it had seen earlier.

## Liquid-tech conversation orb

The converse-mode orb core is now ShaderKit's Liquid Tech [234] field (`LiquidVoiceOrb.metal` in `AgentHubVoicePanel`, SPM-processed Metal resource), tinted center→rim with the selected voice's gradient and masked to the disc:

- **Activity-driven intensity** (`LiquidOrbActivity`, pure + tested): disconnected 0.16 → idle 0.42 → listening 0.6 → speaking 0.78 + assistant level; flow speed rises in step (0.35 → 1.7).
- **User speech doesn't bounce the orb** — only assistant audio swells the scale; listening reads as a subtle opacity dip (0.82) plus a gentle mic glow.
- **`LiquidOrbClock`** accumulates shader phase and low-pass filters intensity/speed so state changes glide instead of hard-cutting the pattern (`time × speed` with large time discontinuities), with frame-gap clamping.
- **Reduce Motion** freezes the flow (timeline paused) while intensity still communicates state.
- Onboarding is untouched.

## Testing

- New/updated: `VoiceAgentToolExecutorTests`, `VoiceToolCatalogTests`, `VoiceSessionCompletionWatcherTests`, `RealtimeSessionConfigurationBuilderTests`, `LiquidVoiceOrbTests` (activity mapping + clock continuity).
- Full gate: fast packages green; the AgentHubCore xcodebuild suite hit 31 issues in 5 suites outside this diff (known parallel-run flakes) — all 5 pass when rerun serially (42/42).
- Verified Xcode builds compile the Metal resource into `default.metallib` (command-line `swift build` copies it raw — runtime shader loading depends on the Xcode-built bundle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)