### PR TITLE
Session hover previews and worktree module badges

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/Models/SessionHoverPreview.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Models/SessionHoverPreview.swift
@@ -1,0 +1,83 @@
+//
+//  SessionHoverPreview.swift
+//  AgentHub
+//
+
+import Foundation
+
+// MARK: - SessionHoverPreview
+
+/// Snapshot of the metadata shown in the hover popup for a sidebar session row.
+/// Built from data the row already has — the session plus the selected
+/// repositories — so the popup never triggers extra I/O.
+public struct SessionHoverPreview: Equatable, Sendable {
+  /// Custom name, slug, or short ID — in that order of preference.
+  public let sessionName: String
+  public let firstMessage: String?
+  /// Parent repository name (the registered repo root, even for worktrees).
+  public let repositoryName: String
+  public let branchName: String?
+  /// Registered worktree root path, only when the session runs in a worktree.
+  public let worktreePath: String?
+
+  public init(
+    sessionName: String,
+    firstMessage: String?,
+    repositoryName: String,
+    branchName: String?,
+    worktreePath: String?
+  ) {
+    self.sessionName = sessionName
+    self.firstMessage = firstMessage
+    self.repositoryName = repositoryName
+    self.branchName = branchName
+    self.worktreePath = worktreePath
+  }
+
+  /// Resolves preview fields for a session. Worktree sessions map back to
+  /// their registered worktree root and parent repository via
+  /// `WorktreeModuleResolver.bestMatch`, so nested launch paths still resolve
+  /// to the right module. Falls back to path-derived names when the session's
+  /// repository is not (or no longer) selected.
+  public static func make(
+    session: CLISession,
+    customName: String?,
+    repositories: [SelectedRepository]
+  ) -> SessionHoverPreview {
+    let match = WorktreeModuleResolver.bestMatch(
+      for: session.projectPath,
+      repositories: repositories
+    )
+
+    let isWorktree = match.map(\.worktree.isWorktree) ?? session.isWorktree
+    let worktreePath: String? = if isWorktree {
+      match?.worktree.path ?? session.projectPath
+    } else {
+      nil
+    }
+
+    let branchName = session.branchName
+      ?? (isWorktree ? match?.worktree.name : nil)
+
+    let trimmedFirstMessage = session.firstMessage?
+      .trimmingCharacters(in: .whitespacesAndNewlines)
+
+    return SessionHoverPreview(
+      sessionName: customName ?? session.displayName,
+      firstMessage: (trimmedFirstMessage?.isEmpty ?? true) ? nil : trimmedFirstMessage,
+      repositoryName: match?.repository.name ?? session.projectName,
+      branchName: branchName,
+      worktreePath: worktreePath
+    )
+  }
+
+  /// Worktree path with the home directory abbreviated for display.
+  public func displayWorktreePath(homeDirectory: String = NSHomeDirectory()) -> String? {
+    guard let worktreePath else { return nil }
+    let normalizedHome = WorktreeModuleResolver.normalizedDirectoryPath(homeDirectory)
+    guard worktreePath == normalizedHome || worktreePath.hasPrefix(normalizedHome + "/") else {
+      return worktreePath
+    }
+    return "~" + worktreePath.dropFirst(normalizedHome.count)
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/ProjectDetailsInventoryService.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/ProjectDetailsInventoryService.swift
@@ -1,0 +1,546 @@
+//
+//  ProjectDetailsInventoryService.swift
+//  AgentHub
+//
+
+import Foundation
+
+// MARK: - Models
+
+/// Where an agent asset (skill, MCP server, rule file) is configured.
+public enum ProjectAssetScope: String, Sendable, CaseIterable, Codable {
+  /// Configured inside the project repository.
+  case project
+  /// Configured in the user's home-level configuration (`~/.claude`, `~/.codex`, …).
+  case personal
+}
+
+/// A skill discovered on disk, merged across providers when the same skill
+/// name is installed for both Claude and Codex within the same scope.
+public struct ProjectAgentSkill: Identifiable, Equatable, Sendable {
+  public var id: String { "\(scope.rawValue)|\(name)" }
+  public let name: String
+  public let skillDescription: String
+  public let scope: ProjectAssetScope
+  public let providers: Set<SessionProviderKind>
+  /// Files bundled beside SKILL.md (references, scripts, …).
+  public let supportingFileCount: Int
+  /// The skill's on-disk directory (contains SKILL.md).
+  public let directoryPath: String
+
+  public init(
+    name: String,
+    skillDescription: String,
+    scope: ProjectAssetScope,
+    providers: Set<SessionProviderKind>,
+    supportingFileCount: Int = 0,
+    directoryPath: String = ""
+  ) {
+    self.name = name
+    self.skillDescription = skillDescription
+    self.scope = scope
+    self.providers = providers
+    self.supportingFileCount = supportingFileCount
+    self.directoryPath = directoryPath
+  }
+}
+
+/// An MCP server entry, merged across providers when the same server name is
+/// configured for both Claude and Codex within the same scope.
+public struct ProjectMCPServerEntry: Identifiable, Equatable, Sendable {
+  public var id: String { "\(scope.rawValue)|\(name)" }
+  public let name: String
+  /// Human-readable transport summary ("npx -y some-server", "https://…").
+  public let detail: String
+  public let scope: ProjectAssetScope
+  public let providers: Set<SessionProviderKind>
+
+  public init(
+    name: String,
+    detail: String,
+    scope: ProjectAssetScope,
+    providers: Set<SessionProviderKind>
+  ) {
+    self.name = name
+    self.detail = detail
+    self.scope = scope
+    self.providers = providers
+  }
+}
+
+/// A rules/instructions file (CLAUDE.md, AGENTS.md, Codex `.rules`).
+public struct ProjectAgentRule: Identifiable, Equatable, Sendable {
+  public var id: String { path }
+  public let title: String
+  public let path: String
+  public let scope: ProjectAssetScope
+  public let providers: Set<SessionProviderKind>
+  public let preview: String
+  public let lineCount: Int
+
+  public init(
+    title: String,
+    path: String,
+    scope: ProjectAssetScope,
+    providers: Set<SessionProviderKind>,
+    preview: String,
+    lineCount: Int
+  ) {
+    self.title = title
+    self.path = path
+    self.scope = scope
+    self.providers = providers
+    self.preview = preview
+    self.lineCount = lineCount
+  }
+}
+
+/// Everything the Project Details panel shows besides sessions.
+public struct ProjectDetailsInventory: Equatable, Sendable {
+  public let skills: [ProjectAgentSkill]
+  public let mcpServers: [ProjectMCPServerEntry]
+  public let rules: [ProjectAgentRule]
+
+  public init(
+    skills: [ProjectAgentSkill] = [],
+    mcpServers: [ProjectMCPServerEntry] = [],
+    rules: [ProjectAgentRule] = []
+  ) {
+    self.skills = skills
+    self.mcpServers = mcpServers
+    self.rules = rules
+  }
+
+  public static let empty = ProjectDetailsInventory()
+}
+
+// MARK: - Service
+
+public protocol ProjectDetailsInventoryServiceProtocol: Sendable {
+  func inventory(forProjectAt projectPath: String) async -> ProjectDetailsInventory
+}
+
+/// Scans the standard Claude and Codex on-disk locations for skills, MCP
+/// servers, and rules files relevant to a project:
+/// - Skills: `~/.claude/skills`, `~/.codex/skills`, `~/.agents/skills` and the
+///   project-level `.claude/skills`, `.codex/skills`, `.agents/skills`.
+/// - MCP servers: `~/.claude.json` (`mcpServers` + `projects[path].mcpServers`),
+///   `{project}/.mcp.json`, and `~/.codex/config.toml` (`[mcp_servers.*]`).
+/// - Rules: `CLAUDE.md` / `AGENTS.md` at personal and project scope, plus
+///   `~/.codex/rules/*.rules`.
+public actor ProjectDetailsInventoryService: ProjectDetailsInventoryServiceProtocol {
+  public static let shared = ProjectDetailsInventoryService()
+
+  private let homeDirectory: URL
+
+  public init(homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser) {
+    self.homeDirectory = homeDirectory
+  }
+
+  public func inventory(forProjectAt projectPath: String) async -> ProjectDetailsInventory {
+    let home = homeDirectory
+    return await Task.detached(priority: .utility) {
+      Self.scan(projectPath: projectPath, homeDirectory: home)
+    }.value
+  }
+
+  // MARK: - Scan (pure, synchronous — exercised directly by unit tests)
+
+  nonisolated static func scan(projectPath: String, homeDirectory: URL) -> ProjectDetailsInventory {
+    let projectURL = URL(fileURLWithPath: NSString(string: projectPath).expandingTildeInPath)
+      .standardizedFileURL
+    return ProjectDetailsInventory(
+      skills: scanSkills(projectURL: projectURL, homeDirectory: homeDirectory),
+      mcpServers: scanMCPServers(projectURL: projectURL, homeDirectory: homeDirectory),
+      rules: scanRules(projectURL: projectURL, homeDirectory: homeDirectory)
+    )
+  }
+
+  // MARK: - Skills
+
+  private struct SkillSource {
+    let root: URL
+    let scope: ProjectAssetScope
+    let providers: Set<SessionProviderKind>
+  }
+
+  private nonisolated static func scanSkills(
+    projectURL: URL,
+    homeDirectory: URL
+  ) -> [ProjectAgentSkill] {
+    let sources: [SkillSource] = [
+      SkillSource(
+        root: homeDirectory.appendingPathComponent(".claude/skills", isDirectory: true),
+        scope: .personal,
+        providers: [.claude]
+      ),
+      SkillSource(
+        root: homeDirectory.appendingPathComponent(".codex/skills", isDirectory: true),
+        scope: .personal,
+        providers: [.codex]
+      ),
+      SkillSource(
+        root: homeDirectory.appendingPathComponent(".agents/skills", isDirectory: true),
+        scope: .personal,
+        providers: [.claude, .codex]
+      ),
+      SkillSource(
+        root: projectURL.appendingPathComponent(".claude/skills", isDirectory: true),
+        scope: .project,
+        providers: [.claude]
+      ),
+      SkillSource(
+        root: projectURL.appendingPathComponent(".codex/skills", isDirectory: true),
+        scope: .project,
+        providers: [.codex]
+      ),
+      SkillSource(
+        root: projectURL.appendingPathComponent(".agents/skills", isDirectory: true),
+        scope: .project,
+        providers: [.claude, .codex]
+      )
+    ]
+
+    var merged: [String: ProjectAgentSkill] = [:]
+    for source in sources {
+      for skill in skills(inRoot: source.root, scope: source.scope, providers: source.providers) {
+        if let existing = merged[skill.id] {
+          merged[skill.id] = ProjectAgentSkill(
+            name: existing.name,
+            skillDescription: existing.skillDescription.isEmpty
+              ? skill.skillDescription
+              : existing.skillDescription,
+            scope: existing.scope,
+            providers: existing.providers.union(skill.providers),
+            supportingFileCount: max(existing.supportingFileCount, skill.supportingFileCount),
+            directoryPath: existing.directoryPath.isEmpty
+              ? skill.directoryPath
+              : existing.directoryPath
+          )
+        } else {
+          merged[skill.id] = skill
+        }
+      }
+    }
+    return merged.values.sorted {
+      $0.name == $1.name ? $0.scope.rawValue < $1.scope.rawValue : $0.name < $1.name
+    }
+  }
+
+  private nonisolated static func skills(
+    inRoot root: URL,
+    scope: ProjectAssetScope,
+    providers: Set<SessionProviderKind>
+  ) -> [ProjectAgentSkill] {
+    let fileManager = FileManager.default
+    guard let entries = try? fileManager.contentsOfDirectory(
+      at: root,
+      includingPropertiesForKeys: [.isDirectoryKey]
+    ) else {
+      return []
+    }
+
+    return entries.compactMap { directory -> ProjectAgentSkill? in
+      var isDirectory: ObjCBool = false
+      guard fileManager.fileExists(atPath: directory.path, isDirectory: &isDirectory),
+            isDirectory.boolValue else {
+        return nil
+      }
+      let skillFile = directory.appendingPathComponent("SKILL.md", isDirectory: false)
+      guard let content = try? String(contentsOf: skillFile, encoding: .utf8) else {
+        return nil
+      }
+      let parsed = parseFrontmatter(content)
+      return ProjectAgentSkill(
+        name: parsed.name ?? directory.lastPathComponent,
+        skillDescription: parsed.description ?? "",
+        scope: scope,
+        providers: providers,
+        supportingFileCount: supportingFileCount(in: directory),
+        directoryPath: directory.path
+      )
+    }
+  }
+
+  /// Files inside the skill directory other than SKILL.md itself.
+  private nonisolated static func supportingFileCount(in directory: URL) -> Int {
+    guard let enumerator = FileManager.default.enumerator(
+      at: directory,
+      includingPropertiesForKeys: [.isRegularFileKey]
+    ) else {
+      return 0
+    }
+    var count = 0
+    for case let file as URL in enumerator {
+      guard (try? file.resourceValues(forKeys: [.isRegularFileKey]))?.isRegularFile == true else {
+        continue
+      }
+      if file.lastPathComponent == "SKILL.md",
+         file.deletingLastPathComponent().path == directory.path {
+        continue
+      }
+      count += 1
+    }
+    return count
+  }
+
+  /// Extracts `name`/`description` from a SKILL.md YAML frontmatter block.
+  nonisolated static func parseFrontmatter(_ content: String) -> (name: String?, description: String?) {
+    let lines = content.components(separatedBy: .newlines)
+    guard lines.first?.trimmingCharacters(in: .whitespaces) == "---" else {
+      return (nil, nil)
+    }
+    var name: String?
+    var description: String?
+    for line in lines.dropFirst() {
+      if line.trimmingCharacters(in: .whitespaces) == "---" { break }
+      if name == nil, let value = frontmatterValue(of: "name", in: line) { name = value }
+      if description == nil, let value = frontmatterValue(of: "description", in: line) {
+        description = value
+      }
+    }
+    return (name, description)
+  }
+
+  private nonisolated static func frontmatterValue(of key: String, in line: String) -> String? {
+    guard line.lowercased().hasPrefix("\(key):") else { return nil }
+    let afterColon = line.drop { $0 != ":" }.dropFirst()
+    let value = afterColon
+      .trimmingCharacters(in: .whitespaces)
+      .trimmingCharacters(in: CharacterSet(charactersIn: "\"'"))
+    return value.isEmpty ? nil : value
+  }
+
+  // MARK: - MCP servers
+
+  private nonisolated static func scanMCPServers(
+    projectURL: URL,
+    homeDirectory: URL
+  ) -> [ProjectMCPServerEntry] {
+    var merged: [String: ProjectMCPServerEntry] = [:]
+
+    func add(_ entry: ProjectMCPServerEntry) {
+      if let existing = merged[entry.id] {
+        merged[entry.id] = ProjectMCPServerEntry(
+          name: existing.name,
+          detail: existing.detail.isEmpty ? entry.detail : existing.detail,
+          scope: existing.scope,
+          providers: existing.providers.union(entry.providers)
+        )
+      } else {
+        merged[entry.id] = entry
+      }
+    }
+
+    // Claude: ~/.claude.json holds global servers plus per-project overrides
+    // keyed by absolute project path.
+    let claudeConfigURL = homeDirectory.appendingPathComponent(".claude.json", isDirectory: false)
+    if let data = try? Data(contentsOf: claudeConfigURL),
+       let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+      if let global = root["mcpServers"] as? [String: Any] {
+        for entry in claudeEntries(global, scope: .personal) { add(entry) }
+      }
+      if let projects = root["projects"] as? [String: Any],
+         let project = projects[projectURL.path] as? [String: Any],
+         let projectServers = project["mcpServers"] as? [String: Any] {
+        for entry in claudeEntries(projectServers, scope: .project) { add(entry) }
+      }
+    }
+
+    // Claude: repo-local .mcp.json (shared, checked-in project servers).
+    let mcpJSONURL = projectURL.appendingPathComponent(".mcp.json", isDirectory: false)
+    if let data = try? Data(contentsOf: mcpJSONURL),
+       let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+       let servers = root["mcpServers"] as? [String: Any] {
+      for entry in claudeEntries(servers, scope: .project) { add(entry) }
+    }
+
+    // Codex: ~/.codex/config.toml [mcp_servers.<name>] tables.
+    let codexConfigURL = homeDirectory.appendingPathComponent(".codex/config.toml", isDirectory: false)
+    if let content = try? String(contentsOf: codexConfigURL, encoding: .utf8) {
+      for entry in codexEntries(fromTOML: content) { add(entry) }
+    }
+
+    return merged.values.sorted {
+      $0.name == $1.name ? $0.scope.rawValue < $1.scope.rawValue : $0.name < $1.name
+    }
+  }
+
+  private nonisolated static func claudeEntries(
+    _ rawServers: [String: Any],
+    scope: ProjectAssetScope
+  ) -> [ProjectMCPServerEntry] {
+    rawServers.compactMap { name, value in
+      guard let dictionary = value as? [String: Any] else { return nil }
+      return ProjectMCPServerEntry(
+        name: name,
+        detail: serverDetail(command: dictionary["command"] as? String,
+                             args: dictionary["args"] as? [String] ?? [],
+                             url: dictionary["url"] as? String),
+        scope: scope,
+        providers: [.claude]
+      )
+    }
+  }
+
+  private nonisolated static func codexEntries(fromTOML content: String) -> [ProjectMCPServerEntry] {
+    var commands: [String: String] = [:]
+    var args: [String: [String]] = [:]
+    var urls: [String: String] = [:]
+    var order: [String] = []
+    var currentServer: String?
+
+    for rawLine in content.components(separatedBy: .newlines) {
+      let line = rawLine.trimmingCharacters(in: .whitespaces)
+      guard !line.isEmpty, !line.hasPrefix("#") else { continue }
+
+      if line.hasPrefix("["), line.hasSuffix("]") {
+        let table = String(line.dropFirst().dropLast())
+        guard table.hasPrefix("mcp_servers.") else {
+          currentServer = nil
+          continue
+        }
+        let suffix = String(table.dropFirst("mcp_servers.".count))
+        let name = (suffix.split(separator: ".").first.map(String.init) ?? "")
+          .trimmingCharacters(in: CharacterSet(charactersIn: "\"'"))
+        guard !name.isEmpty else {
+          currentServer = nil
+          continue
+        }
+        // Sub-tables like [mcp_servers.<name>.env] keep contributing to <name>,
+        // but their keys are not transport details we surface.
+        currentServer = suffix.contains(".") ? nil : name
+        if !order.contains(name) { order.append(name) }
+        continue
+      }
+
+      guard let currentServer, let equals = line.firstIndex(of: "=") else { continue }
+      let key = String(line[..<equals]).trimmingCharacters(in: .whitespaces)
+      let rawValue = String(line[line.index(after: equals)...]).trimmingCharacters(in: .whitespaces)
+      switch key {
+      case "command":
+        commands[currentServer] = tomlString(rawValue)
+      case "args":
+        args[currentServer] = tomlStringArray(rawValue)
+      case "url":
+        urls[currentServer] = tomlString(rawValue)
+      default:
+        break
+      }
+    }
+
+    return order.map { name in
+      ProjectMCPServerEntry(
+        name: name,
+        detail: serverDetail(command: commands[name], args: args[name] ?? [], url: urls[name]),
+        scope: .personal,
+        providers: [.codex]
+      )
+    }
+  }
+
+  private nonisolated static func serverDetail(
+    command: String?,
+    args: [String],
+    url: String?
+  ) -> String {
+    if let url, !url.isEmpty { return url }
+    guard let command, !command.isEmpty else { return "" }
+    return ([command] + args).joined(separator: " ")
+  }
+
+  private nonisolated static func tomlString(_ value: String) -> String? {
+    let trimmed = value.trimmingCharacters(in: .whitespaces)
+    guard trimmed.count >= 2 else { return nil }
+    if (trimmed.first == "\"" && trimmed.last == "\"") ||
+       (trimmed.first == "'" && trimmed.last == "'") {
+      return String(trimmed.dropFirst().dropLast())
+        .replacingOccurrences(of: "\\\"", with: "\"")
+    }
+    return nil
+  }
+
+  private nonisolated static func tomlStringArray(_ value: String) -> [String] {
+    guard let regex = try? NSRegularExpression(pattern: #""([^"\\]|\\.)*"|'[^']*'"#) else {
+      return []
+    }
+    let range = NSRange(value.startIndex..., in: value)
+    return regex.matches(in: value, range: range).compactMap { match in
+      guard let matchRange = Range(match.range, in: value) else { return nil }
+      return tomlString(String(value[matchRange]))
+    }
+  }
+
+  // MARK: - Rules
+
+  private nonisolated static func scanRules(
+    projectURL: URL,
+    homeDirectory: URL
+  ) -> [ProjectAgentRule] {
+    var rules: [ProjectAgentRule] = []
+
+    func addFile(
+      _ url: URL,
+      scope: ProjectAssetScope,
+      providers: Set<SessionProviderKind>
+    ) {
+      guard let content = try? String(contentsOf: url, encoding: .utf8) else { return }
+      rules.append(ProjectAgentRule(
+        title: url.lastPathComponent,
+        path: url.path,
+        scope: scope,
+        providers: providers,
+        preview: rulePreview(content),
+        lineCount: content.components(separatedBy: .newlines).count
+      ))
+    }
+
+    addFile(
+      homeDirectory.appendingPathComponent(".claude/CLAUDE.md", isDirectory: false),
+      scope: .personal,
+      providers: [.claude]
+    )
+    addFile(
+      homeDirectory.appendingPathComponent(".codex/AGENTS.md", isDirectory: false),
+      scope: .personal,
+      providers: [.codex]
+    )
+    addFile(
+      projectURL.appendingPathComponent("CLAUDE.md", isDirectory: false),
+      scope: .project,
+      providers: [.claude]
+    )
+    addFile(
+      projectURL.appendingPathComponent(".claude/CLAUDE.md", isDirectory: false),
+      scope: .project,
+      providers: [.claude]
+    )
+    addFile(
+      projectURL.appendingPathComponent("AGENTS.md", isDirectory: false),
+      scope: .project,
+      providers: [.codex]
+    )
+
+    // Codex prefix rules (~/.codex/rules/*.rules).
+    let codexRulesRoot = homeDirectory.appendingPathComponent(".codex/rules", isDirectory: true)
+    if let entries = try? FileManager.default.contentsOfDirectory(
+      at: codexRulesRoot,
+      includingPropertiesForKeys: nil
+    ) {
+      for file in entries.sorted(by: { $0.lastPathComponent < $1.lastPathComponent })
+      where file.pathExtension == "rules" {
+        addFile(file, scope: .personal, providers: [.codex])
+      }
+    }
+
+    return rules
+  }
+
+  private nonisolated static func rulePreview(_ content: String) -> String {
+    let lines = content
+      .components(separatedBy: .newlines)
+      .map { $0.trimmingCharacters(in: .whitespaces) }
+      .filter { !$0.isEmpty && $0 != "---" }
+    return lines.prefix(3).joined(separator: "\n").prefix(220).description
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/CollapsibleSessionRow.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/CollapsibleSessionRow.swift
@@ -21,6 +21,7 @@ struct CollapsibleSessionRow: View {
   private static let statusLabelMaxWidth: CGFloat = 96
 
   @State private var isHovered = false
+  @State private var showHoverPreview = false
   @State private var showArchiveConfirm = false
   @State private var pulseScale: CGFloat = 1.0
   @State private var isPulseAnimating = false
@@ -85,6 +86,21 @@ struct CollapsibleSessionRow: View {
       linkedPullRequests: linkedPullRequests
     )
     return "\(repositoryKey)|\(isPending)|\(agentHub != nil)"
+  }
+
+  /// Popup metadata resolved from data already on hand: the session itself
+  /// plus the selected repositories, so worktree sessions surface their parent
+  /// repo and registered worktree root.
+  private var hoverPreview: SessionHoverPreview {
+    let repositories = WorktreeModuleResolver.mergedRepositories(
+      (agentHub?.claudeSessionsViewModel.selectedRepositories ?? [])
+        + (agentHub?.codexSessionsViewModel.selectedRepositories ?? [])
+    )
+    return SessionHoverPreview.make(
+      session: session,
+      customName: customName,
+      repositories: repositories
+    )
   }
 
   private var observationStartupDelayMilliseconds: Int {
@@ -188,6 +204,22 @@ struct CollapsibleSessionRow: View {
           showArchiveConfirm = false
         }
       }
+    }
+    .task(id: isHovered) {
+      guard isHovered, !isPending else {
+        showHoverPreview = false
+        return
+      }
+      try? await Task.sleep(for: .milliseconds(600))
+      guard !Task.isCancelled else { return }
+      showHoverPreview = true
+    }
+    .popover(isPresented: $showHoverPreview, arrowEdge: .trailing) {
+      SessionHoverPreviewCard(
+        preview: hoverPreview,
+        timestamp: timestamp,
+        gitHubViewModel: sessionGitHubQuickAccessViewModel
+      )
     }
     .onAppear { startPulseAnimation() }
     .onChange(of: sessionStatus) { _, _ in startPulseAnimation() }
@@ -346,215 +378,6 @@ struct CollapsibleSessionRow: View {
   }
 }
 
-// MARK: - GitHubSessionRowStatusLine
-
-private struct GitHubSessionRowStatusLine: View {
-  let pullRequest: GitHubPullRequest
-  let summary: GitHubCISummary
-  let observationState: GitHubPRObservationState
-  let lastRefreshedAt: Date?
-
-  var body: some View {
-    HStack(spacing: 5) {
-      Image(systemName: primaryIcon)
-        .font(.system(size: 10, weight: .semibold))
-        .foregroundStyle(primaryColor)
-        .frame(width: 12, height: 12)
-
-      Text(primaryText)
-        .font(.geist(size: 10, weight: .medium))
-        .foregroundColor(.secondary.opacity(0.95))
-
-      if let secondaryText {
-        Text("·")
-          .font(.secondaryCaption)
-          .foregroundColor(.secondary.opacity(0.55))
-
-        Image(systemName: secondaryIcon)
-          .font(.system(size: 9, weight: .semibold))
-          .foregroundStyle(secondaryColor)
-          .frame(width: 11, height: 11)
-
-        Text(secondaryText)
-          .font(.secondaryCaption)
-          .foregroundColor(.secondary.opacity(0.86))
-      }
-    }
-    .lineLimit(1)
-    .truncationMode(.tail)
-    .frame(maxWidth: .infinity, alignment: .leading)
-    .help(helpText)
-    .accessibilityLabel(helpText)
-  }
-
-  private var primaryText: String {
-    switch pullRequest.stateKind {
-    case .open:
-      return pullRequest.isDraft ? "Draft PR #\(pullRequest.number)" : "Open PR #\(pullRequest.number)"
-    case .closed:
-      return "Closed PR #\(pullRequest.number)"
-    case .merged:
-      return "Merged PR #\(pullRequest.number)"
-    case .unknown:
-      return "PR #\(pullRequest.number)"
-    }
-  }
-
-  private var secondaryText: String? {
-    if observationState.isRefreshing && summary.total == 0 {
-      return "Refreshing checks"
-    }
-
-    if observationState.isUnavailable {
-      return lastRefreshedAt == nil
-        ? "GitHub unavailable"
-        : "Last known: \(statusText)"
-    }
-
-    return statusText
-  }
-
-  private var statusText: String {
-    let blockers = GitHubPRBlocker.blockers(
-      for: pullRequest,
-      ciSummary: summary
-    ).sorted { $0.rawValue < $1.rawValue }
-    if blockers.count == 1, let blocker = blockers.first {
-      return blocker.displayName
-    }
-    if blockers.count > 1 {
-      return "\(blockers.count) PR blockers"
-    }
-
-    guard summary.total > 0 else {
-      return "No CI checks"
-    }
-
-    switch summary.overallStatus {
-    case .success:
-      return "CI passing \(summary.passed)/\(summary.total)"
-    case .failure:
-      return "CI failing \(summary.failed) failed"
-    case .pending:
-      return "CI running \(summary.pending) pending"
-    case .none:
-      if summary.skipped > 0 {
-        return "CI skipped \(summary.skipped)"
-      }
-      return "No CI checks"
-    }
-  }
-
-  private var primaryIcon: String {
-    return pullRequest.stateIcon
-  }
-
-  private var secondaryIcon: String {
-    if observationState.isRefreshing && summary.total == 0 {
-      return "arrow.clockwise"
-    }
-    if observationState.isUnavailable || !blockers.isEmpty {
-      return "exclamationmark.triangle.fill"
-    }
-    return summary.overallStatus.icon
-  }
-
-  private var primaryColor: Color {
-    switch pullRequest.stateKind {
-    case .open:
-      return pullRequest.isDraft ? .secondary : .green
-    case .closed:
-      return .red
-    case .merged:
-      return .purple
-    case .unknown:
-      return .secondary
-    }
-  }
-
-  private var secondaryColor: Color {
-    if observationState.isRefreshing && summary.total == 0 {
-      return .orange
-    }
-    if !blockers.isEmpty { return .red }
-    if observationState.isUnavailable { return .orange }
-    switch summary.overallStatus {
-    case .success:
-      return .green
-    case .failure:
-      return .red
-    case .pending:
-      return .orange
-    case .none:
-      return .secondary
-    }
-  }
-
-  private var helpText: String {
-    let prText: String
-    switch pullRequest.stateKind {
-    case .open:
-      prText = pullRequest.isDraft
-        ? "Draft PR #\(pullRequest.number)"
-        : "Open PR #\(pullRequest.number)"
-    case .closed:
-      prText = "Closed PR #\(pullRequest.number)"
-    case .merged:
-      prText = "Merged PR #\(pullRequest.number)"
-    case .unknown:
-      prText = "PR #\(pullRequest.number) has an unknown state"
-    }
-
-    return "\(prText). \(ciHelpText)"
-  }
-
-  private var ciHelpText: String {
-    if observationState.isRefreshing && summary.total == 0 {
-      return "CI checks are refreshing."
-    }
-
-    if observationState.isUnavailable {
-      let availability = lastRefreshedAt == nil
-        ? "GitHub status is unavailable."
-        : "GitHub status is unavailable; showing the last known result."
-      return "\(availability) \(currentGitHubHelpText)"
-    }
-
-    return currentGitHubHelpText
-  }
-
-  private var currentGitHubHelpText: String {
-    if !blockers.isEmpty {
-      let descriptions = blockers
-        .sorted { $0.rawValue < $1.rawValue }
-        .map(\.displayName)
-        .joined(separator: ", ")
-      return "Pull request blockers: \(descriptions)."
-    }
-
-    guard summary.total > 0 else {
-      return "No CI checks are reported."
-    }
-
-    switch summary.overallStatus {
-    case .success:
-      return "CI passing: \(summary.passed) of \(summary.total) checks passed."
-    case .failure:
-      return "CI failing: \(summary.failed) failed, \(summary.passed) passed, \(summary.pending) pending."
-    case .pending:
-      return "CI running: \(summary.pending) pending, \(summary.passed) passed, \(summary.failed) failed."
-    case .none:
-      if summary.skipped > 0 {
-        return "CI checks are skipped or neutral: \(summary.skipped) of \(summary.total)."
-      }
-      return "No CI checks are reported."
-    }
-  }
-
-  private var blockers: Set<GitHubPRBlocker> {
-    GitHubPRBlocker.blockers(for: pullRequest, ciSummary: summary)
-  }
-}
 
 // MARK: - Preview
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/GitHubSessionRowStatusLine.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/GitHubSessionRowStatusLine.swift
@@ -1,0 +1,219 @@
+//
+//  GitHubSessionRowStatusLine.swift
+//  AgentHub
+//
+//  Compact PR + CI status line shared by session rows and the hover preview.
+//
+
+import AgentHubGitHub
+import SwiftUI
+
+// MARK: - GitHubSessionRowStatusLine
+
+struct GitHubSessionRowStatusLine: View {
+  let pullRequest: GitHubPullRequest
+  let summary: GitHubCISummary
+  let observationState: GitHubPRObservationState
+  let lastRefreshedAt: Date?
+
+  var body: some View {
+    HStack(spacing: 5) {
+      Image(systemName: primaryIcon)
+        .font(.system(size: 10, weight: .semibold))
+        .foregroundStyle(primaryColor)
+        .frame(width: 12, height: 12)
+
+      Text(primaryText)
+        .font(.geist(size: 10, weight: .medium))
+        .foregroundColor(.secondary.opacity(0.95))
+
+      if let secondaryText {
+        Text("·")
+          .font(.secondaryCaption)
+          .foregroundColor(.secondary.opacity(0.55))
+
+        Image(systemName: secondaryIcon)
+          .font(.system(size: 9, weight: .semibold))
+          .foregroundStyle(secondaryColor)
+          .frame(width: 11, height: 11)
+
+        Text(secondaryText)
+          .font(.secondaryCaption)
+          .foregroundColor(.secondary.opacity(0.86))
+      }
+    }
+    .lineLimit(1)
+    .truncationMode(.tail)
+    .frame(maxWidth: .infinity, alignment: .leading)
+    .help(helpText)
+    .accessibilityLabel(helpText)
+  }
+
+  private var primaryText: String {
+    switch pullRequest.stateKind {
+    case .open:
+      return pullRequest.isDraft ? "Draft PR #\(pullRequest.number)" : "Open PR #\(pullRequest.number)"
+    case .closed:
+      return "Closed PR #\(pullRequest.number)"
+    case .merged:
+      return "Merged PR #\(pullRequest.number)"
+    case .unknown:
+      return "PR #\(pullRequest.number)"
+    }
+  }
+
+  private var secondaryText: String? {
+    if observationState.isRefreshing && summary.total == 0 {
+      return "Refreshing checks"
+    }
+
+    if observationState.isUnavailable {
+      return lastRefreshedAt == nil
+        ? "GitHub unavailable"
+        : "Last known: \(statusText)"
+    }
+
+    return statusText
+  }
+
+  private var statusText: String {
+    let blockers = GitHubPRBlocker.blockers(
+      for: pullRequest,
+      ciSummary: summary
+    ).sorted { $0.rawValue < $1.rawValue }
+    if blockers.count == 1, let blocker = blockers.first {
+      return blocker.displayName
+    }
+    if blockers.count > 1 {
+      return "\(blockers.count) PR blockers"
+    }
+
+    guard summary.total > 0 else {
+      return "No CI checks"
+    }
+
+    switch summary.overallStatus {
+    case .success:
+      return "CI passing \(summary.passed)/\(summary.total)"
+    case .failure:
+      return "CI failing \(summary.failed) failed"
+    case .pending:
+      return "CI running \(summary.pending) pending"
+    case .none:
+      if summary.skipped > 0 {
+        return "CI skipped \(summary.skipped)"
+      }
+      return "No CI checks"
+    }
+  }
+
+  private var primaryIcon: String {
+    return pullRequest.stateIcon
+  }
+
+  private var secondaryIcon: String {
+    if observationState.isRefreshing && summary.total == 0 {
+      return "arrow.clockwise"
+    }
+    if observationState.isUnavailable || !blockers.isEmpty {
+      return "exclamationmark.triangle.fill"
+    }
+    return summary.overallStatus.icon
+  }
+
+  private var primaryColor: Color {
+    switch pullRequest.stateKind {
+    case .open:
+      return pullRequest.isDraft ? .secondary : .green
+    case .closed:
+      return .red
+    case .merged:
+      return .purple
+    case .unknown:
+      return .secondary
+    }
+  }
+
+  private var secondaryColor: Color {
+    if observationState.isRefreshing && summary.total == 0 {
+      return .orange
+    }
+    if !blockers.isEmpty { return .red }
+    if observationState.isUnavailable { return .orange }
+    switch summary.overallStatus {
+    case .success:
+      return .green
+    case .failure:
+      return .red
+    case .pending:
+      return .orange
+    case .none:
+      return .secondary
+    }
+  }
+
+  private var helpText: String {
+    let prText: String
+    switch pullRequest.stateKind {
+    case .open:
+      prText = pullRequest.isDraft
+        ? "Draft PR #\(pullRequest.number)"
+        : "Open PR #\(pullRequest.number)"
+    case .closed:
+      prText = "Closed PR #\(pullRequest.number)"
+    case .merged:
+      prText = "Merged PR #\(pullRequest.number)"
+    case .unknown:
+      prText = "PR #\(pullRequest.number) has an unknown state"
+    }
+
+    return "\(prText). \(ciHelpText)"
+  }
+
+  private var ciHelpText: String {
+    if observationState.isRefreshing && summary.total == 0 {
+      return "CI checks are refreshing."
+    }
+
+    if observationState.isUnavailable {
+      let availability = lastRefreshedAt == nil
+        ? "GitHub status is unavailable."
+        : "GitHub status is unavailable; showing the last known result."
+      return "\(availability) \(currentGitHubHelpText)"
+    }
+
+    return currentGitHubHelpText
+  }
+
+  private var currentGitHubHelpText: String {
+    if !blockers.isEmpty {
+      let descriptions = blockers
+        .sorted { $0.rawValue < $1.rawValue }
+        .map(\.displayName)
+        .joined(separator: ", ")
+      return "Pull request blockers: \(descriptions)."
+    }
+
+    guard summary.total > 0 else {
+      return "No CI checks are reported."
+    }
+
+    switch summary.overallStatus {
+    case .success:
+      return "CI passing: \(summary.passed) of \(summary.total) checks passed."
+    case .failure:
+      return "CI failing: \(summary.failed) failed, \(summary.passed) passed, \(summary.pending) pending."
+    case .pending:
+      return "CI running: \(summary.pending) pending, \(summary.passed) passed, \(summary.failed) failed."
+    case .none:
+      if summary.skipped > 0 {
+        return "CI checks are skipped or neutral: \(summary.skipped) of \(summary.total)."
+      }
+      return "No CI checks are reported."
+    }
+  }
+
+  private var blockers: Set<GitHubPRBlocker> {
+    GitHubPRBlocker.blockers(for: pullRequest, ciSummary: summary)
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringCardView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MonitoringCardView.swift
@@ -666,8 +666,39 @@ public struct MonitoringCardView: View {
 
   // MARK: - Header
 
+  /// Parent module for the header label: repo name plus whether the session
+  /// runs in a worktree, resolved via the selected repositories.
+  private var sessionModulePreview: SessionHoverPreview {
+    SessionHoverPreview.make(
+      session: session,
+      customName: nil,
+      repositories: WorktreeModuleResolver.mergedRepositories(
+        (agentHub?.claudeSessionsViewModel.selectedRepositories ?? [])
+          + (agentHub?.codexSessionsViewModel.selectedRepositories ?? [])
+      )
+    )
+  }
+
+  private var isWorktreeSession: Bool {
+    sessionModulePreview.worktreePath != nil
+  }
+
   private var header: some View {
     HStack(spacing: 8) {
+      // Parent module: folder + repo name, only for worktree sessions — the
+      // path row already identifies root-repo sessions.
+      if isWorktreeSession {
+        Image(systemName: "folder")
+          .font(.caption)
+          .foregroundStyle(.secondary)
+          .layoutPriority(1)
+        Text(sessionModulePreview.repositoryName)
+          .font(.primaryDefault)
+          .foregroundStyle(.secondary)
+          .lineLimit(1)
+          .layoutPriority(1)
+      }
+
       // Activity indicator circle - shows when session is working
       Circle()
         .fill(isHighlighted ? Color.brandPrimary(for: providerKind) : .gray.opacity(0.3))
@@ -917,6 +948,7 @@ public struct MonitoringCardView: View {
     MonitoringCardPathRow(
       session: session,
       providerKind: providerKind,
+      isWorktree: isWorktreeSession,
       contentMode: $contentMode,
       availableContentModes: availableContentModes
     )
@@ -1030,6 +1062,7 @@ enum MonitoringCardContentModeItems {
 private struct MonitoringCardPathRow: View {
   let session: CLISession
   let providerKind: SessionProviderKind
+  let isWorktree: Bool
   @Binding var contentMode: MonitoringCardContentMode
   let availableContentModes: [MonitoringCardContentMode]
 
@@ -1086,7 +1119,7 @@ private struct MonitoringCardPathRow: View {
 
   private var projectPathLabel: some View {
     HStack(spacing: 4) {
-      Image(systemName: "folder")
+      Image(systemName: isWorktree ? "arrow.triangle.branch" : "folder")
         .font(.caption)
         .foregroundStyle(.secondary)
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
@@ -1391,8 +1391,13 @@ public struct MultiProviderSessionsListView: View {
               )
 
               if isExpanded {
-                workspaceRows(for: groupWorkspaces, ownedItems: workspaceOwnedItems)
-                sessionRows(for: group.items.filter { !isWorkspaceOwned($0) })
+                // Indent module children so the module → session hierarchy reads
+                // at a glance.
+                VStack(alignment: .leading, spacing: 0) {
+                  workspaceRows(for: groupWorkspaces, ownedItems: workspaceOwnedItems)
+                  sessionRows(for: group.items.filter { !isWorkspaceOwned($0) })
+                }
+                .padding(.leading, 12)
               }
             }
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
@@ -27,6 +27,14 @@ private struct GitHubSheetItem: Identifiable {
   let projectPath: String
 }
 
+// MARK: - ProjectDetailsSheetItem
+
+private struct ProjectDetailsSheetItem: Identifiable {
+  let id = UUID()
+  let projectPath: String
+  let displayName: String
+}
+
 // MARK: - ArchiveConfirmation
 
 private struct ArchiveConfirmation {
@@ -156,6 +164,7 @@ public struct MultiProviderSessionsListView: View {
   @State private var createWorktreeContext: WorktreeCreateContext?
   @State private var startSessionSheetContext: StartSessionSheetContext?
   @State private var gitHubSheetItem: GitHubSheetItem?
+  @State private var projectDetailsSheetItem: ProjectDetailsSheetItem?
   @State private var archiveConfirmation: ArchiveConfirmation?
   @State private var removeConfirmation: RemoveConfirmation?
   @State private var worktreeModuleDeleteConfirmation: WorktreeModuleDeleteConfirmation?
@@ -419,6 +428,21 @@ public struct MultiProviderSessionsListView: View {
         launchViewModel: context.launchViewModel,
         intelligenceViewModel: intelligenceViewModel,
         onDismiss: { startSessionSheetContext = nil }
+      )
+    }
+    .sheet(item: $projectDetailsSheetItem) { item in
+      ProjectDetailsSheetView(
+        modulePath: item.projectPath,
+        displayName: item.displayName,
+        claudeViewModel: claudeViewModel,
+        codexViewModel: codexViewModel,
+        onDismiss: { projectDetailsSheetItem = nil },
+        onSelectSession: { sessionItem in
+          projectDetailsSheetItem = nil
+          selectedWorkspaceID = nil
+          selectedModuleLandingPath = nil
+          primarySessionId = sessionItem.id
+        }
       )
     }
     .modifier(ArchiveConfirmationAlert(confirmation: $archiveConfirmation))
@@ -1349,6 +1373,12 @@ public struct MultiProviderSessionsListView: View {
                 },
                 onCreateWorkspace: {
                   createWorkspace(projectPath: group.id)
+                },
+                onShowProjectDetails: {
+                  projectDetailsSheetItem = ProjectDetailsSheetItem(
+                    projectPath: group.id,
+                    displayName: group.displayName
+                  )
                 },
                 onOpenInFinder: {
                   NSWorkspace.shared.selectFile(nil, inFileViewerRootedAtPath: group.id)
@@ -2578,6 +2608,7 @@ private struct ProjectGroupHeader: View {
   let repoPath: String
   let onStartSession: () -> Void
   let onCreateWorkspace: () -> Void
+  let onShowProjectDetails: () -> Void
   let onOpenInFinder: () -> Void
   let onOpenGitHub: () -> Void
   let onArchiveSessions: (() -> Void)?
@@ -2617,6 +2648,9 @@ private struct ProjectGroupHeader: View {
       HeaderIconMenu(systemName: "ellipsis", size: 14, help: "More actions") {
         Button(action: onCreateWorkspace) {
           Label("New Workspace", systemImage: "rectangle.3.group")
+        }
+        Button(action: onShowProjectDetails) {
+          Label("Project Details", systemImage: "info.circle")
         }
         Divider()
         Button(action: onOpenInFinder) {
@@ -2842,7 +2876,7 @@ private struct SessionsSectionHeader: View {
   var body: some View {
     VStack(spacing: 0) {
       HStack(spacing: 2) {
-        Text("Sessions")
+        Text("Projects")
           .font(.heading)
           .foregroundColor(.secondary)
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/ProjectDetailsSheetView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/ProjectDetailsSheetView.swift
@@ -1,0 +1,975 @@
+//
+//  ProjectDetailsSheetView.swift
+//  AgentHub
+//
+//  Project Details panel: every session that belongs to a module (including
+//  worktree sessions) plus the skills, rules, and MCP servers available to it,
+//  with personal-vs-project scope and Claude/Codex availability called out.
+//
+
+import SwiftUI
+
+// MARK: - ProjectDetailsSessionItem
+
+struct ProjectDetailsSessionItem: Identifiable {
+  let id: String
+  let session: CLISession
+  let providerKind: SessionProviderKind
+  let timestamp: Date
+  let isPending: Bool
+  let status: SessionStatus?
+  let customName: String?
+
+  var displayName: String {
+    customName ?? session.displayName
+  }
+}
+
+// MARK: - ProjectDetailsTab
+
+private enum ProjectDetailsTab: String, CaseIterable, Identifiable {
+  case sessions = "Sessions"
+  case skills = "Skills"
+  case rules = "Rules"
+  case mcps = "MCPs"
+
+  var id: String { rawValue }
+}
+
+// MARK: - ProjectDetailsScopeFilter
+
+private enum ProjectDetailsScopeFilter: Hashable {
+  case all
+  case scope(ProjectAssetScope)
+
+  func allows(_ scope: ProjectAssetScope) -> Bool {
+    switch self {
+    case .all: return true
+    case .scope(let filter): return filter == scope
+    }
+  }
+}
+
+// MARK: - ProjectDetailsSheetView
+
+struct ProjectDetailsSheetView: View {
+  let modulePath: String
+  let displayName: String
+  let claudeViewModel: CLISessionsViewModel
+  let codexViewModel: CLISessionsViewModel
+  let onDismiss: () -> Void
+  let onSelectSession: (ProjectDetailsSessionItem) -> Void
+
+  @State private var viewModel: ProjectDetailsViewModel
+  @State private var selectedTab: ProjectDetailsTab = .sessions
+  @State private var skillScopeFilter: ProjectDetailsScopeFilter = .all
+  @State private var selectedSkill: ProjectAgentSkill?
+  @State private var selectedRule: ProjectAgentRule?
+  @Environment(\.colorScheme) private var colorScheme
+
+  init(
+    modulePath: String,
+    displayName: String,
+    claudeViewModel: CLISessionsViewModel,
+    codexViewModel: CLISessionsViewModel,
+    inventoryService: any ProjectDetailsInventoryServiceProtocol = ProjectDetailsInventoryService.shared,
+    onDismiss: @escaping () -> Void,
+    onSelectSession: @escaping (ProjectDetailsSessionItem) -> Void
+  ) {
+    self.modulePath = modulePath
+    self.displayName = displayName
+    self.claudeViewModel = claudeViewModel
+    self.codexViewModel = codexViewModel
+    self.onDismiss = onDismiss
+    self.onSelectSession = onSelectSession
+    let rootPath = WorktreeModuleResolver.bestMatch(
+      for: modulePath,
+      repositories: WorktreeModuleResolver.mergedRepositories(
+        claudeViewModel.selectedRepositories + codexViewModel.selectedRepositories
+      )
+    )?.repository.path ?? WorktreeModuleResolver.normalizedDirectoryPath(modulePath)
+    _viewModel = State(initialValue: ProjectDetailsViewModel(
+      projectPath: rootPath,
+      service: inventoryService
+    ))
+  }
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 0) {
+      header
+        .padding(.horizontal, 20)
+        .padding(.top, 18)
+        .padding(.bottom, 14)
+
+      ProjectDetailsTabBar(
+        tabs: ProjectDetailsTab.allCases,
+        count: tabCount,
+        selection: $selectedTab
+      )
+      .padding(.horizontal, 20)
+
+      Divider()
+
+      tabContent
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+    }
+    .onChange(of: selectedTab) { _, _ in
+      selectedSkill = nil
+      selectedRule = nil
+    }
+    .background(Color.surfacePanel)
+    .frame(
+      minWidth: 960,
+      idealWidth: 1240,
+      maxWidth: .infinity,
+      minHeight: 700,
+      idealHeight: 920,
+      maxHeight: .infinity
+    )
+    .onExitCommand { onDismiss() }
+    .task { await viewModel.load() }
+  }
+
+  // MARK: Header
+
+  private var header: some View {
+    HStack(spacing: 12) {
+      Image(systemName: "folder")
+        .font(.system(size: 15, weight: .medium))
+        .foregroundStyle(.primary)
+        .frame(width: 36, height: 36)
+        .background(
+          RoundedRectangle(cornerRadius: 8, style: .continuous)
+            .fill(Color.surfaceElevated)
+        )
+        .overlay(
+          RoundedRectangle(cornerRadius: 8, style: .continuous)
+            .stroke(Color.secondary.opacity(0.14), lineWidth: 1)
+        )
+
+      VStack(alignment: .leading, spacing: 2) {
+        Text(displayName)
+          .font(.geist(size: 16, weight: .bold))
+          .foregroundStyle(.primary)
+        Text((moduleRootPath as NSString).abbreviatingWithTildeInPath)
+          .font(.primarySmall)
+          .foregroundStyle(.secondary)
+          .lineLimit(1)
+          .truncationMode(.middle)
+      }
+
+      Spacer(minLength: 8)
+
+      Button(action: onDismiss) {
+        Image(systemName: "xmark")
+          .font(.system(size: 12, weight: .semibold))
+          .foregroundStyle(.secondary)
+          .frame(width: 26, height: 26)
+          .contentShape(Rectangle())
+      }
+      .buttonStyle(.plain)
+      .help("Close")
+    }
+  }
+
+  // MARK: Tab content
+
+  @ViewBuilder
+  private var tabContent: some View {
+    switch selectedTab {
+    case .sessions:
+      ProjectDetailsSessionsGrid(items: sessionItems, onSelect: onSelectSession)
+    case .skills:
+      if let selectedSkill {
+        ProjectSkillDetailView(skill: selectedSkill) {
+          self.selectedSkill = nil
+        }
+      } else {
+        ProjectDetailsSkillsGrid(
+          skills: viewModel.inventory.skills,
+          isLoading: viewModel.isLoading,
+          scopeFilter: $skillScopeFilter,
+          onOpenSkill: { selectedSkill = $0 }
+        )
+      }
+    case .rules:
+      if let selectedRule {
+        ProjectRuleDetailView(rule: selectedRule) {
+          self.selectedRule = nil
+        }
+      } else {
+        ProjectDetailsRulesList(
+          rules: viewModel.inventory.rules,
+          isLoading: viewModel.isLoading,
+          onOpenRule: { selectedRule = $0 }
+        )
+      }
+    case .mcps:
+      ProjectDetailsMCPGrid(
+        servers: viewModel.inventory.mcpServers,
+        isLoading: viewModel.isLoading
+      )
+    }
+  }
+
+  private func tabCount(_ tab: ProjectDetailsTab) -> Int {
+    switch tab {
+    case .sessions: return sessionItems.count
+    case .skills: return viewModel.inventory.skills.count
+    case .rules: return viewModel.inventory.rules.count
+    case .mcps: return viewModel.inventory.mcpServers.count
+    }
+  }
+
+  // MARK: Session items
+
+  private var mergedRepositories: [SelectedRepository] {
+    WorktreeModuleResolver.mergedRepositories(
+      claudeViewModel.selectedRepositories + codexViewModel.selectedRepositories
+    )
+  }
+
+  private var moduleRootPath: String {
+    viewModel.projectPath
+  }
+
+  /// All sessions belonging to this module, worktree sessions included:
+  /// resolving with `.parent` mode maps every worktree session back to the
+  /// module root.
+  private var sessionItems: [ProjectDetailsSessionItem] {
+    let repositories = mergedRepositories
+    let root = moduleRootPath
+
+    func belongs(_ path: String) -> Bool {
+      WorktreeModuleResolver.modulePath(for: path, repositories: repositories, mode: .parent) == root
+    }
+
+    var items: [ProjectDetailsSessionItem] = []
+    for (providerViewModel, provider) in [(claudeViewModel, SessionProviderKind.claude),
+                                          (codexViewModel, .codex)] {
+      for pending in providerViewModel.pendingHubSessions
+      where belongs(pending.placeholderSession.projectPath) {
+        items.append(ProjectDetailsSessionItem(
+          id: SidebarSessionItemID.pending(provider: provider, pendingId: pending.id),
+          session: pending.placeholderSession,
+          providerKind: provider,
+          timestamp: pending.startedAt,
+          isPending: true,
+          status: nil,
+          customName: nil
+        ))
+      }
+      for session in providerViewModel.monitoredCLISessions where belongs(session.projectPath) {
+        items.append(ProjectDetailsSessionItem(
+          id: SidebarSessionItemID.monitored(provider: provider, sessionId: session.id),
+          session: session,
+          providerKind: provider,
+          timestamp: session.lastActivityAt,
+          isPending: false,
+          status: providerViewModel.sessionStatus(for: session.id),
+          customName: providerViewModel.sessionCustomNames[session.id]
+        ))
+      }
+    }
+    return items.sorted { $0.timestamp > $1.timestamp }
+  }
+}
+
+// MARK: - ProjectDetailsTabBar
+
+private struct ProjectDetailsTabBar: View {
+  let tabs: [ProjectDetailsTab]
+  let count: (ProjectDetailsTab) -> Int
+  @Binding var selection: ProjectDetailsTab
+
+  @Environment(\.runtimeTheme) private var runtimeTheme
+
+  var body: some View {
+    HStack(spacing: 22) {
+      ForEach(tabs) { tab in
+        tabButton(for: tab)
+      }
+      Spacer(minLength: 0)
+    }
+  }
+
+  private func tabButton(for tab: ProjectDetailsTab) -> some View {
+    let isSelected = tab == selection
+    return Button {
+      selection = tab
+    } label: {
+      VStack(spacing: 6) {
+        HStack(spacing: 5) {
+          Text(tab.rawValue)
+            .font(.geist(size: 13, weight: isSelected ? .semibold : .medium))
+            .foregroundStyle(isSelected ? Color.primary : Color.secondary)
+          Text("\(count(tab))")
+            .font(.secondaryCaption)
+            .foregroundStyle(.secondary)
+            .monospacedDigit()
+        }
+        // The active theme's highlight (Ghostty-adopted themes included)
+        // marks the selected tab.
+        Rectangle()
+          .fill(isSelected ? Color.brandPrimary(from: runtimeTheme) : Color.clear)
+          .frame(height: 2)
+      }
+      .contentShape(Rectangle())
+    }
+    .buttonStyle(.plain)
+  }
+}
+
+// MARK: - Sessions grid
+
+private struct ProjectDetailsSessionsGrid: View {
+  let items: [ProjectDetailsSessionItem]
+  let onSelect: (ProjectDetailsSessionItem) -> Void
+
+  private let columns = [
+    GridItem(.adaptive(minimum: 300, maximum: 460), spacing: 12)
+  ]
+
+  var body: some View {
+    if items.isEmpty {
+      ProjectDetailsEmptyState(
+        systemImage: "rectangle.stack",
+        title: "No sessions",
+        message: "Sessions launched in this module or its worktrees will show up here."
+      )
+    } else {
+      ScrollView {
+        LazyVGrid(columns: columns, alignment: .leading, spacing: 12) {
+          ForEach(items) { item in
+            ProjectSessionGridCard(item: item) {
+              onSelect(item)
+            }
+          }
+        }
+        .padding(20)
+      }
+    }
+  }
+}
+
+// MARK: - ProjectSessionGridCard
+
+/// Grid variant of the floating Sessions panel row: status dot, name,
+/// provider tag, activity time, status line, and the session's paths.
+private struct ProjectSessionGridCard: View {
+  let item: ProjectDetailsSessionItem
+  let onSelect: () -> Void
+
+  @State private var isHovered = false
+  @Environment(\.colorScheme) private var colorScheme
+  @Environment(\.runtimeTheme) private var runtimeTheme
+
+  var body: some View {
+    Button(action: onSelect) {
+      HStack(alignment: .top, spacing: 10) {
+        Circle()
+          .fill(statusColor)
+          .frame(width: 8, height: 8)
+          .shadow(color: statusColor.opacity(isWorking ? 0.55 : 0), radius: 4)
+          .padding(.top, 5)
+
+        VStack(alignment: .leading, spacing: 5) {
+          topLine
+          detailLine
+          pathLines
+        }
+
+        Spacer(minLength: 8)
+
+        Image(systemName: "arrow.up.forward")
+          .font(.system(size: 10, weight: .semibold))
+          .foregroundStyle(.secondary.opacity(isHovered ? 0.9 : 0.45))
+          .padding(.top, 3)
+      }
+      .padding(.horizontal, 11)
+      .padding(.vertical, 11)
+      .frame(maxWidth: .infinity, minHeight: 78, alignment: .topLeading)
+      .background(cardBackground)
+      .contentShape(Rectangle())
+    }
+    .buttonStyle(.plain)
+    .onHover { hovering in
+      withAnimation(.easeInOut(duration: 0.12)) {
+        isHovered = hovering
+      }
+    }
+  }
+
+  private var topLine: some View {
+    HStack(spacing: 6) {
+      Text(item.displayName)
+        .font(.primaryDefault)
+        .foregroundStyle(.primary)
+        .lineLimit(1)
+        .truncationMode(.tail)
+
+      Text(item.providerKind.rawValue)
+        .font(.secondaryCaption)
+        .foregroundStyle(Color.brandPrimary(from: runtimeTheme))
+        .fixedSize(horizontal: true, vertical: false)
+
+      Spacer(minLength: 4)
+
+      Text(item.timestamp.timeAgoDisplay())
+        .font(.secondaryCaption)
+        .foregroundStyle(.secondary)
+        .monospacedDigit()
+        .fixedSize(horizontal: true, vertical: false)
+    }
+  }
+
+  private var detailLine: some View {
+    HStack(spacing: 6) {
+      Text(statusText)
+        .font(.secondarySmall)
+        .foregroundStyle(statusColor)
+        .lineLimit(1)
+
+      Text("·")
+        .font(.secondaryCaption)
+        .foregroundStyle(.secondary.opacity(0.7))
+
+      Text(projectText)
+        .font(.secondarySmall)
+        .foregroundStyle(.secondary)
+        .lineLimit(1)
+        .truncationMode(.middle)
+    }
+  }
+
+  private var pathLines: some View {
+    HStack(spacing: 5) {
+      Image(systemName: item.session.isWorktree ? "arrow.triangle.branch" : "house")
+        .font(.system(size: 9, weight: .semibold))
+        .foregroundStyle(.secondary.opacity(0.7))
+        .frame(width: 12, height: 12)
+
+      Text((item.session.projectPath as NSString).abbreviatingWithTildeInPath)
+        .font(.secondaryCaption)
+        .foregroundStyle(.secondary)
+        .lineLimit(1)
+        .truncationMode(.middle)
+    }
+    .help(item.session.projectPath)
+  }
+
+  private var cardBackground: some View {
+    RoundedRectangle(cornerRadius: 8, style: .continuous)
+      .fill(isHovered
+            ? Color.brandPrimary(from: runtimeTheme).opacity(colorScheme == .dark ? 0.16 : 0.22)
+            : Color.surfaceOverlay.opacity(colorScheme == .dark ? 0.55 : 0.65))
+      .overlay(
+        RoundedRectangle(cornerRadius: 8, style: .continuous)
+          .stroke(Color.secondary.opacity(isHovered ? 0.24 : 0.12), lineWidth: 1)
+      )
+  }
+
+  private var projectText: String {
+    if let branchName = item.session.branchName, !branchName.isEmpty {
+      return "\(item.session.projectName) · \(branchName)"
+    }
+    return item.session.projectName
+  }
+
+  private var isWorking: Bool {
+    if case .thinking = item.status { return true }
+    if case .executingTool = item.status { return true }
+    return false
+  }
+
+  private var statusText: String {
+    if item.isPending { return "starting" }
+    guard let status = item.status else { return item.session.isActive ? "active" : "idle" }
+    switch status {
+    case .thinking:
+      return "working"
+    case .executingTool(let name):
+      return name.lowercased()
+    case .waitingForUser:
+      return "ready"
+    case .awaitingApproval(let tool):
+      return "approval: \(tool.lowercased())"
+    case .idle:
+      return "idle"
+    }
+  }
+
+  private var statusColor: Color {
+    if item.isPending { return .orange }
+    guard let status = item.status else { return .secondary }
+    switch status {
+    case .thinking, .executingTool:
+      return .blue
+    case .waitingForUser:
+      return .green
+    case .awaitingApproval:
+      return .yellow
+    case .idle:
+      return .secondary
+    }
+  }
+}
+
+// MARK: - Skills grid
+
+private struct ProjectDetailsSkillsGrid: View {
+  let skills: [ProjectAgentSkill]
+  let isLoading: Bool
+  @Binding var scopeFilter: ProjectDetailsScopeFilter
+  let onOpenSkill: (ProjectAgentSkill) -> Void
+
+  private let columns = [
+    GridItem(.flexible(), spacing: 12),
+    GridItem(.flexible(), spacing: 12)
+  ]
+
+  var body: some View {
+    if isLoading, skills.isEmpty {
+      ProjectDetailsLoadingState()
+    } else if skills.isEmpty {
+      ProjectDetailsEmptyState(
+        systemImage: "sparkles",
+        title: "No skills found",
+        message: "Skills installed in ~/.claude/skills, ~/.codex/skills, or this project's .claude/skills will show up here."
+      )
+    } else {
+      VStack(alignment: .leading, spacing: 0) {
+        ProjectDetailsScopeFilterChips(
+          filter: $scopeFilter,
+          totalCount: skills.count,
+          personalCount: skills.filter { $0.scope == .personal }.count,
+          projectCount: skills.filter { $0.scope == .project }.count
+        )
+        .padding(.horizontal, 20)
+        .padding(.top, 14)
+
+        ScrollView {
+          LazyVGrid(columns: columns, alignment: .leading, spacing: 12) {
+            ForEach(filteredSkills) { skill in
+              ProjectSkillCard(skill: skill) {
+                onOpenSkill(skill)
+              }
+            }
+          }
+          .padding(20)
+        }
+      }
+    }
+  }
+
+  private var filteredSkills: [ProjectAgentSkill] {
+    skills.filter { scopeFilter.allows($0.scope) }
+  }
+}
+
+// MARK: - ProjectDetailsScopeFilterChips
+
+private struct ProjectDetailsScopeFilterChips: View {
+  @Binding var filter: ProjectDetailsScopeFilter
+  let totalCount: Int
+  let personalCount: Int
+  let projectCount: Int
+
+  @Environment(\.runtimeTheme) private var runtimeTheme
+
+  var body: some View {
+    HStack(spacing: 8) {
+      chip("All", count: totalCount, value: .all)
+      chip("Personal", count: personalCount, value: .scope(.personal))
+      chip("Project", count: projectCount, value: .scope(.project))
+      Spacer(minLength: 0)
+    }
+  }
+
+  private func chip(_ title: String, count: Int, value: ProjectDetailsScopeFilter) -> some View {
+    let isSelected = filter == value
+    return Button {
+      filter = value
+    } label: {
+      HStack(spacing: 4) {
+        Text(title)
+          .font(.geist(size: 11, weight: isSelected ? .semibold : .medium))
+        Text("\(count)")
+          .font(.secondaryCaption)
+          .monospacedDigit()
+          .opacity(0.7)
+      }
+      .foregroundStyle(isSelected ? Color.primary : Color.secondary)
+      .padding(.horizontal, 10)
+      .padding(.vertical, 5)
+      .background(
+        Capsule().fill(isSelected ? Color.surfaceElevated : Color.clear)
+      )
+      .overlay(
+        Capsule().stroke(
+          isSelected
+            ? Color.brandPrimary(from: runtimeTheme).opacity(0.55)
+            : Color.secondary.opacity(0.15),
+          lineWidth: 1
+        )
+      )
+      .contentShape(Capsule())
+    }
+    .buttonStyle(.plain)
+  }
+}
+
+// MARK: - ProjectSkillCard
+
+private struct ProjectSkillCard: View {
+  let skill: ProjectAgentSkill
+  let onTap: () -> Void
+
+  @State private var isHovered = false
+
+  var body: some View {
+    Button(action: onTap) {
+      HStack(alignment: .top, spacing: 10) {
+        ProjectAssetCardIcon(systemImage: "sparkles")
+
+        VStack(alignment: .leading, spacing: 6) {
+          Text(skill.name)
+            .font(.primaryDefault)
+            .foregroundStyle(.primary)
+            .lineLimit(1)
+
+          if !skill.skillDescription.isEmpty {
+            Text(skill.skillDescription)
+              .font(.secondarySmall)
+              .foregroundStyle(.secondary)
+              .lineLimit(3)
+              .fixedSize(horizontal: false, vertical: true)
+          }
+
+          HStack(spacing: 6) {
+            ProjectAssetScopeBadge(scope: skill.scope)
+            ProjectAssetProviderBadges(providers: skill.providers)
+            if skill.supportingFileCount > 0 {
+              ProjectAssetBadge(
+                text: "\(skill.supportingFileCount) file\(skill.supportingFileCount == 1 ? "" : "s")"
+              )
+            }
+          }
+        }
+
+        Spacer(minLength: 0)
+
+        Image(systemName: "chevron.right")
+          .font(.system(size: 10, weight: .semibold))
+          .foregroundStyle(.secondary.opacity(isHovered ? 0.9 : 0.4))
+          .padding(.top, 4)
+      }
+      .padding(12)
+      .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+      .projectDetailsCardBackground(highlighted: isHovered)
+      .contentShape(Rectangle())
+    }
+    .buttonStyle(.plain)
+    .onHover { hovering in
+      withAnimation(.easeInOut(duration: 0.12)) {
+        isHovered = hovering
+      }
+    }
+  }
+}
+
+// MARK: - Rules list
+
+private struct ProjectDetailsRulesList: View {
+  let rules: [ProjectAgentRule]
+  let isLoading: Bool
+  let onOpenRule: (ProjectAgentRule) -> Void
+
+  private let columns = [
+    GridItem(.flexible(), spacing: 12),
+    GridItem(.flexible(), spacing: 12)
+  ]
+
+  var body: some View {
+    if isLoading, rules.isEmpty {
+      ProjectDetailsLoadingState()
+    } else if rules.isEmpty {
+      ProjectDetailsEmptyState(
+        systemImage: "list.bullet.rectangle",
+        title: "No rules found",
+        message: "CLAUDE.md, AGENTS.md, and Codex rules files for this project will show up here."
+      )
+    } else {
+      ScrollView {
+        LazyVGrid(columns: columns, alignment: .leading, spacing: 12) {
+          ForEach(rules) { rule in
+            ProjectRuleCard(rule: rule) {
+              onOpenRule(rule)
+            }
+          }
+        }
+        .padding(20)
+      }
+    }
+  }
+}
+
+// MARK: - ProjectRuleCard
+
+private struct ProjectRuleCard: View {
+  let rule: ProjectAgentRule
+  let onTap: () -> Void
+
+  @State private var isHovered = false
+
+  var body: some View {
+    Button(action: onTap) {
+      HStack(alignment: .top, spacing: 10) {
+        ProjectAssetCardIcon(systemImage: "list.bullet.rectangle")
+
+        VStack(alignment: .leading, spacing: 6) {
+          Text(rule.title)
+            .font(.primaryDefault)
+            .foregroundStyle(.primary)
+            .lineLimit(1)
+
+          Text((rule.path as NSString).abbreviatingWithTildeInPath)
+            .font(.secondaryCaption)
+            .foregroundStyle(.secondary)
+            .lineLimit(1)
+            .truncationMode(.middle)
+
+          if !rule.preview.isEmpty {
+            Text(rule.preview)
+              .font(.secondarySmall)
+              .foregroundStyle(.secondary)
+              .lineLimit(3)
+              .fixedSize(horizontal: false, vertical: true)
+          }
+
+          HStack(spacing: 6) {
+            ProjectAssetScopeBadge(scope: rule.scope)
+            ProjectAssetProviderBadges(providers: rule.providers)
+            ProjectAssetBadge(text: "\(rule.lineCount) lines")
+          }
+        }
+
+        Spacer(minLength: 0)
+
+        Image(systemName: "chevron.right")
+          .font(.system(size: 10, weight: .semibold))
+          .foregroundStyle(.secondary.opacity(isHovered ? 0.9 : 0.4))
+          .padding(.top, 4)
+      }
+      .padding(12)
+      .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+      .projectDetailsCardBackground(highlighted: isHovered)
+      .contentShape(Rectangle())
+    }
+    .buttonStyle(.plain)
+    .onHover { hovering in
+      withAnimation(.easeInOut(duration: 0.12)) {
+        isHovered = hovering
+      }
+    }
+  }
+}
+
+// MARK: - MCP grid
+
+private struct ProjectDetailsMCPGrid: View {
+  let servers: [ProjectMCPServerEntry]
+  let isLoading: Bool
+
+  private let columns = [
+    GridItem(.flexible(), spacing: 12),
+    GridItem(.flexible(), spacing: 12)
+  ]
+
+  var body: some View {
+    if isLoading, servers.isEmpty {
+      ProjectDetailsLoadingState()
+    } else if servers.isEmpty {
+      ProjectDetailsEmptyState(
+        systemImage: "server.rack",
+        title: "No MCP servers found",
+        message: "MCP servers configured in ~/.claude.json, this project's .mcp.json, or ~/.codex/config.toml will show up here."
+      )
+    } else {
+      ScrollView {
+        LazyVGrid(columns: columns, alignment: .leading, spacing: 12) {
+          ForEach(servers) { server in
+            ProjectMCPCard(server: server)
+          }
+        }
+        .padding(20)
+      }
+    }
+  }
+}
+
+// MARK: - ProjectMCPCard
+
+private struct ProjectMCPCard: View {
+  let server: ProjectMCPServerEntry
+
+  var body: some View {
+    HStack(alignment: .top, spacing: 10) {
+      ProjectAssetCardIcon(systemImage: "server.rack")
+
+      VStack(alignment: .leading, spacing: 6) {
+        Text(server.name)
+          .font(.primaryDefault)
+          .foregroundStyle(.primary)
+          .lineLimit(1)
+
+        if !server.detail.isEmpty {
+          Text(server.detail)
+            .font(.primaryCaption)
+            .foregroundStyle(.secondary)
+            .lineLimit(2)
+            .truncationMode(.middle)
+        }
+
+        HStack(spacing: 6) {
+          ProjectAssetScopeBadge(scope: server.scope)
+          ProjectAssetProviderBadges(providers: server.providers)
+        }
+      }
+
+      Spacer(minLength: 0)
+    }
+    .padding(12)
+    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+    .projectDetailsCardBackground()
+  }
+}
+
+// MARK: - Badges
+
+struct ProjectAssetScopeBadge: View {
+  let scope: ProjectAssetScope
+
+  var body: some View {
+    ProjectAssetBadge(text: scope == .personal ? "Personal" : "Project")
+  }
+}
+
+struct ProjectAssetProviderBadges: View {
+  let providers: Set<SessionProviderKind>
+
+  var body: some View {
+    ForEach(SessionProviderKind.allCases.filter(providers.contains), id: \.self) { provider in
+      ProjectAssetBadge(text: provider.rawValue)
+    }
+  }
+}
+
+/// Neutral pill badge — theme accents are reserved for selection and the tab
+/// underline, so metadata stays quiet.
+struct ProjectAssetBadge: View {
+  let text: String
+
+  var body: some View {
+    Text(text)
+      .font(.geist(size: 10, weight: .medium))
+      .foregroundStyle(.secondary)
+      .padding(.horizontal, 8)
+      .padding(.vertical, 3)
+      .background(
+        RoundedRectangle(cornerRadius: 5, style: .continuous)
+          .fill(Color.surfaceElevated)
+      )
+      .overlay(
+        RoundedRectangle(cornerRadius: 5, style: .continuous)
+          .stroke(Color.secondary.opacity(0.14), lineWidth: 1)
+      )
+      .fixedSize()
+  }
+}
+
+/// Neutral rounded-square icon used by every asset card.
+struct ProjectAssetCardIcon: View {
+  let systemImage: String
+
+  var body: some View {
+    Image(systemName: systemImage)
+      .font(.system(size: 12, weight: .semibold))
+      .foregroundStyle(.secondary)
+      .frame(width: 28, height: 28)
+      .background(
+        RoundedRectangle(cornerRadius: 6, style: .continuous)
+          .fill(Color.surfaceElevated)
+      )
+      .overlay(
+        RoundedRectangle(cornerRadius: 6, style: .continuous)
+          .stroke(Color.secondary.opacity(0.12), lineWidth: 1)
+      )
+  }
+}
+
+// MARK: - Empty & loading states
+
+private struct ProjectDetailsEmptyState: View {
+  let systemImage: String
+  let title: String
+  let message: String
+
+  var body: some View {
+    VStack(spacing: 10) {
+      Image(systemName: systemImage)
+        .font(.system(size: 26, weight: .regular))
+        .foregroundStyle(.secondary.opacity(0.6))
+      Text(title)
+        .font(.secondaryDefault)
+        .foregroundStyle(.primary)
+      Text(message)
+        .font(.secondarySmall)
+        .foregroundStyle(.secondary)
+        .multilineTextAlignment(.center)
+        .frame(maxWidth: 380)
+    }
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+  }
+}
+
+private struct ProjectDetailsLoadingState: View {
+  var body: some View {
+    VStack(spacing: 10) {
+      ProgressView()
+        .controlSize(.small)
+      Text("Scanning configuration…")
+        .font(.secondarySmall)
+        .foregroundStyle(.secondary)
+    }
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+  }
+}
+
+// MARK: - Card background
+
+private struct ProjectDetailsCardBackground: ViewModifier {
+  var highlighted = false
+
+  @Environment(\.colorScheme) private var colorScheme
+
+  func body(content: Content) -> some View {
+    content
+      .background(
+        RoundedRectangle(cornerRadius: 8, style: .continuous)
+          .fill(highlighted
+                ? Color.surfaceHover.opacity(colorScheme == .dark ? 0.8 : 0.9)
+                : Color.surfaceOverlay.opacity(colorScheme == .dark ? 0.55 : 0.65))
+          .overlay(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+              .stroke(Color.secondary.opacity(highlighted ? 0.24 : 0.12), lineWidth: 1)
+          )
+      )
+  }
+}
+
+private extension View {
+  func projectDetailsCardBackground(highlighted: Bool = false) -> some View {
+    modifier(ProjectDetailsCardBackground(highlighted: highlighted))
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/ProjectSkillDetailView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/ProjectSkillDetailView.swift
@@ -1,0 +1,397 @@
+//
+//  ProjectSkillDetailView.swift
+//  AgentHub
+//
+//  Detail page for a skill inside the Project Details panel: a file list for
+//  the skill's bundle on the left, and the selected file rendered on the
+//  right — markdown through the same MarkdownCardView the plan view uses.
+//
+
+import SwiftUI
+
+struct ProjectSkillDetailView: View {
+  let skill: ProjectAgentSkill
+  let onBack: () -> Void
+
+  @State private var files: [SkillBundleFile] = []
+  @State private var selectedFile: SkillBundleFile?
+  @State private var fileContent: String?
+  @State private var isLoadingContent = true
+
+  @Environment(\.runtimeTheme) private var runtimeTheme
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 0) {
+      backBar
+        .padding(.horizontal, 20)
+        .padding(.vertical, 12)
+
+      HStack(alignment: .top, spacing: 14) {
+        fileList
+          .frame(width: 190)
+
+        contentPane
+          .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+      }
+      .padding(.horizontal, 20)
+      .padding(.bottom, 20)
+    }
+    .task(id: skill.id) {
+      await loadFiles()
+    }
+    .task(id: selectedFile?.id) {
+      await loadSelectedFileContent()
+    }
+  }
+
+  // MARK: Back bar
+
+  private var backBar: some View {
+    Button(action: onBack) {
+      HStack(spacing: 6) {
+        Image(systemName: "arrow.left")
+          .font(.system(size: 11, weight: .semibold))
+        Text("Back to skills")
+          .font(.secondaryDefault)
+      }
+      .foregroundStyle(.secondary)
+      .contentShape(Rectangle())
+    }
+    .buttonStyle(.plain)
+    .keyboardShortcut(.leftArrow, modifiers: [.command])
+    .help("Back to skills")
+  }
+
+  // MARK: File list
+
+  private var fileList: some View {
+    ScrollView {
+      VStack(alignment: .leading, spacing: 2) {
+        ForEach(files) { file in
+          fileRow(file)
+        }
+      }
+    }
+  }
+
+  private func fileRow(_ file: SkillBundleFile) -> some View {
+    let isSelected = file.id == selectedFile?.id
+    return Button {
+      selectedFile = file
+    } label: {
+      Text(file.relativePath)
+        .font(.primarySmall)
+        .foregroundStyle(isSelected ? Color.primary : Color.secondary)
+        .lineLimit(1)
+        .truncationMode(.middle)
+        .padding(.horizontal, 10)
+        .padding(.vertical, 7)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+          RoundedRectangle(cornerRadius: 6, style: .continuous)
+            .fill(isSelected ? Color.surfaceElevated : Color.clear)
+        )
+        .overlay(
+          RoundedRectangle(cornerRadius: 6, style: .continuous)
+            .stroke(
+              isSelected
+                ? Color.brandPrimary(from: runtimeTheme).opacity(0.4)
+                : Color.clear,
+              lineWidth: 1
+            )
+        )
+        .contentShape(Rectangle())
+    }
+    .buttonStyle(.plain)
+  }
+
+  // MARK: Content pane
+
+  private var contentPane: some View {
+    ScrollView {
+      VStack(alignment: .leading, spacing: 14) {
+        skillHeader
+
+        Divider()
+
+        if isLoadingContent {
+          ProgressView()
+            .controlSize(.small)
+            .frame(maxWidth: .infinity, alignment: .center)
+            .padding(.vertical, 40)
+        } else if let fileContent {
+          if selectedFile?.isMarkdown == true {
+            MarkdownCardView(content: markdownBody(fileContent), transparent: true)
+          } else {
+            Text(fileContent)
+              .font(.primarySmall)
+              .foregroundStyle(.primary)
+              .textSelection(.enabled)
+              .frame(maxWidth: .infinity, alignment: .leading)
+          }
+        } else {
+          Text("Could not read this file.")
+            .font(.secondarySmall)
+            .foregroundStyle(.secondary)
+        }
+      }
+      .padding(16)
+    }
+    .background(
+      RoundedRectangle(cornerRadius: 8, style: .continuous)
+        .fill(Color.surfaceOverlay.opacity(0.4))
+        .overlay(
+          RoundedRectangle(cornerRadius: 8, style: .continuous)
+            .stroke(Color.secondary.opacity(0.12), lineWidth: 1)
+        )
+    )
+  }
+
+  private var skillHeader: some View {
+    HStack(alignment: .top, spacing: 10) {
+      ProjectAssetCardIcon(systemImage: "sparkles")
+
+      VStack(alignment: .leading, spacing: 5) {
+        Text(skill.name)
+          .font(.primaryLarge)
+          .foregroundStyle(.primary)
+
+        if !skill.skillDescription.isEmpty {
+          Text(skill.skillDescription)
+            .font(.secondarySmall)
+            .foregroundStyle(.secondary)
+            .fixedSize(horizontal: false, vertical: true)
+        }
+
+        HStack(spacing: 6) {
+          ProjectAssetScopeBadge(scope: skill.scope)
+          ProjectAssetProviderBadges(providers: skill.providers)
+        }
+      }
+
+      Spacer(minLength: 0)
+    }
+  }
+
+  /// Renders the body without the YAML frontmatter block — name and
+  /// description are already in the header above.
+  private func markdownBody(_ content: String) -> String {
+    let lines = content.components(separatedBy: "\n")
+    guard lines.first?.trimmingCharacters(in: .whitespaces) == "---" else { return content }
+    guard let closingIndex = lines.dropFirst().firstIndex(where: {
+      $0.trimmingCharacters(in: .whitespaces) == "---"
+    }) else {
+      return content
+    }
+    return lines[(closingIndex + 1)...].joined(separator: "\n")
+      .trimmingCharacters(in: .whitespacesAndNewlines)
+  }
+
+  // MARK: Loading
+
+  private func loadFiles() async {
+    let directoryPath = skill.directoryPath
+    guard !directoryPath.isEmpty else {
+      files = []
+      selectedFile = nil
+      return
+    }
+    let loaded = await Task.detached(priority: .utility) {
+      SkillBundleFile.files(inSkillDirectory: directoryPath)
+    }.value
+    files = loaded
+    selectedFile = loaded.first
+  }
+
+  private func loadSelectedFileContent() async {
+    guard let selectedFile else {
+      fileContent = nil
+      isLoadingContent = false
+      return
+    }
+    isLoadingContent = true
+    let path = selectedFile.path
+    fileContent = await Task.detached(priority: .utility) {
+      try? String(contentsOfFile: path, encoding: .utf8)
+    }.value
+    isLoadingContent = false
+  }
+}
+
+// MARK: - ProjectRuleDetailView
+
+/// Inline reader for a rules file (CLAUDE.md, AGENTS.md, `.rules`), same
+/// pattern as the skill detail: back bar, header, then the file rendered as
+/// markdown (or monospace for non-markdown files).
+struct ProjectRuleDetailView: View {
+  let rule: ProjectAgentRule
+  let onBack: () -> Void
+
+  @State private var fileContent: String?
+  @State private var isLoadingContent = true
+
+  private var isMarkdown: Bool {
+    let ext = (rule.path as NSString).pathExtension.lowercased()
+    return ext == "md" || ext == "markdown"
+  }
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 0) {
+      backBar
+        .padding(.horizontal, 20)
+        .padding(.vertical, 12)
+
+      contentPane
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .padding(.horizontal, 20)
+        .padding(.bottom, 20)
+    }
+    .task(id: rule.id) {
+      await loadContent()
+    }
+  }
+
+  private var backBar: some View {
+    Button(action: onBack) {
+      HStack(spacing: 6) {
+        Image(systemName: "arrow.left")
+          .font(.system(size: 11, weight: .semibold))
+        Text("Back to rules")
+          .font(.secondaryDefault)
+      }
+      .foregroundStyle(.secondary)
+      .contentShape(Rectangle())
+    }
+    .buttonStyle(.plain)
+    .keyboardShortcut(.leftArrow, modifiers: [.command])
+    .help("Back to rules")
+  }
+
+  private var contentPane: some View {
+    ScrollView {
+      VStack(alignment: .leading, spacing: 14) {
+        ruleHeader
+
+        Divider()
+
+        if isLoadingContent {
+          ProgressView()
+            .controlSize(.small)
+            .frame(maxWidth: .infinity, alignment: .center)
+            .padding(.vertical, 40)
+        } else if let fileContent {
+          if isMarkdown {
+            MarkdownCardView(content: fileContent, transparent: true)
+          } else {
+            Text(fileContent)
+              .font(.primarySmall)
+              .foregroundStyle(.primary)
+              .textSelection(.enabled)
+              .frame(maxWidth: .infinity, alignment: .leading)
+          }
+        } else {
+          Text("Could not read this file.")
+            .font(.secondarySmall)
+            .foregroundStyle(.secondary)
+        }
+      }
+      .padding(16)
+    }
+    .background(
+      RoundedRectangle(cornerRadius: 8, style: .continuous)
+        .fill(Color.surfaceOverlay.opacity(0.4))
+        .overlay(
+          RoundedRectangle(cornerRadius: 8, style: .continuous)
+            .stroke(Color.secondary.opacity(0.12), lineWidth: 1)
+        )
+    )
+  }
+
+  private var ruleHeader: some View {
+    HStack(alignment: .top, spacing: 10) {
+      ProjectAssetCardIcon(systemImage: "list.bullet.rectangle")
+
+      VStack(alignment: .leading, spacing: 5) {
+        Text(rule.title)
+          .font(.primaryLarge)
+          .foregroundStyle(.primary)
+
+        Text((rule.path as NSString).abbreviatingWithTildeInPath)
+          .font(.secondaryCaption)
+          .foregroundStyle(.secondary)
+          .lineLimit(1)
+          .truncationMode(.middle)
+
+        HStack(spacing: 6) {
+          ProjectAssetScopeBadge(scope: rule.scope)
+          ProjectAssetProviderBadges(providers: rule.providers)
+          ProjectAssetBadge(text: "\(rule.lineCount) lines")
+        }
+      }
+
+      Spacer(minLength: 8)
+
+      Button {
+        NSWorkspace.shared.open(URL(fileURLWithPath: rule.path))
+      } label: {
+        Image(systemName: "arrow.up.forward.square")
+          .font(.system(size: 12, weight: .semibold))
+          .foregroundStyle(.secondary)
+          .frame(width: 24, height: 24)
+          .contentShape(Rectangle())
+      }
+      .buttonStyle(.plain)
+      .help("Open in default editor")
+    }
+  }
+
+  private func loadContent() async {
+    isLoadingContent = true
+    let path = rule.path
+    fileContent = await Task.detached(priority: .utility) {
+      try? String(contentsOfFile: path, encoding: .utf8)
+    }.value
+    isLoadingContent = false
+  }
+}
+
+// MARK: - SkillBundleFile
+
+struct SkillBundleFile: Identifiable, Equatable, Sendable {
+  var id: String { path }
+  let path: String
+  let relativePath: String
+
+  var isMarkdown: Bool {
+    let ext = (path as NSString).pathExtension.lowercased()
+    return ext == "md" || ext == "markdown"
+  }
+
+  /// All regular files in the skill directory, SKILL.md first, the rest
+  /// sorted by relative path.
+  static func files(inSkillDirectory directoryPath: String) -> [SkillBundleFile] {
+    let directoryURL = URL(fileURLWithPath: directoryPath, isDirectory: true)
+    guard let enumerator = FileManager.default.enumerator(
+      at: directoryURL,
+      includingPropertiesForKeys: [.isRegularFileKey]
+    ) else {
+      return []
+    }
+
+    var results: [SkillBundleFile] = []
+    for case let file as URL in enumerator {
+      guard (try? file.resourceValues(forKeys: [.isRegularFileKey]))?.isRegularFile == true else {
+        continue
+      }
+      let relative = String(file.path.dropFirst(directoryURL.path.count))
+        .trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+      results.append(SkillBundleFile(path: file.path, relativePath: relative))
+    }
+
+    return results.sorted { lhs, rhs in
+      if lhs.relativePath == "SKILL.md" { return true }
+      if rhs.relativePath == "SKILL.md" { return false }
+      return lhs.relativePath < rhs.relativePath
+    }
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/SessionHoverPreviewCard.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/SessionHoverPreviewCard.swift
@@ -1,0 +1,109 @@
+//
+//  SessionHoverPreviewCard.swift
+//  AgentHub
+//
+//  Popup shown when hovering a sidebar session row: session name, first user
+//  message, parent repo, worktree path, branch, and PR/CI status.
+//
+
+import AgentHubGitHub
+import SwiftUI
+
+// MARK: - SessionHoverPreviewCard
+
+struct SessionHoverPreviewCard: View {
+  let preview: SessionHoverPreview
+  let timestamp: Date
+  let gitHubViewModel: SessionGitHubQuickAccessViewModel
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      HStack(alignment: .firstTextBaseline, spacing: 8) {
+        Text(preview.sessionName)
+          .font(.primaryDefault.weight(.semibold))
+          .foregroundStyle(.primary)
+          .lineLimit(1)
+
+        Spacer(minLength: 12)
+
+        Text(timestamp.timeAgoDisplay())
+          .font(.secondaryCaption)
+          .foregroundStyle(.secondary)
+          .fixedSize()
+      }
+
+      if let firstMessage = preview.firstMessage {
+        Text(firstMessage)
+          .font(.secondaryDefault)
+          .foregroundStyle(.primary.opacity(0.85))
+          .lineLimit(4)
+          .multilineTextAlignment(.leading)
+          .fixedSize(horizontal: false, vertical: true)
+      }
+
+      Divider()
+
+      VStack(alignment: .leading, spacing: 6) {
+        SessionHoverPreviewDetailRow(icon: "folder", text: preview.repositoryName)
+
+        if let worktreePath = preview.displayWorktreePath() {
+          SessionHoverPreviewDetailRow(icon: "arrow.triangle.pull", text: worktreePath)
+        }
+
+        if let branch = preview.branchName {
+          SessionHoverPreviewDetailRow(icon: "arrow.triangle.branch", text: branch)
+        }
+
+        if let pullRequest = gitHubViewModel.currentBranchPR {
+          GitHubSessionRowStatusLine(
+            pullRequest: pullRequest,
+            summary: gitHubViewModel.ciSummary,
+            observationState: gitHubViewModel.observationState,
+            lastRefreshedAt: gitHubViewModel.lastRefreshedAt
+          )
+        }
+      }
+    }
+    .padding(12)
+    .frame(width: 300, alignment: .leading)
+  }
+}
+
+// MARK: - SessionHoverPreviewDetailRow
+
+struct SessionHoverPreviewDetailRow: View {
+  let icon: String
+  let text: String
+
+  var body: some View {
+    HStack(spacing: 6) {
+      Image(systemName: icon)
+        .font(.system(size: 10, weight: .medium))
+        .foregroundStyle(.secondary)
+        .frame(width: 12, height: 12)
+
+      Text(text)
+        .font(.secondarySmall)
+        .foregroundStyle(.secondary)
+        .lineLimit(1)
+        .truncationMode(.middle)
+    }
+  }
+}
+
+// MARK: - Preview
+
+#Preview("SessionHoverPreviewCard") {
+  SessionHoverPreviewCard(
+    preview: SessionHoverPreview(
+      sessionName: "cryptic-orbiting-flame",
+      firstMessage: "lets modify the aspect ratio of the shader canvas so it fills the window",
+      repositoryName: "ShaderKit",
+      branchName: "main",
+      worktreePath: "~/Developer/ShaderKit-shader-canvas"
+    ),
+    timestamp: Date().addingTimeInterval(-90 * 24 * 3600),
+    gitHubViewModel: SessionGitHubQuickAccessViewModel()
+  )
+  .padding()
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/ProjectDetailsViewModel.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/ProjectDetailsViewModel.swift
@@ -1,0 +1,35 @@
+//
+//  ProjectDetailsViewModel.swift
+//  AgentHub
+//
+
+import Foundation
+import Observation
+
+/// Drives the Project Details panel: loads the skills / MCP servers / rules
+/// inventory for a module. Session rows are derived live from the two
+/// provider `CLISessionsViewModel`s by the view.
+@MainActor
+@Observable
+public final class ProjectDetailsViewModel {
+  public private(set) var inventory: ProjectDetailsInventory = .empty
+  public private(set) var isLoading = false
+
+  public let projectPath: String
+
+  private let service: any ProjectDetailsInventoryServiceProtocol
+
+  public init(
+    projectPath: String,
+    service: any ProjectDetailsInventoryServiceProtocol = ProjectDetailsInventoryService.shared
+  ) {
+    self.projectPath = projectPath
+    self.service = service
+  }
+
+  public func load() async {
+    isLoading = true
+    inventory = await service.inventory(forProjectAt: projectPath)
+    isLoading = false
+  }
+}

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/ProjectDetailsInventoryServiceTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/ProjectDetailsInventoryServiceTests.swift
@@ -1,0 +1,373 @@
+import Foundation
+import Testing
+
+@testable import AgentHubCore
+
+@Suite("Project details inventory")
+struct ProjectDetailsInventoryServiceTests {
+
+  // MARK: - Fixture
+
+  /// Builds a fake home directory + project directory tree, runs the scan,
+  /// and tears everything down.
+  private func withFixture(
+    _ body: (_ home: URL, _ project: URL) throws -> Void
+  ) throws {
+    let root = FileManager.default.temporaryDirectory
+      .appendingPathComponent("project-details-\(UUID().uuidString)", isDirectory: true)
+    let home = root.appendingPathComponent("home", isDirectory: true)
+    let project = root.appendingPathComponent("project", isDirectory: true)
+    try FileManager.default.createDirectory(at: home, withIntermediateDirectories: true)
+    try FileManager.default.createDirectory(at: project, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: root) }
+    try body(home, project)
+  }
+
+  private func writeFile(_ url: URL, _ content: String) throws {
+    try FileManager.default.createDirectory(
+      at: url.deletingLastPathComponent(),
+      withIntermediateDirectories: true
+    )
+    try content.write(to: url, atomically: true, encoding: .utf8)
+  }
+
+  private func writeSkill(
+    root: URL,
+    directory: String,
+    name: String?,
+    description: String
+  ) throws {
+    var frontmatter = "---\n"
+    if let name {
+      frontmatter += "name: \(name)\n"
+    }
+    frontmatter += "description: \(description)\n---\n\n# Skill\n"
+    try writeFile(
+      root.appendingPathComponent("\(directory)/SKILL.md", isDirectory: false),
+      frontmatter
+    )
+  }
+
+  private func scan(home: URL, project: URL) -> ProjectDetailsInventory {
+    ProjectDetailsInventoryService.scan(projectPath: project.path, homeDirectory: home)
+  }
+
+  // MARK: - Skills
+
+  @Test("Same-named skill in Claude and Codex personal dirs merges into one entry with both providers")
+  func personalSkillMergesAcrossProviders() throws {
+    try withFixture { home, project in
+      try writeSkill(
+        root: home.appendingPathComponent(".claude/skills"),
+        directory: "swiftui-animation",
+        name: "swiftui-animation",
+        description: "Animations"
+      )
+      try writeSkill(
+        root: home.appendingPathComponent(".codex/skills"),
+        directory: "swiftui-animation",
+        name: "swiftui-animation",
+        description: "Animations"
+      )
+      try writeSkill(
+        root: home.appendingPathComponent(".codex/skills"),
+        directory: "codex-only",
+        name: "codex-only",
+        description: "Codex thing"
+      )
+
+      let inventory = scan(home: home, project: project)
+
+      #expect(inventory.skills.count == 2)
+      let merged = try #require(inventory.skills.first { $0.name == "swiftui-animation" })
+      #expect(merged.providers == [.claude, .codex])
+      #expect(merged.scope == .personal)
+      #expect(merged.directoryPath.hasSuffix(".claude/skills/swiftui-animation"))
+      let codexOnly = try #require(inventory.skills.first { $0.name == "codex-only" })
+      #expect(codexOnly.providers == [.codex])
+    }
+  }
+
+  @Test("Project skills keep their own scope and don't merge with same-named personal skills")
+  func projectScopeStaysDistinctFromPersonal() throws {
+    try withFixture { home, project in
+      try writeSkill(
+        root: home.appendingPathComponent(".claude/skills"),
+        directory: "deploy",
+        name: "deploy",
+        description: "Personal deploy"
+      )
+      try writeSkill(
+        root: project.appendingPathComponent(".claude/skills"),
+        directory: "deploy",
+        name: "deploy",
+        description: "Project deploy"
+      )
+
+      let inventory = scan(home: home, project: project)
+
+      #expect(inventory.skills.count == 2)
+      let scopes = Set(inventory.skills.map(\.scope))
+      #expect(scopes == [.personal, .project])
+    }
+  }
+
+  @Test("Skills in .agents/skills are marked available to both providers")
+  func agentsDirectorySkillsCoverBothProviders() throws {
+    try withFixture { home, project in
+      try writeSkill(
+        root: project.appendingPathComponent(".agents/skills"),
+        directory: "shared",
+        name: "shared",
+        description: "Shared"
+      )
+
+      let inventory = scan(home: home, project: project)
+
+      let skill = try #require(inventory.skills.first)
+      #expect(skill.providers == [.claude, .codex])
+      #expect(skill.scope == .project)
+    }
+  }
+
+  @Test("Skill name falls back to directory name and supporting files are counted")
+  func skillNameFallbackAndSupportingFiles() throws {
+    try withFixture { home, project in
+      let skillsRoot = home.appendingPathComponent(".claude/skills")
+      try writeSkill(root: skillsRoot, directory: "no-name", name: nil, description: "Desc")
+      try writeFile(
+        skillsRoot.appendingPathComponent("no-name/references/guide.md"),
+        "# Guide"
+      )
+      try writeFile(
+        skillsRoot.appendingPathComponent("no-name/scripts/run.sh"),
+        "echo hi"
+      )
+
+      let inventory = scan(home: home, project: project)
+
+      let skill = try #require(inventory.skills.first)
+      #expect(skill.name == "no-name")
+      #expect(skill.skillDescription == "Desc")
+      #expect(skill.supportingFileCount == 2)
+    }
+  }
+
+  // MARK: - MCP servers
+
+  @Test("Claude global, Claude project, .mcp.json, and Codex servers land in the right scopes")
+  func mcpServerScopes() throws {
+    try withFixture { home, project in
+      let normalizedProjectPath = URL(fileURLWithPath: project.path).standardizedFileURL.path
+      let claudeJSON = """
+      {
+        "mcpServers": {
+          "figma": { "command": "npx", "args": ["-y", "figma-mcp"] }
+        },
+        "projects": {
+          "\(normalizedProjectPath)": {
+            "mcpServers": {
+              "proj-server": { "command": "node", "args": ["server.js"] }
+            }
+          }
+        }
+      }
+      """
+      try writeFile(home.appendingPathComponent(".claude.json"), claudeJSON)
+      try writeFile(
+        project.appendingPathComponent(".mcp.json"),
+        #"{ "mcpServers": { "shared": { "url": "https://example.com/mcp" } } }"#
+      )
+      try writeFile(
+        home.appendingPathComponent(".codex/config.toml"),
+        """
+        model = "gpt-5"
+
+        [mcp_servers.xctrace]
+        command = "uvx"
+        args = ["xctrace-mcp"]
+
+        [mcp_servers.xctrace.env]
+        KEY = "value"
+        """
+      )
+
+      let inventory = scan(home: home, project: project)
+
+      #expect(inventory.mcpServers.count == 4)
+
+      let figma = try #require(inventory.mcpServers.first { $0.name == "figma" })
+      #expect(figma.scope == .personal)
+      #expect(figma.providers == [.claude])
+      #expect(figma.detail == "npx -y figma-mcp")
+
+      let projServer = try #require(inventory.mcpServers.first { $0.name == "proj-server" })
+      #expect(projServer.scope == .project)
+
+      let shared = try #require(inventory.mcpServers.first { $0.name == "shared" })
+      #expect(shared.scope == .project)
+      #expect(shared.detail == "https://example.com/mcp")
+
+      let xctrace = try #require(inventory.mcpServers.first { $0.name == "xctrace" })
+      #expect(xctrace.scope == .personal)
+      #expect(xctrace.providers == [.codex])
+      #expect(xctrace.detail == "uvx xctrace-mcp")
+    }
+  }
+
+  @Test("Same-named personal server configured for Claude and Codex merges providers")
+  func mcpServerMergesAcrossProviders() throws {
+    try withFixture { home, project in
+      try writeFile(
+        home.appendingPathComponent(".claude.json"),
+        #"{ "mcpServers": { "excalidraw": { "command": "npx", "args": ["excalidraw-mcp"] } } }"#
+      )
+      try writeFile(
+        home.appendingPathComponent(".codex/config.toml"),
+        """
+        [mcp_servers.excalidraw]
+        command = "npx"
+        args = ["excalidraw-mcp"]
+        """
+      )
+
+      let inventory = scan(home: home, project: project)
+
+      #expect(inventory.mcpServers.count == 1)
+      let merged = try #require(inventory.mcpServers.first)
+      #expect(merged.providers == [.claude, .codex])
+    }
+  }
+
+  // MARK: - Rules
+
+  @Test("Rules files are collected with the right scope and provider")
+  func rulesCollection() throws {
+    try withFixture { home, project in
+      try writeFile(
+        home.appendingPathComponent(".claude/CLAUDE.md"),
+        "# Personal rules\n\n- Use spaces\n"
+      )
+      try writeFile(
+        home.appendingPathComponent(".codex/AGENTS.md"),
+        "# Codex personal\n"
+      )
+      try writeFile(
+        project.appendingPathComponent("CLAUDE.md"),
+        "# Project rules\n\nDetails here.\n"
+      )
+      try writeFile(
+        project.appendingPathComponent("AGENTS.md"),
+        "# Project agents\n"
+      )
+      try writeFile(
+        home.appendingPathComponent(".codex/rules/default.rules"),
+        "prefix_rule(pattern=[\"git\"], decision=\"allow\")\n"
+      )
+
+      let inventory = scan(home: home, project: project)
+
+      #expect(inventory.rules.count == 5)
+
+      let personalClaude = try #require(
+        inventory.rules.first { $0.title == "CLAUDE.md" && $0.scope == .personal }
+      )
+      #expect(personalClaude.providers == [.claude])
+      #expect(personalClaude.preview.contains("# Personal rules"))
+      #expect(personalClaude.lineCount > 1)
+
+      let projectClaude = try #require(
+        inventory.rules.first { $0.title == "CLAUDE.md" && $0.scope == .project }
+      )
+      #expect(projectClaude.preview.contains("# Project rules"))
+
+      let codexRules = try #require(inventory.rules.first { $0.title == "default.rules" })
+      #expect(codexRules.scope == .personal)
+      #expect(codexRules.providers == [.codex])
+
+      let projectAgents = try #require(
+        inventory.rules.first { $0.title == "AGENTS.md" && $0.scope == .project }
+      )
+      #expect(projectAgents.providers == [.codex])
+    }
+  }
+
+  @Test("Missing directories and files produce an empty inventory without errors")
+  func missingEverythingIsEmpty() throws {
+    try withFixture { home, project in
+      let inventory = scan(home: home, project: project)
+      #expect(inventory == .empty)
+    }
+  }
+
+  // MARK: - Actor service
+
+  @Test("Actor service scans through the injected home directory")
+  func actorServiceUsesInjectedHome() async throws {
+    let root = FileManager.default.temporaryDirectory
+      .appendingPathComponent("project-details-actor-\(UUID().uuidString)", isDirectory: true)
+    let home = root.appendingPathComponent("home", isDirectory: true)
+    let project = root.appendingPathComponent("project", isDirectory: true)
+    try FileManager.default.createDirectory(at: home, withIntermediateDirectories: true)
+    try FileManager.default.createDirectory(at: project, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    try writeSkill(
+      root: home.appendingPathComponent(".claude/skills"),
+      directory: "only-skill",
+      name: "only-skill",
+      description: "The one"
+    )
+
+    let service = ProjectDetailsInventoryService(homeDirectory: home)
+    let inventory = await service.inventory(forProjectAt: project.path)
+
+    #expect(inventory.skills.map(\.name) == ["only-skill"])
+  }
+}
+
+// MARK: - ProjectDetailsViewModel
+
+private final class MockInventoryService: ProjectDetailsInventoryServiceProtocol, @unchecked Sendable {
+  let result: ProjectDetailsInventory
+  init(result: ProjectDetailsInventory) {
+    self.result = result
+  }
+
+  func inventory(forProjectAt projectPath: String) async -> ProjectDetailsInventory {
+    result
+  }
+}
+
+@Suite("Project details view model")
+@MainActor
+struct ProjectDetailsViewModelTests {
+
+  @Test("Load publishes the scanned inventory and clears the loading flag")
+  func loadPublishesInventory() async {
+    let expected = ProjectDetailsInventory(
+      skills: [
+        ProjectAgentSkill(
+          name: "s",
+          skillDescription: "d",
+          scope: .personal,
+          providers: [.claude]
+        )
+      ],
+      mcpServers: [
+        ProjectMCPServerEntry(name: "m", detail: "npx m", scope: .project, providers: [.codex])
+      ],
+      rules: []
+    )
+    let viewModel = ProjectDetailsViewModel(
+      projectPath: "/tmp/some-project",
+      service: MockInventoryService(result: expected)
+    )
+
+    #expect(viewModel.inventory == .empty)
+    await viewModel.load()
+
+    #expect(viewModel.inventory == expected)
+    #expect(viewModel.isLoading == false)
+  }
+}

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/SessionHoverPreviewTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/SessionHoverPreviewTests.swift
@@ -1,0 +1,167 @@
+import Foundation
+import Testing
+
+@testable import AgentHubCore
+
+@Suite("Session hover preview")
+struct SessionHoverPreviewTests {
+
+  private func repo() -> SelectedRepository {
+    SelectedRepository(
+      path: "/tmp/RepoA",
+      worktrees: [
+        WorktreeBranch(name: "main", path: "/tmp/RepoA", isWorktree: false),
+        WorktreeBranch(name: "feature/popup", path: "/tmp/RepoA-popup", isWorktree: true)
+      ]
+    )
+  }
+
+  @Test("Worktree session resolves parent repo and registered worktree root")
+  func worktreeSessionResolvesParentRepo() {
+    let session = CLISession(
+      id: "11111111-aaaa-bbbb-cccc-000000000001",
+      projectPath: "/tmp/RepoA-popup",
+      branchName: "feature/popup",
+      isWorktree: true,
+      firstMessage: "Add a hover popup"
+    )
+
+    let preview = SessionHoverPreview.make(
+      session: session,
+      customName: nil,
+      repositories: [repo()]
+    )
+
+    #expect(preview.repositoryName == "RepoA")
+    #expect(preview.worktreePath == "/tmp/RepoA-popup")
+    #expect(preview.branchName == "feature/popup")
+    #expect(preview.firstMessage == "Add a hover popup")
+  }
+
+  @Test("Nested launch path maps back to the worktree root")
+  func nestedLaunchPathResolvesWorktreeRoot() {
+    let session = CLISession(
+      id: "11111111-aaaa-bbbb-cccc-000000000002",
+      projectPath: "/tmp/RepoA-popup/ios/App",
+      isWorktree: true
+    )
+
+    let preview = SessionHoverPreview.make(
+      session: session,
+      customName: nil,
+      repositories: [repo()]
+    )
+
+    #expect(preview.repositoryName == "RepoA")
+    #expect(preview.worktreePath == "/tmp/RepoA-popup")
+    #expect(preview.branchName == "feature/popup")
+  }
+
+  @Test("Root session has no worktree path")
+  func rootSessionHasNoWorktreePath() {
+    let session = CLISession(
+      id: "11111111-aaaa-bbbb-cccc-000000000003",
+      projectPath: "/tmp/RepoA",
+      branchName: "main"
+    )
+
+    let preview = SessionHoverPreview.make(
+      session: session,
+      customName: nil,
+      repositories: [repo()]
+    )
+
+    #expect(preview.repositoryName == "RepoA")
+    #expect(preview.worktreePath == nil)
+    #expect(preview.branchName == "main")
+  }
+
+  @Test("Unmatched repository falls back to path-derived names")
+  func unmatchedRepositoryFallsBack() {
+    let session = CLISession(
+      id: "11111111-aaaa-bbbb-cccc-000000000004",
+      projectPath: "/tmp/Elsewhere-wt",
+      branchName: "fix/thing",
+      isWorktree: true
+    )
+
+    let preview = SessionHoverPreview.make(
+      session: session,
+      customName: nil,
+      repositories: [repo()]
+    )
+
+    #expect(preview.repositoryName == "Elsewhere-wt")
+    #expect(preview.worktreePath == "/tmp/Elsewhere-wt")
+    #expect(preview.branchName == "fix/thing")
+  }
+
+  @Test("Session name prefers custom name, then slug, then short ID")
+  func sessionNamePrecedence() {
+    let session = CLISession(
+      id: "abcdef12-3456-7890-aaaa-000000000005",
+      projectPath: "/tmp/RepoA",
+      slug: "cryptic-orbiting-flame"
+    )
+
+    let custom = SessionHoverPreview.make(
+      session: session,
+      customName: "My Session",
+      repositories: [repo()]
+    )
+    #expect(custom.sessionName == "My Session")
+
+    let slugged = SessionHoverPreview.make(
+      session: session,
+      customName: nil,
+      repositories: [repo()]
+    )
+    #expect(slugged.sessionName == "cryptic-orbiting-flame")
+
+    var noSlug = session
+    noSlug.slug = nil
+    let short = SessionHoverPreview.make(
+      session: noSlug,
+      customName: nil,
+      repositories: [repo()]
+    )
+    #expect(short.sessionName == "abcdef12")
+  }
+
+  @Test("Blank first message becomes nil")
+  func blankFirstMessageBecomesNil() {
+    let session = CLISession(
+      id: "11111111-aaaa-bbbb-cccc-000000000006",
+      projectPath: "/tmp/RepoA",
+      firstMessage: "   \n  "
+    )
+
+    let preview = SessionHoverPreview.make(
+      session: session,
+      customName: nil,
+      repositories: [repo()]
+    )
+
+    #expect(preview.firstMessage == nil)
+  }
+
+  @Test("Display worktree path abbreviates the home directory")
+  func displayWorktreePathAbbreviatesHome() {
+    let preview = SessionHoverPreview(
+      sessionName: "name",
+      firstMessage: nil,
+      repositoryName: "RepoA",
+      branchName: "main",
+      worktreePath: "/Users/dev/Developer/RepoA-popup"
+    )
+
+    #expect(
+      preview.displayWorktreePath(homeDirectory: "/Users/dev")
+        == "~/Developer/RepoA-popup"
+    )
+    #expect(
+      preview.displayWorktreePath(homeDirectory: "/Users/other")
+        == "/Users/dev/Developer/RepoA-popup"
+    )
+  }
+}


### PR DESCRIPTION
## Summary

Two improvements to how sessions present themselves in the sidebar and monitoring cards:

### Hover preview popup on session rows
Hovering any session row (sidebar list, workspace-owned rows, collapsed panel) for 600ms opens a popover showing the session name, first user message, parent repository, worktree root path (when the session runs in a worktree), branch, and the live PR/CI status line.

- `SessionHoverPreview` — testable model resolving the popup fields via `WorktreeModuleResolver.bestMatch`, so nested launch paths map back to the registered worktree root and parent repository
- `SessionHoverPreviewCard` — the popover content view
- `GitHubSessionRowStatusLine` moved to its own file so the row and popup share it; CI state reuses the row's existing `SessionGitHubQuickAccessViewModel` (no new polling), and no-PR branches stay quiet
- Pending rows never show a preview; leaving the row dismisses it

### Parent module badge on monitoring cards (worktrees only)
Worktree sessions lead the card header with a folder icon + parent repo name before the activity circle and session name, and the path row swaps its folder icon for a branch icon. Root-repo sessions are unchanged — the path row already identifies them, so no redundant badge is shown.

## Testing

- New `SessionHoverPreviewTests` (7 tests): worktree/nested-path/root/unmatched-repo resolution, name precedence, blank-message handling, home-directory abbreviation
- Full local gate run: fast packages passed; the `AgentHubCore` xcodebuild suite initially failed 6 suites unrelated to this diff (investigation, workspace attach, worktree progress, GitDiff timeout) under heavy parallel xcodebuild load — all 41 tests in those suites pass on a serial rerun, consistent with the known headless timing flakes

🤖 Generated with [Claude Code](https://claude.com/claude-code)