### PR TITLE
Voice: session awareness, announcement mic gating, watch tools, and HUD call semantics

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubProvider.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubProvider.swift
@@ -272,7 +272,10 @@ public final class AgentHubProvider {
 
   public private(set) lazy var voiceToolCatalog: any VoiceToolCataloging =
     VoiceToolCatalog(
-      executor: voiceToolExecutor
+      executor: voiceToolExecutor,
+      onBackgroundWaitCountChanged: { [weak self] count in
+        self?.realtimeVoiceEngine.setAwaitingBackgroundWork(count > 0)
+      }
     ) { [weak self] update in
       self?.realtimeVoiceEngine.pushBackgroundUpdate(update)
     }

--- a/app/modules/AgentHubCore/Sources/AgentHub/Models/VoiceAgentModels.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Models/VoiceAgentModels.swift
@@ -147,6 +147,36 @@ public struct VoiceApprovalResponseResult: Codable, Equatable, Sendable {
   }
 }
 
+public struct VoiceTranscriptTurn: Codable, Equatable, Sendable {
+  public let role: String
+  public let text: String
+
+  public init(role: String, text: String) {
+    self.role = role
+    self.text = text
+  }
+}
+
+public struct VoiceSessionHistory: Codable, Equatable, Sendable {
+  public let sessionId: String
+  public let provider: SessionProviderKind
+  public let name: String
+  /// Oldest first, so reading top to bottom matches conversation order.
+  public let turns: [VoiceTranscriptTurn]
+
+  public init(
+    sessionId: String,
+    provider: SessionProviderKind,
+    name: String,
+    turns: [VoiceTranscriptTurn]
+  ) {
+    self.sessionId = sessionId
+    self.provider = provider
+    self.name = name
+    self.turns = turns
+  }
+}
+
 public struct VoiceLatestResponse: Codable, Equatable, Sendable {
   public let sessionId: String
   public let provider: SessionProviderKind

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/AgentHubVoiceHUDHost.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/AgentHubVoiceHUDHost.swift
@@ -68,6 +68,13 @@ public final class AgentHubVoiceHUDHost: VoiceHUDHost {
     )
   }
 
+  public func makeSessionContext() -> String? {
+    guard let provider else { return nil }
+    return VoiceSessionContextBuilder.make(
+      summary: provider.voiceToolExecutor.listSessions()
+    )
+  }
+
   public func resolveAPIKey() async throws -> String? {
     guard let provider else { return nil }
     return try await provider.openAIKeyProvider.resolve()?.key

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/VoiceAgentToolExecutor.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/VoiceAgentToolExecutor.swift
@@ -40,10 +40,26 @@ extension CLISessionsViewModel: VoiceSessionManaging {
   }
 }
 
+public enum VoiceSessionStatusLimits {
+  public static let defaultActivityCount = 3
+  public static let maximumActivityCount = 20
+}
+
+public enum VoiceSessionHistoryLimits {
+  public static let defaultTurnCount = 6
+}
+
 @MainActor
 public protocol VoiceAgentToolExecuting: AnyObject {
   func listSessions() -> VoiceSessionsSummary
-  func sessionStatus(sessionId: String) -> VoiceSessionStatusDetail?
+  func sessionStatus(
+    sessionId: String,
+    activityLimit: Int
+  ) -> VoiceSessionStatusDetail?
+  func sessionHistory(
+    sessionId: String?,
+    turnLimit: Int
+  ) async -> VoiceSessionHistory?
   func sendPrompt(sessionId: String, prompt: String) -> VoicePromptDeliveryResult
   func focusSession(sessionId: String) -> Bool
   func launchSession(
@@ -63,6 +79,15 @@ public protocol VoiceAgentToolExecuting: AnyObject {
   ) -> VoiceApprovalResponseResult
   func completionStream(sessionId: String) -> AsyncStream<SessionStatus>
   func latestResponse(sessionId: String?) async -> VoiceLatestResponse?
+}
+
+extension VoiceAgentToolExecuting {
+  public func sessionStatus(sessionId: String) -> VoiceSessionStatusDetail? {
+    sessionStatus(
+      sessionId: sessionId,
+      activityLimit: VoiceSessionStatusLimits.defaultActivityCount
+    )
+  }
 }
 
 @MainActor
@@ -171,15 +196,25 @@ public final class VoiceAgentToolExecutor: VoiceAgentToolExecuting {
     )
   }
 
-  public func sessionStatus(sessionId: String) -> VoiceSessionStatusDetail? {
+  public func sessionStatus(
+    sessionId: String,
+    activityLimit: Int
+  ) -> VoiceSessionStatusDetail? {
     if let resolvedSessionId = resolvedSessionID(forPendingID: sessionId) {
-      return sessionStatus(sessionId: resolvedSessionId)
+      return sessionStatus(
+        sessionId: resolvedSessionId,
+        activityLimit: activityLimit
+      )
     }
     guard let record = record(sessionId: sessionId) else {
       return nil
     }
+    let limit = min(
+      max(1, activityLimit),
+      VoiceSessionStatusLimits.maximumActivityCount
+    )
     let state = record.viewModel.monitorStates[sessionId]
-    let activities = Array(state?.recentActivities.suffix(3) ?? []).map { activity in
+    let activities = Array(state?.recentActivities.suffix(limit) ?? []).map { activity in
       VoiceSessionActivity(
         timestamp: activity.timestamp,
         description: Self.truncate(activity.description, limit: 200)
@@ -436,6 +471,47 @@ public final class VoiceAgentToolExecutor: VoiceAgentToolExecuting {
   }
 
   public func latestResponse(sessionId: String?) async -> VoiceLatestResponse? {
+    guard let transcript = resolveTranscript(sessionId: sessionId) else {
+      return nil
+    }
+    guard let text = await transcriptReader.latestAssistantText(
+      atPath: transcript.path,
+      provider: transcript.provider
+    ), !text.isEmpty else {
+      return nil
+    }
+    return VoiceLatestResponse(
+      sessionId: transcript.sessionId,
+      provider: transcript.provider,
+      name: transcript.name,
+      text: text
+    )
+  }
+
+  public func sessionHistory(
+    sessionId: String?,
+    turnLimit: Int
+  ) async -> VoiceSessionHistory? {
+    guard let transcript = resolveTranscript(sessionId: sessionId) else {
+      return nil
+    }
+    let turns = await transcriptReader.recentTurns(
+      atPath: transcript.path,
+      provider: transcript.provider,
+      turnLimit: turnLimit
+    )
+    guard !turns.isEmpty else { return nil }
+    return VoiceSessionHistory(
+      sessionId: transcript.sessionId,
+      provider: transcript.provider,
+      name: transcript.name,
+      turns: turns
+    )
+  }
+
+  private func resolveTranscript(
+    sessionId: String?
+  ) -> (sessionId: String, provider: SessionProviderKind, name: String, path: String)? {
     guard var lookupId = sessionId
       ?? targetResolver.resolve(manualSessionId: nil)?.sessionId else {
       return nil
@@ -452,18 +528,12 @@ public final class VoiceAgentToolExecutor: VoiceAgentToolExecuting {
         record.session.sessionFilePath
       }
     guard let path else { return nil }
-    guard let text = await transcriptReader.latestAssistantText(
-      atPath: path,
-      provider: record.provider
-    ), !text.isEmpty else {
-      return nil
-    }
-    return VoiceLatestResponse(
+    return (
       sessionId: lookupId,
       provider: record.provider,
       name: record.viewModel.sessionCustomNames[lookupId]
         ?? record.session.displayName,
-      text: text
+      path: path
     )
   }
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/VoiceSessionCompletionWatcher.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/VoiceSessionCompletionWatcher.swift
@@ -2,9 +2,15 @@ import Foundation
 
 @MainActor
 public protocol VoiceSessionCompletionWatching: AnyObject {
-  func watch(sessionId: String, name: String)
+  func watch(sessionId: String, name: String, announceTimeout: Bool)
   func cancel(sessionId: String)
   func cancelAll()
+}
+
+extension VoiceSessionCompletionWatching {
+  public func watch(sessionId: String, name: String) {
+    watch(sessionId: sessionId, name: name, announceTimeout: false)
+  }
 }
 
 @MainActor
@@ -33,7 +39,11 @@ public final class VoiceSessionCompletionWatcher: VoiceSessionCompletionWatching
     self.onUpdate = onUpdate
   }
 
-  public func watch(sessionId: String, name: String) {
+  public func watch(
+    sessionId: String,
+    name: String,
+    announceTimeout: Bool
+  ) {
     cancel(sessionId: sessionId)
     let stream = executor.completionStream(sessionId: sessionId)
     let armingDelay = self.armingDelay
@@ -104,6 +114,11 @@ public final class VoiceSessionCompletionWatcher: VoiceSessionCompletionWatching
           }
         }
       }
+      // Reached only when the maximum-duration cap finished the stream —
+      // every completion/approval report returns from inside the loop. An
+      // explicitly requested watch must not end silently.
+      guard announceTimeout, !Task.isCancelled else { return }
+      onUpdate("\(name) is still running — I've stopped watching it.")
     }
     onActiveCountChanged?(tasks.count)
   }

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/VoiceSessionCompletionWatcher.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/VoiceSessionCompletionWatcher.swift
@@ -11,6 +11,7 @@ public protocol VoiceSessionCompletionWatching: AnyObject {
 public final class VoiceSessionCompletionWatcher: VoiceSessionCompletionWatching {
   private let executor: any VoiceAgentToolExecuting
   private let onUpdate: @MainActor @Sendable (String) -> Void
+  private let onActiveCountChanged: (@MainActor @Sendable (Int) -> Void)?
   private let armingDelay: Duration
   private let completionDebounce: Duration
   private let maximumDuration: Duration
@@ -21,12 +22,14 @@ public final class VoiceSessionCompletionWatcher: VoiceSessionCompletionWatching
     armingDelay: Duration = .seconds(10),
     completionDebounce: Duration = .seconds(2),
     maximumDuration: Duration = .seconds(1_800),
+    onActiveCountChanged: (@MainActor @Sendable (Int) -> Void)? = nil,
     onUpdate: @escaping @MainActor @Sendable (String) -> Void
   ) {
     self.executor = executor
     self.armingDelay = armingDelay
     self.completionDebounce = completionDebounce
     self.maximumDuration = maximumDuration
+    self.onActiveCountChanged = onActiveCountChanged
     self.onUpdate = onUpdate
   }
 
@@ -60,6 +63,9 @@ public final class VoiceSessionCompletionWatcher: VoiceSessionCompletionWatching
         capTask.cancel()
         continuation.finish()
         tasks.removeValue(forKey: sessionId)
+        // The single end-of-watch point: report, approval, cap, or cancel
+        // all pass through here.
+        onActiveCountChanged?(tasks.count)
       }
 
       var isArmed = false
@@ -99,10 +105,12 @@ public final class VoiceSessionCompletionWatcher: VoiceSessionCompletionWatching
         }
       }
     }
+    onActiveCountChanged?(tasks.count)
   }
 
   public func cancel(sessionId: String) {
     tasks.removeValue(forKey: sessionId)?.cancel()
+    onActiveCountChanged?(tasks.count)
   }
 
   public func cancelAll() {
@@ -111,6 +119,7 @@ public final class VoiceSessionCompletionWatcher: VoiceSessionCompletionWatching
     for task in running {
       task.cancel()
     }
+    onActiveCountChanged?(tasks.count)
   }
 
   private func reportCompletionIfStable(

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/VoiceSessionContextBuilder.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/VoiceSessionContextBuilder.swift
@@ -1,0 +1,54 @@
+//
+//  VoiceSessionContextBuilder.swift
+//  AgentHub
+//
+//  Builds the compact session roster injected into the realtime voice
+//  instructions at connect time. Names and statuses only — no session IDs,
+//  so the model still has to call list_sessions before acting, and the
+//  snapshot stays cheap in model context.
+//
+
+import Foundation
+
+public enum VoiceSessionContextBuilder {
+  public static let maximumSessions = 10
+  public static let maximumCharacters = 1_000
+
+  public static func make(summary: VoiceSessionsSummary) -> String? {
+    guard !summary.sessions.isEmpty else { return nil }
+    let ordered = summary.sessions.sorted {
+      $0.secondsSinceActivity < $1.secondsSinceActivity
+    }
+    let count = ordered.count
+    var lines = ["\(count) session\(count == 1 ? "" : "s"):"]
+    var total = lines[0].count
+    var included = 0
+    for session in ordered.prefix(maximumSessions) {
+      let line = describe(session, isTarget: session.id == summary.targetSessionId)
+      guard total + line.count <= maximumCharacters else { break }
+      lines.append(line)
+      total += line.count
+      included += 1
+    }
+    guard included > 0 else { return nil }
+    if count > included {
+      lines.append("…and \(count - included) more.")
+    }
+    return lines.joined(separator: "\n")
+  }
+
+  private static func describe(
+    _ session: VoiceSessionSummary,
+    isTarget: Bool
+  ) -> String {
+    let repo = (session.worktree as NSString).lastPathComponent
+    var line = "- \(session.name) (\(session.provider.rawValue), \(repo), \(session.status))"
+    if session.pendingApprovalTool != nil {
+      line += ", needs approval"
+    }
+    if isTarget {
+      line += " — current target"
+    }
+    return line
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/VoiceSessionTranscriptReader.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/VoiceSessionTranscriptReader.swift
@@ -14,12 +14,24 @@ public protocol VoiceSessionTranscriptReading: Sendable {
     atPath path: String,
     provider: SessionProviderKind
   ) async -> String?
+
+  func recentTurns(
+    atPath path: String,
+    provider: SessionProviderKind,
+    turnLimit: Int
+  ) async -> [VoiceTranscriptTurn]
 }
 
 public struct VoiceSessionTranscriptReader: VoiceSessionTranscriptReading {
   /// Spoken summaries never need more than this; it also bounds tool payloads
   /// sent to the realtime API.
   public static let maximumCharacters = 4_000
+  /// Per-turn cap for history reads: enough to convey a prompt or answer
+  /// without flooding the realtime context with a whole essay per turn.
+  public static let maximumTurnCharacters = 700
+  /// Total cap across all returned turns; oldest turns are dropped first.
+  public static let maximumHistoryCharacters = 6_000
+  public static let maximumTurnCount = 20
 
   public init() {}
 
@@ -32,6 +44,23 @@ public struct VoiceSessionTranscriptReader: VoiceSessionTranscriptReading {
         return nil
       }
       return Self.extractLatestAssistantText(fromJSONL: content, provider: provider)
+    }.value
+  }
+
+  public func recentTurns(
+    atPath path: String,
+    provider: SessionProviderKind,
+    turnLimit: Int
+  ) async -> [VoiceTranscriptTurn] {
+    await Task.detached(priority: .utility) {
+      guard let content = try? String(contentsOfFile: path, encoding: .utf8) else {
+        return []
+      }
+      return Self.extractRecentTurns(
+        fromJSONL: content,
+        provider: provider,
+        turnLimit: turnLimit
+      )
     }.value
   }
 
@@ -106,6 +135,138 @@ public struct VoiceSessionTranscriptReader: VoiceSessionTranscriptReading {
       return truncate(trimmed)
     }
     return nil
+  }
+
+  public static func extractRecentTurns(
+    fromJSONL content: String,
+    provider: SessionProviderKind,
+    turnLimit: Int
+  ) -> [VoiceTranscriptTurn] {
+    let limit = min(max(1, turnLimit), maximumTurnCount)
+    let turns = switch provider {
+    case .claude:
+      extractRecentClaudeTurns(fromJSONL: content, turnLimit: limit)
+    case .codex:
+      extractRecentCodexTurns(fromJSONL: content, turnLimit: limit)
+    }
+    return trimToHistoryBudget(turns)
+  }
+
+  /// Consecutive text lines from the same role merge into one turn, so a
+  /// multi-line assistant answer reads as a single history entry.
+  static func extractRecentClaudeTurns(
+    fromJSONL content: String,
+    turnLimit: Int
+  ) -> [VoiceTranscriptTurn] {
+    var turns: [VoiceTranscriptTurn] = []
+    var currentRole: String?
+    var currentTexts: [String] = []
+
+    func finalizeCurrent() {
+      guard let role = currentRole, !currentTexts.isEmpty else { return }
+      turns.insert(
+        VoiceTranscriptTurn(
+          role: role,
+          text: truncateTurn(currentTexts.joined(separator: "\n\n"))
+        ),
+        at: 0
+      )
+      currentRole = nil
+      currentTexts = []
+    }
+
+    for line in content.split(separator: "\n").reversed() {
+      guard let object = decodeObject(String(line)) else { continue }
+      guard let role = object["type"] as? String,
+            role == "assistant" || role == "user",
+            object["isMeta"] as? Bool != true,
+            let text = claudeMessageText(from: object) else {
+        continue
+      }
+      if role == "user", isClaudeCommandNoise(text) { continue }
+      if currentRole == role {
+        currentTexts.insert(text, at: 0)
+      } else {
+        finalizeCurrent()
+        if turns.count >= turnLimit { break }
+        currentRole = role
+        currentTexts = [text]
+      }
+    }
+    finalizeCurrent()
+    if turns.count > turnLimit {
+      turns.removeFirst(turns.count - turnLimit)
+    }
+    return turns
+  }
+
+  static func extractRecentCodexTurns(
+    fromJSONL content: String,
+    turnLimit: Int
+  ) -> [VoiceTranscriptTurn] {
+    let roles = ["user_message": "user", "agent_message": "assistant"]
+    var turns: [VoiceTranscriptTurn] = []
+    for line in content.split(separator: "\n").reversed() {
+      guard turns.count < turnLimit else { break }
+      guard let object = decodeObject(String(line)),
+            object["type"] as? String == "event_msg",
+            let payload = object["payload"] as? [String: Any],
+            let payloadType = payload["type"] as? String,
+            let role = roles[payloadType],
+            let message = payload["message"] as? String else {
+        continue
+      }
+      let trimmed = message.trimmingCharacters(in: .whitespacesAndNewlines)
+      guard !trimmed.isEmpty, !isCodexContextNoise(trimmed) else { continue }
+      turns.insert(VoiceTranscriptTurn(role: role, text: truncateTurn(trimmed)), at: 0)
+    }
+    return turns
+  }
+
+  /// Text content of a Claude JSONL line's message: plain-string content or
+  /// the joined `text` blocks. Tool results and thinking blocks are excluded.
+  private static func claudeMessageText(from object: [String: Any]) -> String? {
+    guard let message = object["message"] as? [String: Any] else { return nil }
+    let text: String
+    if let string = message["content"] as? String {
+      text = string
+    } else if let blocks = message["content"] as? [[String: Any]] {
+      text = blocks.compactMap { block -> String? in
+        guard block["type"] as? String == "text" else { return nil }
+        return block["text"] as? String
+      }.joined(separator: "\n")
+    } else {
+      return nil
+    }
+    let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+    return trimmed.isEmpty ? nil : trimmed
+  }
+
+  /// Slash-command echoes and local command output are terminal plumbing,
+  /// not something the user said.
+  private static func isClaudeCommandNoise(_ text: String) -> Bool {
+    text.hasPrefix("<command-") || text.hasPrefix("<local-command")
+  }
+
+  /// Codex rollouts replay instruction/environment blocks as user messages.
+  private static func isCodexContextNoise(_ text: String) -> Bool {
+    text.hasPrefix("<user_instructions>") || text.hasPrefix("<environment_context>")
+  }
+
+  private static func trimToHistoryBudget(
+    _ turns: [VoiceTranscriptTurn]
+  ) -> [VoiceTranscriptTurn] {
+    var trimmed = turns
+    var total = trimmed.reduce(0) { $0 + $1.text.count }
+    while trimmed.count > 1, total > maximumHistoryCharacters {
+      total -= trimmed.removeFirst().text.count
+    }
+    return trimmed
+  }
+
+  private static func truncateTurn(_ text: String) -> String {
+    guard text.count > maximumTurnCharacters else { return text }
+    return String(text.prefix(maximumTurnCharacters)) + "…"
   }
 
   private static func decodeObject(_ line: String) -> [String: Any]? {

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/VoiceToolCatalog.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/VoiceToolCatalog.swift
@@ -51,6 +51,8 @@ public final class VoiceToolCatalog: VoiceToolCataloging {
       readResponseTool(),
       readHistoryTool(),
       sendPromptTool(),
+      watchSessionTool(),
+      stopWatchingTool(),
       focusSessionTool(),
       listWorktreesTool(),
       launchSessionTool(),
@@ -274,6 +276,83 @@ public final class VoiceToolCatalog: VoiceToolCataloging {
         completionWatcher.watch(sessionId: arguments.sessionId, name: name)
       }
       return Self.encode(result)
+    }
+  }
+
+  private func watchSessionTool() -> VoiceTool {
+    VoiceTool(
+      name: "watch_session",
+      description: """
+        Watch a session without sending it anything, and announce when it
+        finishes or needs approval. Use when the user asks to observe a
+        session, keep an eye on it, or be told when it's done — typically
+        while they work in a different session. If the watch times out,
+        AgentHub announces the session is still running.
+        """,
+      parameters: objectSchema(
+        properties: [
+          "session_id": [
+            "type": "string",
+            "description": "Exact ID returned by list_sessions.",
+          ],
+        ],
+        required: ["session_id"]
+      )
+    ) { [weak self] data in
+      guard let self else { return Self.unavailableJSON }
+      guard let arguments = Self.decode(SessionArguments.self, from: data) else {
+        return Self.invalidArgumentsJSON
+      }
+      guard let detail = executor.sessionStatus(
+        sessionId: arguments.sessionId
+      ) else {
+        return Self.encode(
+          BasicToolResult(
+            status: "not_found",
+            message: "No session has that ID."
+          )
+        )
+      }
+      completionWatcher.watch(
+        sessionId: arguments.sessionId,
+        name: detail.name,
+        announceTimeout: true
+      )
+      return Self.encode(
+        BasicToolResult(
+          status: "watching",
+          message: "Watching \(detail.name)."
+        )
+      )
+    }
+  }
+
+  private func stopWatchingTool() -> VoiceTool {
+    VoiceTool(
+      name: "stop_watching",
+      description: """
+        Stop watching a session the user asked to observe. Omit session_id
+        to stop every active watch.
+        """,
+      parameters: objectSchema(
+        properties: [
+          "session_id": [
+            "type": "string",
+            "description": """
+              Exact ID returned by list_sessions. Omit to stop all watches.
+              """,
+          ],
+        ]
+      )
+    ) { [weak self] data in
+      guard let self else { return Self.unavailableJSON }
+      let arguments = Self.decode(OptionalSessionArguments.self, from: data)
+      if let sessionId = arguments?.sessionId {
+        completionWatcher.cancel(sessionId: sessionId)
+      } else {
+        completionWatcher.cancelAll()
+      }
+      return Self.encode(BasicToolResult(status: "stopped", message: nil))
     }
   }
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/VoiceToolCatalog.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/VoiceToolCatalog.swift
@@ -17,9 +17,12 @@ public final class VoiceToolCatalog: VoiceToolCataloging {
   private let screenCapture: any VoiceScreenCapturing
   private let isScreenCaptureEnabled: @MainActor @Sendable () -> Bool
   private let onBackgroundUpdate: @MainActor @Sendable (String) -> Void
+  private let onBackgroundWaitCountChanged:
+    (@MainActor @Sendable (Int) -> Void)?
   private var confirmations: [String: ApprovalConfirmation] = [:]
   private lazy var completionWatcher: VoiceSessionCompletionWatcher = .init(
     executor: executor,
+    onActiveCountChanged: onBackgroundWaitCountChanged,
     onUpdate: onBackgroundUpdate
   )
 
@@ -31,11 +34,13 @@ public final class VoiceToolCatalog: VoiceToolCataloging {
         forKey: AgentHubDefaults.voiceScreenCaptureEnabled
       ) as? Bool) ?? true
     },
+    onBackgroundWaitCountChanged: (@MainActor @Sendable (Int) -> Void)? = nil,
     onBackgroundUpdate: @escaping @MainActor @Sendable (String) -> Void
   ) {
     self.executor = executor
     self.screenCapture = screenCapture
     self.isScreenCaptureEnabled = isScreenCaptureEnabled
+    self.onBackgroundWaitCountChanged = onBackgroundWaitCountChanged
     self.onBackgroundUpdate = onBackgroundUpdate
   }
 
@@ -44,6 +49,7 @@ public final class VoiceToolCatalog: VoiceToolCataloging {
       listSessionsTool(),
       sessionStatusTool(),
       readResponseTool(),
+      readHistoryTool(),
       sendPromptTool(),
       focusSessionTool(),
       listWorktreesTool(),
@@ -97,6 +103,51 @@ public final class VoiceToolCatalog: VoiceToolCataloging {
     }
   }
 
+  private func readHistoryTool() -> VoiceTool {
+    VoiceTool(
+      name: "read_session_history",
+      description: """
+        Read a session's recent user/assistant exchanges, oldest first. Use
+        this when the user asks what they asked earlier, or what a session has
+        been working on beyond its latest answer. For just the latest answer,
+        prefer read_session_response.
+        """,
+      parameters: objectSchema(
+        properties: [
+          "session_id": [
+            "type": "string",
+            "description": """
+              Exact ID returned by list_sessions. Omit to use the current
+              target session.
+              """,
+          ],
+          "turn_limit": [
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 20,
+            "description": "How many turns to return. Defaults to 6.",
+          ],
+        ]
+      )
+    ) { [weak self] data in
+      guard let self else { return Self.unavailableJSON }
+      let arguments = Self.decode(SessionHistoryArguments.self, from: data)
+      guard let history = await executor.sessionHistory(
+        sessionId: arguments?.sessionId,
+        turnLimit: arguments?.turnLimit
+          ?? VoiceSessionHistoryLimits.defaultTurnCount
+      ) else {
+        return Self.encode(
+          BasicToolResult(
+            status: "not_found",
+            message: "That session has no readable conversation yet."
+          )
+        )
+      }
+      return Self.encode(history)
+    }
+  }
+
   private func listSessionsTool() -> VoiceTool {
     VoiceTool(
       name: "list_sessions",
@@ -144,15 +195,31 @@ public final class VoiceToolCatalog: VoiceToolCataloging {
             "type": "string",
             "description": "Exact ID returned by list_sessions.",
           ],
+          "activity_limit": [
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 20,
+            "description": """
+              How many recent activities to return. Defaults to 3; only raise
+              it when the user asks for more detail.
+              """,
+          ],
         ],
         required: ["session_id"]
       )
     ) { [weak self] data in
       guard let self else { return Self.unavailableJSON }
-      guard let arguments = Self.decode(SessionArguments.self, from: data) else {
+      guard let arguments = Self.decode(
+        SessionStatusArguments.self,
+        from: data
+      ) else {
         return Self.invalidArgumentsJSON
       }
-      guard let detail = executor.sessionStatus(sessionId: arguments.sessionId) else {
+      guard let detail = executor.sessionStatus(
+        sessionId: arguments.sessionId,
+        activityLimit: arguments.activityLimit
+          ?? VoiceSessionStatusLimits.defaultActivityCount
+      ) else {
         return Self.encode(
           BasicToolResult(
             status: "not_found",
@@ -555,6 +622,16 @@ private struct SessionArguments: Decodable {
 
 private struct OptionalSessionArguments: Decodable {
   let sessionId: String?
+}
+
+private struct SessionStatusArguments: Decodable {
+  let sessionId: String
+  let activityLimit: Int?
+}
+
+private struct SessionHistoryArguments: Decodable {
+  let sessionId: String?
+  let turnLimit: Int?
 }
 
 private struct SendPromptArguments: Decodable {

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/VoiceAgentToolExecutorTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/VoiceAgentToolExecutorTests.swift
@@ -55,12 +55,21 @@ private final class MockVoiceSessionManager: VoiceSessionManaging {
 
 private struct StubTranscriptReader: VoiceSessionTranscriptReading {
   let textsByPath: [String: String]
+  var turnsByPath: [String: [VoiceTranscriptTurn]] = [:]
 
   func latestAssistantText(
     atPath path: String,
     provider: SessionProviderKind
   ) async -> String? {
     textsByPath[path]
+  }
+
+  func recentTurns(
+    atPath path: String,
+    provider: SessionProviderKind,
+    turnLimit: Int
+  ) async -> [VoiceTranscriptTurn] {
+    Array((turnsByPath[path] ?? []).suffix(turnLimit))
   }
 }
 
@@ -310,6 +319,87 @@ struct VoiceAgentToolExecutorTests {
     #expect(await executor.latestResponse(sessionId: "s1") == nil)
     #expect(await executor.latestResponse(sessionId: "missing") == nil)
     #expect(await executor.latestResponse(sessionId: nil) == nil)
+  }
+
+  @Test
+  func sessionHistoryReadsTurnsAndFallsBackToTargetSession() async {
+    let turns = [
+      VoiceTranscriptTurn(role: "user", text: "run the tests"),
+      VoiceTranscriptTurn(role: "assistant", text: "All 23 passed."),
+    ]
+    let reader = StubTranscriptReader(
+      textsByPath: [:],
+      turnsByPath: ["/tmp/s1.jsonl": turns]
+    )
+    let target = VoiceSessionTarget(
+      sessionId: "s1",
+      provider: .claude,
+      name: "Build",
+      projectPath: "/repo",
+      lastActivityAt: Date()
+    )
+    let (executor, claude, _) = makeExecutor(
+      target: target,
+      transcriptReader: reader
+    )
+    claude.voiceSessions = [
+      session(id: "s1", sessionFilePath: "/tmp/s1.jsonl")
+    ]
+    claude.sessionCustomNames["s1"] = "Build"
+
+    let explicit = await executor.sessionHistory(sessionId: "s1", turnLimit: 6)
+    #expect(explicit?.sessionId == "s1")
+    #expect(explicit?.name == "Build")
+    #expect(explicit?.turns == turns)
+
+    let limited = await executor.sessionHistory(sessionId: "s1", turnLimit: 1)
+    #expect(limited?.turns == [turns[1]])
+
+    let defaulted = await executor.sessionHistory(sessionId: nil, turnLimit: 6)
+    #expect(defaulted?.sessionId == "s1")
+
+    #expect(await executor.sessionHistory(sessionId: "missing", turnLimit: 6) == nil)
+  }
+
+  @Test
+  func sessionHistoryIsNilWithoutTurns() async {
+    let (executor, claude, _) = makeExecutor(target: nil)
+    claude.voiceSessions = [
+      session(id: "s1", sessionFilePath: "/tmp/s1.jsonl")
+    ]
+
+    #expect(await executor.sessionHistory(sessionId: "s1", turnLimit: 6) == nil)
+  }
+
+  @Test
+  func sessionStatusHonorsActivityLimitAndClampsIt() {
+    let (executor, claude, _) = makeExecutor()
+    claude.voiceSessions = [session(id: "s1")]
+    let activities = (1...30).map { index in
+      ActivityEntry(
+        timestamp: Date(),
+        type: .toolUse(name: "Bash"),
+        description: "activity \(index)"
+      )
+    }
+    claude.monitorStates["s1"] = SessionMonitorState(
+      status: .thinking,
+      recentActivities: activities
+    )
+
+    let defaulted = executor.sessionStatus(sessionId: "s1")
+    #expect(defaulted?.recentActivities.count == 3)
+    #expect(defaulted?.recentActivities.last?.description == "activity 30")
+
+    let expanded = executor.sessionStatus(sessionId: "s1", activityLimit: 10)
+    #expect(expanded?.recentActivities.count == 10)
+    #expect(expanded?.recentActivities.first?.description == "activity 21")
+
+    let clamped = executor.sessionStatus(sessionId: "s1", activityLimit: 500)
+    #expect(
+      clamped?.recentActivities.count
+        == VoiceSessionStatusLimits.maximumActivityCount
+    )
   }
 
   @Test

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/VoiceSessionCompletionWatcherTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/VoiceSessionCompletionWatcherTests.swift
@@ -21,7 +21,10 @@ private final class CompletionWatcherExecutor: VoiceAgentToolExecuting {
     .init(sessions: [], targetSessionId: nil)
   }
 
-  func sessionStatus(sessionId: String) -> VoiceSessionStatusDetail? {
+  func sessionStatus(
+    sessionId: String,
+    activityLimit: Int
+  ) -> VoiceSessionStatusDetail? {
     guard let currentStatus else { return nil }
     return .init(
       sessionId: sessionId,
@@ -33,6 +36,13 @@ private final class CompletionWatcherExecutor: VoiceAgentToolExecuting {
       pendingApproval: nil,
       recentActivities: []
     )
+  }
+
+  func sessionHistory(
+    sessionId: String?,
+    turnLimit: Int
+  ) async -> VoiceSessionHistory? {
+    nil
   }
 
   func sendPrompt(
@@ -153,6 +163,51 @@ struct VoiceSessionCompletionWatcherTests {
     #expect(updates.count == 1)
     #expect(updates[0].contains("Build finished."))
     #expect(updates[0].contains("All 23 tests passed."))
+  }
+
+  @Test
+  func reportsActiveWatchCountAcrossTheWatchLifecycle() async {
+    let executor = CompletionWatcherExecutor()
+    var counts: [Int] = []
+    var updates: [String] = []
+    let watcher = VoiceSessionCompletionWatcher(
+      executor: executor,
+      armingDelay: .seconds(1),
+      completionDebounce: .milliseconds(5),
+      maximumDuration: .seconds(1),
+      onActiveCountChanged: { counts.append($0) }
+    ) {
+      updates.append($0)
+    }
+
+    watcher.watch(sessionId: "session-1", name: "Build")
+    #expect(counts.last == 1)
+
+    executor.yield(.thinking)
+    executor.yield(.idle)
+    await waitUntil { !updates.isEmpty }
+    await waitUntil { counts.last == 0 }
+
+    #expect(counts.last == 0)
+  }
+
+  @Test
+  func cancelAllReportsZeroActiveWatches() async {
+    let executor = CompletionWatcherExecutor()
+    var counts: [Int] = []
+    let watcher = VoiceSessionCompletionWatcher(
+      executor: executor,
+      armingDelay: .seconds(1),
+      completionDebounce: .seconds(1),
+      maximumDuration: .seconds(1),
+      onActiveCountChanged: { counts.append($0) }
+    ) { _ in }
+
+    watcher.watch(sessionId: "session-1", name: "Build")
+    #expect(counts.last == 1)
+
+    watcher.cancelAll()
+    #expect(counts.last == 0)
   }
 
   @Test

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/VoiceSessionCompletionWatcherTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/VoiceSessionCompletionWatcherTests.swift
@@ -211,6 +211,48 @@ struct VoiceSessionCompletionWatcherTests {
   }
 
   @Test
+  func explicitWatchAnnouncesTimeoutInsteadOfEndingSilently() async {
+    let executor = CompletionWatcherExecutor()
+    var updates: [String] = []
+    let watcher = VoiceSessionCompletionWatcher(
+      executor: executor,
+      armingDelay: .seconds(1),
+      completionDebounce: .seconds(1),
+      maximumDuration: .milliseconds(20)
+    ) {
+      updates.append($0)
+    }
+
+    watcher.watch(sessionId: "session-1", name: "Build", announceTimeout: true)
+    executor.yield(.thinking)
+    await waitUntil { !updates.isEmpty }
+
+    #expect(updates == ["Build is still running — I've stopped watching it."])
+  }
+
+  @Test
+  func implicitWatchStillTimesOutSilently() async {
+    let executor = CompletionWatcherExecutor()
+    var updates: [String] = []
+    var counts: [Int] = []
+    let watcher = VoiceSessionCompletionWatcher(
+      executor: executor,
+      armingDelay: .seconds(1),
+      completionDebounce: .seconds(1),
+      maximumDuration: .milliseconds(20),
+      onActiveCountChanged: { counts.append($0) }
+    ) {
+      updates.append($0)
+    }
+
+    watcher.watch(sessionId: "session-1", name: "Build")
+    executor.yield(.thinking)
+    await waitUntil { counts.last == 0 }
+
+    #expect(updates.isEmpty)
+  }
+
+  @Test
   func reportsApprovalImmediately() async {
     let executor = CompletionWatcherExecutor()
     var updates: [String] = []

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/VoiceSessionContextBuilderTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/VoiceSessionContextBuilderTests.swift
@@ -1,0 +1,109 @@
+import Foundation
+import Testing
+@testable import AgentHubCore
+
+struct VoiceSessionContextBuilderTests {
+  @Test
+  func emptySummaryProducesNoContext() {
+    let context = VoiceSessionContextBuilder.make(
+      summary: VoiceSessionsSummary(sessions: [], targetSessionId: nil)
+    )
+    #expect(context == nil)
+  }
+
+  @Test
+  func listsSessionsMostRecentFirstWithTargetAndApprovalMarkers() throws {
+    let summary = VoiceSessionsSummary(
+      sessions: [
+        session(
+          id: "old",
+          name: "Refactor",
+          worktree: "/repos/agenthub-refactor",
+          status: "Idle",
+          secondsSinceActivity: 900
+        ),
+        session(
+          id: "busy",
+          name: "Fix login",
+          worktree: "/repos/agenthub",
+          status: "Thinking",
+          pendingApprovalTool: "Bash",
+          secondsSinceActivity: 5
+        ),
+      ],
+      targetSessionId: "busy"
+    )
+
+    let context = try #require(VoiceSessionContextBuilder.make(summary: summary))
+    let lines = context.split(separator: "\n").map(String.init)
+
+    #expect(lines[0] == "2 sessions:")
+    #expect(
+      lines[1]
+        == "- Fix login (Claude, agenthub, Thinking), needs approval — current target"
+    )
+    #expect(lines[2] == "- Refactor (Claude, agenthub-refactor, Idle)")
+    #expect(!context.contains("busy"))
+  }
+
+  @Test
+  func capsSessionCountAndReportsOmissions() throws {
+    let sessions = (1...14).map { index in
+      session(
+        id: "s\(index)",
+        name: "Session \(index)",
+        worktree: "/repos/repo\(index)",
+        status: "Idle",
+        secondsSinceActivity: index
+      )
+    }
+    let summary = VoiceSessionsSummary(sessions: sessions, targetSessionId: nil)
+
+    let context = try #require(VoiceSessionContextBuilder.make(summary: summary))
+
+    #expect(context.hasPrefix("14 sessions:"))
+    #expect(context.contains("Session 10"))
+    #expect(!context.contains("Session 11"))
+    #expect(context.hasSuffix("…and 4 more."))
+  }
+
+  @Test
+  func staysWithinCharacterBudget() throws {
+    let sessions = (1...10).map { index in
+      session(
+        id: "s\(index)",
+        name: String(repeating: "n", count: 200) + "\(index)",
+        worktree: "/repos/repo",
+        status: "Idle",
+        secondsSinceActivity: index
+      )
+    }
+    let summary = VoiceSessionsSummary(sessions: sessions, targetSessionId: nil)
+
+    let context = try #require(VoiceSessionContextBuilder.make(summary: summary))
+
+    #expect(context.count
+      <= VoiceSessionContextBuilder.maximumCharacters + "…and 9 more.".count + 1)
+    #expect(context.contains("…and"))
+  }
+
+  private func session(
+    id: String,
+    name: String,
+    worktree: String,
+    status: String,
+    pendingApprovalTool: String? = nil,
+    secondsSinceActivity: Int
+  ) -> VoiceSessionSummary {
+    VoiceSessionSummary(
+      id: id,
+      name: name,
+      provider: .claude,
+      worktree: worktree,
+      status: status,
+      pendingApprovalTool: pendingApprovalTool,
+      secondsSinceActivity: secondsSinceActivity,
+      localhostURL: nil
+    )
+  }
+}

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/VoiceSessionTranscriptReaderTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/VoiceSessionTranscriptReaderTests.swift
@@ -140,6 +140,151 @@ struct VoiceSessionTranscriptReaderTests {
     #expect(missing == nil)
   }
 
+  @Test
+  func claudeRecentTurnsMergeConsecutiveRolesOldestFirst() {
+    let jsonl = lines(
+      claudeUser("run the tests"),
+      claudeAssistant(text: "Starting the test run."),
+      claudeAssistant(toolUse: "Bash"),
+      claudeToolResult("exit 0"),
+      claudeAssistant(text: "All 23 tests passed."),
+      claudeAssistant(text: "No further action needed."),
+      claudeUser("now fix the flaky one")
+    )
+
+    let turns = VoiceSessionTranscriptReader.extractRecentTurns(
+      fromJSONL: jsonl,
+      provider: .claude,
+      turnLimit: 6
+    )
+
+    #expect(turns == [
+      VoiceTranscriptTurn(role: "user", text: "run the tests"),
+      VoiceTranscriptTurn(
+        role: "assistant",
+        text: "Starting the test run.\n\nAll 23 tests passed.\n\nNo further action needed."
+      ),
+      VoiceTranscriptTurn(role: "user", text: "now fix the flaky one"),
+    ])
+  }
+
+  @Test
+  func claudeRecentTurnsKeepNewestWhenLimited() {
+    let jsonl = lines(
+      claudeUser("first"),
+      claudeAssistant(text: "First answer."),
+      claudeUser("second"),
+      claudeAssistant(text: "Second answer.")
+    )
+
+    let turns = VoiceSessionTranscriptReader.extractRecentTurns(
+      fromJSONL: jsonl,
+      provider: .claude,
+      turnLimit: 2
+    )
+
+    #expect(turns == [
+      VoiceTranscriptTurn(role: "user", text: "second"),
+      VoiceTranscriptTurn(role: "assistant", text: "Second answer."),
+    ])
+  }
+
+  @Test
+  func claudeRecentTurnsSkipCommandNoiseAndTruncateLongTurns() {
+    let long = String(repeating: "a", count: 2_000)
+    let jsonl = lines(
+      claudeUser("<command-name>/model</command-name>"),
+      claudeUser("real question"),
+      claudeAssistant(text: long)
+    )
+
+    let turns = VoiceSessionTranscriptReader.extractRecentTurns(
+      fromJSONL: jsonl,
+      provider: .claude,
+      turnLimit: 6
+    )
+
+    #expect(turns.count == 2)
+    #expect(turns.first == VoiceTranscriptTurn(role: "user", text: "real question"))
+    #expect(
+      turns.last?.text.count
+        == VoiceSessionTranscriptReader.maximumTurnCharacters + 1
+    )
+    #expect(turns.last?.text.hasSuffix("…") == true)
+  }
+
+  @Test
+  func codexRecentTurnsPairUserAndAgentMessages() {
+    let jsonl = lines(
+      codexEvent(type: "user_message", message: "run the tests"),
+      codexEvent(type: "agent_reasoning", message: "thinking"),
+      codexEvent(type: "agent_message", message: "Tests passed."),
+      codexEvent(type: "user_message", message: "ship it")
+    )
+
+    let turns = VoiceSessionTranscriptReader.extractRecentTurns(
+      fromJSONL: jsonl,
+      provider: .codex,
+      turnLimit: 6
+    )
+
+    #expect(turns == [
+      VoiceTranscriptTurn(role: "user", text: "run the tests"),
+      VoiceTranscriptTurn(role: "assistant", text: "Tests passed."),
+      VoiceTranscriptTurn(role: "user", text: "ship it"),
+    ])
+  }
+
+  @Test
+  func recentTurnsDropOldestBeyondTotalBudget() {
+    let turnText = String(repeating: "b", count: 650)
+    let jsonl = lines(
+      (1...12).flatMap { index in
+        [
+          claudeUser("\(turnText) q\(index)"),
+          claudeAssistant(text: "\(turnText) a\(index)"),
+        ]
+      }.joined(separator: "\n")
+    )
+
+    let turns = VoiceSessionTranscriptReader.extractRecentTurns(
+      fromJSONL: jsonl,
+      provider: .claude,
+      turnLimit: 20
+    )
+
+    let total = turns.reduce(0) { $0 + $1.text.count }
+    #expect(total <= VoiceSessionTranscriptReader.maximumHistoryCharacters)
+    #expect(turns.last?.text.hasSuffix("a12") == true)
+  }
+
+  @Test
+  func recentTurnsReadFromFileOnDisk() async throws {
+    let path = FileManager.default.temporaryDirectory
+      .appendingPathComponent("voice-turns-\(UUID().uuidString).jsonl")
+      .path
+    defer { try? FileManager.default.removeItem(atPath: path) }
+    try lines(
+      claudeUser("hello"),
+      claudeAssistant(text: "Hi there.")
+    ).write(toFile: path, atomically: true, encoding: .utf8)
+
+    let reader = VoiceSessionTranscriptReader()
+    let turns = await reader.recentTurns(
+      atPath: path,
+      provider: .claude,
+      turnLimit: 6
+    )
+    #expect(turns.map(\.role) == ["user", "assistant"])
+
+    let missing = await reader.recentTurns(
+      atPath: path + ".missing",
+      provider: .claude,
+      turnLimit: 6
+    )
+    #expect(missing.isEmpty)
+  }
+
   // MARK: - Fixtures
 
   private func lines(_ entries: String...) -> String {

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/VoiceToolCatalogTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/VoiceToolCatalogTests.swift
@@ -159,6 +159,8 @@ struct VoiceToolCatalogTests {
         "read_session_response",
         "read_session_history",
         "send_prompt",
+        "watch_session",
+        "stop_watching",
         "focus_session",
         "list_worktrees",
         "launch_session",
@@ -360,6 +362,40 @@ struct VoiceToolCatalogTests {
     )
     let statusToolRequests = executor.statusRequests.filter { $0.0 == "claude-1" }
     #expect(statusToolRequests.map(\.1) == [3, 12])
+  }
+
+  @Test
+  func watchSessionArmsAWatcherWithoutSendingAnything() async throws {
+    let executor = MockVoiceToolExecutor()
+    executor.details["claude-1"] = detail(
+      sessionId: "claude-1",
+      provider: .claude
+    )
+    let catalog = VoiceToolCatalog(
+      executor: executor,
+      onBackgroundUpdate: { _ in }
+    )
+    let registry = VoiceToolRegistry(tools: catalog.makeTools())
+
+    let missing = await registry.execute(
+      name: "watch_session",
+      arguments: #"{"session_id":"unknown"}"#
+    )
+    #expect(try status(missing) == "not_found")
+    #expect(executor.completionStreamSessionIds.isEmpty)
+
+    let watching = await registry.execute(
+      name: "watch_session",
+      arguments: #"{"session_id":"claude-1"}"#
+    )
+    #expect(try status(watching) == "watching")
+    #expect(executor.completionStreamSessionIds == ["claude-1"])
+
+    let stopped = await registry.execute(
+      name: "stop_watching",
+      arguments: "{}"
+    )
+    #expect(try status(stopped) == "stopped")
   }
 
   @Test

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/VoiceToolCatalogTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/VoiceToolCatalogTests.swift
@@ -15,8 +15,27 @@ private final class MockVoiceToolExecutor: VoiceAgentToolExecuting {
     sessions
   }
 
-  func sessionStatus(sessionId: String) -> VoiceSessionStatusDetail? {
-    details[sessionId]
+  private(set) var statusRequests: [(String, Int)] = []
+
+  func sessionStatus(
+    sessionId: String,
+    activityLimit: Int
+  ) -> VoiceSessionStatusDetail? {
+    statusRequests.append((sessionId, activityLimit))
+    return details[sessionId]
+  }
+
+  var histories: [String: VoiceSessionHistory] = [:]
+  var defaultHistory: VoiceSessionHistory?
+  private(set) var historyRequests: [(String?, Int)] = []
+
+  func sessionHistory(
+    sessionId: String?,
+    turnLimit: Int
+  ) async -> VoiceSessionHistory? {
+    historyRequests.append((sessionId, turnLimit))
+    guard let sessionId else { return defaultHistory }
+    return histories[sessionId]
   }
 
   func sendPrompt(
@@ -138,6 +157,7 @@ struct VoiceToolCatalogTests {
         "list_sessions",
         "get_session_status",
         "read_session_response",
+        "read_session_history",
         "send_prompt",
         "focus_session",
         "list_worktrees",
@@ -268,6 +288,78 @@ struct VoiceToolCatalogTests {
       arguments: "{}"
     )
     #expect(try status(missing) == "not_found")
+  }
+
+  @Test
+  func readSessionHistoryDefaultsToTargetAndSixTurns() async throws {
+    let executor = MockVoiceToolExecutor()
+    executor.histories["claude-1"] = VoiceSessionHistory(
+      sessionId: "claude-1",
+      provider: .claude,
+      name: "Build",
+      turns: [
+        VoiceTranscriptTurn(role: "user", text: "run the tests"),
+        VoiceTranscriptTurn(role: "assistant", text: "All 23 passed."),
+      ]
+    )
+    executor.defaultHistory = VoiceSessionHistory(
+      sessionId: "target-1",
+      provider: .codex,
+      name: "Target",
+      turns: [VoiceTranscriptTurn(role: "assistant", text: "Target turn.")]
+    )
+    let catalog = VoiceToolCatalog(
+      executor: executor,
+      onBackgroundUpdate: { _ in }
+    )
+    let registry = VoiceToolRegistry(tools: catalog.makeTools())
+
+    let explicit = await registry.execute(
+      name: "read_session_history",
+      arguments: #"{"session_id":"claude-1","turn_limit":10}"#
+    )
+    #expect(explicit.contains("run the tests"))
+    #expect(explicit.contains("All 23 passed."))
+
+    let defaulted = await registry.execute(
+      name: "read_session_history",
+      arguments: "{}"
+    )
+    #expect(defaulted.contains("Target turn."))
+    #expect(executor.historyRequests.map(\.0) == ["claude-1", nil])
+    #expect(executor.historyRequests.map(\.1) == [10, 6])
+
+    executor.defaultHistory = nil
+    let missing = await registry.execute(
+      name: "read_session_history",
+      arguments: "{}"
+    )
+    #expect(try status(missing) == "not_found")
+  }
+
+  @Test
+  func sessionStatusPassesActivityLimitAndDefaultsToThree() async throws {
+    let executor = MockVoiceToolExecutor()
+    executor.details["claude-1"] = detail(
+      sessionId: "claude-1",
+      provider: .claude
+    )
+    let catalog = VoiceToolCatalog(
+      executor: executor,
+      onBackgroundUpdate: { _ in }
+    )
+    let registry = VoiceToolRegistry(tools: catalog.makeTools())
+
+    _ = await registry.execute(
+      name: "get_session_status",
+      arguments: #"{"session_id":"claude-1"}"#
+    )
+    _ = await registry.execute(
+      name: "get_session_status",
+      arguments: #"{"session_id":"claude-1","activity_limit":12}"#
+    )
+    let statusToolRequests = executor.statusRequests.filter { $0.0 == "claude-1" }
+    #expect(statusToolRequests.map(\.1) == [3, 12])
   }
 
   @Test

--- a/app/modules/AgentHubVoice/Sources/AgentHubVoice/HUD/VoiceHUDContract.swift
+++ b/app/modules/AgentHubVoice/Sources/AgentHubVoice/HUD/VoiceHUDContract.swift
@@ -56,6 +56,12 @@ public enum VoiceDictationOutcome: Equatable, Sendable {
   case failed(String)
 }
 
+extension VoiceHUDHost {
+  public func makeSessionContext() -> String? {
+    nil
+  }
+}
+
 /// Implemented by the host app to back the voice HUD.
 @MainActor
 public protocol VoiceHUDHost: AnyObject {
@@ -67,6 +73,11 @@ public protocol VoiceHUDHost: AnyObject {
 
   /// Tools exposed to the realtime conversation.
   func makeToolRegistry() -> VoiceToolRegistry
+
+  /// Compact, human-readable snapshot of the host's current sessions,
+  /// injected once into the realtime instructions at connect time. Keep it
+  /// short — it is paid model context. Return nil to omit.
+  func makeSessionContext() -> String?
 
   /// The OpenAI API key, or nil when not configured yet.
   func resolveAPIKey() async throws -> String?

--- a/app/modules/AgentHubVoice/Sources/AgentHubVoice/Realtime/RealtimeSessionConfigurationBuilder.swift
+++ b/app/modules/AgentHubVoice/Sources/AgentHubVoice/Realtime/RealtimeSessionConfigurationBuilder.swift
@@ -43,9 +43,16 @@ public enum RealtimeSessionConfigurationBuilder {
     earlier answer. After the tool returns, tell the user which repository was used.
     """
 
+  public static let sessionHistoryInstructions = """
+    read_session_response only returns a session's latest answer. When the user asks about
+    earlier prompts, or what a session has been working on over time, call
+    read_session_history instead.
+    """
+
   public static func instructions(
     for tools: VoiceToolRegistry,
-    language: String? = nil
+    language: String? = nil,
+    sessionContext: String? = nil
   ) -> String {
     var combined: String
     if let language, let name = languageName(for: language) {
@@ -69,12 +76,27 @@ public enum RealtimeSessionConfigurationBuilder {
     if hasWorktreeTasks {
       combined += "\n" + worktreeTaskInstructions
     }
+    let hasSessionHistory = tools.tools.contains { $0.name == "read_session_history" }
+    if hasSessionHistory {
+      combined += "\n" + sessionHistoryInstructions
+    }
+    if let sessionContext = sessionContext?.trimmingCharacters(
+      in: .whitespacesAndNewlines
+    ), !sessionContext.isEmpty {
+      combined += """
+        \nSession snapshot from when this conversation connected — it may be \
+        stale and has no IDs. Use it for awareness only; always call \
+        list_sessions before acting on a session.
+        \(sessionContext)
+        """
+    }
     return combined
   }
 
   public static func make(
     settings: VoiceEngineSettings,
-    tools: VoiceToolRegistry
+    tools: VoiceToolRegistry,
+    sessionContext: String? = nil
   ) -> OpenAIRealtimeSessionConfiguration {
     let eagerness =
       OpenAIRealtimeSessionConfiguration.TurnDetection.DetectionType.Eagerness(
@@ -87,7 +109,11 @@ public enum RealtimeSessionConfigurationBuilder {
         model: settings.dictationModel,
         language: settings.language
       ),
-      instructions: instructions(for: tools, language: settings.language),
+      instructions: instructions(
+        for: tools,
+        language: settings.language,
+        sessionContext: sessionContext
+      ),
       modalities: [.audio],
       outputAudioFormat: .pcm16,
       tools: tools.functionTools,

--- a/app/modules/AgentHubVoice/Sources/AgentHubVoice/Realtime/RealtimeVoiceEngine.swift
+++ b/app/modules/AgentHubVoice/Sources/AgentHubVoice/Realtime/RealtimeVoiceEngine.swift
@@ -39,6 +39,16 @@ public final class RealtimeVoiceEngine {
   public private(set) var isAssistantSpeaking = false
   public private(set) var errorMessage: String?
   public private(set) var isMicrophoneMuted = false
+  /// True while the delivery gate is dropping microphone frames (a session
+  /// announcement is in flight). The UI should render the microphone as
+  /// paused — showing a hot mic here would misstate what the engine hears.
+  public var isMicrophoneGated: Bool { isDeliveringBackgroundUpdate }
+  /// True while the engine auto-muted the microphone because a session
+  /// completion is being awaited: background noise during a long wait would
+  /// otherwise reach the model as phantom turns. Unlike the delivery gate
+  /// this is user-overridable — tapping unmute releases it for the current
+  /// wait.
+  public private(set) var isStandbyMuted = false
 
   private let transportFactory: RealtimeTransportFactory
   private let audioFactory: RealtimeAudioFactory
@@ -52,6 +62,15 @@ public final class RealtimeVoiceEngine {
   private var currentAudioItemID: String?
   private var isResponseCreatePending = false
   private var backgroundUpdates: [String] = []
+  private var allowBargeIn = false
+  /// Gates the microphone while a background update is being delivered —
+  /// from flush until the announcement's turn settles. In that window the
+  /// engine is between responses, so background noise would either interrupt
+  /// the pending announcement or be committed as a phantom user turn.
+  /// Deliberately separate from `isMicrophoneMuted`, which is the user's
+  /// manual mute and must never be clobbered by this transient gate.
+  private var isDeliveringBackgroundUpdate = false
+  private var isAwaitingBackgroundWork = false
 
   public init(
     transportFactory: @escaping RealtimeTransportFactory = {
@@ -79,7 +98,8 @@ public final class RealtimeVoiceEngine {
   public func start(
     service: any OpenAIService,
     settings: VoiceEngineSettings,
-    tools: VoiceToolRegistry
+    tools: VoiceToolRegistry,
+    sessionContext: String? = nil
   ) async {
     stop()
     state = .connecting
@@ -89,11 +109,13 @@ public final class RealtimeVoiceEngine {
       fail("Microphone permission is required for conversation mode.")
       return
     }
+    allowBargeIn = settings.allowBargeIn
 
     do {
       let configuration = RealtimeSessionConfigurationBuilder.make(
         settings: settings,
-        tools: tools
+        tools: tools,
+        sessionContext: sessionContext
       )
       let pair = try await Task { @RealtimeActor in
         let transport = try await transportFactory(
@@ -147,6 +169,10 @@ public final class RealtimeVoiceEngine {
     activeResponseID = nil
     currentAudioItemID = nil
     isResponseCreatePending = false
+    isDeliveringBackgroundUpdate = false
+    isAwaitingBackgroundWork = false
+    isStandbyMuted = false
+    allowBargeIn = false
     backgroundUpdates.removeAll()
     microphoneLevel = 0
     assistantLevel = 0
@@ -155,10 +181,33 @@ public final class RealtimeVoiceEngine {
   }
 
   public func setMicrophoneMuted(_ isMuted: Bool) {
+    // The user took control of the microphone; standby yields either way.
+    isStandbyMuted = false
     isMicrophoneMuted = isMuted
     if isMuted {
       microphoneLevel = 0
     }
+  }
+
+  /// Signals whether any session completion is being awaited (watchers
+  /// active). Engages standby mute on the false→true transition only, so a
+  /// user who unmuted mid-wait is not re-muted by repeated signals.
+  public func setAwaitingBackgroundWork(_ awaiting: Bool) {
+    let wasAwaiting = isAwaitingBackgroundWork
+    isAwaitingBackgroundWork = awaiting
+    if awaiting, !wasAwaiting, !isMicrophoneMuted {
+      isStandbyMuted = true
+      microphoneLevel = 0
+    }
+    if !awaiting {
+      isStandbyMuted = false
+    }
+  }
+
+  /// Releases standby for the current wait without touching the user mute —
+  /// the unmute affordance while the engine is standby-muted.
+  public func overrideStandbyMute() {
+    isStandbyMuted = false
   }
 
   public func pushBackgroundUpdate(_ update: String) {
@@ -245,6 +294,10 @@ public final class RealtimeVoiceEngine {
     case .responseAudioDone:
       assistantLevel = 0
     case .inputAudioBufferSpeechStarted:
+      // Unreachable while the delivery gate holds (no frames reach the
+      // server), but if speech was detected the microphone is demonstrably
+      // live — never leave the gate stuck on.
+      isDeliveringBackgroundUpdate = false
       let audioEndMS = await audio.interruptPlayback()
       if let currentAudioItemID, let audioEndMS {
         await transport.send(
@@ -303,6 +356,10 @@ public final class RealtimeVoiceEngine {
       if activeResponseID != nil || isResponseCreatePending {
         break
       }
+      // The turn is fully settled (tool-call continuations included), so an
+      // announcement in flight has finished — reopen the microphone before
+      // the next queued update re-gates it.
+      isDeliveringBackgroundUpdate = false
       state = .idle
       flushBackgroundUpdateIfPossible()
     case .error(let message):
@@ -353,11 +410,12 @@ public final class RealtimeVoiceEngine {
     microphoneLevel: Float,
     playbackActive: Bool
   ) -> Bool {
-    self.microphoneLevel = microphoneLevel
+    let silenced = isDeliveringBackgroundUpdate || isStandbyMuted
+    self.microphoneLevel = silenced ? 0 : microphoneLevel
     // Mic buffers are the heartbeat (~50ms): they keep this true for the
     // whole audible response and flip it off when the playback queue drains.
     isAssistantSpeaking = playbackActive
-    return isMicrophoneMuted
+    return isMicrophoneMuted || silenced
   }
 
   private func flushBackgroundUpdateIfPossible() {
@@ -368,6 +426,11 @@ public final class RealtimeVoiceEngine {
       return
     }
     let update = backgroundUpdates.removeFirst()
+    // Barge-in users opted into interrupting the assistant, and that
+    // includes cutting off an announcement — only gate for everyone else.
+    if !allowBargeIn {
+      isDeliveringBackgroundUpdate = true
+    }
     state = .thinking
     isResponseCreatePending = true
     Task { @RealtimeActor in
@@ -379,6 +442,7 @@ public final class RealtimeVoiceEngine {
   private func fail(_ message: String) {
     errorMessage = message
     state = .failed(message)
+    isDeliveringBackgroundUpdate = false
   }
 
   private func handleStreamFailure(_ error: any Error) {

--- a/app/modules/AgentHubVoice/Sources/AgentHubVoice/Secrets/OpenAIClientFactory.swift
+++ b/app/modules/AgentHubVoice/Sources/AgentHubVoice/Secrets/OpenAIClientFactory.swift
@@ -21,8 +21,14 @@ public final class OpenAIClient: @unchecked Sendable {
   public func startRealtime(
     engine: RealtimeVoiceEngine,
     settings: VoiceEngineSettings,
-    tools: VoiceToolRegistry
+    tools: VoiceToolRegistry,
+    sessionContext: String? = nil
   ) async {
-    await engine.start(service: service, settings: settings, tools: tools)
+    await engine.start(
+      service: service,
+      settings: settings,
+      tools: tools,
+      sessionContext: sessionContext
+    )
   }
 }

--- a/app/modules/AgentHubVoice/Sources/AgentHubVoicePanel/VoiceHUDView.swift
+++ b/app/modules/AgentHubVoice/Sources/AgentHubVoicePanel/VoiceHUDView.swift
@@ -62,13 +62,13 @@ public struct VoiceHUDView: View {
         VoiceHUDErrorBanner(message: errorMessage)
       }
 
-      VoiceMicButton(
-        mode: viewModel.mode,
-        state: viewModel.realtimeState,
-        isActive: viewModel.isActive,
-        level: viewModel.microphoneLevel,
-        action: viewModel.toggleMicrophone
-      )
+      if viewModel.mode == .converse, viewModel.isActive {
+        Text(converseStatusCaption)
+          .font(.caption)
+          .foregroundStyle(.secondary)
+      }
+
+      controlBar
     }
     .padding(16)
     .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -95,6 +95,59 @@ public struct VoiceHUDView: View {
           showsOnboarding = false
         }
       )
+    }
+  }
+
+  /// Primary start/end control centered, with the mute toggle beside it
+  /// while a conversation is live.
+  private var controlBar: some View {
+    ZStack {
+      VoiceMicButton(
+        mode: viewModel.mode,
+        state: viewModel.realtimeState,
+        isActive: viewModel.isActive,
+        level: viewModel.microphoneLevel,
+        productName: viewModel.configuration.productName,
+        action: viewModel.toggleMicrophone
+      )
+
+      if viewModel.mode == .converse, viewModel.isActive {
+        HStack {
+          Spacer()
+          VoiceMuteButton(
+            isMuted: viewModel.isMicrophoneMuted,
+            isGated: viewModel.isMicrophoneGated,
+            isStandby: viewModel.isMicrophoneStandbyMuted,
+            action: viewModel.toggleMicrophoneMute
+          )
+        }
+        .padding(.trailing, 24)
+      }
+    }
+  }
+
+  private var converseStatusCaption: String {
+    if viewModel.isMicrophoneGated {
+      return "Sharing an update…"
+    }
+    if viewModel.isMicrophoneStandbyMuted {
+      return "Muted while waiting — tap the mic to talk"
+    }
+    switch viewModel.realtimeState {
+    case .connecting:
+      return "Connecting…"
+    case .idle:
+      return viewModel.isMicrophoneMuted ? "Muted" : "Listening"
+    case .userSpeaking:
+      return "You're speaking"
+    case .thinking:
+      return "Thinking…"
+    case .speaking:
+      return "\(viewModel.configuration.productName) is speaking"
+    case .executingTool(let name):
+      return "Running \(name)"
+    case .disconnected, .failed:
+      return ""
     }
   }
 }

--- a/app/modules/AgentHubVoice/Sources/AgentHubVoicePanel/VoiceHUDViewModel.swift
+++ b/app/modules/AgentHubVoice/Sources/AgentHubVoicePanel/VoiceHUDViewModel.swift
@@ -80,6 +80,28 @@ public final class VoiceHUDViewModel {
     mode == .converse && engine.isAssistantSpeaking
   }
 
+  public var isMicrophoneMuted: Bool {
+    engine.isMicrophoneMuted
+  }
+
+  public var isMicrophoneGated: Bool {
+    mode == .converse && engine.isMicrophoneGated
+  }
+
+  public var isMicrophoneStandbyMuted: Bool {
+    mode == .converse && engine.isStandbyMuted
+  }
+
+  public func toggleMicrophoneMute() {
+    // A standby-muted mic looks muted, so the tap must unmute — releasing
+    // standby for this wait — not engage the user mute on top of it.
+    if engine.isStandbyMuted, !engine.isMicrophoneMuted {
+      engine.overrideStandbyMute()
+      return
+    }
+    engine.setMicrophoneMuted(!engine.isMicrophoneMuted)
+  }
+
   public var dictationState: DictationState {
     dictationController?.state ?? .idle
   }
@@ -198,7 +220,8 @@ public final class VoiceHUDViewModel {
       await service.startRealtime(
         engine: engine,
         settings: settings,
-        tools: host.makeToolRegistry()
+        tools: host.makeToolRegistry(),
+        sessionContext: host.makeSessionContext()
       )
     default:
       engine.stop()

--- a/app/modules/AgentHubVoice/Sources/AgentHubVoicePanel/VoiceMicButton.swift
+++ b/app/modules/AgentHubVoice/Sources/AgentHubVoicePanel/VoiceMicButton.swift
@@ -6,22 +6,27 @@ struct VoiceMicButton: View {
   let state: VoiceEngineState
   let isActive: Bool
   let level: Float
+  let productName: String
   let action: () -> Void
   @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
   var body: some View {
     Button(action: action) {
       ZStack {
+        // The original halo ring, blurred into a soft glow — drawn behind
+        // the fill so it bleeds out from the button's edge, breathing with
+        // the mic level.
         Circle()
-          .stroke(Color.accentColor.opacity(0.25), lineWidth: 7)
+          .stroke(Color.accentColor.opacity(0.35), lineWidth: 9)
+          .blur(radius: 5 + CGFloat(level) * 5)
           .scaleEffect(1 + CGFloat(level) * 0.16)
 
         Circle()
-          .fill(isActive ? Color.accentColor : Color.secondary.opacity(0.2))
+          .fill(Color.secondary.opacity(0.2))
 
         Image(systemName: icon)
           .font(.title2)
-          .foregroundStyle(isActive ? .white : .primary)
+          .foregroundStyle(.primary)
       }
       .frame(width: 64, height: 64)
       .animation(
@@ -34,15 +39,27 @@ struct VoiceMicButton: View {
     .accessibilityValue(stateDescription)
   }
 
+  // Dictate is a recording (mic → stop); converse is a live session, so its
+  // active state reads as "close the session", not "stop recording".
   private var icon: String {
     if case .executingTool = state {
       return "gearshape.fill"
     }
-    return isActive ? "stop.fill" : "mic.fill"
+    switch mode {
+    case .dictate:
+      return isActive ? "stop.fill" : "mic.fill"
+    case .converse:
+      return isActive ? "xmark" : "waveform"
+    }
   }
 
   private var accessibilityLabel: String {
-    isActive ? "Stop \(mode.label)" : "Start \(mode.label)"
+    switch mode {
+    case .dictate:
+      isActive ? "Stop dictation" : "Start dictation"
+    case .converse:
+      isActive ? "End conversation" : "Start conversation"
+    }
   }
 
   private var stateDescription: String {
@@ -58,7 +75,7 @@ struct VoiceMicButton: View {
     case .thinking:
       "Thinking"
     case .speaking:
-      "AgentHub is speaking"
+      "\(productName) is speaking"
     case .executingTool(let name):
       "Running \(name)"
     case .failed(let message):

--- a/app/modules/AgentHubVoice/Sources/AgentHubVoicePanel/VoiceMuteButton.swift
+++ b/app/modules/AgentHubVoice/Sources/AgentHubVoicePanel/VoiceMuteButton.swift
@@ -1,0 +1,104 @@
+import SwiftUI
+
+/// Mute toggle shown beside the primary button during a conversation.
+/// Reflects everything that silences the microphone: the user's manual mute
+/// and the engine's transient delivery gate (a session announcement in
+/// flight) — the mic must never look hot while the engine drops its frames.
+struct VoiceMuteButton: View {
+  let isMuted: Bool
+  let isGated: Bool
+  let isStandby: Bool
+  let action: () -> Void
+
+  enum DisplayState: Equatable {
+    /// Microphone is live and streaming.
+    case live
+    /// The user muted the microphone; persists until they unmute.
+    case userMuted
+    /// The engine paused the microphone while delivering an announcement;
+    /// clears itself when the announcement finishes.
+    case gated
+    /// The engine auto-muted while awaiting a session completion; tapping
+    /// unmutes for the current wait.
+    case standby
+
+    static func make(
+      isMuted: Bool,
+      isGated: Bool,
+      isStandby: Bool
+    ) -> DisplayState {
+      // The user's mute wins: it outlives both automatic pauses, and tapping
+      // the button in this state must read as "unmute", not as overriding
+      // the engine. The delivery gate outranks standby — an announcement in
+      // flight is the more specific reason the mic is closed.
+      if isMuted { return .userMuted }
+      if isGated { return .gated }
+      if isStandby { return .standby }
+      return .live
+    }
+  }
+
+  private var displayState: DisplayState {
+    .make(isMuted: isMuted, isGated: isGated, isStandby: isStandby)
+  }
+
+  var body: some View {
+    Button(action: action) {
+      ZStack {
+        Circle()
+          .fill(fillColor)
+
+        Image(systemName: icon)
+          .font(.callout)
+          .foregroundStyle(iconColor)
+      }
+      .frame(width: 36, height: 36)
+    }
+    .buttonStyle(.plain)
+    .accessibilityLabel(accessibilityLabel)
+    .accessibilityValue(accessibilityValue)
+  }
+
+  private var icon: String {
+    displayState == .live ? "mic.fill" : "mic.slash.fill"
+  }
+
+  private var fillColor: Color {
+    switch displayState {
+    case .live:
+      Color.secondary.opacity(0.2)
+    case .userMuted:
+      Color.red
+    case .gated, .standby:
+      Color.secondary.opacity(0.35)
+    }
+  }
+
+  private var iconColor: Color {
+    displayState == .userMuted ? .white : .primary
+  }
+
+  private var accessibilityLabel: String {
+    switch displayState {
+    case .live:
+      "Mute microphone"
+    case .userMuted, .standby:
+      "Unmute microphone"
+    case .gated:
+      "Mute microphone"
+    }
+  }
+
+  private var accessibilityValue: String {
+    switch displayState {
+    case .live:
+      "Microphone on"
+    case .userMuted:
+      "Muted"
+    case .gated:
+      "Paused while sharing an update"
+    case .standby:
+      "Muted while waiting for a session"
+    }
+  }
+}

--- a/app/modules/AgentHubVoice/Tests/AgentHubVoicePanelTests/VoiceMuteButtonTests.swift
+++ b/app/modules/AgentHubVoice/Tests/AgentHubVoicePanelTests/VoiceMuteButtonTests.swift
@@ -1,0 +1,66 @@
+import Testing
+@testable import AgentHubVoicePanel
+
+struct VoiceMuteButtonTests {
+  @Test
+  func liveWhenNothingSilencesTheMicrophone() {
+    #expect(
+      VoiceMuteButton.DisplayState.make(
+        isMuted: false,
+        isGated: false,
+        isStandby: false
+      ) == .live
+    )
+  }
+
+  @Test
+  func gateShowsAsPausedWhileAnnouncementIsInFlight() {
+    #expect(
+      VoiceMuteButton.DisplayState.make(
+        isMuted: false,
+        isGated: true,
+        isStandby: false
+      ) == .gated
+    )
+  }
+
+  @Test
+  func standbyShowsWhileAwaitingASessionCompletion() {
+    #expect(
+      VoiceMuteButton.DisplayState.make(
+        isMuted: false,
+        isGated: false,
+        isStandby: true
+      ) == .standby
+    )
+  }
+
+  @Test
+  func deliveryGateOutranksStandby() {
+    #expect(
+      VoiceMuteButton.DisplayState.make(
+        isMuted: false,
+        isGated: true,
+        isStandby: true
+      ) == .gated
+    )
+  }
+
+  @Test
+  func userMuteWinsOverEveryAutomaticPause() {
+    #expect(
+      VoiceMuteButton.DisplayState.make(
+        isMuted: true,
+        isGated: true,
+        isStandby: true
+      ) == .userMuted
+    )
+    #expect(
+      VoiceMuteButton.DisplayState.make(
+        isMuted: true,
+        isGated: false,
+        isStandby: false
+      ) == .userMuted
+    )
+  }
+}

--- a/app/modules/AgentHubVoice/Tests/AgentHubVoiceTests/RealtimeSessionConfigurationBuilderTests.swift
+++ b/app/modules/AgentHubVoice/Tests/AgentHubVoiceTests/RealtimeSessionConfigurationBuilderTests.swift
@@ -129,6 +129,75 @@ struct RealtimeSessionConfigurationBuilderTests {
   }
 
   @Test
+  func sessionHistoryInstructionsOnlyAppearWithTheHistoryTool() {
+    let historyTool = VoiceTool(
+      name: "read_session_history",
+      description: "Reads history",
+      parameters: ["type": "object"]
+    ) { _ in
+      "{}"
+    }
+    let otherTool = VoiceTool(
+      name: "list_sessions",
+      description: "Lists sessions",
+      parameters: ["type": "object"]
+    ) { _ in
+      "{}"
+    }
+
+    let withHistory = RealtimeSessionConfigurationBuilder.instructions(
+      for: VoiceToolRegistry(tools: [otherTool, historyTool])
+    )
+    #expect(withHistory.contains("read_session_history"))
+
+    let withoutHistory = RealtimeSessionConfigurationBuilder.instructions(
+      for: VoiceToolRegistry(tools: [otherTool])
+    )
+    #expect(!withoutHistory.contains("read_session_history"))
+  }
+
+  @Test
+  func sessionContextIsAppendedWithStalenessWarningWhenPresent() {
+    let context = "2 sessions:\n- Fix login (claude, agenthub, Thinking)"
+
+    let withContext = RealtimeSessionConfigurationBuilder.instructions(
+      for: VoiceToolRegistry(tools: []),
+      sessionContext: context
+    )
+    #expect(withContext.contains("Session snapshot"))
+    #expect(withContext.contains("may be stale"))
+    #expect(withContext.contains("Fix login (claude, agenthub, Thinking)"))
+    #expect(withContext.hasSuffix(context))
+
+    let withoutContext = RealtimeSessionConfigurationBuilder.instructions(
+      for: VoiceToolRegistry(tools: []),
+      sessionContext: "   \n"
+    )
+    #expect(!withoutContext.contains("Session snapshot"))
+
+    let nilContext = RealtimeSessionConfigurationBuilder.instructions(
+      for: VoiceToolRegistry(tools: [])
+    )
+    #expect(!nilContext.contains("Session snapshot"))
+  }
+
+  @Test
+  func makeThreadsSessionContextIntoConfigurationInstructions() throws {
+    let configuration = RealtimeSessionConfigurationBuilder.make(
+      settings: VoiceEngineSettings(),
+      tools: VoiceToolRegistry(tools: []),
+      sessionContext: "1 session:\n- Build (codex, repo, Idle)"
+    )
+
+    let data = try JSONEncoder().encode(configuration)
+    let object = try #require(
+      JSONSerialization.jsonObject(with: data) as? [String: Any]
+    )
+    let instructions = try #require(object["instructions"] as? String)
+    #expect(instructions.contains("- Build (codex, repo, Idle)"))
+  }
+
+  @Test
   func worktreeTaskInstructionsOnlyAppearWithTheTaskTool() {
     let taskTool = VoiceTool(
       name: "create_worktree_tasks",

--- a/app/modules/AgentHubVoice/Tests/AgentHubVoiceTests/RealtimeVoiceEngineTests.swift
+++ b/app/modules/AgentHubVoice/Tests/AgentHubVoiceTests/RealtimeVoiceEngineTests.swift
@@ -426,6 +426,206 @@ struct RealtimeVoiceEngineTests {
   }
 
   @Test
+  func backgroundUpdateDeliveryGatesMicrophoneUntilTurnSettles() async {
+    let transport = await FakeRealtimeTransport()
+    let audio = await FakeRealtimeAudioController()
+    let engine = makeEngine(transport: transport, audio: audio)
+
+    await engine.start(
+      service: OpenAIServiceFactory.service(apiKey: "test"),
+      settings: VoiceEngineSettings(allowBargeIn: false),
+      tools: VoiceToolRegistry(tools: [])
+    )
+    transport.yield(.sessionUpdated)
+    await waitUntil { engine.state == .idle }
+
+    engine.pushBackgroundUpdate("Session finished")
+    await waitUntil {
+      await transport.sentCommands().count == 2
+    }
+
+    // Between the flush and the announcement finishing, background noise
+    // must not reach the server as a phantom user turn.
+    await audio.yieldMicrophoneBuffer()
+    for _ in 0..<20 {
+      await Task.yield()
+    }
+    #expect(!(await sentInputAudio(transport)))
+    #expect(engine.microphoneLevel == 0)
+    // The gate is transient plumbing — it must not read as a user mute,
+    // but the UI must still be able to show the mic as paused.
+    #expect(!engine.isMicrophoneMuted)
+    #expect(engine.isMicrophoneGated)
+
+    transport.yield(.responseCreated(responseID: "announce-1"))
+    transport.yield(
+      .responseDone(
+        responseID: "announce-1",
+        status: "completed",
+        statusDetails: nil
+      )
+    )
+    await waitUntil { engine.state == .idle }
+    #expect(!engine.isMicrophoneGated)
+
+    await audio.yieldMicrophoneBuffer()
+    await waitUntil { await sentInputAudio(transport) }
+    #expect(await sentInputAudio(transport))
+  }
+
+  @Test
+  func bargeInKeepsMicrophoneLiveDuringBackgroundUpdateDelivery() async {
+    let transport = await FakeRealtimeTransport()
+    let audio = await FakeRealtimeAudioController()
+    let engine = makeEngine(transport: transport, audio: audio)
+
+    await engine.start(
+      service: OpenAIServiceFactory.service(apiKey: "test"),
+      settings: VoiceEngineSettings(allowBargeIn: true),
+      tools: VoiceToolRegistry(tools: [])
+    )
+    transport.yield(.sessionUpdated)
+    await waitUntil { engine.state == .idle }
+
+    engine.pushBackgroundUpdate("Session finished")
+    await waitUntil {
+      await transport.sentCommands().count == 2
+    }
+
+    await audio.yieldMicrophoneBuffer()
+    await waitUntil { await sentInputAudio(transport) }
+    #expect(await sentInputAudio(transport))
+    #expect(!engine.isMicrophoneGated)
+  }
+
+  @Test
+  func failedAnnouncementReleasesTheDeliveryGate() async {
+    let transport = await FakeRealtimeTransport()
+    let audio = await FakeRealtimeAudioController()
+    let engine = makeEngine(transport: transport, audio: audio)
+
+    await engine.start(
+      service: OpenAIServiceFactory.service(apiKey: "test"),
+      settings: VoiceEngineSettings(allowBargeIn: false),
+      tools: VoiceToolRegistry(tools: [])
+    )
+    transport.yield(.sessionUpdated)
+    await waitUntil { engine.state == .idle }
+
+    engine.pushBackgroundUpdate("Session finished")
+    await waitUntil {
+      await transport.sentCommands().count == 2
+    }
+
+    transport.yield(.responseCreated(responseID: "announce-1"))
+    transport.yield(
+      .responseDone(
+        responseID: "announce-1",
+        status: "failed",
+        statusDetails: [
+          "status_details": [
+            "type": "failed",
+            "error": [
+              "code": "server_error",
+              "message": "The server had a hiccup.",
+            ],
+          ]
+        ]
+      )
+    )
+    await waitUntil { engine.state == .idle }
+
+    await audio.yieldMicrophoneBuffer()
+    await waitUntil { await sentInputAudio(transport) }
+    #expect(await sentInputAudio(transport))
+  }
+
+  @Test
+  func standbyMutesMicrophoneWhileAwaitingBackgroundWork() async {
+    let transport = await FakeRealtimeTransport()
+    let audio = await FakeRealtimeAudioController()
+    let engine = makeEngine(transport: transport, audio: audio)
+
+    await engine.start(
+      service: OpenAIServiceFactory.service(apiKey: "test"),
+      settings: VoiceEngineSettings(allowBargeIn: false),
+      tools: VoiceToolRegistry(tools: [])
+    )
+    transport.yield(.sessionUpdated)
+    await waitUntil { engine.state == .idle }
+
+    engine.setAwaitingBackgroundWork(true)
+    #expect(engine.isStandbyMuted)
+    #expect(!engine.isMicrophoneMuted)
+
+    await audio.yieldMicrophoneBuffer()
+    for _ in 0..<20 {
+      await Task.yield()
+    }
+    #expect(!(await sentInputAudio(transport)))
+
+    engine.setAwaitingBackgroundWork(false)
+    #expect(!engine.isStandbyMuted)
+    await audio.yieldMicrophoneBuffer()
+    await waitUntil { await sentInputAudio(transport) }
+    #expect(await sentInputAudio(transport))
+  }
+
+  @Test
+  func standbyOverrideStaysReleasedUntilTheNextWaitBegins() async {
+    let transport = await FakeRealtimeTransport()
+    let audio = await FakeRealtimeAudioController()
+    let engine = makeEngine(transport: transport, audio: audio)
+
+    await engine.start(
+      service: OpenAIServiceFactory.service(apiKey: "test"),
+      settings: VoiceEngineSettings(allowBargeIn: false),
+      tools: VoiceToolRegistry(tools: [])
+    )
+    transport.yield(.sessionUpdated)
+    await waitUntil { engine.state == .idle }
+
+    engine.setAwaitingBackgroundWork(true)
+    #expect(engine.isStandbyMuted)
+
+    // The user taps unmute to talk mid-wait: standby releases and repeated
+    // "still waiting" signals must not re-mute them.
+    engine.overrideStandbyMute()
+    #expect(!engine.isStandbyMuted)
+    engine.setAwaitingBackgroundWork(true)
+    #expect(!engine.isStandbyMuted)
+
+    // A fresh wait after this one ends re-engages standby.
+    engine.setAwaitingBackgroundWork(false)
+    engine.setAwaitingBackgroundWork(true)
+    #expect(engine.isStandbyMuted)
+  }
+
+  @Test
+  func standbyNeverClobbersTheUserMute() async {
+    let transport = await FakeRealtimeTransport()
+    let audio = await FakeRealtimeAudioController()
+    let engine = makeEngine(transport: transport, audio: audio)
+
+    await engine.start(
+      service: OpenAIServiceFactory.service(apiKey: "test"),
+      settings: VoiceEngineSettings(allowBargeIn: false),
+      tools: VoiceToolRegistry(tools: [])
+    )
+    transport.yield(.sessionUpdated)
+    await waitUntil { engine.state == .idle }
+
+    engine.setMicrophoneMuted(true)
+    engine.setAwaitingBackgroundWork(true)
+    #expect(!engine.isStandbyMuted)
+    #expect(engine.isMicrophoneMuted)
+
+    // The wait ending must not unmute a user who muted themselves.
+    engine.setAwaitingBackgroundWork(false)
+    #expect(engine.isMicrophoneMuted)
+  }
+
+  @Test
   func assistantSpeakingFollowsAudiblePlaybackNotDeltaArrival() async {
     let transport = await FakeRealtimeTransport()
     let audio = await FakeRealtimeAudioController()
@@ -459,6 +659,13 @@ struct RealtimeVoiceEngineTests {
     await audio.yieldMicrophoneBuffer()
     await waitUntil { !engine.isAssistantSpeaking }
     #expect(!engine.isAssistantSpeaking)
+  }
+
+  private func sentInputAudio(_ transport: FakeRealtimeTransport) async -> Bool {
+    await transport.sentCommands().contains {
+      if case .inputAudio = $0 { return true }
+      return false
+    }
   }
 
   private func makeEngine(


### PR DESCRIPTION
## Summary

Makes the voice agent genuinely session-aware and fixes the mic/UX around background announcements.

### Session awareness (pull-based, token-conscious)
- **New `read_session_history` tool** — role-tagged recent user/assistant turns from the JSONL transcript (both providers), default 6 / max 20 turns, per-turn (700) and total (6k) character caps; slash-command echoes and Codex instruction-replay blocks filtered out.
- **Connect-time session roster** — a compact snapshot (names, repos, statuses, target/approval markers; deliberately no session IDs) is injected once into the realtime instructions via `VoiceHUDHost.makeSessionContext()`, so "how are my sessions doing?" answers without a tool round-trip. Capped at 10 sessions / 1k chars.
- **`get_session_status` gains opt-in `activity_limit`** (1–20); the default stays 3 so casual checks cost the same as before.

### Watch tools
- **New `watch_session` / `stop_watching`** — observe a session the voice agent never prompted (e.g. one you're driving yourself) and get the spoken completion/approval announcement regardless of focus switches. Explicit watches announce their 30-minute timeout instead of ending silently; implicit prompt/launch watches keep the quiet timeout.

### Microphone gating around announcements
- **Delivery gate** — mic frames are dropped from the moment a queued announcement flushes until its turn settles (tool-call continuations included), so background noise can't interrupt the announcement or commit as a phantom user turn.
- **Standby mute** — the mic auto-mutes for the whole time completion watchers are pending (watcher active-count → provider → engine) and releases when the last watch ends. Tap-to-unmute overrides it for the current wait without being re-muted by repeated signals.
- Both are separate from the user's manual mute (never clobbered), skipped/overridable when barge-in is enabled, and cleared on turn settle, speech-started, failure, and teardown so the mic can never stay dead.

### HUD
- Converse mode reads as a live session: `waveform` to start, `×` to end, soft blurred accent glow that breathes with mic level (replaces the stroked ring), and a status caption ("Listening", "Sharing an update…", "Muted while waiting — tap the mic to talk").
- **New mute button** with live / user-muted / delivering / standby states (user mute > delivery gate > standby precedence). Dictate mode keeps its recorder semantics (mic → stop) untouched.
- `VoiceMicButton` no longer hardcodes "AgentHub" — uses `configuration.productName` per the panel module contract.

## Test plan

- `AgentHubVoice` package: 63/63 (engine gate/standby lifecycle with real mic frames, config-builder context, mute-button display precedence).
- Targeted `AgentHubCore` suites: transcript reader turns, executor history/activity limits, tool catalog (including watch tools), completion watcher lifecycle + timeout announcements, context builder — all green.
- Full `./scripts/test.sh` gate: all fast packages pass; the AgentHubCore suite fails only in the known headless-flaky suites (workspaces view model, request monitors, hot reload controller, CI notifier — see TestQuarantine.md / #380), none voice-related and matching the clean-tree baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)