### PR TITLE
Context engineering: curated launch context, reusable context sets, and per-project defaults

### DIFF
--- a/app/modules/AgentHubCLI/Sources/AgentHubCLIKit/ContextProfileIndexStore.swift
+++ b/app/modules/AgentHubCLI/Sources/AgentHubCLIKit/ContextProfileIndexStore.swift
@@ -1,0 +1,149 @@
+import Foundation
+
+/// A compact, agent-readable summary of one context profile.
+public struct ContextProfileIndexEntry: Codable, Equatable, Sendable, Identifiable {
+  public let id: String
+  public let name: String
+  /// "personal" or "project".
+  public let scope: String
+  public let isDefault: Bool
+  /// Project-relative paths included by the profile.
+  public let relativeFilePaths: [String]
+  /// Absolute paths outside the repository (documents, other repos, books).
+  public let externalPaths: [String]
+  /// Titles of pasted-text snippets stored in the set.
+  public let textSnippetTitles: [String]
+  public let instructions: String
+  public let updatedAt: Date
+
+  public init(
+    id: String,
+    name: String,
+    scope: String,
+    isDefault: Bool,
+    relativeFilePaths: [String],
+    externalPaths: [String] = [],
+    textSnippetTitles: [String] = [],
+    instructions: String,
+    updatedAt: Date
+  ) {
+    self.id = id
+    self.name = name
+    self.scope = scope
+    self.isDefault = isDefault
+    self.relativeFilePaths = relativeFilePaths
+    self.externalPaths = externalPaths
+    self.textSnippetTitles = textSnippetTitles
+    self.instructions = instructions
+    self.updatedAt = updatedAt
+  }
+
+  private enum CodingKeys: String, CodingKey {
+    case id, name, scope, isDefault, relativeFilePaths, externalPaths, textSnippetTitles, instructions, updatedAt
+  }
+
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    id = try container.decode(String.self, forKey: .id)
+    name = try container.decode(String.self, forKey: .name)
+    scope = try container.decode(String.self, forKey: .scope)
+    isDefault = try container.decode(Bool.self, forKey: .isDefault)
+    relativeFilePaths = try container.decode([String].self, forKey: .relativeFilePaths)
+    externalPaths = try container.decodeIfPresent([String].self, forKey: .externalPaths) ?? []
+    textSnippetTitles = try container.decodeIfPresent([String].self, forKey: .textSnippetTitles) ?? []
+    instructions = try container.decode(String.self, forKey: .instructions)
+    updatedAt = try container.decode(Date.self, forKey: .updatedAt)
+  }
+}
+
+public struct ContextProfileIndex: Codable, Equatable, Sendable {
+  public let projectPath: String
+  public let updatedAt: Date
+  public let profiles: [ContextProfileIndexEntry]
+
+  public init(projectPath: String, updatedAt: Date, profiles: [ContextProfileIndexEntry]) {
+    self.projectPath = projectPath
+    self.updatedAt = updatedAt
+    self.profiles = profiles
+  }
+}
+
+/// A read-only view of a project's context profiles, for the `agenthub` CLI.
+///
+/// The CLI runs as a separate process and deliberately does not open the app's
+/// SQLite database. The app republishes this small JSON index whenever a
+/// project's profiles change (personal profiles are merged into every project's
+/// index at publish time), and the CLI only ever reads it.
+///
+/// The app writes the index under the project's canonical key *and* under every
+/// session path that resolves to it (a worktree, say), so the CLI can look it
+/// up from `AGENTHUB_PROJECT_PATH` alone without knowing about worktree rollup.
+public struct ContextProfileIndexStore: Sendable {
+  public let directoryURL: URL
+
+  public init(directoryURL: URL = ContextProfileIndexStore.defaultDirectoryURL()) {
+    self.directoryURL = directoryURL
+  }
+
+  public static func defaultDirectoryURL(fileManager: FileManager = .default) -> URL {
+    let appSupportURL = fileManager.urls(
+      for: .applicationSupportDirectory,
+      in: .userDomainMask
+    ).first ?? URL(fileURLWithPath: NSHomeDirectory()).appendingPathComponent("Library/Application Support")
+
+    return appSupportURL
+      .appendingPathComponent("AgentHub", isDirectory: true)
+      .appendingPathComponent("context-index", isDirectory: true)
+  }
+
+  /// Filesystem-safe, collision-free file name for a project path.
+  ///
+  /// Percent-encoding rather than substituting separators: turning `/` into `-`
+  /// makes `/a/b-c` and `/a-b/c` collide, which would silently merge two
+  /// projects' profiles.
+  public static func fileName(forProjectPath projectPath: String) -> String {
+    let allowed = CharacterSet.alphanumerics
+    let encoded = projectPath.addingPercentEncoding(withAllowedCharacters: allowed)
+      ?? projectPath
+    return "\(encoded).json"
+  }
+
+  public func fileURL(forProjectPath projectPath: String) -> URL {
+    directoryURL.appendingPathComponent(
+      Self.fileName(forProjectPath: projectPath),
+      isDirectory: false
+    )
+  }
+
+  public func read(projectPath: String) -> ContextProfileIndex? {
+    let url = fileURL(forProjectPath: projectPath)
+    guard let data = try? Data(contentsOf: url) else { return nil }
+    let decoder = JSONDecoder()
+    decoder.dateDecodingStrategy = .iso8601
+    return try? decoder.decode(ContextProfileIndex.self, from: data)
+  }
+
+  /// Publishes an index, mirroring it to every alias path so a worktree session
+  /// finds the same list its parent repo sees.
+  public func write(_ index: ContextProfileIndex, aliasPaths: [String] = []) throws {
+    try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+    encoder.dateEncodingStrategy = .iso8601
+    let data = try encoder.encode(index)
+
+    for path in Set([index.projectPath] + aliasPaths) where !path.isEmpty {
+      let finalURL = fileURL(forProjectPath: path)
+      let temporaryURL = directoryURL.appendingPathComponent(
+        ".\(UUID().uuidString).tmp",
+        isDirectory: false
+      )
+      try data.write(to: temporaryURL, options: [.atomic])
+      if FileManager.default.fileExists(atPath: finalURL.path) {
+        try FileManager.default.removeItem(at: finalURL)
+      }
+      try FileManager.default.moveItem(at: temporaryURL, to: finalURL)
+    }
+  }
+}

--- a/app/modules/AgentHubCLI/Tests/AgentHubCLIKitTests/ContextProfileIndexStoreTests.swift
+++ b/app/modules/AgentHubCLI/Tests/AgentHubCLIKitTests/ContextProfileIndexStoreTests.swift
@@ -1,0 +1,94 @@
+import Foundation
+import Testing
+
+@testable import AgentHubCLIKit
+
+@Suite("ContextProfileIndexStore")
+struct ContextProfileIndexStoreTests {
+  @Test("An index round-trips with selection paths and instructions")
+  func indexRoundTrips() throws {
+    let directory = try temporaryIndexDirectory()
+    defer { try? FileManager.default.removeItem(at: directory.deletingLastPathComponent()) }
+
+    let store = ContextProfileIndexStore(directoryURL: directory)
+    try store.write(makeIndex(projectPath: "/tmp/project"))
+
+    let read = try #require(store.read(projectPath: "/tmp/project"))
+    #expect(read.profiles.map(\.id) == ["profile-1"])
+    #expect(read.profiles.first?.relativeFilePaths == ["CLAUDE.md", "Sources/App/Main.swift"])
+    #expect(read.profiles.first?.isDefault == true)
+    #expect(read.profiles.first?.scope == "project")
+  }
+
+  /// The CLI only knows `AGENTHUB_PROJECT_PATH`, which for a worktree session is
+  /// the worktree — not the repo the profiles are filed under. Mirroring to
+  /// aliases is what lets it find the list anyway.
+  @Test("Aliases resolve a worktree path to the parent repo's index")
+  func aliasesResolveWorktreePaths() throws {
+    let directory = try temporaryIndexDirectory()
+    defer { try? FileManager.default.removeItem(at: directory.deletingLastPathComponent()) }
+
+    let store = ContextProfileIndexStore(directoryURL: directory)
+    try store.write(
+      makeIndex(projectPath: "/Users/me/code/app"),
+      aliasPaths: ["/Users/me/code/app-feature"]
+    )
+
+    #expect(store.read(projectPath: "/Users/me/code/app-feature")?.profiles.count == 1)
+    #expect(store.read(projectPath: "/Users/me/code/app-feature")?.projectPath == "/Users/me/code/app")
+  }
+
+  @Test("An unknown project reads back as nothing rather than failing")
+  func unknownProjectReadsBackNil() throws {
+    let directory = try temporaryIndexDirectory()
+    defer { try? FileManager.default.removeItem(at: directory.deletingLastPathComponent()) }
+
+    #expect(ContextProfileIndexStore(directoryURL: directory).read(projectPath: "/tmp/nothing") == nil)
+  }
+
+  @Test("Rewriting replaces the previous index rather than appending")
+  func rewritingReplaces() throws {
+    let directory = try temporaryIndexDirectory()
+    defer { try? FileManager.default.removeItem(at: directory.deletingLastPathComponent()) }
+
+    let store = ContextProfileIndexStore(directoryURL: directory)
+    try store.write(makeIndex(projectPath: "/tmp/project"))
+    try store.write(ContextProfileIndex(projectPath: "/tmp/project", updatedAt: .now, profiles: []))
+
+    #expect(store.read(projectPath: "/tmp/project")?.profiles.isEmpty == true)
+  }
+
+  /// Substituting separators (`/` → `-`) would make these two collide and
+  /// silently merge two projects' profiles.
+  @Test("Similar paths do not collide on disk")
+  func similarPathsDoNotCollide() {
+    let first = ContextProfileIndexStore.fileName(forProjectPath: "/a/b-c")
+    let second = ContextProfileIndexStore.fileName(forProjectPath: "/a-b/c")
+    #expect(first != second)
+  }
+}
+
+private func makeIndex(projectPath: String) -> ContextProfileIndex {
+  ContextProfileIndex(
+    projectPath: projectPath,
+    updatedAt: Date(timeIntervalSince1970: 5_000),
+    profiles: [
+      ContextProfileIndexEntry(
+        id: "profile-1",
+        name: "Voice work",
+        scope: "project",
+        isDefault: true,
+        relativeFilePaths: ["CLAUDE.md", "Sources/App/Main.swift"],
+        instructions: "Focus on the voice stack.",
+        updatedAt: Date(timeIntervalSince1970: 4_000)
+      )
+    ]
+  )
+}
+
+private func temporaryIndexDirectory() throws -> URL {
+  let root = FileManager.default.temporaryDirectory
+    .appendingPathComponent("agenthub-context-index-tests-\(UUID().uuidString)", isDirectory: true)
+  try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+  return root.appendingPathComponent("index", isDirectory: true)
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubProvider.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Configuration/AgentHubProvider.swift
@@ -145,6 +145,12 @@ public final class AgentHubProvider {
     return AIConfigService(metadataStore: store)
   }()
 
+  /// Saved context profiles (per-project and personal) for curated launch context
+  public private(set) lazy var contextProfileService: (any ContextProfileServiceProtocol)? = {
+    guard let store = metadataStore else { return nil }
+    return ContextProfileService(metadataStore: store)
+  }()
+
   /// Shared `claude -p` invocation service used by short, non-interactive
   /// callers (branch naming, session investigation, etc.).
   public private(set) lazy var programmaticClaudeService: any ClaudeProgrammaticServiceProtocol = ClaudeProgrammaticService(

--- a/app/modules/AgentHubCore/Sources/AgentHub/Models/AIModelOption.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Models/AIModelOption.swift
@@ -41,6 +41,9 @@ public struct AIModelOption: Identifiable, Hashable, Sendable {
   public let reasoningEfforts: [AIReasoningEffort]
   /// The model's default reasoning level, if the provider reports one.
   public let defaultReasoningEffort: String?
+  /// Context window in tokens, when the provider reports one (Codex's
+  /// `models_cache.json` carries `context_window`; Claude has no local source).
+  public let contextWindowTokens: Int?
 
   public var id: String { identifier }
 
@@ -49,12 +52,14 @@ public struct AIModelOption: Identifiable, Hashable, Sendable {
     displayName: String,
     detail: String? = nil,
     reasoningEfforts: [AIReasoningEffort] = [],
-    defaultReasoningEffort: String? = nil
+    defaultReasoningEffort: String? = nil,
+    contextWindowTokens: Int? = nil
   ) {
     self.identifier = identifier
     self.displayName = displayName
     self.detail = detail
     self.reasoningEfforts = reasoningEfforts
     self.defaultReasoningEffort = defaultReasoningEffort
+    self.contextWindowTokens = contextWindowTokens
   }
 }

--- a/app/modules/AgentHubCore/Sources/AgentHub/Models/ContextProfile.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Models/ContextProfile.swift
@@ -1,0 +1,48 @@
+//
+//  ContextProfile.swift
+//  AgentHub
+//
+//  A named, reusable context selection. Project-scoped profiles belong to one
+//  repository; personal profiles live at the user level and resolve their
+//  project-relative paths against whichever project they are applied to
+//  (missing paths are tolerated and reported, never fatal).
+//
+
+import Foundation
+
+public enum ContextProfileScope: String, Codable, Sendable {
+  case personal
+  case project
+}
+
+public struct ContextProfile: Codable, Equatable, Identifiable, Sendable {
+  public var id: String
+  public var name: String
+  public var scope: ContextProfileScope
+  /// Normalized repository root the profile belongs to; empty for personal profiles.
+  public var projectPath: String
+  public var selection: ContextSelection
+  public var isDefault: Bool
+  public var createdAt: Date
+  public var updatedAt: Date
+
+  public init(
+    id: String = UUID().uuidString,
+    name: String,
+    scope: ContextProfileScope,
+    projectPath: String,
+    selection: ContextSelection,
+    isDefault: Bool = false,
+    createdAt: Date = Date(),
+    updatedAt: Date = Date()
+  ) {
+    self.id = id
+    self.name = name
+    self.scope = scope
+    self.projectPath = scope == .personal ? "" : projectPath
+    self.selection = selection
+    self.isDefault = isDefault
+    self.createdAt = createdAt
+    self.updatedAt = updatedAt
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/Models/ContextProfileRecord.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Models/ContextProfileRecord.swift
@@ -1,0 +1,98 @@
+//
+//  ContextProfileRecord.swift
+//  AgentHub
+//
+//  SQLite record for one saved context profile.
+//
+
+import Foundation
+import GRDB
+
+/// Persisted context profile.
+///
+/// The evolving part of a profile — its selection (file paths, future slices,
+/// instructions) — is stored as an encoded `ContextSelection` blob so it can
+/// grow without migrations; `payloadVersion` versions that payload. Everything
+/// else (name, scope, default flag, timestamps) is queried or listed without
+/// decoding, so those are real columns — and because the selection is the
+/// *only* thing in the payload, a column update like flipping `isDefault`
+/// cannot drift from a stale copy inside the blob.
+public struct ContextProfileRecord: Codable, Equatable, Identifiable, Sendable, FetchableRecord, PersistableRecord {
+  public static let currentPayloadVersion = 1
+
+  public var id: String
+  /// Storage scope: normalized repo root, or "" for personal (user-level) profiles.
+  public var projectPath: String
+  public var scope: String
+  public var name: String
+  public var isDefault: Bool
+  public var createdAt: Date
+  public var updatedAt: Date
+  public var payloadVersion: Int
+  public var payloadData: Data
+
+  public static var databaseTableName: String { "context_profiles" }
+
+  /// Coders pinned to ISO-8601 so a payload written by one build always decodes
+  /// in the next one.
+  private static var payloadEncoder: JSONEncoder {
+    let encoder = JSONEncoder()
+    encoder.dateEncodingStrategy = .iso8601
+    return encoder
+  }
+
+  private static var payloadDecoder: JSONDecoder {
+    let decoder = JSONDecoder()
+    decoder.dateDecodingStrategy = .iso8601
+    return decoder
+  }
+
+  public init(
+    id: String,
+    projectPath: String,
+    scope: String,
+    name: String,
+    isDefault: Bool,
+    createdAt: Date,
+    updatedAt: Date,
+    payloadVersion: Int,
+    payloadData: Data
+  ) {
+    self.id = id
+    self.projectPath = projectPath
+    self.scope = scope
+    self.name = name
+    self.isDefault = isDefault
+    self.createdAt = createdAt
+    self.updatedAt = updatedAt
+    self.payloadVersion = payloadVersion
+    self.payloadData = payloadData
+  }
+
+  public init(profile: ContextProfile) throws {
+    self.init(
+      id: profile.id,
+      projectPath: profile.scope == .personal ? "" : profile.projectPath,
+      scope: profile.scope.rawValue,
+      name: profile.name,
+      isDefault: profile.isDefault,
+      createdAt: profile.createdAt,
+      updatedAt: profile.updatedAt,
+      payloadVersion: Self.currentPayloadVersion,
+      payloadData: try Self.payloadEncoder.encode(profile.selection)
+    )
+  }
+
+  public func decodedProfile() throws -> ContextProfile {
+    ContextProfile(
+      id: id,
+      name: name,
+      scope: ContextProfileScope(rawValue: scope) ?? .project,
+      projectPath: projectPath,
+      selection: try Self.payloadDecoder.decode(ContextSelection.self, from: payloadData),
+      isDefault: isDefault,
+      createdAt: createdAt,
+      updatedAt: updatedAt
+    )
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/Models/ContextSelection.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Models/ContextSelection.swift
@@ -1,0 +1,82 @@
+//
+//  ContextSelection.swift
+//  AgentHub
+//
+//  Curated launch context: the files (and standing instructions) handed to an
+//  agent before its first turn. Project files are stored as project-relative
+//  paths so a selection stays valid inside a freshly created worktree of the
+//  same repository; anything outside the repo — another folder, a document, a
+//  book — is stored as an absolute path.
+//
+
+import Foundation
+
+public struct ContextFileSelection: Codable, Equatable, Sendable, Identifiable {
+  public var id: String { relativePath }
+  public let relativePath: String
+
+  public init(relativePath: String) {
+    self.relativePath = relativePath
+  }
+}
+
+/// Pasted text stored directly in the selection — notes, snippets, prompt
+/// material that has no file on disk.
+public struct ContextTextSnippet: Codable, Equatable, Sendable, Identifiable {
+  public let id: String
+  public var title: String
+  public var content: String
+
+  public init(id: String = UUID().uuidString, title: String, content: String) {
+    self.id = id
+    self.title = title
+    self.content = content
+  }
+}
+
+public struct ContextSelection: Equatable, Sendable {
+  /// Project files, relative to the repository root.
+  public var files: [ContextFileSelection]
+  /// Files outside the repository, as absolute paths (other repos, documents,
+  /// books, notes — anything the user pointed at).
+  public var externalPaths: [String]
+  /// Pasted text stored directly in the set (no file on disk).
+  public var textSnippets: [ContextTextSnippet]
+  public var instructions: String
+
+  public init(
+    files: [ContextFileSelection] = [],
+    externalPaths: [String] = [],
+    textSnippets: [ContextTextSnippet] = [],
+    instructions: String = ""
+  ) {
+    self.files = files
+    self.externalPaths = externalPaths
+    self.textSnippets = textSnippets
+    self.instructions = instructions
+  }
+
+  public var isEmpty: Bool {
+    files.isEmpty && externalPaths.isEmpty && textSnippets.isEmpty
+      && instructions.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+  }
+}
+
+// Custom Codable so selections saved before `externalPaths`/`textSnippets`
+// existed still decode (profile payloads persist in SQLite).
+extension ContextSelection: Codable {
+  private enum CodingKeys: String, CodingKey {
+    case files
+    case externalPaths
+    case textSnippets
+    case instructions
+  }
+
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    files = try container.decodeIfPresent([ContextFileSelection].self, forKey: .files) ?? []
+    externalPaths = try container.decodeIfPresent([String].self, forKey: .externalPaths) ?? []
+    textSnippets = try container.decodeIfPresent([ContextTextSnippet].self, forKey: .textSnippets) ?? []
+    instructions = try container.decodeIfPresent(String.self, forKey: .instructions) ?? ""
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/Models/SessionMonitorState.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Models/SessionMonitorState.swift
@@ -111,8 +111,15 @@ public struct SessionMonitorState: Equatable, Sendable {
 
   // MARK: - Context Window
 
-  /// Context window size (200K for Claude models)
-  public var contextWindowSize: Int { 200_000 }
+  /// Conservative default window (the Claude Code standard 200K).
+  public static let defaultContextWindowSize = ModelContextWindowResolver.conservativeDefaultTokens
+
+  /// Context window for this session's resolved model: Claude `[1m]`-suffixed
+  /// ids report 1M, Codex models report their cached `context_window`, and
+  /// everything else falls back to the conservative 200K.
+  public var contextWindowSize: Int {
+    ModelContextWindowResolver.window(forModelIdentifier: model)
+  }
 
   /// Context window usage as a percentage (0.0 to 1.0+)
   public var contextWindowUsagePercentage: Double {

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/CodexModelCatalog.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/CodexModelCatalog.swift
@@ -113,7 +113,8 @@ public struct CodexModelCatalog: CodexModelCatalogProviding {
           displayName: displayName,
           detail: (trimmedDetail?.isEmpty == false) ? trimmedDetail : nil,
           reasoningEfforts: efforts,
-          defaultReasoningEffort: model.defaultReasoningLevel
+          defaultReasoningEffort: model.defaultReasoningLevel,
+          contextWindowTokens: model.contextWindow
         )
       }
   }
@@ -167,6 +168,7 @@ public struct CodexModelCatalog: CodexModelCatalogProviding {
     let priority: Int?
     let supportedReasoningLevels: [ReasoningLevel]?
     let defaultReasoningLevel: String?
+    let contextWindow: Int?
 
     private enum CodingKeys: String, CodingKey {
       case slug
@@ -176,6 +178,7 @@ public struct CodexModelCatalog: CodexModelCatalogProviding {
       case priority
       case supportedReasoningLevels = "supported_reasoning_levels"
       case defaultReasoningLevel = "default_reasoning_level"
+      case contextWindow = "context_window"
     }
   }
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/ContextAssembler.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/ContextAssembler.swift
@@ -1,0 +1,106 @@
+//
+//  ContextAssembler.swift
+//  AgentHub
+//
+//  Builds the exact context block handed to an agent from loaded file contents
+//  and user instructions. Output is deterministic: files are sorted by path
+//  regardless of selection order, so the same selection always produces the
+//  same block (previews, tests, and token estimates stay stable).
+//
+
+import Foundation
+
+public struct ContextAssemblyInput: Sendable {
+  public let files: [ContextLoadedFile]
+  public let missingPaths: [String]
+  /// Files that are part of the context but not inlined (binary or oversized);
+  /// the agent is told to read them with its own tools.
+  public let attachmentPaths: [String]
+  /// Pasted text stored directly in the selection.
+  public let textSnippets: [ContextTextSnippet]
+  public let instructions: String
+
+  public init(
+    files: [ContextLoadedFile],
+    missingPaths: [String] = [],
+    attachmentPaths: [String] = [],
+    textSnippets: [ContextTextSnippet] = [],
+    instructions: String = ""
+  ) {
+    self.files = files
+    self.missingPaths = missingPaths
+    self.attachmentPaths = attachmentPaths
+    self.textSnippets = textSnippets
+    self.instructions = instructions
+  }
+}
+
+public struct ContextAssemblyResult: Equatable, Sendable {
+  public let block: String
+  public let byteCount: Int
+
+  public init(block: String) {
+    self.block = block
+    self.byteCount = block.utf8.count
+  }
+}
+
+public protocol ContextAssembling: Sendable {
+  func assemble(_ input: ContextAssemblyInput) -> ContextAssemblyResult
+}
+
+public struct ContextAssembler: ContextAssembling {
+
+  public init() {}
+
+  public func assemble(_ input: ContextAssemblyInput) -> ContextAssemblyResult {
+    let files = input.files.sorted { $0.relativePath < $1.relativePath }
+    let missing = input.missingPaths.sorted()
+    let attachments = input.attachmentPaths.sorted()
+    let snippets = input.textSnippets.sorted {
+      ($0.title, $0.id) < ($1.title, $1.id)
+    }
+    let instructions = input.instructions.trimmingCharacters(in: .whitespacesAndNewlines)
+
+    var sections: [String] = []
+
+    if !files.isEmpty || !missing.isEmpty || !attachments.isEmpty || !snippets.isEmpty {
+      var mapEntries = files.map { "\($0.relativePath) (\($0.metrics.lineCount) lines)" }
+      mapEntries.append(contentsOf: missing.map { "\($0) (missing)" })
+      mapEntries.append(contentsOf: attachments.map { "\($0) (attachment — read separately)" })
+      mapEntries.append(contentsOf: snippets.map { "\($0.title) (pasted text)" })
+      mapEntries.sort()
+      sections.append("<file_map>\n\(mapEntries.joined(separator: "\n"))\n</file_map>")
+    }
+
+    if !files.isEmpty {
+      let fileBlocks = files.map { file in
+        "<file path=\"\(file.relativePath)\">\n\(file.content)\n</file>"
+      }
+      sections.append("<files>\n\(fileBlocks.joined(separator: "\n"))\n</files>")
+    }
+
+    if !snippets.isEmpty {
+      let snippetBlocks = snippets.map { snippet in
+        "<snippet title=\"\(snippet.title)\">\n\(snippet.content)\n</snippet>"
+      }
+      sections.append("<snippets>\n\(snippetBlocks.joined(separator: "\n"))\n</snippets>")
+    }
+
+    if !attachments.isEmpty {
+      sections.append(
+        "<attachments>\nThese files are part of the context but are not inlined (binary or large). Read them with your file tools:\n\(attachments.joined(separator: "\n"))\n</attachments>"
+      )
+    }
+
+    if !instructions.isEmpty {
+      sections.append("<instructions>\n\(instructions)\n</instructions>")
+    }
+
+    guard !sections.isEmpty else {
+      return ContextAssemblyResult(block: "")
+    }
+
+    return ContextAssemblyResult(block: "<context>\n\(sections.joined(separator: "\n"))\n</context>")
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/ContextFileLoader.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/ContextFileLoader.swift
@@ -1,0 +1,264 @@
+//
+//  ContextFileLoader.swift
+//  AgentHub
+//
+//  Resolves a context selection's project-relative paths into file contents,
+//  off the main actor, with a bounded number of contents held in flight.
+//  Reads go through FileIndexService so path validation (stay inside the
+//  project root) and UTF-8 checking are enforced in one place.
+//
+
+import Foundation
+
+public struct ContextLoadedFile: Equatable, Sendable {
+  public let relativePath: String
+  public let content: String
+  public let metrics: TextFileMetrics
+
+  public init(relativePath: String, content: String, metrics: TextFileMetrics) {
+    self.relativePath = relativePath
+    self.content = content
+    self.metrics = metrics
+  }
+
+  public init(relativePath: String, content: String) {
+    self.init(relativePath: relativePath, content: content, metrics: .metrics(for: content))
+  }
+}
+
+public struct ContextFileLoadResult: Sendable {
+  /// Successfully read files, sorted by relative path.
+  public let loaded: [ContextLoadedFile]
+  /// Relative paths that could not be read (missing, unreadable, non-UTF-8,
+  /// or outside the project root), sorted.
+  public let missing: [String]
+  /// Paths that exist but cannot be inlined (binary formats such as PDFs and
+  /// images, or files over the inline size cap). Included in the context as
+  /// references the agent reads with its own tools.
+  public let attachments: [String]
+
+  public init(loaded: [ContextLoadedFile], missing: [String], attachments: [String] = []) {
+    self.loaded = loaded
+    self.missing = missing
+    self.attachments = attachments
+  }
+}
+
+/// What an external (outside-the-repo) path resolves to.
+public enum ContextExternalFileStatus: Equatable, Sendable {
+  /// UTF-8 text small enough to inline.
+  case text(TextFileMetrics)
+  /// Exists but is referenced by path instead of inlined (binary or too large).
+  case attachment
+  case missing
+}
+
+public protocol ContextFileLoading: Sendable {
+  func loadFiles(relativePaths: [String], projectPath: String) async -> ContextFileLoadResult
+  /// Metrics only (no contents retained) — cheap enough to refresh a token
+  /// column on every selection toggle. Unreadable paths are omitted.
+  func fileMetrics(relativePaths: [String], projectPath: String) async -> [String: TextFileMetrics]
+  /// Loads files from absolute paths outside the project root (other repos,
+  /// documents, books). Binary or oversized files land in `attachments`.
+  func loadExternalFiles(absolutePaths: [String]) async -> ContextFileLoadResult
+  /// Classifies external paths without retaining contents.
+  func externalFileStatuses(absolutePaths: [String]) async -> [String: ContextExternalFileStatus]
+}
+
+public actor ContextFileLoader: ContextFileLoading {
+
+  private struct MetricsCacheEntry {
+    let fileSize: Int
+    let modificationDate: Date
+    let metrics: TextFileMetrics
+  }
+
+  private let fileIndexService: FileIndexService
+  private let maxConcurrentReads: Int
+  private var metricsCache: [String: MetricsCacheEntry] = [:]
+
+  public init(fileIndexService: FileIndexService = .shared, maxConcurrentReads: Int = 8) {
+    self.fileIndexService = fileIndexService
+    self.maxConcurrentReads = max(1, maxConcurrentReads)
+  }
+
+  public func loadFiles(relativePaths: [String], projectPath: String) async -> ContextFileLoadResult {
+    let uniquePaths = orderedUnique(relativePaths)
+    var loaded: [ContextLoadedFile] = []
+    var missing: [String] = []
+
+    await withTaskGroup(of: (String, ProjectTextFile?).self) { group in
+      var iterator = uniquePaths.makeIterator()
+      var inFlight = 0
+
+      func addNext() {
+        guard let relativePath = iterator.next() else { return }
+        inFlight += 1
+        let absolutePath = Self.absolutePath(for: relativePath, projectPath: projectPath)
+        group.addTask { [fileIndexService] in
+          let file = try? await fileIndexService.readTextFile(at: absolutePath, projectPath: projectPath)
+          return (relativePath, file)
+        }
+      }
+
+      for _ in 0..<maxConcurrentReads { addNext() }
+
+      for await (relativePath, file) in group {
+        inFlight -= 1
+        if let file {
+          loaded.append(ContextLoadedFile(
+            relativePath: relativePath,
+            content: file.content,
+            metrics: file.metrics
+          ))
+          cacheMetrics(file.metrics, relativePath: relativePath, projectPath: projectPath)
+        } else {
+          missing.append(relativePath)
+        }
+        addNext()
+      }
+    }
+
+    return ContextFileLoadResult(
+      loaded: loaded.sorted { $0.relativePath < $1.relativePath },
+      missing: missing.sorted()
+    )
+  }
+
+  public func fileMetrics(relativePaths: [String], projectPath: String) async -> [String: TextFileMetrics] {
+    var result: [String: TextFileMetrics] = [:]
+    for relativePath in orderedUnique(relativePaths) {
+      let absolutePath = Self.absolutePath(for: relativePath, projectPath: projectPath)
+      guard let attributes = Self.fileAttributes(atPath: absolutePath) else { continue }
+
+      if let entry = metricsCache[absolutePath],
+        entry.fileSize == attributes.fileSize,
+        entry.modificationDate == attributes.modificationDate {
+        result[relativePath] = entry.metrics
+        continue
+      }
+
+      guard let file = try? await fileIndexService.readTextFile(at: absolutePath, projectPath: projectPath) else {
+        continue
+      }
+      metricsCache[absolutePath] = MetricsCacheEntry(
+        fileSize: attributes.fileSize,
+        modificationDate: attributes.modificationDate,
+        metrics: file.metrics
+      )
+      result[relativePath] = file.metrics
+    }
+    return result
+  }
+
+  // MARK: - Private
+
+  private func cacheMetrics(_ metrics: TextFileMetrics, relativePath: String, projectPath: String) {
+    let absolutePath = Self.absolutePath(for: relativePath, projectPath: projectPath)
+    guard let attributes = Self.fileAttributes(atPath: absolutePath) else { return }
+    metricsCache[absolutePath] = MetricsCacheEntry(
+      fileSize: attributes.fileSize,
+      modificationDate: attributes.modificationDate,
+      metrics: metrics
+    )
+  }
+
+  private func orderedUnique(_ paths: [String]) -> [String] {
+    var seen = Set<String>()
+    return paths.filter { seen.insert($0).inserted }
+  }
+
+  private static func absolutePath(for relativePath: String, projectPath: String) -> String {
+    (projectPath as NSString).appendingPathComponent(relativePath)
+  }
+
+  private static func fileAttributes(atPath path: String) -> (fileSize: Int, modificationDate: Date)? {
+    guard let attributes = try? FileManager.default.attributesOfItem(atPath: path),
+      let size = attributes[.size] as? Int,
+      let modified = attributes[.modificationDate] as? Date
+    else { return nil }
+    return (size, modified)
+  }
+
+  // MARK: - External files
+
+  /// External text files above this size are referenced as attachments instead
+  /// of inlined — a book-sized text would blow past any context window anyway.
+  public static let maxExternalInlineBytes = 10 * 1024 * 1024
+
+  public func loadExternalFiles(absolutePaths: [String]) async -> ContextFileLoadResult {
+    var loaded: [ContextLoadedFile] = []
+    var missing: [String] = []
+    var attachments: [String] = []
+
+    for path in orderedUnique(absolutePaths) {
+      switch Self.readExternalFile(atPath: path) {
+      case .text(let content, let metrics):
+        loaded.append(ContextLoadedFile(relativePath: path, content: content, metrics: metrics))
+      case .attachment:
+        attachments.append(path)
+      case .missing:
+        missing.append(path)
+      }
+    }
+
+    return ContextFileLoadResult(
+      loaded: loaded.sorted { $0.relativePath < $1.relativePath },
+      missing: missing.sorted(),
+      attachments: attachments.sorted()
+    )
+  }
+
+  public func externalFileStatuses(absolutePaths: [String]) async -> [String: ContextExternalFileStatus] {
+    var statuses: [String: ContextExternalFileStatus] = [:]
+    for path in orderedUnique(absolutePaths) {
+      switch Self.readExternalFile(atPath: path) {
+      case .text(_, let metrics): statuses[path] = .text(metrics)
+      case .attachment: statuses[path] = .attachment
+      case .missing: statuses[path] = .missing
+      }
+    }
+    return statuses
+  }
+
+  private enum ExternalRead {
+    case text(String, TextFileMetrics)
+    case attachment
+    case missing
+  }
+
+  private static func readExternalFile(atPath path: String) -> ExternalRead {
+    var isDirectory: ObjCBool = false
+    guard FileManager.default.fileExists(atPath: path, isDirectory: &isDirectory),
+      !isDirectory.boolValue
+    else { return .missing }
+
+    guard let attributes = fileAttributes(atPath: path) else { return .missing }
+    guard attributes.fileSize <= maxExternalInlineBytes else { return .attachment }
+
+    guard let data = try? Data(contentsOf: URL(fileURLWithPath: path), options: [.mappedIfSafe]),
+      let content = String(data: data, encoding: .utf8)
+    else {
+      // Exists but is not UTF-8 text (PDF, image, docx, …) — reference it.
+      return .attachment
+    }
+    return .text(content, TextFileMetrics.metrics(forUTF8Data: data))
+  }
+
+  /// Filters user-picked URLs down to existing regular files (external
+  /// selection is files-only; the picker multi-selects so many files can be
+  /// added in one pass).
+  public static func regularFilePaths(from urls: [URL]) -> [String] {
+    var paths: [String] = []
+    var seen = Set<String>()
+    for url in urls {
+      var isDirectory: ObjCBool = false
+      guard FileManager.default.fileExists(atPath: url.path, isDirectory: &isDirectory),
+        !isDirectory.boolValue,
+        seen.insert(url.path).inserted
+      else { continue }
+      paths.append(url.path)
+    }
+    return paths
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/ContextPayloadStore.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/ContextPayloadStore.swift
@@ -1,0 +1,100 @@
+//
+//  ContextPayloadStore.swift
+//  AgentHub
+//
+//  Decides how an assembled context block travels to the CLI. Small blocks go
+//  inline in the first prompt; oversized blocks are written to an
+//  AgentHub-owned file under Application Support and the prompt references the
+//  path instead (large pastes stall the Claude TUI, and Codex receives its
+//  prompt via argv). Nothing is ever written inside a user's repository.
+//
+
+import Foundation
+
+public enum ContextPromptPayload: Equatable, Sendable {
+  case inline(String)
+  case fileReference(path: String, prompt: String)
+
+  public var promptText: String {
+    switch self {
+    case .inline(let block):
+      return block
+    case .fileReference(_, let prompt):
+      return prompt
+    }
+  }
+}
+
+public protocol ContextPayloadStoring: Sendable {
+  func materializeIfNeeded(block: String) throws -> ContextPromptPayload
+}
+
+public struct ContextPayloadStore: ContextPayloadStoring {
+
+  /// 48 KB ≈ 14K estimated tokens inline. Above this the Claude terminal paste
+  /// visibly stalls, so the block is referenced by file path instead. The same
+  /// threshold applies to Codex (argv) so assembly output stays provider-agnostic.
+  public static let inlineByteThreshold = 48 * 1024
+
+  /// Payloads are read once at session start; anything a week old is dead.
+  public static let stalePayloadMaxAge: TimeInterval = 7 * 24 * 60 * 60
+
+  public let directoryURL: URL
+  public let inlineByteThreshold: Int
+
+  public static func defaultDirectoryURL(fileManager: FileManager = .default) -> URL {
+    let base = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+      ?? fileManager.temporaryDirectory
+    return base
+      .appendingPathComponent("AgentHub", isDirectory: true)
+      .appendingPathComponent("context", isDirectory: true)
+      .appendingPathComponent("payloads", isDirectory: true)
+  }
+
+  public init(
+    directoryURL: URL = Self.defaultDirectoryURL(),
+    inlineByteThreshold: Int = Self.inlineByteThreshold
+  ) {
+    self.directoryURL = directoryURL
+    self.inlineByteThreshold = inlineByteThreshold
+  }
+
+  public func materializeIfNeeded(block: String) throws -> ContextPromptPayload {
+    guard block.utf8.count > inlineByteThreshold else {
+      return .inline(block)
+    }
+
+    try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+    pruneStalePayloads()
+
+    let fileURL = directoryURL.appendingPathComponent("context-\(UUID().uuidString).md")
+    try block.write(to: fileURL, atomically: true, encoding: .utf8)
+
+    let prompt = """
+      <context>
+      Curated context for this session (file map, file contents, instructions) is in:
+      \(fileURL.path)
+      Read that file before doing anything else.
+      </context>
+      """
+    return .fileReference(path: fileURL.path, prompt: prompt)
+  }
+
+  private func pruneStalePayloads() {
+    let fileManager = FileManager.default
+    guard let contents = try? fileManager.contentsOfDirectory(
+      at: directoryURL,
+      includingPropertiesForKeys: [.contentModificationDateKey],
+      options: [.skipsHiddenFiles]
+    ) else { return }
+
+    let cutoff = Date().addingTimeInterval(-Self.stalePayloadMaxAge)
+    for url in contents {
+      let modified = (try? url.resourceValues(forKeys: [.contentModificationDateKey]))?
+        .contentModificationDate
+      if let modified, modified < cutoff {
+        try? fileManager.removeItem(at: url)
+      }
+    }
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/ContextProfileService.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/ContextProfileService.swift
@@ -1,0 +1,111 @@
+//
+//  ContextProfileService.swift
+//  AgentHub
+//
+//  CRUD for saved context profiles, plus the JSON index republish that keeps
+//  the agent/CLI-visible mirror in sync with SQLite. Profiles are stored in
+//  the app database only — never as files inside a user's repository.
+//
+
+import AgentHubCLIKit
+import Foundation
+
+public protocol ContextProfileServiceProtocol: Sendable {
+  /// Profiles applicable to a project: its project-scoped profiles first,
+  /// then personal (user-level) ones, each group name-ordered.
+  func profiles(forProjectPath projectPath: String) async throws -> [ContextProfile]
+  func save(_ profile: ContextProfile) async throws
+  func delete(id: String, projectPath: String) async throws
+  /// Marks a project-scoped profile as the project's default (nil clears it).
+  func setDefault(id: String?, forProjectPath projectPath: String) async throws
+  func defaultProfile(forProjectPath projectPath: String) async throws -> ContextProfile?
+}
+
+public actor ContextProfileService: ContextProfileServiceProtocol {
+
+  private let metadataStore: SessionMetadataStore
+  private let indexStore: ContextProfileIndexStore
+
+  public init(
+    metadataStore: SessionMetadataStore,
+    indexStore: ContextProfileIndexStore = ContextProfileIndexStore()
+  ) {
+    self.metadataStore = metadataStore
+    self.indexStore = indexStore
+  }
+
+  public func profiles(forProjectPath projectPath: String) async throws -> [ContextProfile] {
+    let project = try await metadataStore.getContextProfiles(forProjectPath: projectPath)
+    let personal = try await metadataStore.getPersonalContextProfiles()
+    return (project + personal).compactMap { try? $0.decodedProfile() }
+  }
+
+  public func save(_ profile: ContextProfile) async throws {
+    var stamped = profile
+    stamped.updatedAt = Date()
+    try await metadataStore.saveContextProfile(ContextProfileRecord(profile: stamped))
+    await republish(afterMutationOf: stamped.scope, projectPath: stamped.projectPath)
+  }
+
+  public func delete(id: String, projectPath: String) async throws {
+    let wasPersonal = try await metadataStore.getPersonalContextProfiles()
+      .contains { $0.id == id }
+    try await metadataStore.deleteContextProfile(id: id)
+    await republish(afterMutationOf: wasPersonal ? .personal : .project, projectPath: projectPath)
+  }
+
+  public func setDefault(id: String?, forProjectPath projectPath: String) async throws {
+    try await metadataStore.setDefaultContextProfile(id: id, forProjectPath: projectPath)
+    await republish(afterMutationOf: .project, projectPath: projectPath)
+  }
+
+  public func defaultProfile(forProjectPath projectPath: String) async throws -> ContextProfile? {
+    try await metadataStore.getContextProfiles(forProjectPath: projectPath)
+      .first { $0.isDefault }
+      .flatMap { try? $0.decodedProfile() }
+  }
+
+  /// Republishes a project's JSON index, mirroring to `aliasPaths` (worktree
+  /// paths that resolve to this project) when the caller knows them.
+  public func republishIndex(forProjectPath projectPath: String, aliasPaths: [String] = []) async {
+    guard let allProfiles = try? await profiles(forProjectPath: projectPath) else { return }
+    let key = MeasurementProjectScope.normalized(projectPath)
+    let index = ContextProfileIndex(
+      projectPath: key,
+      updatedAt: Date(),
+      profiles: allProfiles.map { profile in
+        ContextProfileIndexEntry(
+          id: profile.id,
+          name: profile.name,
+          scope: profile.scope.rawValue,
+          isDefault: profile.isDefault,
+          relativeFilePaths: profile.selection.files.map(\.relativePath),
+          externalPaths: profile.selection.externalPaths,
+          textSnippetTitles: profile.selection.textSnippets.map(\.title),
+          instructions: profile.selection.instructions,
+          updatedAt: profile.updatedAt
+        )
+      }
+    )
+    try? indexStore.write(index, aliasPaths: aliasPaths)
+  }
+
+  // MARK: - Private
+
+  /// A project-scope mutation touches one index; a personal-scope mutation is
+  /// visible from every project that has profiles, so all of them republish.
+  private func republish(afterMutationOf scope: ContextProfileScope, projectPath: String) async {
+    switch scope {
+    case .project:
+      await republishIndex(forProjectPath: projectPath)
+    case .personal:
+      let projectPaths = (try? await metadataStore.getProjectPathsWithContextProfiles()) ?? []
+      for path in projectPaths {
+        await republishIndex(forProjectPath: path)
+      }
+      if !projectPath.isEmpty {
+        await republishIndex(forProjectPath: projectPath)
+      }
+    }
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/ContextTokenEstimator.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/ContextTokenEstimator.swift
@@ -1,0 +1,26 @@
+//
+//  ContextTokenEstimator.swift
+//  AgentHub
+//
+//  Model-agnostic approximate token cost for curated context. Deliberately
+//  overestimates (code tokenizes denser than prose) so budget warnings err
+//  toward caution. All values surfaced to users must be labeled approximate.
+//
+
+import Foundation
+
+public protocol ContextTokenEstimating: Sendable {
+  func estimatedTokens(forByteCount byteCount: Int) -> Int
+}
+
+public struct ContextTokenEstimator: ContextTokenEstimating {
+  public static let bytesPerToken = 4.0
+  public static let safetyMultiplier = 1.15
+
+  public init() {}
+
+  public func estimatedTokens(forByteCount byteCount: Int) -> Int {
+    guard byteCount > 0 else { return 0 }
+    return Int((Double(byteCount) / Self.bytesPerToken * Self.safetyMultiplier).rounded(.up))
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/ModelContextWindowResolver.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/ModelContextWindowResolver.swift
@@ -1,0 +1,59 @@
+//
+//  ModelContextWindowResolver.swift
+//  AgentHub
+//
+//  Resolves a model identifier to its context window, from local evidence
+//  rather than a hardcoded constant:
+//
+//  - Codex models report `context_window` in `~/.codex/models_cache.json`
+//    (already read by `CodexModelCatalog`) — real per-model data.
+//  - Claude Code sessions record the resolved model per turn; ids carry a
+//    `[1m]` suffix when the 1M-context beta is active. A plain Claude id runs
+//    the standard 200K window regardless of what the raw API model supports,
+//    so the suffix — not the model family — is the correct signal.
+//  - Anything unknown falls back to a conservative 200K so budget warnings
+//    err toward caution.
+//
+
+import Foundation
+
+public enum ModelContextWindowResolver {
+
+  /// Conservative fallback, and the Claude Code standard window.
+  public static let conservativeDefaultTokens = 200_000
+
+  /// Window for Claude ids carrying the 1M-context beta suffix.
+  static let oneMillionTokens = 1_000_000
+
+  /// Codex per-model windows from the on-disk models cache, read once.
+  private static let cachedCodexWindows: [String: Int] = {
+    var windows: [String: Int] = [:]
+    for option in CodexModelCatalog().cachedModels() {
+      if let tokens = option.contextWindowTokens {
+        windows[option.identifier.lowercased()] = tokens
+      }
+    }
+    return windows
+  }()
+
+  public static func window(forModelIdentifier identifier: String?) -> Int {
+    window(forModelIdentifier: identifier, codexWindows: cachedCodexWindows)
+  }
+
+  /// Pure variant with an injectable Codex lookup, for tests.
+  static func window(forModelIdentifier identifier: String?, codexWindows: [String: Int]) -> Int {
+    guard let identifier = identifier?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased(),
+      !identifier.isEmpty
+    else {
+      return conservativeDefaultTokens
+    }
+
+    if identifier.hasSuffix("[1m]") {
+      return oneMillionTokens
+    }
+    if let codexWindow = codexWindows[identifier] {
+      return codexWindow
+    }
+    return conservativeDefaultTokens
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/SessionMetadataStore.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/SessionMetadataStore.swift
@@ -30,6 +30,7 @@ public actor SessionMetadataStore: TerminalWorkspaceStoreProtocol, AgentWorkspac
     static let createPinnedSessionOrder = "v13_create_pinned_session_order"
     static let createSessionMeasurements = "v14_create_session_measurements"
     static let addMeasurementProjectPath = "v15_add_measurement_project_path"
+    static let createContextProfiles = "v16_create_context_profiles"
   }
 
   static let migrationIdentifiers = [
@@ -47,7 +48,8 @@ public actor SessionMetadataStore: TerminalWorkspaceStoreProtocol, AgentWorkspac
     MigrationID.createAgentWorkspaces,
     MigrationID.createPinnedSessionOrder,
     MigrationID.createSessionMeasurements,
-    MigrationID.addMeasurementProjectPath
+    MigrationID.addMeasurementProjectPath,
+    MigrationID.createContextProfiles
   ]
 
   private let dbQueue: DatabaseQueue
@@ -295,6 +297,34 @@ public actor SessionMetadataStore: TerminalWorkspaceStoreProtocol, AgentWorkspac
         on: "session_measurements",
         columns: ["projectPath"]
       )
+    }
+
+    // Named context profiles for curated launch context. projectPath "" is the
+    // personal (user-level) scope, matching the v15 sentinel convention. The
+    // partial unique index makes "one default per project" a database
+    // guarantee rather than app discipline.
+    //
+    // The drop guard clears a `context_profiles` table left by an abandoned
+    // experiment on a development branch (its `v11_create_context_profiles`
+    // was never in this lineage, so no migration here ever created that
+    // table). On databases from this lineage the drop is a no-op.
+    migrator.registerMigration(MigrationID.createContextProfiles) { db in
+      try db.execute(sql: "DROP TABLE IF EXISTS context_profiles")
+      try db.create(table: "context_profiles") { t in
+        t.column("id", .text).primaryKey(onConflict: .replace)
+        t.column("projectPath", .text).notNull().defaults(to: "").indexed()
+        t.column("scope", .text).notNull()
+        t.column("name", .text).notNull()
+        t.column("isDefault", .boolean).notNull().defaults(to: false)
+        t.column("createdAt", .datetime).notNull()
+        t.column("updatedAt", .datetime).notNull()
+        t.column("payloadVersion", .integer).notNull()
+        t.column("payloadData", .blob).notNull()
+      }
+      try db.execute(sql: """
+        CREATE UNIQUE INDEX idx_context_profiles_default
+        ON context_profiles(projectPath) WHERE isDefault = 1
+        """)
     }
 
     return migrator
@@ -865,6 +895,108 @@ extension SessionMetadataStore {
         .filter(Column("projectPath") == "")
         .deleteAll(db)
     }
+  }
+}
+
+// MARK: - Context Profiles
+
+extension SessionMetadataStore {
+  /// Stores one context profile. `save` (upsert) so re-saving an edited profile
+  /// replaces rather than duplicates.
+  public func saveContextProfile(_ record: ContextProfileRecord) throws {
+    try dbQueue.write { db in
+      try record.save(db)
+    }
+  }
+
+  /// Project-scoped profiles for a project, name-ordered.
+  public func getContextProfiles(forProjectPath projectPath: String) throws -> [ContextProfileRecord] {
+    let key = MeasurementProjectScope.normalized(projectPath)
+    return try dbQueue.read { db in
+      try ContextProfileRecord
+        .filter(Column("projectPath") == key)
+        .order(Column("name").collating(.localizedCaseInsensitiveCompare))
+        .fetchAll(db)
+    }
+  }
+
+  /// Personal (user-level) profiles, name-ordered.
+  public func getPersonalContextProfiles() throws -> [ContextProfileRecord] {
+    try dbQueue.read { db in
+      try ContextProfileRecord
+        .filter(Column("projectPath") == "")
+        .order(Column("name").collating(.localizedCaseInsensitiveCompare))
+        .fetchAll(db)
+    }
+  }
+
+  /// Projects that have at least one profile — used to republish the JSON index
+  /// after a personal-scope mutation without loading every payload.
+  public func getProjectPathsWithContextProfiles() throws -> Set<String> {
+    try dbQueue.read { db in
+      let paths = try String.fetchAll(
+        db,
+        sql: "SELECT DISTINCT projectPath FROM \(ContextProfileRecord.databaseTableName)"
+      )
+      return Set(paths.filter { !$0.isEmpty })
+    }
+  }
+
+  public func deleteContextProfile(id: String) throws {
+    _ = try dbQueue.write { db in
+      try ContextProfileRecord.deleteOne(db, key: id)
+    }
+  }
+
+  /// Marks `id` as the project's default profile (or clears the default when
+  /// `id` is nil). One transaction: the old default is cleared before the new
+  /// one is set, so the partial unique index turns any race into a constraint
+  /// error instead of silent double-defaults. Personal profiles cannot be a
+  /// project default.
+  public func setDefaultContextProfile(id: String?, forProjectPath projectPath: String) throws {
+    let key = MeasurementProjectScope.normalized(projectPath)
+    try dbQueue.write { db in
+      try db.execute(
+        sql: "UPDATE \(ContextProfileRecord.databaseTableName) SET isDefault = 0 WHERE projectPath = ?",
+        arguments: [key]
+      )
+      guard let id else { return }
+      guard let record = try ContextProfileRecord.fetchOne(db, key: id),
+        record.projectPath == key,
+        record.scope == ContextProfileScope.project.rawValue
+      else {
+        throw DatabaseError(
+          resultCode: .SQLITE_CONSTRAINT,
+          message: "Default context profile must be a project-scoped profile of the same project."
+        )
+      }
+      try db.execute(
+        sql: "UPDATE \(ContextProfileRecord.databaseTableName) SET isDefault = 1 WHERE id = ?",
+        arguments: [id]
+      )
+    }
+  }
+
+  /// Synchronous read for launch-time chip gating, safe from non-async contexts.
+  public nonisolated func getDefaultContextProfileSync(forProjectPath projectPath: String) -> ContextProfileRecord? {
+    let key = MeasurementProjectScope.normalized(projectPath)
+    return try? dbQueue.read { db in
+      try ContextProfileRecord
+        .filter(Column("projectPath") == key)
+        .filter(Column("isDefault") == true)
+        .fetchOne(db)
+    }
+  }
+
+  /// Synchronous project-scoped profile list. Returns empty if unreadable.
+  public nonisolated func getContextProfilesSync(forProjectPath projectPath: String) -> [ContextProfileRecord] {
+    let key = MeasurementProjectScope.normalized(projectPath)
+    return (try? dbQueue.read { db in
+      try ContextProfileRecord
+        .filter(Column("projectPath") == key)
+        .order(Column("name").collating(.localizedCaseInsensitiveCompare))
+        .fetchAll(db)
+    }) ?? []
   }
 }
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/ContextBuilderPanes.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/ContextBuilderPanes.swift
@@ -1,0 +1,562 @@
+//
+//  ContextBuilderPanes.swift
+//  AgentHub
+//
+//  The Context Builder's composable panes: file picker, selected-files list,
+//  token budget bar, and the exact assembled-block preview.
+//
+
+import AppKit
+import SwiftUI
+
+// MARK: - File Picker
+
+struct ContextFilePickerPane: View {
+  let viewModel: ContextBuilderViewModel
+  @State private var showingTextContentSheet = false
+
+  private var projectName: String {
+    (viewModel.projectPath as NSString).lastPathComponent
+  }
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      ContextSourceSectionHeader(
+        icon: "folder",
+        title: "This Project",
+        subtitle: projectName
+      )
+      searchField
+      resultsList
+
+      Divider()
+        .padding(.vertical, 2)
+
+      ContextSourceSectionHeader(
+        icon: "externaldrive",
+        title: "Anywhere on Disk",
+        subtitle: "documents, other repos, books"
+      )
+      addExternalFilesButton
+      Text("Added by absolute path. Binary files (PDFs, images) are attached for the agent to read itself.")
+        .font(.secondaryCaption)
+        .foregroundColor(.secondary.opacity(0.8))
+        .fixedSize(horizontal: false, vertical: true)
+
+      Divider()
+        .padding(.vertical, 2)
+
+      ContextSourceSectionHeader(
+        icon: "text.quote",
+        title: "Pasted Text",
+        subtitle: "notes, snippets, prompts"
+      )
+      addTextContentButton
+      Text("Stored inside the context set — no file needed.")
+        .font(.secondaryCaption)
+        .foregroundColor(.secondary.opacity(0.8))
+        .fixedSize(horizontal: false, vertical: true)
+    }
+    .padding(14)
+    .task(id: viewModel.searchQuery) {
+      try? await Task.sleep(for: .milliseconds(150))
+      guard !Task.isCancelled else { return }
+      await viewModel.performSearch()
+    }
+    .sheet(isPresented: $showingTextContentSheet) {
+      ContextTextSnippetSheet { title, content in
+        viewModel.addTextSnippet(title: title, content: content)
+      }
+    }
+  }
+
+  private var addTextContentButton: some View {
+    Button {
+      showingTextContentSheet = true
+    } label: {
+      Label("Add Text Content…", systemImage: "plus.circle")
+        .frame(maxWidth: .infinity)
+    }
+    .buttonStyle(.bordered)
+    .help("Type or paste text — a note, a spec, a prompt — and store it in the context set.")
+  }
+
+  private var searchField: some View {
+    HStack(spacing: 6) {
+      Image(systemName: "magnifyingglass")
+        .font(.system(size: 11))
+        .foregroundColor(.secondary)
+      TextField("Search files in \(projectName)", text: Bindable(viewModel).searchQuery)
+        .textFieldStyle(.plain)
+        .font(.system(size: 12))
+    }
+    .padding(6)
+    .background(
+      RoundedRectangle(cornerRadius: DesignTokens.Radius.sm)
+        .fill(Color(NSColor.controlBackgroundColor))
+    )
+    .overlay(
+      RoundedRectangle(cornerRadius: DesignTokens.Radius.sm)
+        .stroke(Color.borderSubtle, lineWidth: 1)
+    )
+  }
+
+  private var resultsList: some View {
+    ScrollView {
+      LazyVStack(alignment: .leading, spacing: 2) {
+        if viewModel.searchResults.isEmpty && !viewModel.isSearching {
+          Text(viewModel.searchQuery.isEmpty
+            ? "Recent files in \(projectName) appear here."
+            : "No matches in \(projectName).")
+            .font(.secondaryCaption)
+            .foregroundColor(.secondary)
+            .padding(.top, 8)
+        }
+        ForEach(viewModel.searchResults) { result in
+          ContextFilePickerRow(
+            result: result,
+            isSelected: viewModel.isSelected(relativePath: result.relativePath)
+          ) {
+            Task { await viewModel.toggleSelection(relativePath: result.relativePath) }
+          }
+        }
+      }
+    }
+    .frame(maxHeight: .infinity)
+  }
+
+  private var addExternalFilesButton: some View {
+    Button {
+      presentExternalFilePicker()
+    } label: {
+      Label("Add External Files…", systemImage: "plus.circle")
+        .frame(maxWidth: .infinity)
+    }
+    .buttonStyle(.bordered)
+    .help("Select multiple files at once — repeat for files from other locations.")
+  }
+
+  /// Deferred to a later run-loop turn — creating NSOpenPanel synchronously
+  /// inside a button action can deadlock during GCD queue drain (see
+  /// MultiSessionLaunchViewModel.selectRepository).
+  private func presentExternalFilePicker() {
+    let viewModel = self.viewModel
+    DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+      MainActor.assumeIsolated {
+        let panel = NSOpenPanel()
+        panel.title = "Add External Context Files"
+        panel.message = "Pick files from anywhere — you can select many at once"
+        panel.canChooseFiles = true
+        panel.canChooseDirectories = false
+        panel.allowsMultipleSelection = true
+        panel.canCreateDirectories = false
+        if panel.runModal() == .OK {
+          let urls = panel.urls
+          Task { await viewModel.addExternalFiles(urls) }
+        }
+      }
+    }
+  }
+}
+
+// MARK: - Source section header
+
+/// Labels one context source in the picker so the hierarchy — this project's
+/// files vs. external files — is visible structure, not implied.
+private struct ContextSourceSectionHeader: View {
+  let icon: String
+  let title: String
+  let subtitle: String
+
+  var body: some View {
+    HStack(spacing: 6) {
+      Image(systemName: icon)
+        .font(.system(size: 10, weight: .semibold))
+        .foregroundColor(.secondary)
+      Text(title.uppercased())
+        .font(.geist(size: 10, weight: .semibold))
+        .foregroundColor(.secondary)
+        .kerning(0.6)
+      Text(subtitle)
+        .font(.secondaryCaption)
+        .foregroundColor(.secondary.opacity(0.7))
+        .lineLimit(1)
+        .truncationMode(.middle)
+      Spacer(minLength: 0)
+    }
+  }
+}
+
+private struct ContextFilePickerRow: View {
+  let result: FileSearchResult
+  let isSelected: Bool
+  let onToggle: () -> Void
+
+  var body: some View {
+    Button(action: onToggle) {
+      HStack(spacing: 6) {
+        Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
+          .font(.system(size: 11))
+          .foregroundColor(isSelected ? .brandPrimary : .secondary)
+        VStack(alignment: .leading, spacing: 1) {
+          Text(result.name)
+            .font(.system(size: 12))
+            .lineLimit(1)
+          Text(result.relativePath)
+            .font(.secondaryCaption)
+            .foregroundColor(.secondary)
+            .lineLimit(1)
+            .truncationMode(.head)
+        }
+        Spacer(minLength: 0)
+      }
+      .contentShape(Rectangle())
+      .padding(.vertical, 3)
+      .padding(.horizontal, 4)
+    }
+    .buttonStyle(.plain)
+  }
+}
+
+// MARK: - Selected Files
+
+struct ContextSelectedFilesList: View {
+  let viewModel: ContextBuilderViewModel
+
+  private var itemCount: Int {
+    viewModel.selectedRows.count + viewModel.textSnippets.count
+  }
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 4) {
+      Text("Selected items (\(itemCount))")
+        .font(.secondaryCaption)
+        .foregroundColor(.secondary)
+      if itemCount == 0 {
+        Text("Pick files on the left, or paste text — everything here is handed to the agent at launch.")
+          .font(.secondaryCaption)
+          .foregroundColor(.secondary.opacity(0.7))
+          .padding(.vertical, 6)
+      } else {
+        ScrollView {
+          LazyVStack(alignment: .leading, spacing: 2) {
+            ForEach(viewModel.selectedRows) { row in
+              ContextSelectedFileRowView(row: row) {
+                viewModel.removeSelection(relativePath: row.relativePath)
+              }
+            }
+            ForEach(viewModel.textSnippets) { snippet in
+              ContextSnippetRowView(snippet: snippet) {
+                viewModel.removeTextSnippet(id: snippet.id)
+              }
+            }
+          }
+        }
+        .frame(minHeight: 70, maxHeight: 160)
+      }
+    }
+  }
+}
+
+private struct ContextSnippetRowView: View {
+  let snippet: ContextTextSnippet
+  let onRemove: () -> Void
+
+  var body: some View {
+    HStack(spacing: 6) {
+      Image(systemName: "text.quote")
+        .font(.system(size: 10))
+        .foregroundColor(.secondary)
+      Text(snippet.title)
+        .font(.system(size: 11, design: .monospaced))
+        .lineLimit(1)
+        .help(String(snippet.content.prefix(400)))
+      Text("pasted text")
+        .font(.secondaryCaption)
+        .foregroundColor(.secondary.opacity(0.7))
+      Spacer(minLength: 4)
+      Text("~\(SessionMonitorState.formatTokenCount(ContextTokenEstimator().estimatedTokens(forByteCount: snippet.content.utf8.count)))")
+        .font(.secondaryCaption)
+        .foregroundColor(.secondary)
+      Button(action: onRemove) {
+        Image(systemName: "xmark")
+          .font(.system(size: 8, weight: .bold))
+          .foregroundColor(.secondary)
+      }
+      .buttonStyle(.plain)
+    }
+    .padding(.vertical, 2)
+  }
+}
+
+// MARK: - Text snippet sheet
+
+/// "Add text content": title + pasted body, stored inside the context set.
+struct ContextTextSnippetSheet: View {
+  @State private var title = ""
+  @State private var content = ""
+  @Environment(\.dismiss) private var dismiss
+  @Environment(\.runtimeTheme) private var runtimeTheme
+  let onAdd: (String, String) -> Void
+
+  private var isValid: Bool {
+    !title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && !content.isEmpty
+  }
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 12) {
+      HStack {
+        Text("Add Text Content")
+          .font(.primaryDefault)
+          .fontWeight(.semibold)
+        Spacer()
+        Button(action: { dismiss() }) {
+          Image(systemName: "xmark")
+            .font(.system(size: 11, weight: .semibold))
+            .foregroundColor(.secondary)
+        }
+        .buttonStyle(.plain)
+        .keyboardShortcut(.cancelAction)
+      }
+
+      Text("Title")
+        .font(.secondaryCaption)
+        .foregroundColor(.secondary)
+      TextField("Name your content", text: $title)
+        .textFieldStyle(.roundedBorder)
+
+      Text("Content")
+        .font(.secondaryCaption)
+        .foregroundColor(.secondary)
+      ZStack(alignment: .topLeading) {
+        if content.isEmpty {
+          Text("Type or paste in content…")
+            .font(.system(size: 12))
+            .foregroundColor(.secondary.opacity(0.6))
+            .padding(.leading, 7)
+            .padding(.top, 6)
+        }
+        TextEditor(text: $content)
+          .font(.system(size: 12))
+          .scrollContentBackground(.hidden)
+          .padding(4)
+      }
+      .frame(minHeight: 220, maxHeight: .infinity)
+      .background(
+        RoundedRectangle(cornerRadius: DesignTokens.Radius.sm)
+          .fill(Color(NSColor.controlBackgroundColor))
+      )
+      .overlay(
+        RoundedRectangle(cornerRadius: DesignTokens.Radius.sm)
+          .stroke(Color.borderSubtle, lineWidth: 1)
+      )
+
+      HStack {
+        Spacer()
+        Button("Cancel") { dismiss() }
+        Button("Add Content") {
+          onAdd(title, content)
+          dismiss()
+        }
+        .keyboardShortcut(.defaultAction)
+        .buttonStyle(.borderedProminent)
+        .tint(Color.brandPrimary(from: runtimeTheme))
+        .disabled(!isValid)
+      }
+    }
+    .padding(16)
+    .frame(minWidth: 520, idealWidth: 600, minHeight: 380, idealHeight: 440)
+  }
+}
+
+private struct ContextSelectedFileRowView: View {
+  let row: ContextSelectedFileRow
+  let onRemove: () -> Void
+
+  private var iconName: String {
+    if row.isMissing { return "exclamationmark.triangle" }
+    if row.isAttachment { return "paperclip" }
+    if row.isExternal { return "arrow.up.right.square" }
+    return "doc.text"
+  }
+
+  private var displayPath: String {
+    row.isExternal ? (row.relativePath as NSString).abbreviatingWithTildeInPath : row.relativePath
+  }
+
+  var body: some View {
+    HStack(spacing: 6) {
+      Image(systemName: iconName)
+        .font(.system(size: 10))
+        .foregroundColor(row.isMissing ? .orange : .secondary)
+      Text(displayPath)
+        .font(.system(size: 11, design: .monospaced))
+        .strikethrough(row.isMissing)
+        .foregroundColor(row.isMissing ? .secondary : .primary)
+        .lineLimit(1)
+        .truncationMode(.head)
+        .help(row.relativePath)
+      Spacer(minLength: 4)
+      if row.isMissing {
+        Text("missing")
+          .font(.secondaryCaption)
+          .foregroundColor(.orange)
+      } else if row.isAttachment {
+        Text("attached by path")
+          .font(.secondaryCaption)
+          .foregroundColor(.secondary)
+          .help("Binary or very large — the agent is given the path and reads it with its own tools instead of inlining the contents.")
+      } else if let tokens = row.estimatedTokens {
+        Text("~\(SessionMonitorState.formatTokenCount(tokens))")
+          .font(.secondaryCaption)
+          .foregroundColor(.secondary)
+      }
+      Button(action: onRemove) {
+        Image(systemName: "xmark")
+          .font(.system(size: 8, weight: .bold))
+          .foregroundColor(.secondary)
+      }
+      .buttonStyle(.plain)
+    }
+    .padding(.vertical, 2)
+  }
+}
+
+// MARK: - Token Budget
+
+struct ContextTokenBudgetBar: View {
+  let viewModel: ContextBuilderViewModel
+  @State private var showingEstimateHelp = false
+
+  private var barColor: Color {
+    if viewModel.windowFraction > 0.9 { return .red }
+    if viewModel.windowFraction > 0.75 { return .orange }
+    return .brandPrimary
+  }
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 4) {
+      HStack(spacing: 6) {
+        Text(summaryText)
+          .font(.system(.caption, design: .monospaced))
+          .foregroundColor(.secondary)
+        Button {
+          showingEstimateHelp.toggle()
+        } label: {
+          Image(systemName: "questionmark.circle")
+            .font(.system(size: 10))
+            .foregroundColor(.secondary)
+        }
+        .buttonStyle(.plain)
+        .popover(isPresented: $showingEstimateHelp) {
+          VStack(alignment: .leading, spacing: 8) {
+            Text("Why is this approximate?")
+              .font(.subheadline)
+              .fontWeight(.semibold)
+            Text("Token counts are estimated from file size (UTF-8 bytes ÷ 4, plus a 15% safety margin), not computed by a real tokenizer. Actual counts vary by model and content — code often tokenizes denser than prose — so estimates deliberately err high. \(windowAssumptionText)")
+              .font(.caption)
+              .foregroundColor(.secondary)
+              .fixedSize(horizontal: false, vertical: true)
+          }
+          .padding(12)
+          .frame(width: 280)
+        }
+        if viewModel.willUseFileFallback {
+          Label("will attach as file", systemImage: "doc.badge.arrow.up")
+            .font(.secondaryCaption)
+            .foregroundColor(.secondary)
+            .help("The assembled context exceeds the inline paste limit, so it will be written to a file the agent reads at start.")
+        }
+        Spacer()
+      }
+      GeometryReader { geometry in
+        ZStack(alignment: .leading) {
+          RoundedRectangle(cornerRadius: 2)
+            .fill(Color.gray.opacity(0.2))
+          RoundedRectangle(cornerRadius: 2)
+            .fill(barColor)
+            .frame(width: geometry.size.width * min(viewModel.windowFraction, 1.0))
+        }
+      }
+      .frame(height: 4)
+      if viewModel.windowFraction > 0.75 {
+        Text("Large context — the agent has less room to work. Nothing is dropped automatically.")
+          .font(.secondaryCaption)
+          .foregroundColor(.orange)
+      }
+    }
+  }
+
+  private var summaryText: String {
+    let total = SessionMonitorState.formatTokenCount(viewModel.totalEstimatedTokens)
+    let window = SessionMonitorState.formatTokenCount(viewModel.contextWindowTokens)
+    let percent = Int((viewModel.windowFraction * 100).rounded())
+    return "~\(total) / \(window) (~\(percent)%) approx."
+  }
+
+  private var windowAssumptionText: String {
+    let window = SessionMonitorState.formatTokenCount(viewModel.contextWindowTokens)
+    if let model = viewModel.modelIdentifier, !model.isEmpty {
+      return "The window percentage assumes the \(window)-token context window of “\(model)”, your configured default model."
+    }
+    return "The window percentage assumes a conservative \(window)-token context window (no default model is configured)."
+  }
+}
+
+// MARK: - Assembled Preview
+
+struct ContextAssembledPreview: View {
+  let viewModel: ContextBuilderViewModel
+  @State private var isExpanded = true
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 4) {
+      Button {
+        withAnimation(.easeInOut(duration: 0.18)) {
+          isExpanded.toggle()
+        }
+        if isExpanded {
+          Task { await viewModel.refreshPreview() }
+        }
+      } label: {
+        HStack(spacing: 4) {
+          Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
+            .font(.system(size: 9, weight: .semibold))
+          Text("Preview exact context block")
+            .font(.secondaryCaption)
+        }
+        .foregroundColor(.secondary)
+      }
+      .buttonStyle(.plain)
+
+      if isExpanded {
+        if let fullBytes = viewModel.previewTruncatedByteCount {
+          Text("Preview truncated — the full block is \(ByteCountFormatter.string(fromByteCount: Int64(fullBytes), countStyle: .file)) and is assembled in full at launch.")
+            .font(.secondaryCaption)
+            .foregroundColor(.orange)
+        }
+        ScrollView {
+          Text(viewModel.assembledPreview.isEmpty ? "Nothing selected." : viewModel.assembledPreview)
+            .font(.system(size: 10, design: .monospaced))
+            .textSelection(.enabled)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(6)
+        }
+        .frame(minHeight: 140, maxHeight: .infinity)
+        .background(
+          RoundedRectangle(cornerRadius: DesignTokens.Radius.sm)
+            .fill(Color(NSColor.controlBackgroundColor))
+        )
+        .overlay(
+          RoundedRectangle(cornerRadius: DesignTokens.Radius.sm)
+            .stroke(Color.borderSubtle, lineWidth: 1)
+        )
+        .task(id: viewModel.selectedRows) {
+          guard isExpanded else { return }
+          await viewModel.refreshPreview()
+        }
+      }
+    }
+    .frame(maxHeight: isExpanded ? .infinity : nil, alignment: .top)
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/ContextBuilderView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/ContextBuilderView.swift
@@ -1,0 +1,413 @@
+//
+//  ContextBuilderView.swift
+//  AgentHub
+//
+//  Curate exact launch context: pick project files, watch the approximate
+//  token cost, preview the exact assembled block, and apply or save it as a
+//  reusable context set. In launch mode a leading rail lists the saved sets —
+//  tap to load one, edit it, and save; "Use This Context" stays the primary
+//  action in the header.
+//
+
+import AppKit
+import SwiftUI
+
+public enum ContextBuilderMode {
+  /// Launcher curation: primary button applies the selection to the pending launch.
+  case launch(onApply: (ContextSelection) -> Void)
+  /// Context-set editing: primary button saves back into the set being edited.
+  case editProfile(onSave: (ContextProfile) -> Void)
+  /// New context set: primary button names and saves the selection.
+  case createProfile(onSave: (ContextProfile) -> Void)
+}
+
+public struct ContextBuilderView: View {
+  @State private var viewModel: ContextBuilderViewModel
+  @State private var showingSaveAsPopover = false
+  @State private var showingDeleteConfirmation = false
+  @State private var saveErrorMessage: String?
+  @Environment(\.runtimeTheme) private var runtimeTheme
+  private let mode: ContextBuilderMode
+  private let onDeleted: (() -> Void)?
+  private let onDismiss: () -> Void
+
+  /// `onDeleted` opts the editor into showing its explicit delete action —
+  /// only the Project Details flow passes it; the session launcher never
+  /// exposes deletion.
+  public init(
+    viewModel: ContextBuilderViewModel,
+    mode: ContextBuilderMode,
+    onDeleted: (() -> Void)? = nil,
+    onDismiss: @escaping () -> Void
+  ) {
+    _viewModel = State(initialValue: viewModel)
+    self.mode = mode
+    self.onDeleted = onDeleted
+    self.onDismiss = onDismiss
+  }
+
+  private var isLaunchMode: Bool {
+    if case .launch = mode { return true }
+    return false
+  }
+
+  public var body: some View {
+    VStack(spacing: 0) {
+      header
+      Divider()
+      HStack(alignment: .top, spacing: 0) {
+        if isLaunchMode && viewModel.profileServiceAvailable {
+          ContextSetsSidePanel(viewModel: viewModel)
+            .frame(width: 190)
+          Divider()
+        }
+        ContextFilePickerPane(viewModel: viewModel)
+          .frame(minWidth: 250, idealWidth: 280)
+        Divider()
+        selectionColumn
+          .frame(minWidth: 380)
+      }
+    }
+    .frame(
+      minWidth: isLaunchMode ? 880 : 700,
+      idealWidth: isLaunchMode ? 980 : 780,
+      minHeight: 540,
+      idealHeight: 640
+    )
+    .task {
+      await viewModel.prepareSearchIndex()
+      await viewModel.loadProfiles()
+      await viewModel.refreshMetrics()
+    }
+  }
+
+  // MARK: - Header
+
+  private var header: some View {
+    HStack(spacing: 10) {
+      Text(headerTitle)
+        .font(.primaryDefault)
+        .fontWeight(.semibold)
+
+      Spacer()
+
+      Button("Cancel", action: onDismiss)
+        .keyboardShortcut(.cancelAction)
+
+      if case .launch(let onApply) = mode {
+        Button("Use This Context") {
+          onApply(viewModel.currentSelection())
+          onDismiss()
+        }
+        .keyboardShortcut(.defaultAction)
+        .buttonStyle(.borderedProminent)
+        .tint(Color.brandPrimary(from: runtimeTheme))
+        .disabled(!viewModel.hasSelection)
+      }
+    }
+    .padding(.horizontal, 16)
+    .padding(.vertical, 12)
+  }
+
+  private var headerTitle: String {
+    switch mode {
+    case .launch: return "Session Context"
+    case .editProfile: return viewModel.sourceProfile.map { "Edit “\($0.name)”" } ?? "Edit Context Set"
+    case .createProfile: return "New Context Set"
+    }
+  }
+
+  // MARK: - Selection Column
+
+  private var selectionColumn: some View {
+    VStack(alignment: .leading, spacing: 10) {
+      ContextSelectedFilesList(viewModel: viewModel)
+      ContextTokenBudgetBar(viewModel: viewModel)
+      instructionsEditor
+      ContextAssembledPreview(viewModel: viewModel)
+      bottomBar
+    }
+    .padding(14)
+  }
+
+  private var instructionsEditor: some View {
+    VStack(alignment: .leading, spacing: 4) {
+      Text("Instructions (included in the context block)")
+        .font(.secondaryCaption)
+        .foregroundColor(.secondary)
+      TextEditor(text: Bindable(viewModel).instructions)
+        .font(.system(size: 12))
+        .scrollContentBackground(.hidden)
+        .padding(4)
+        .frame(minHeight: 44, maxHeight: 80)
+        .background(
+          RoundedRectangle(cornerRadius: DesignTokens.Radius.sm)
+            .fill(Color(NSColor.controlBackgroundColor))
+        )
+        .overlay(
+          RoundedRectangle(cornerRadius: DesignTokens.Radius.sm)
+            .stroke(Color.borderSubtle, lineWidth: 1)
+        )
+    }
+  }
+
+  // MARK: - Bottom bar (save actions)
+
+  private var bottomBar: some View {
+    HStack(spacing: 10) {
+      if showsDeleteButton {
+        deleteButton
+      }
+      if let saveErrorMessage {
+        Text(saveErrorMessage)
+          .font(.secondaryCaption)
+          .foregroundColor(.red)
+          .lineLimit(1)
+      }
+      Spacer()
+      saveAction
+    }
+  }
+
+  private var showsDeleteButton: Bool {
+    guard case .editProfile = mode else { return false }
+    return onDeleted != nil && viewModel.sourceProfile != nil
+  }
+
+  private var deleteButton: some View {
+    Button {
+      showingDeleteConfirmation = true
+    } label: {
+      Label("Delete Context Set", systemImage: "trash")
+        .foregroundColor(.primary)
+    }
+    .buttonStyle(.bordered)
+    .alert(
+      "Delete “\(viewModel.sourceProfile?.name ?? "")”?",
+      isPresented: $showingDeleteConfirmation
+    ) {
+      Button("Delete", role: .destructive) {
+        Task {
+          guard let profile = viewModel.sourceProfile else { return }
+          await viewModel.deleteProfile(profile)
+          onDeleted?()
+          onDismiss()
+        }
+      }
+      Button("Cancel", role: .cancel) {}
+    } message: {
+      Text("The context set is removed everywhere it is offered at session launch. Files on disk are not touched.")
+    }
+  }
+
+  @ViewBuilder
+  private var saveAction: some View {
+    switch mode {
+    case .launch:
+      if viewModel.profileServiceAvailable {
+        if viewModel.sourceProfile != nil {
+          saveChangesButton(isPrimary: false, onSaved: { _ in })
+        } else {
+          saveAsNewButton(isPrimary: false)
+        }
+      }
+    case .editProfile(let onSave):
+      saveChangesButton(isPrimary: true) { saved in
+        onSave(saved)
+        onDismiss()
+      }
+    case .createProfile:
+      saveAsNewButton(isPrimary: true)
+    }
+  }
+
+  private func saveChangesButton(
+    isPrimary: Bool,
+    onSaved: @escaping (ContextProfile) -> Void
+  ) -> some View {
+    let button = Button("Save Changes") {
+      Task {
+        do {
+          if let saved = try await viewModel.saveEditedProfile() {
+            saveErrorMessage = nil
+            onSaved(saved)
+          }
+        } catch {
+          saveErrorMessage = "Could not save context set."
+        }
+      }
+    }
+    .disabled(!viewModel.hasSelection || !viewModel.hasUnsavedChanges)
+
+    // A tinted `.bordered` button renders a muddy translucent pill when
+    // disabled — the primary style must be `.borderedProminent`, which grays
+    // out properly.
+    return Group {
+      if isPrimary {
+        button
+          .buttonStyle(.borderedProminent)
+          .tint(Color.brandPrimary(from: runtimeTheme))
+      } else {
+        button
+          .buttonStyle(.bordered)
+      }
+    }
+  }
+
+  private func saveAsNewButton(isPrimary: Bool) -> some View {
+    let button = Button("Save as Context Set…") {
+      showingSaveAsPopover = true
+    }
+    .disabled(!viewModel.hasSelection)
+
+    return Group {
+      if isPrimary {
+        button
+          .buttonStyle(.borderedProminent)
+          .tint(Color.brandPrimary(from: runtimeTheme))
+      } else {
+        button
+          .buttonStyle(.bordered)
+      }
+    }
+    .popover(isPresented: $showingSaveAsPopover, arrowEdge: .top) {
+      ContextProfileSaveForm { name, scope in
+        Task {
+          do {
+            if let saved = try await viewModel.saveAsProfile(name: name, scope: scope) {
+              saveErrorMessage = nil
+              showingSaveAsPopover = false
+              if case .createProfile(let onSave) = mode {
+                onSave(saved)
+                onDismiss()
+              }
+            }
+          } catch {
+            saveErrorMessage = "Could not save context set."
+          }
+        }
+      }
+    }
+  }
+}
+
+// MARK: - Context sets rail
+
+/// Leading rail in launch mode: saved context sets, tap to load and edit.
+private struct ContextSetsSidePanel: View {
+  let viewModel: ContextBuilderViewModel
+  @Environment(\.runtimeTheme) private var runtimeTheme
+  @State private var hoveredProfileID: String?
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      Text("CONTEXT SETS")
+        .font(.geist(size: 10, weight: .semibold))
+        .foregroundColor(.secondary)
+        .kerning(0.6)
+
+      Button {
+        viewModel.startNewDraft()
+      } label: {
+        Label("New Context Set", systemImage: "plus")
+          .font(.secondaryCaption)
+          .frame(maxWidth: .infinity)
+      }
+      .buttonStyle(.bordered)
+
+      Divider()
+
+      if viewModel.availableProfiles.isEmpty {
+        Text("Saved sets appear here.")
+          .font(.secondaryCaption)
+          .foregroundColor(.secondary.opacity(0.7))
+          .padding(.top, 4)
+      } else {
+        ScrollView {
+          LazyVStack(alignment: .leading, spacing: 2) {
+            ForEach(viewModel.availableProfiles) { profile in
+              setRow(profile)
+            }
+          }
+        }
+      }
+      Spacer(minLength: 0)
+    }
+    .padding(12)
+  }
+
+  private func setRow(_ profile: ContextProfile) -> some View {
+    let isSelected = viewModel.sourceProfile?.id == profile.id
+    let isHovered = hoveredProfileID == profile.id
+    return HStack(spacing: 6) {
+      Image(systemName: profile.isDefault ? "star.fill" : "square.stack.3d.up")
+        .font(.system(size: 10))
+        .foregroundColor(isSelected ? Color.brandPrimary(from: runtimeTheme) : .secondary)
+      VStack(alignment: .leading, spacing: 1) {
+        Text(profile.name)
+          .font(.system(size: 12))
+          .foregroundColor(.primary)
+          .lineLimit(1)
+        if profile.scope == .personal {
+          Text("Global")
+            .font(.secondaryCaption)
+            .foregroundColor(.secondary)
+        }
+      }
+      Spacer(minLength: 0)
+    }
+    .padding(.horizontal, 6)
+    .padding(.vertical, 4)
+    .background(
+      RoundedRectangle(cornerRadius: DesignTokens.Radius.sm)
+        .fill(
+          isSelected
+            ? Color.brandPrimary(from: runtimeTheme).opacity(0.14)
+            : (isHovered ? Color.primary.opacity(0.06) : Color.clear)
+        )
+    )
+    .contentShape(Rectangle())
+    .onTapGesture {
+      Task { await viewModel.applyProfile(profile) }
+    }
+    .onHover { hovering in
+      hoveredProfileID = hovering ? profile.id : (hoveredProfileID == profile.id ? nil : hoveredProfileID)
+    }
+  }
+}
+
+// MARK: - Save Form
+
+private struct ContextProfileSaveForm: View {
+  @State private var name: String = ""
+  @State private var scope: ContextProfileScope = .project
+  @Environment(\.runtimeTheme) private var runtimeTheme
+  let onSave: (String, ContextProfileScope) -> Void
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 10) {
+      Text("Save as Context Set")
+        .font(.primaryDefault)
+        .fontWeight(.semibold)
+      TextField("Context set name", text: $name)
+        .textFieldStyle(.roundedBorder)
+      Picker("Scope", selection: $scope) {
+        Text("This project").tag(ContextProfileScope.project)
+        Text("Global (all projects)").tag(ContextProfileScope.personal)
+      }
+      .pickerStyle(.radioGroup)
+      HStack {
+        Spacer()
+        Button("Save") {
+          onSave(name, scope)
+        }
+        .keyboardShortcut(.defaultAction)
+        .buttonStyle(.borderedProminent)
+        .tint(Color.brandPrimary(from: runtimeTheme))
+        .disabled(name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+      }
+    }
+    .padding(14)
+    .frame(width: 260)
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/ContextLaunchSection.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/ContextLaunchSection.swift
@@ -1,0 +1,155 @@
+//
+//  ContextLaunchSection.swift
+//  AgentHub
+//
+//  Launcher row for curated context: shows the attached profile (or ad-hoc
+//  curation) as a removable chip with an approximate token cost, and opens the
+//  Context Builder. Rendered in both compact and full launcher styles.
+//
+
+import SwiftUI
+
+struct ContextLaunchSection: View {
+  @Bindable var viewModel: MultiSessionLaunchViewModel
+  @State private var showingContextBuilder = false
+  @Environment(\.agentHub) private var agentHub
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 6) {
+      headerRow
+      if viewModel.activeContextSelection != nil {
+        chipRow
+          .transition(.scale(scale: 0.92).combined(with: .opacity))
+      }
+      if !viewModel.contextMissingPaths.isEmpty {
+        missingWarning
+          .transition(.opacity)
+      }
+    }
+    .animation(.easeInOut(duration: 0.2), value: viewModel.attachedContextProfile)
+    .animation(.easeInOut(duration: 0.2), value: viewModel.pendingContextSelection)
+    .animation(.easeInOut(duration: 0.2), value: viewModel.contextMissingPaths)
+    .task(id: viewModel.selectedRepository?.path) {
+      await viewModel.loadDefaultContextProfile()
+      await viewModel.refreshContextSummary()
+    }
+    .sheet(isPresented: $showingContextBuilder) {
+      contextBuilderSheet
+    }
+  }
+
+  // MARK: - Rows
+
+  private var headerRow: some View {
+    HStack(spacing: 8) {
+      Text("Context")
+        .font(.secondaryCaption)
+        .foregroundColor(.secondary)
+      Spacer()
+      Button {
+        showingContextBuilder = true
+      } label: {
+        Label(
+          viewModel.activeContextSelection == nil ? "Add Context…" : "Edit…",
+          systemImage: "square.stack.3d.up"
+        )
+        .font(.secondaryCaption)
+      }
+      .buttonStyle(.plain)
+      .foregroundColor(.secondary)
+      .help("Choose exactly which files the agent starts with — pick from saved context sets or curate ad hoc — and preview the assembled block")
+    }
+  }
+
+  private var chipRow: some View {
+    HStack(spacing: 6) {
+      HStack(spacing: 4) {
+        Image(systemName: "square.stack.3d.up")
+          .font(.system(size: 9))
+        Text(chipTitle)
+          .font(.secondaryCaption)
+          .lineLimit(1)
+        if viewModel.attachedContextProfile?.isDefault == true && viewModel.pendingContextSelection == nil {
+          Text("default")
+            .font(.system(size: 8, weight: .semibold))
+            .padding(.horizontal, 4)
+            .padding(.vertical, 1)
+            .background(Capsule().fill(Color.brandPrimary.opacity(0.15)))
+            .foregroundColor(.brandPrimary)
+        }
+        if let tokens = viewModel.contextSummaryTokens {
+          Text("~\(SessionMonitorState.formatTokenCount(tokens)) tokens")
+            .font(.secondaryCaption)
+            .foregroundColor(.secondary)
+            .help("Approximate — estimated from file size (bytes ÷ 4 with a safety margin), not a real tokenizer.")
+        }
+        Button(action: { viewModel.removeAttachedContextProfile() }) {
+          Image(systemName: "xmark")
+            .font(.system(size: 8, weight: .bold))
+            .foregroundColor(.secondary)
+        }
+        .buttonStyle(.plain)
+        .help("Launch without curated context")
+      }
+      .padding(.horizontal, 8)
+      .padding(.vertical, 4)
+      .background(Capsule().fill(Color.primary.opacity(0.08)))
+      .overlay(Capsule().stroke(Color.borderSubtle, lineWidth: 1))
+      Spacer(minLength: 0)
+    }
+  }
+
+  private var chipTitle: String {
+    if let selection = viewModel.pendingContextSelection {
+      let count = selection.files.count + selection.externalPaths.count + selection.textSnippets.count
+      return "Ad-hoc context (\(count) item\(count == 1 ? "" : "s"))"
+    }
+    if let profile = viewModel.attachedContextProfile {
+      let selection = profile.selection
+      let count = selection.files.count + selection.externalPaths.count + selection.textSnippets.count
+      return "\(profile.name) (\(count) items)"
+    }
+    return ""
+  }
+
+  private var missingWarning: some View {
+    Label(
+      "\(viewModel.contextMissingPaths.count) selected file\(viewModel.contextMissingPaths.count == 1 ? " could" : "s could") not be found and will be skipped",
+      systemImage: "exclamationmark.triangle"
+    )
+    .font(.secondaryCaption)
+    .foregroundColor(.orange)
+  }
+
+  // MARK: - Builder Sheet
+
+  /// The configured default model for the selected provider, so the builder's
+  /// window percentage reflects that model's real context window.
+  private var configuredModelIdentifier: String? {
+    let provider = viewModel.isCodexSelected && !viewModel.isClaudeSelected ? "codex" : "claude"
+    let model = agentHub?.metadataStore?.getAIConfigSync(for: provider)?.defaultModel
+    return (model?.isEmpty == false) ? model : nil
+  }
+
+  @ViewBuilder
+  private var contextBuilderSheet: some View {
+    if let repo = viewModel.selectedRepository {
+      ContextBuilderView(
+        viewModel: ContextBuilderViewModel(
+          projectPath: repo.path,
+          initialSelection: viewModel.activeContextSelection,
+          sourceProfile: viewModel.pendingContextSelection == nil ? viewModel.attachedContextProfile : nil,
+          modelIdentifier: configuredModelIdentifier,
+          fileLoader: viewModel.contextFileLoader,
+          estimator: viewModel.contextTokenEstimator,
+          profileService: viewModel.contextProfileService
+        ),
+        mode: .launch { selection in
+          viewModel.applyCuratedContext(selection)
+          Task { await viewModel.refreshContextSummary() }
+        },
+        onDismiss: { showingContextBuilder = false }
+      )
+    }
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/EmbeddedTerminalView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/EmbeddedTerminalView.swift
@@ -433,10 +433,16 @@ public class TerminalContainerView: NSView, ManagedLocalProcessTerminalViewDeleg
       return
     }
 
-    // Normal prompt: send text then Enter
-    terminal.send(txt: prompt)
+    // Normal prompt: bracketed paste (a bare multi-line block would submit on
+    // its first newline), then Enter after a size-scaled delay so the CLI has
+    // processed the payload before the submit arrives.
+    terminal.send(TerminalPromptSubmissionPayload.textBytes(
+      prompt: prompt,
+      bracketedPasteMode: terminal.terminal?.bracketedPasteMode ?? false
+    ))
+    let delay = Self.submitDelay(forByteCount: prompt.utf8.count)
     Task { @MainActor [weak terminal] in
-      try? await Task.sleep(for: .milliseconds(100))
+      try? await Task.sleep(for: delay)
       terminal?.send([13])  // ASCII 13 = carriage return (Enter key)
     }
   }
@@ -461,11 +467,12 @@ public class TerminalContainerView: NSView, ManagedLocalProcessTerminalViewDeleg
 
   /// Scales the delay between pasting text and pressing Enter so the CLI
   /// has time to process larger payloads before receiving the submit signal.
-  private static func submitDelay(forByteCount count: Int) -> Duration {
+  static func submitDelay(forByteCount count: Int) -> Duration {
     switch count {
-    case ..<500:   return .milliseconds(100)
-    case ..<2000:  return .milliseconds(250)
-    default:       return .milliseconds(500)
+    case ..<500:    return .milliseconds(100)
+    case ..<2000:   return .milliseconds(250)
+    case ..<16_384: return .milliseconds(500)
+    default:        return .seconds(1)
     }
   }
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
@@ -436,6 +436,7 @@ public struct MultiProviderSessionsListView: View {
         displayName: item.displayName,
         claudeViewModel: claudeViewModel,
         codexViewModel: codexViewModel,
+        contextProfileService: agentHub?.contextProfileService,
         onDismiss: { projectDetailsSheetItem = nil },
         onSelectSession: { sessionItem in
           projectDetailsSheetItem = nil
@@ -2337,7 +2338,8 @@ public struct MultiProviderSessionsListView: View {
       codexViewModel: codexViewModel,
       intelligenceViewModel: intelligenceViewModel,
       worktreeBranchNamingService: worktreeBranchNamingService,
-      worktreeSuccessSoundService: worktreeSuccessSoundService
+      worktreeSuccessSoundService: worktreeSuccessSoundService,
+      contextProfileService: agentHub?.contextProfileService
     )
   }
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiSessionLaunchView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiSessionLaunchView.swift
@@ -77,6 +77,10 @@ public struct MultiSessionLaunchView: View {
           }
         }
 
+        if viewModel.launchMode == .manual && viewModel.selectedRepository != nil {
+          ContextLaunchSection(viewModel: viewModel)
+        }
+
         if viewModel.launchMode == .manual {
           if style == .compact {
             // Compact order: providers first, then work mode.

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/ProjectContextTabView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/ProjectContextTabView.swift
@@ -1,0 +1,285 @@
+//
+//  ProjectContextTabView.swift
+//  AgentHub
+//
+//  The Project Details Context tab: saved context profiles as cards (with
+//  scope chips and token badges), plus the panel's first editing surface —
+//  create, edit, delete, and set-default — via the shared Context Builder.
+//
+
+import SwiftUI
+
+// MARK: - Editor state
+
+enum ProjectContextEditorState: Identifiable {
+  case create
+  case edit(ContextProfile)
+
+  var id: String {
+    switch self {
+    case .create: return "create"
+    case .edit(let profile): return profile.id
+    }
+  }
+}
+
+// MARK: - Tab (grid)
+
+struct ProjectContextTabView: View {
+  let viewModel: ProjectContextViewModel
+  @Binding var scopeFilter: ProjectDetailsScopeFilter
+  let onEdit: (ContextProfile) -> Void
+  let onNew: () -> Void
+  @Environment(\.runtimeTheme) private var runtimeTheme
+
+  private let columns = [
+    GridItem(.flexible(), spacing: 12),
+    GridItem(.flexible(), spacing: 12)
+  ]
+
+  var body: some View {
+    if !viewModel.isAvailable {
+      ProjectDetailsEmptyState(
+        systemImage: "square.stack.3d.up",
+        title: "Context sets unavailable",
+        message: "The app database could not be opened, so saved context sets are disabled."
+      )
+    } else if viewModel.isLoading, viewModel.profiles.isEmpty {
+      ProjectDetailsLoadingState()
+    } else if viewModel.profiles.isEmpty {
+      emptyState
+    } else {
+      grid
+    }
+  }
+
+  /// Inline layout instead of `ProjectDetailsEmptyState` so the button sits
+  /// centered with the message rather than pinned below its greedy frame.
+  private var emptyState: some View {
+    VStack(spacing: 12) {
+      Image(systemName: "square.stack.3d.up")
+        .font(.system(size: 26, weight: .regular))
+        .foregroundStyle(.secondary.opacity(0.6))
+      Text("No context sets yet")
+        .font(.secondaryDefault)
+        .foregroundStyle(.primary)
+      Text("A context set is a saved bundle of files and instructions handed to every agent you launch with it. Create one here or save one from the launcher.")
+        .font(.secondarySmall)
+        .foregroundStyle(.secondary)
+        .multilineTextAlignment(.center)
+        .frame(maxWidth: 380)
+      Button(action: onNew) {
+        Label("New Context Set", systemImage: "plus")
+      }
+      .buttonStyle(.borderedProminent)
+      .tint(Color.brandPrimary(from: runtimeTheme))
+      .padding(.top, 6)
+    }
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+  }
+
+  private var grid: some View {
+    VStack(alignment: .leading, spacing: 0) {
+      HStack(spacing: 8) {
+        ProjectDetailsScopeFilterChips(
+          filter: $scopeFilter,
+          totalCount: viewModel.profiles.count,
+          personalCount: viewModel.profiles.filter { $0.scope == .personal }.count,
+          projectCount: viewModel.profiles.filter { $0.scope == .project }.count,
+          personalLabel: "Global"
+        )
+        Button(action: onNew) {
+          Label("New Context Set", systemImage: "plus")
+            .font(.secondaryCaption)
+        }
+        .buttonStyle(.plain)
+        .foregroundColor(.secondary)
+      }
+      .padding(.horizontal, 20)
+      .padding(.top, 14)
+
+      if let error = viewModel.lastActionError {
+        Text(error)
+          .font(.secondaryCaption)
+          .foregroundColor(.red)
+          .padding(.horizontal, 20)
+          .padding(.top, 8)
+      }
+
+      ScrollView {
+        LazyVGrid(columns: columns, alignment: .leading, spacing: 12) {
+          ForEach(filteredProfiles) { profile in
+            ProjectContextProfileCard(
+              profile: profile,
+              estimatedTokens: viewModel.estimatedTokensByProfileId[profile.id],
+              onOpen: { onEdit(profile) },
+              onSetDefault: { Task { await viewModel.setDefault(profile) } },
+              onClearDefault: { Task { await viewModel.setDefault(nil) } }
+            )
+          }
+        }
+        .padding(20)
+      }
+    }
+  }
+
+  private var filteredProfiles: [ContextProfile] {
+    viewModel.profiles.filter { scopeFilter.allows($0.scope == .personal ? .personal : .project) }
+  }
+}
+
+// MARK: - Profile card
+
+private struct ProjectContextProfileCard: View {
+  let profile: ContextProfile
+  let estimatedTokens: Int?
+  let onOpen: () -> Void
+  let onSetDefault: () -> Void
+  let onClearDefault: () -> Void
+
+  @State private var isHovered = false
+  @Environment(\.runtimeTheme) private var runtimeTheme
+
+  var body: some View {
+    Button(action: onOpen) {
+      HStack(alignment: .top, spacing: 10) {
+        ProjectAssetCardIcon(systemImage: "square.stack.3d.up")
+
+        VStack(alignment: .leading, spacing: 6) {
+          HStack(spacing: 6) {
+            Text(profile.name)
+              .font(.primaryDefault)
+              .foregroundStyle(.primary)
+              .lineLimit(1)
+            if profile.isDefault {
+              Text("Default")
+                .font(.system(size: 9, weight: .semibold))
+                .padding(.horizontal, 5)
+                .padding(.vertical, 1.5)
+                .background(Capsule().fill(Color.brandPrimary(from: runtimeTheme).opacity(0.16)))
+                .foregroundStyle(Color.brandPrimary(from: runtimeTheme))
+            }
+          }
+
+          if !profile.selection.instructions.isEmpty {
+            Text(profile.selection.instructions)
+              .font(.secondarySmall)
+              .foregroundStyle(.secondary)
+              .lineLimit(2)
+              .fixedSize(horizontal: false, vertical: true)
+          }
+
+          HStack(spacing: 6) {
+            ProjectAssetBadge(text: profile.scope == .personal ? "Global" : "Project")
+            ProjectAssetBadge(
+              text: {
+                let selection = profile.selection
+                let count = selection.files.count + selection.externalPaths.count + selection.textSnippets.count
+                return "\(count) item\(count == 1 ? "" : "s")"
+              }()
+            )
+            if let estimatedTokens {
+              ProjectAssetBadge(text: "~\(SessionMonitorState.formatTokenCount(estimatedTokens)) tokens")
+            }
+          }
+        }
+
+        Spacer(minLength: 0)
+
+        Image(systemName: "chevron.right")
+          .font(.system(size: 10, weight: .semibold))
+          .foregroundStyle(.secondary.opacity(isHovered ? 0.9 : 0.4))
+          .padding(.top, 4)
+      }
+      .padding(12)
+      .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+      .projectDetailsCardBackground(highlighted: isHovered)
+      .contentShape(Rectangle())
+    }
+    .buttonStyle(.plain)
+    .onHover { hovering in
+      withAnimation(.easeInOut(duration: 0.12)) {
+        isHovered = hovering
+      }
+    }
+    // Deletion is deliberately absent here: it lives as the explicit
+    // confirmed action inside the editor, never behind a right-click.
+    .contextMenu {
+      if profile.scope == .project {
+        if profile.isDefault {
+          Button("Clear Default", action: onClearDefault)
+        } else {
+          Button("Set as Default", action: onSetDefault)
+        }
+      }
+      Button("Edit", action: onOpen)
+    }
+  }
+}
+
+// MARK: - Editor page (create / edit)
+
+struct ProjectContextEditorView: View {
+  let state: ProjectContextEditorState
+  let viewModel: ProjectContextViewModel
+  let onBack: () -> Void
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 0) {
+      backBar
+      Divider()
+      ContextBuilderView(
+        viewModel: builderViewModel,
+        mode: builderMode,
+        onDeleted: { Task { await viewModel.load() } },
+        onDismiss: onBack
+      )
+      // Re-key the builder when the target changes, otherwise @State keeps the
+      // previous profile's view model.
+      .id(state.id)
+    }
+  }
+
+  private var backBar: some View {
+    HStack(spacing: 8) {
+      Button(action: onBack) {
+        Label("Context Sets", systemImage: "chevron.left")
+          .font(.secondaryDefault)
+      }
+      .buttonStyle(.plain)
+      .foregroundColor(.secondary)
+      .keyboardShortcut(.leftArrow, modifiers: [.command])
+      Spacer()
+    }
+    .padding(.horizontal, 20)
+    .padding(.vertical, 10)
+  }
+
+  private var builderViewModel: ContextBuilderViewModel {
+    switch state {
+    case .create:
+      return ContextBuilderViewModel(
+        projectPath: viewModel.projectPath,
+        fileLoader: viewModel.contextFileLoader,
+        profileService: viewModel.profileService
+      )
+    case .edit(let profile):
+      return ContextBuilderViewModel(
+        projectPath: viewModel.projectPath,
+        initialSelection: profile.selection,
+        sourceProfile: profile,
+        fileLoader: viewModel.contextFileLoader,
+        profileService: viewModel.profileService
+      )
+    }
+  }
+
+  private var builderMode: ContextBuilderMode {
+    switch state {
+    case .create:
+      return .createProfile { _ in Task { await viewModel.load() } }
+    case .edit:
+      return .editProfile { _ in Task { await viewModel.load() } }
+    }
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/ProjectDetailsSheetView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/ProjectDetailsSheetView.swift
@@ -29,6 +29,7 @@ struct ProjectDetailsSessionItem: Identifiable {
 
 private enum ProjectDetailsTab: String, CaseIterable, Identifiable {
   case sessions = "Sessions"
+  case context = "Context"
   case skills = "Skills"
   case rules = "Rules"
   case mcps = "MCPs"
@@ -38,7 +39,7 @@ private enum ProjectDetailsTab: String, CaseIterable, Identifiable {
 
 // MARK: - ProjectDetailsScopeFilter
 
-private enum ProjectDetailsScopeFilter: Hashable {
+enum ProjectDetailsScopeFilter: Hashable {
   case all
   case scope(ProjectAssetScope)
 
@@ -61,10 +62,13 @@ struct ProjectDetailsSheetView: View {
   let onSelectSession: (ProjectDetailsSessionItem) -> Void
 
   @State private var viewModel: ProjectDetailsViewModel
+  @State private var contextViewModel: ProjectContextViewModel
   @State private var selectedTab: ProjectDetailsTab = .sessions
   @State private var skillScopeFilter: ProjectDetailsScopeFilter = .all
+  @State private var contextScopeFilter: ProjectDetailsScopeFilter = .all
   @State private var selectedSkill: ProjectAgentSkill?
   @State private var selectedRule: ProjectAgentRule?
+  @State private var contextEditorState: ProjectContextEditorState?
   @Environment(\.colorScheme) private var colorScheme
 
   init(
@@ -73,6 +77,7 @@ struct ProjectDetailsSheetView: View {
     claudeViewModel: CLISessionsViewModel,
     codexViewModel: CLISessionsViewModel,
     inventoryService: any ProjectDetailsInventoryServiceProtocol = ProjectDetailsInventoryService.shared,
+    contextProfileService: (any ContextProfileServiceProtocol)? = nil,
     onDismiss: @escaping () -> Void,
     onSelectSession: @escaping (ProjectDetailsSessionItem) -> Void
   ) {
@@ -91,6 +96,10 @@ struct ProjectDetailsSheetView: View {
     _viewModel = State(initialValue: ProjectDetailsViewModel(
       projectPath: rootPath,
       service: inventoryService
+    ))
+    _contextViewModel = State(initialValue: ProjectContextViewModel(
+      projectPath: rootPath,
+      service: contextProfileService
     ))
   }
 
@@ -116,6 +125,7 @@ struct ProjectDetailsSheetView: View {
     .onChange(of: selectedTab) { _, _ in
       selectedSkill = nil
       selectedRule = nil
+      contextEditorState = nil
     }
     .background(Color.surfacePanel)
     .frame(
@@ -127,7 +137,10 @@ struct ProjectDetailsSheetView: View {
       maxHeight: .infinity
     )
     .onExitCommand { onDismiss() }
-    .task { await viewModel.load() }
+    .task {
+      await viewModel.load()
+      await contextViewModel.load()
+    }
   }
 
   // MARK: Header
@@ -179,6 +192,32 @@ struct ProjectDetailsSheetView: View {
     switch selectedTab {
     case .sessions:
       ProjectDetailsSessionsGrid(items: sessionItems, onSelect: onSelectSession)
+    case .context:
+      ZStack {
+        if let contextEditorState {
+          ProjectContextEditorView(
+            state: contextEditorState,
+            viewModel: contextViewModel,
+            onBack: { self.contextEditorState = nil }
+          )
+          .transition(.asymmetric(
+            insertion: .move(edge: .trailing).combined(with: .opacity),
+            removal: .move(edge: .trailing).combined(with: .opacity)
+          ))
+        } else {
+          ProjectContextTabView(
+            viewModel: contextViewModel,
+            scopeFilter: $contextScopeFilter,
+            onEdit: { contextEditorState = .edit($0) },
+            onNew: { contextEditorState = .create }
+          )
+          .transition(.asymmetric(
+            insertion: .move(edge: .leading).combined(with: .opacity),
+            removal: .move(edge: .leading).combined(with: .opacity)
+          ))
+        }
+      }
+      .animation(.spring(response: 0.32, dampingFraction: 0.86), value: contextEditorState?.id)
     case .skills:
       if let selectedSkill {
         ProjectSkillDetailView(skill: selectedSkill) {
@@ -215,6 +254,7 @@ struct ProjectDetailsSheetView: View {
   private func tabCount(_ tab: ProjectDetailsTab) -> Int {
     switch tab {
     case .sessions: return sessionItems.count
+    case .context: return contextViewModel.profiles.count
     case .skills: return viewModel.inventory.skills.count
     case .rules: return viewModel.inventory.rules.count
     case .mcps: return viewModel.inventory.mcpServers.count
@@ -569,18 +609,20 @@ private struct ProjectDetailsSkillsGrid: View {
 
 // MARK: - ProjectDetailsScopeFilterChips
 
-private struct ProjectDetailsScopeFilterChips: View {
+struct ProjectDetailsScopeFilterChips: View {
   @Binding var filter: ProjectDetailsScopeFilter
   let totalCount: Int
   let personalCount: Int
   let projectCount: Int
+  /// Display label for the personal scope ("Global" on the Context tab).
+  var personalLabel: String = "Personal"
 
   @Environment(\.runtimeTheme) private var runtimeTheme
 
   var body: some View {
     HStack(spacing: 8) {
       chip("All", count: totalCount, value: .all)
-      chip("Personal", count: personalCount, value: .scope(.personal))
+      chip(personalLabel, count: personalCount, value: .scope(.personal))
       chip("Project", count: projectCount, value: .scope(.project))
       Spacer(minLength: 0)
     }
@@ -910,7 +952,7 @@ struct ProjectAssetCardIcon: View {
 
 // MARK: - Empty & loading states
 
-private struct ProjectDetailsEmptyState: View {
+struct ProjectDetailsEmptyState: View {
   let systemImage: String
   let title: String
   let message: String
@@ -933,7 +975,7 @@ private struct ProjectDetailsEmptyState: View {
   }
 }
 
-private struct ProjectDetailsLoadingState: View {
+struct ProjectDetailsLoadingState: View {
   var body: some View {
     VStack(spacing: 10) {
       ProgressView()
@@ -948,7 +990,7 @@ private struct ProjectDetailsLoadingState: View {
 
 // MARK: - Card background
 
-private struct ProjectDetailsCardBackground: ViewModifier {
+struct ProjectDetailsCardBackground: ViewModifier {
   var highlighted = false
 
   @Environment(\.colorScheme) private var colorScheme
@@ -968,7 +1010,7 @@ private struct ProjectDetailsCardBackground: ViewModifier {
   }
 }
 
-private extension View {
+extension View {
   func projectDetailsCardBackground(highlighted: Bool = false) -> some View {
     modifier(ProjectDetailsCardBackground(highlighted: highlighted))
   }

--- a/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/CLISessionsViewModel.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/CLISessionsViewModel.swift
@@ -3548,18 +3548,23 @@ public final class CLISessionsViewModel {
   /// Starts a new Claude session in the Hub's embedded terminal (not external terminal)
   /// - Parameters:
   ///   - worktree: The worktree to start the session in
+  ///   - contextBlock: Already-materialized curated context (inline block or
+  ///     temp-file reference prompt) prepended to the first message. Nil keeps
+  ///     the launch identical to a launch without the context feature.
   ///   - dangerouslySkipPermissions: If true, adds --dangerously-skip-permissions flag
   public func startNewSessionInHub(
     _ worktree: WorktreeBranch,
     launchPath: String? = nil,
     initialPrompt: String? = nil,
     initialInputText: String? = nil,
+    contextBlock: String? = nil,
     dangerouslySkipPermissions: Bool = false,
     permissionModePlan: Bool = false,
     worktreeName: String? = nil
   ) {
-    let promptForTerminalSubmission = providerKind == .claude ? nonEmpty(initialPrompt) : nil
-    let promptForProcessLaunch = providerKind == .claude ? nil : initialPrompt
+    let mergedPrompt = Self.mergedLaunchPrompt(contextBlock: contextBlock, initialPrompt: initialPrompt)
+    let promptForTerminalSubmission = providerKind == .claude ? nonEmpty(mergedPrompt) : nil
+    let promptForProcessLaunch = providerKind == .claude ? nil : mergedPrompt
 
     // Each pending session gets a unique ID, so no need to clear existing terminals
     // Terminals are now keyed by session ID, not worktree path
@@ -3589,6 +3594,20 @@ public final class CLISessionsViewModel {
     Task { @MainActor in
       await watchForNewSession(pending: pending, worktree: worktree)
     }
+  }
+
+  /// Merges curated context with the user's first prompt — one rule for both
+  /// providers. Nil/empty context returns the prompt untouched, so a launch
+  /// without curated context is byte-for-byte today's behavior.
+  static func mergedLaunchPrompt(contextBlock: String?, initialPrompt: String?) -> String? {
+    guard let context = contextBlock?.trimmingCharacters(in: .whitespacesAndNewlines), !context.isEmpty else {
+      return initialPrompt
+    }
+    guard let prompt = initialPrompt, !prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+      return context
+        + "\n\nThis is background context for the tasks I'm about to give you. Load it and acknowledge in one line."
+    }
+    return context + "\n\n" + prompt
   }
 
   /// Removes a pending Hub session (e.g., if user cancels)

--- a/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/ContextBuilderViewModel.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/ContextBuilderViewModel.swift
@@ -1,0 +1,386 @@
+//
+//  ContextBuilderViewModel.swift
+//  AgentHub
+//
+//  Drives the Context Builder: file selection, per-file/total token estimates,
+//  the exact assembled-block preview, and profile apply/save.
+//
+
+import Foundation
+import Observation
+
+public struct ContextSelectedFileRow: Identifiable, Equatable, Sendable {
+  public var id: String { relativePath }
+  /// Project-relative path for repo files; absolute path for external items.
+  public let relativePath: String
+  public let byteCount: Int?
+  public let estimatedTokens: Int?
+  /// True when the path did not resolve (stale profile entry, deleted file).
+  /// Kept in the selection so saving preserves intent.
+  public let isMissing: Bool
+  /// True for files outside the project repository (absolute paths).
+  public let isExternal: Bool
+  /// True when the file exists but will be referenced by path instead of
+  /// inlined (binary formats like PDFs, or oversized files).
+  public let isAttachment: Bool
+
+  public init(
+    relativePath: String,
+    byteCount: Int?,
+    estimatedTokens: Int?,
+    isMissing: Bool,
+    isExternal: Bool = false,
+    isAttachment: Bool = false
+  ) {
+    self.relativePath = relativePath
+    self.byteCount = byteCount
+    self.estimatedTokens = estimatedTokens
+    self.isMissing = isMissing
+    self.isExternal = isExternal
+    self.isAttachment = isAttachment
+  }
+}
+
+@MainActor
+@Observable
+public final class ContextBuilderViewModel {
+
+  // MARK: - Dependencies
+
+  private let fileLoader: any ContextFileLoading
+  private let assembler: any ContextAssembling
+  private let estimator: any ContextTokenEstimating
+  private let payloadThreshold: Int
+  private let profileService: (any ContextProfileServiceProtocol)?
+  private let fileIndexService: FileIndexService
+
+  // MARK: - State
+
+  public let projectPath: String
+  /// The model the launch is expected to use (configured provider default),
+  /// so the window percentage reflects that model's real context window.
+  public let modelIdentifier: String?
+  public private(set) var contextWindowTokens: Int
+  public var searchQuery: String = ""
+  public var searchResults: [FileSearchResult] = []
+  public var isSearching: Bool = false
+  public var selectedRows: [ContextSelectedFileRow] = []
+  /// Pasted text stored directly in the set being edited.
+  public var textSnippets: [ContextTextSnippet] = []
+  public var instructions: String = ""
+  public var assembledPreview: String = ""
+  /// Full size of the assembled block when the preview display was truncated.
+  public var previewTruncatedByteCount: Int?
+  public var availableProfiles: [ContextProfile] = []
+
+  /// Rendering megabytes into one SwiftUI `Text` freezes the main thread in
+  /// CoreText layout — the preview shows at most this many characters. The
+  /// launch path always assembles the full block; only the display is capped.
+  public static let previewDisplayCharacterLimit = 20_000
+  /// Set when the current state came from / was saved as a profile.
+  public var sourceProfile: ContextProfile?
+
+  public init(
+    projectPath: String,
+    initialSelection: ContextSelection? = nil,
+    sourceProfile: ContextProfile? = nil,
+    modelIdentifier: String? = nil,
+    fileLoader: any ContextFileLoading = ContextFileLoader(),
+    assembler: any ContextAssembling = ContextAssembler(),
+    estimator: any ContextTokenEstimating = ContextTokenEstimator(),
+    payloadThreshold: Int = ContextPayloadStore.inlineByteThreshold,
+    profileService: (any ContextProfileServiceProtocol)? = nil,
+    fileIndexService: FileIndexService = .shared
+  ) {
+    self.projectPath = projectPath
+    self.modelIdentifier = modelIdentifier
+    self.contextWindowTokens = ModelContextWindowResolver.window(forModelIdentifier: modelIdentifier)
+    self.fileLoader = fileLoader
+    self.assembler = assembler
+    self.estimator = estimator
+    self.payloadThreshold = payloadThreshold
+    self.profileService = profileService
+    self.fileIndexService = fileIndexService
+    self.sourceProfile = sourceProfile
+    if let initialSelection {
+      selectedRows = initialSelection.files.map {
+        ContextSelectedFileRow(relativePath: $0.relativePath, byteCount: nil, estimatedTokens: nil, isMissing: false)
+      }
+      selectedRows.append(contentsOf: initialSelection.externalPaths.map {
+        ContextSelectedFileRow(
+          relativePath: $0, byteCount: nil, estimatedTokens: nil, isMissing: false, isExternal: true)
+      })
+      textSnippets = initialSelection.textSnippets
+      instructions = initialSelection.instructions
+    }
+  }
+
+  // MARK: - Derived
+
+  public var totalEstimatedTokens: Int {
+    selectedRows.compactMap(\.estimatedTokens).reduce(0, +)
+      + textSnippets.reduce(0) { $0 + estimator.estimatedTokens(forByteCount: $1.content.utf8.count) }
+      + estimator.estimatedTokens(forByteCount: instructions.utf8.count)
+  }
+
+  /// Fraction of the model context window the selection would occupy.
+  public var windowFraction: Double {
+    guard contextWindowTokens > 0 else { return 0 }
+    return Double(totalEstimatedTokens) / Double(contextWindowTokens)
+  }
+
+  /// True when the assembled block will be handed over as a temp-file
+  /// reference instead of pasted inline.
+  public var willUseFileFallback: Bool {
+    let selectedBytes = selectedRows.compactMap(\.byteCount).reduce(0, +)
+    let snippetBytes = textSnippets.reduce(0) { $0 + $1.content.utf8.count }
+    return selectedBytes + snippetBytes + instructions.utf8.count > payloadThreshold
+  }
+
+  public var missingPaths: [String] {
+    selectedRows.filter(\.isMissing).map(\.relativePath)
+  }
+
+  public var hasSelection: Bool {
+    !currentSelection().isEmpty
+  }
+
+  public var profileServiceAvailable: Bool { profileService != nil }
+
+  /// True when the loaded context set differs from the current editor state —
+  /// gates "Save Changes" so it only lights up after an actual edit.
+  public var hasUnsavedChanges: Bool {
+    guard let sourceProfile else { return false }
+    let saved = ContextSelection(
+      files: sourceProfile.selection.files,
+      externalPaths: sourceProfile.selection.externalPaths,
+      textSnippets: sourceProfile.selection.textSnippets,
+      instructions: sourceProfile.selection.instructions
+        .trimmingCharacters(in: .whitespacesAndNewlines)
+    )
+    return currentSelection() != saved
+  }
+
+  public func isSelected(relativePath: String) -> Bool {
+    selectedRows.contains { $0.relativePath == relativePath }
+  }
+
+  public func currentSelection() -> ContextSelection {
+    ContextSelection(
+      files: selectedRows.filter { !$0.isExternal }
+        .map { ContextFileSelection(relativePath: $0.relativePath) },
+      externalPaths: selectedRows.filter(\.isExternal).map(\.relativePath),
+      textSnippets: textSnippets,
+      instructions: instructions.trimmingCharacters(in: .whitespacesAndNewlines)
+    )
+  }
+
+  // MARK: - Selection
+
+  public func toggleSelection(relativePath: String) async {
+    if isSelected(relativePath: relativePath) {
+      selectedRows.removeAll { $0.relativePath == relativePath }
+    } else {
+      selectedRows.append(
+        ContextSelectedFileRow(relativePath: relativePath, byteCount: nil, estimatedTokens: nil, isMissing: false))
+      await refreshMetrics()
+    }
+  }
+
+  public func removeSelection(relativePath: String) {
+    selectedRows.removeAll { $0.relativePath == relativePath }
+  }
+
+  // MARK: - Text snippets
+
+  public func addTextSnippet(title: String, content: String) {
+    let trimmedTitle = title.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmedTitle.isEmpty, !content.isEmpty else { return }
+    textSnippets.append(ContextTextSnippet(title: trimmedTitle, content: content))
+  }
+
+  public func removeTextSnippet(id: String) {
+    textSnippets.removeAll { $0.id == id }
+  }
+
+  /// Adds user-picked external files (the picker multi-selects; directories
+  /// are ignored — external selection is deliberately files-only).
+  public func addExternalFiles(_ urls: [URL]) async {
+    let existing = Set(selectedRows.map(\.relativePath))
+    let newPaths = ContextFileLoader.regularFilePaths(from: urls)
+      .filter { !existing.contains($0) }
+    guard !newPaths.isEmpty else { return }
+    selectedRows.append(contentsOf: newPaths.map {
+      ContextSelectedFileRow(
+        relativePath: $0, byteCount: nil, estimatedTokens: nil, isMissing: false, isExternal: true)
+    })
+    await refreshMetrics()
+  }
+
+  /// Refreshes byte counts / token estimates for every selected row and marks
+  /// rows whose file no longer resolves.
+  public func refreshMetrics() async {
+    guard !selectedRows.isEmpty else { return }
+    let projectPaths = selectedRows.filter { !$0.isExternal }.map(\.relativePath)
+    let externalPaths = selectedRows.filter(\.isExternal).map(\.relativePath)
+    let metrics = await fileLoader.fileMetrics(relativePaths: projectPaths, projectPath: projectPath)
+    let externalStatuses = await fileLoader.externalFileStatuses(absolutePaths: externalPaths)
+
+    selectedRows = selectedRows.map { row in
+      if row.isExternal {
+        switch externalStatuses[row.relativePath] {
+        case .text(let fileMetrics):
+          return ContextSelectedFileRow(
+            relativePath: row.relativePath,
+            byteCount: fileMetrics.byteCount,
+            estimatedTokens: estimator.estimatedTokens(forByteCount: fileMetrics.byteCount),
+            isMissing: false,
+            isExternal: true
+          )
+        case .attachment:
+          return ContextSelectedFileRow(
+            relativePath: row.relativePath,
+            byteCount: nil,
+            estimatedTokens: estimator.estimatedTokens(forByteCount: row.relativePath.utf8.count),
+            isMissing: false,
+            isExternal: true,
+            isAttachment: true
+          )
+        case .missing, nil:
+          return ContextSelectedFileRow(
+            relativePath: row.relativePath, byteCount: nil, estimatedTokens: nil,
+            isMissing: true, isExternal: true)
+        }
+      }
+      if let fileMetrics = metrics[row.relativePath] {
+        return ContextSelectedFileRow(
+          relativePath: row.relativePath,
+          byteCount: fileMetrics.byteCount,
+          estimatedTokens: estimator.estimatedTokens(forByteCount: fileMetrics.byteCount),
+          isMissing: false
+        )
+      }
+      return ContextSelectedFileRow(
+        relativePath: row.relativePath, byteCount: nil, estimatedTokens: nil, isMissing: true)
+    }
+  }
+
+  // MARK: - Search
+
+  public func performSearch() async {
+    let query = searchQuery.trimmingCharacters(in: .whitespaces)
+    guard !query.isEmpty else {
+      searchResults = await fileIndexService.recentFiles(in: projectPath)
+      return
+    }
+    isSearching = true
+    defer { isSearching = false }
+    searchResults = await fileIndexService.search(query: query, in: projectPath)
+  }
+
+  public func prepareSearchIndex() async {
+    await fileIndexService.prepareSearchIndex(projectPath: projectPath)
+    if searchQuery.isEmpty {
+      searchResults = await fileIndexService.recentFiles(in: projectPath)
+    }
+  }
+
+  // MARK: - Preview
+
+  /// Regenerates the exact assembled block (loads full contents; on-demand only).
+  public func refreshPreview() async {
+    let selection = currentSelection()
+    guard !selection.isEmpty else {
+      assembledPreview = ""
+      return
+    }
+    let projectLoad = await fileLoader.loadFiles(
+      relativePaths: selection.files.map(\.relativePath),
+      projectPath: projectPath
+    )
+    let externalLoad = await fileLoader.loadExternalFiles(absolutePaths: selection.externalPaths)
+    let result = assembler.assemble(ContextAssemblyInput(
+      files: projectLoad.loaded + externalLoad.loaded,
+      missingPaths: projectLoad.missing + externalLoad.missing,
+      attachmentPaths: projectLoad.attachments + externalLoad.attachments,
+      textSnippets: selection.textSnippets,
+      instructions: selection.instructions
+    ))
+    if result.block.count > Self.previewDisplayCharacterLimit {
+      assembledPreview = String(result.block.prefix(Self.previewDisplayCharacterLimit))
+      previewTruncatedByteCount = result.byteCount
+    } else {
+      assembledPreview = result.block
+      previewTruncatedByteCount = nil
+    }
+  }
+
+  // MARK: - Profiles
+
+  public func loadProfiles() async {
+    guard let profileService else { return }
+    availableProfiles = (try? await profileService.profiles(forProjectPath: projectPath)) ?? []
+  }
+
+  /// Clears the editor to a fresh, unsaved draft (the rail's "New Context Set").
+  public func startNewDraft() {
+    sourceProfile = nil
+    selectedRows = []
+    textSnippets = []
+    instructions = ""
+    assembledPreview = ""
+    previewTruncatedByteCount = nil
+  }
+
+  public func applyProfile(_ profile: ContextProfile) async {
+    sourceProfile = profile
+    instructions = profile.selection.instructions
+    selectedRows = profile.selection.files.map {
+      ContextSelectedFileRow(relativePath: $0.relativePath, byteCount: nil, estimatedTokens: nil, isMissing: false)
+    }
+    selectedRows.append(contentsOf: profile.selection.externalPaths.map {
+      ContextSelectedFileRow(
+        relativePath: $0, byteCount: nil, estimatedTokens: nil, isMissing: false, isExternal: true)
+    })
+    textSnippets = profile.selection.textSnippets
+    await refreshMetrics()
+  }
+
+  @discardableResult
+  public func saveAsProfile(name: String, scope: ContextProfileScope) async throws -> ContextProfile? {
+    guard let profileService else { return nil }
+    let trimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmedName.isEmpty else { return nil }
+    let profile = ContextProfile(
+      name: trimmedName,
+      scope: scope,
+      projectPath: projectPath,
+      selection: currentSelection()
+    )
+    try await profileService.save(profile)
+    sourceProfile = profile
+    await loadProfiles()
+    return profile
+  }
+
+  /// Deletes a saved context set. If it was loaded in the editor, the editor
+  /// resets to a fresh draft.
+  public func deleteProfile(_ profile: ContextProfile) async {
+    guard let profileService else { return }
+    try? await profileService.delete(id: profile.id, projectPath: projectPath)
+    if sourceProfile?.id == profile.id {
+      startNewDraft()
+    }
+    await loadProfiles()
+  }
+
+  /// Saves edits back into the context set being edited.
+  public func saveEditedProfile() async throws -> ContextProfile? {
+    guard let profileService, var profile = sourceProfile else { return nil }
+    profile.selection = currentSelection()
+    try await profileService.save(profile)
+    sourceProfile = profile
+    await loadProfiles()
+    return profile
+  }
+}

--- a/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/MultiSessionLaunchViewModel.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/MultiSessionLaunchViewModel.swift
@@ -127,6 +127,11 @@ public final class MultiSessionLaunchViewModel {
   private let intelligenceViewModel: IntelligenceViewModel?
   private let worktreeBranchNamingService: (any WorktreeBranchNamingServiceProtocol)?
   private let worktreeSuccessSoundService: (any WorktreeSuccessSoundServiceProtocol)?
+  let contextProfileService: (any ContextProfileServiceProtocol)?
+  let contextFileLoader: any ContextFileLoading
+  private let contextAssembler: any ContextAssembling
+  private let contextPayloadStore: any ContextPayloadStoring
+  let contextTokenEstimator: any ContextTokenEstimating
   private var playedWorktreeSuccessPaths: Set<String> = []
   /// Stable id for the in-flight branch-naming step, so its progress maps to a
   /// single transient row in the unified top bar (the coordinator).
@@ -183,6 +188,21 @@ public final class MultiSessionLaunchViewModel {
   public var smartProvider: SmartProvider = .claude
   public var smartPlanText: String = ""
   public var smartOrchestrationPlan: OrchestrationPlan?
+
+  // MARK: - Context State
+
+  /// Profile pre-attached to the launch (the project default, or one the user
+  /// picked). Shown as a removable chip in the launcher.
+  public var attachedContextProfile: ContextProfile?
+  /// Ad-hoc curation from the Context Builder; overrides the attached profile.
+  public var pendingContextSelection: ContextSelection?
+  /// Selected paths that did not resolve in the repo, surfaced next to the chip.
+  public var contextMissingPaths: [String] = []
+  /// Approximate token cost of the active selection, for the chip row.
+  public var contextSummaryTokens: Int?
+  /// Once the user removes the chip, the default profile must not silently
+  /// reattach on the next repository refresh.
+  private var contextRemovedByUser = false
 
   // MARK: - Callbacks
 
@@ -242,7 +262,12 @@ public final class MultiSessionLaunchViewModel {
     worktreeService: GitWorktreeService = GitWorktreeService(),
     intelligenceViewModel: IntelligenceViewModel? = nil,
     worktreeBranchNamingService: (any WorktreeBranchNamingServiceProtocol)? = nil,
-    worktreeSuccessSoundService: (any WorktreeSuccessSoundServiceProtocol)? = nil
+    worktreeSuccessSoundService: (any WorktreeSuccessSoundServiceProtocol)? = nil,
+    contextProfileService: (any ContextProfileServiceProtocol)? = nil,
+    contextFileLoader: (any ContextFileLoading)? = nil,
+    contextAssembler: any ContextAssembling = ContextAssembler(),
+    contextPayloadStore: any ContextPayloadStoring = ContextPayloadStore(),
+    contextTokenEstimator: any ContextTokenEstimating = ContextTokenEstimator()
   ) {
     self.claudeViewModel = claudeViewModel
     self.codexViewModel = codexViewModel
@@ -250,6 +275,11 @@ public final class MultiSessionLaunchViewModel {
     self.intelligenceViewModel = intelligenceViewModel
     self.worktreeBranchNamingService = worktreeBranchNamingService
     self.worktreeSuccessSoundService = worktreeSuccessSoundService
+    self.contextProfileService = contextProfileService
+    self.contextFileLoader = contextFileLoader ?? ContextFileLoader()
+    self.contextAssembler = contextAssembler
+    self.contextPayloadStore = contextPayloadStore
+    self.contextTokenEstimator = contextTokenEstimator
   }
 
   // MARK: - Attachments
@@ -264,6 +294,118 @@ public final class MultiSessionLaunchViewModel {
       try? FileManager.default.removeItem(at: file.url)
     }
     attachedFiles.removeAll { $0.id == file.id }
+  }
+
+  // MARK: - Context
+
+  /// The selection that will launch: ad-hoc curation wins over the attached profile.
+  public var activeContextSelection: ContextSelection? {
+    let selection = pendingContextSelection ?? attachedContextProfile?.selection
+    guard let selection, !selection.isEmpty else { return nil }
+    return selection
+  }
+
+  public var contextProfilesAvailable: Bool { contextProfileService != nil }
+
+  /// Attaches the project's default profile as a removable chip. No-op when the
+  /// user already curated context or explicitly removed the chip.
+  public func loadDefaultContextProfile() async {
+    guard let repo = selectedRepository,
+      let contextProfileService,
+      attachedContextProfile == nil,
+      pendingContextSelection == nil,
+      !contextRemovedByUser
+    else { return }
+    guard let profile = try? await contextProfileService.defaultProfile(forProjectPath: repo.path) else { return }
+    // The repository can change while the profile loads; never attach across repos.
+    guard selectedRepository?.path == repo.path else { return }
+    attachedContextProfile = profile
+  }
+
+  public func attachContextProfile(_ profile: ContextProfile) {
+    attachedContextProfile = profile
+    pendingContextSelection = nil
+    contextMissingPaths = []
+    contextRemovedByUser = false
+  }
+
+  public func applyCuratedContext(_ selection: ContextSelection) {
+    pendingContextSelection = selection.isEmpty ? nil : selection
+    contextMissingPaths = []
+    contextRemovedByUser = selection.isEmpty
+  }
+
+  public func removeAttachedContextProfile() {
+    attachedContextProfile = nil
+    pendingContextSelection = nil
+    contextMissingPaths = []
+    contextSummaryTokens = nil
+    contextRemovedByUser = true
+  }
+
+  /// Cheap metrics pass for the chip row: approximate tokens plus which
+  /// selected paths do not resolve. Never loads file contents into UI state.
+  public func refreshContextSummary() async {
+    guard let repo = selectedRepository, let selection = activeContextSelection else {
+      contextSummaryTokens = nil
+      contextMissingPaths = []
+      return
+    }
+    let paths = selection.files.map(\.relativePath)
+    let metrics = await contextFileLoader.fileMetrics(relativePaths: paths, projectPath: repo.path)
+    let externalStatuses = await contextFileLoader.externalFileStatuses(
+      absolutePaths: selection.externalPaths
+    )
+
+    var missing = paths.filter { metrics[$0] == nil }
+    var tokens = metrics.values.reduce(0) {
+      $0 + contextTokenEstimator.estimatedTokens(forByteCount: $1.byteCount)
+    }
+    for (path, status) in externalStatuses {
+      switch status {
+      case .text(let fileMetrics):
+        tokens += contextTokenEstimator.estimatedTokens(forByteCount: fileMetrics.byteCount)
+      case .attachment:
+        // Only the referenced path costs tokens; the agent reads the file itself.
+        tokens += contextTokenEstimator.estimatedTokens(forByteCount: path.utf8.count)
+      case .missing:
+        missing.append(path)
+      }
+    }
+    contextMissingPaths = missing.sorted()
+    let snippetTokens = selection.textSnippets.reduce(0) {
+      $0 + contextTokenEstimator.estimatedTokens(forByteCount: $1.content.utf8.count)
+    }
+    contextSummaryTokens =
+      tokens + snippetTokens
+      + contextTokenEstimator.estimatedTokens(forByteCount: selection.instructions.utf8.count)
+  }
+
+  /// Loads, assembles, and materializes the active selection into the prompt
+  /// text handed to `startNewSessionInHub`. Nil when nothing is selected — the
+  /// launch then behaves exactly as before the context feature existed.
+  func resolveContextBlock(repoPath: String) async -> String? {
+    guard let selection = activeContextSelection else { return nil }
+    let projectLoad = await contextFileLoader.loadFiles(
+      relativePaths: selection.files.map(\.relativePath),
+      projectPath: repoPath
+    )
+    let externalLoad = await contextFileLoader.loadExternalFiles(
+      absolutePaths: selection.externalPaths
+    )
+    contextMissingPaths = (projectLoad.missing + externalLoad.missing).sorted()
+    let assembled = contextAssembler.assemble(ContextAssemblyInput(
+      files: projectLoad.loaded + externalLoad.loaded,
+      missingPaths: contextMissingPaths,
+      attachmentPaths: projectLoad.attachments + externalLoad.attachments,
+      textSnippets: selection.textSnippets,
+      instructions: selection.instructions
+    ))
+    guard !assembled.block.isEmpty else { return nil }
+    guard let payload = try? contextPayloadStore.materializeIfNeeded(block: assembled.block) else {
+      return assembled.block
+    }
+    return payload.promptText
   }
 
   // MARK: - Actions
@@ -540,6 +682,7 @@ public final class MultiSessionLaunchViewModel {
     let initialInputText: String? =
       trimmedPrompt.isEmpty && !attachmentPaths.isEmpty ? "\(attachmentPaths) " : nil
     let repoPath = repo.path
+    let contextBlock = await resolveContextBlock(repoPath: repoPath)
 
     switch workMode {
     case .local:
@@ -552,7 +695,12 @@ public final class MultiSessionLaunchViewModel {
           "\(Self.aiWorktreeLogPrefix, privacy: .public) Skipping AI worktree naming because the Start Session launch is in local mode"
         )
       }
-      try await launchLocalSessions(initialPrompt: initialPrompt, initialInputText: initialInputText, repoPath: repoPath)
+      try await launchLocalSessions(
+        initialPrompt: initialPrompt,
+        initialInputText: initialInputText,
+        contextBlock: contextBlock,
+        repoPath: repoPath
+      )
     case .worktree:
       let providers = selectedProviders
       let worktreeNamingModeName = worktreeNamingMode.rawValue
@@ -589,13 +737,19 @@ public final class MultiSessionLaunchViewModel {
       }
 
       if providers.count > 1 {
-        try await launchBothProviders(initialPrompt: initialPrompt, initialInputText: initialInputText, repoPath: repoPath)
+        try await launchBothProviders(
+          initialPrompt: initialPrompt,
+          initialInputText: initialInputText,
+          contextBlock: contextBlock,
+          repoPath: repoPath
+        )
       } else if let provider = providers.first {
         switch provider {
         case .claude:
           try await launchSingleProvider(
             initialPrompt: initialPrompt,
             initialInputText: initialInputText,
+            contextBlock: contextBlock,
             repoPath: repoPath,
             branchName: singleBranchName,
             viewModel: claudeViewModel,
@@ -609,6 +763,7 @@ public final class MultiSessionLaunchViewModel {
           try await launchSingleProvider(
             initialPrompt: initialPrompt,
             initialInputText: initialInputText,
+            contextBlock: contextBlock,
             repoPath: repoPath,
             branchName: singleBranchName,
             viewModel: codexViewModel,
@@ -951,12 +1106,21 @@ public final class MultiSessionLaunchViewModel {
     smartProvider = .claude
     smartPlanText = ""
     smartOrchestrationPlan = nil
+    attachedContextProfile = nil
+    pendingContextSelection = nil
+    contextMissingPaths = []
+    contextRemovedByUser = false
   }
 
   // MARK: - Private
 
   /// Starts sessions directly in repo directory without worktree creation
-  private func launchLocalSessions(initialPrompt: String?, initialInputText: String?, repoPath: String) async throws {
+  private func launchLocalSessions(
+    initialPrompt: String?,
+    initialInputText: String?,
+    contextBlock: String?,
+    repoPath: String
+  ) async throws {
     let providers = selectedProviders
 
     for provider in providers {
@@ -985,6 +1149,7 @@ public final class MultiSessionLaunchViewModel {
         worktree,
         initialPrompt: initialPrompt,
         initialInputText: initialInputText,
+        contextBlock: contextBlock,
         dangerouslySkipPermissions: claudeMode.dangerouslySkipPermissions,
         permissionModePlan: isPlanModeEnabled,
         worktreeName: claudeWorktreeOption
@@ -1001,6 +1166,7 @@ public final class MultiSessionLaunchViewModel {
         worktree,
         initialPrompt: initialPrompt,
         initialInputText: initialInputText,
+        contextBlock: contextBlock,
         permissionModePlan: isPlanModeEnabled
       )
     }
@@ -1009,7 +1175,12 @@ public final class MultiSessionLaunchViewModel {
     codexViewModel.refresh()
   }
 
-  private func launchBothProviders(initialPrompt: String?, initialInputText: String?, repoPath: String) async throws {
+  private func launchBothProviders(
+    initialPrompt: String?,
+    initialInputText: String?,
+    contextBlock: String?,
+    repoPath: String
+  ) async throws {
     // Ensure the repository is added to both providers
     claudeViewModel.addRepository(at: repoPath)
     codexViewModel.addRepository(at: repoPath)
@@ -1075,6 +1246,7 @@ public final class MultiSessionLaunchViewModel {
         worktree,
         initialPrompt: initialPrompt,
         initialInputText: initialInputText,
+        contextBlock: contextBlock,
         dangerouslySkipPermissions: claudeMode.dangerouslySkipPermissions,
         permissionModePlan: isPlanModeEnabled
       )
@@ -1093,6 +1265,7 @@ public final class MultiSessionLaunchViewModel {
         worktree,
         initialPrompt: initialPrompt,
         initialInputText: initialInputText,
+        contextBlock: contextBlock,
         permissionModePlan: isPlanModeEnabled
       )
     }
@@ -1104,6 +1277,7 @@ public final class MultiSessionLaunchViewModel {
   private func launchSingleProvider(
     initialPrompt: String?,
     initialInputText: String?,
+    contextBlock: String? = nil,
     repoPath: String,
     branchName: String,
     viewModel: CLISessionsViewModel,
@@ -1151,6 +1325,7 @@ public final class MultiSessionLaunchViewModel {
       worktree,
       initialPrompt: initialPrompt,
       initialInputText: initialInputText,
+      contextBlock: contextBlock,
       dangerouslySkipPermissions: dangerouslySkipPermissions,
       permissionModePlan: permissionModePlan
     )

--- a/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/ProjectContextViewModel.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/ProjectContextViewModel.swift
@@ -1,0 +1,102 @@
+//
+//  ProjectContextViewModel.swift
+//  AgentHub
+//
+//  Drives the Project Details Context tab: the project's saved context
+//  profiles (project + personal scope), per-profile token estimates, and the
+//  panel's first editing actions (delete, set default).
+//
+
+import Foundation
+import Observation
+
+@MainActor
+@Observable
+public final class ProjectContextViewModel {
+
+  private let service: (any ContextProfileServiceProtocol)?
+  private let fileLoader: any ContextFileLoading
+  private let estimator: any ContextTokenEstimating
+
+  public let projectPath: String
+  public private(set) var profiles: [ContextProfile] = []
+  /// Approximate token cost per profile id, for the card badge.
+  public private(set) var estimatedTokensByProfileId: [String: Int] = [:]
+  public private(set) var isLoading = false
+  public var lastActionError: String?
+
+  public var isAvailable: Bool { service != nil }
+  var profileService: (any ContextProfileServiceProtocol)? { service }
+  var contextFileLoader: any ContextFileLoading { fileLoader }
+
+  public init(
+    projectPath: String,
+    service: (any ContextProfileServiceProtocol)?,
+    fileLoader: any ContextFileLoading = ContextFileLoader(),
+    estimator: any ContextTokenEstimating = ContextTokenEstimator()
+  ) {
+    self.projectPath = projectPath
+    self.service = service
+    self.fileLoader = fileLoader
+    self.estimator = estimator
+  }
+
+  public func load() async {
+    guard let service else { return }
+    isLoading = true
+    defer { isLoading = false }
+    profiles = (try? await service.profiles(forProjectPath: projectPath)) ?? []
+    await refreshEstimates()
+  }
+
+  public func delete(_ profile: ContextProfile) async {
+    guard let service else { return }
+    do {
+      try await service.delete(id: profile.id, projectPath: projectPath)
+      lastActionError = nil
+    } catch {
+      lastActionError = "Could not delete “\(profile.name)”."
+    }
+    await load()
+  }
+
+  /// Marks `profile` as the project default; pass nil to clear it.
+  public func setDefault(_ profile: ContextProfile?) async {
+    guard let service else { return }
+    do {
+      try await service.setDefault(id: profile?.id, forProjectPath: projectPath)
+      lastActionError = nil
+    } catch {
+      lastActionError = "Only a project-scoped profile can be the default."
+    }
+    await load()
+  }
+
+  private func refreshEstimates() async {
+    var estimates: [String: Int] = [:]
+    for profile in profiles {
+      let metrics = await fileLoader.fileMetrics(
+        relativePaths: profile.selection.files.map(\.relativePath),
+        projectPath: projectPath
+      )
+      let externalStatuses = await fileLoader.externalFileStatuses(
+        absolutePaths: profile.selection.externalPaths
+      )
+      var tokens = metrics.values.reduce(0) {
+        $0 + estimator.estimatedTokens(forByteCount: $1.byteCount)
+      }
+      for status in externalStatuses.values {
+        if case .text(let fileMetrics) = status {
+          tokens += estimator.estimatedTokens(forByteCount: fileMetrics.byteCount)
+        }
+      }
+      let snippetTokens = profile.selection.textSnippets.reduce(0) {
+        $0 + estimator.estimatedTokens(forByteCount: $1.content.utf8.count)
+      }
+      estimates[profile.id] =
+        tokens + snippetTokens
+        + estimator.estimatedTokens(forByteCount: profile.selection.instructions.utf8.count)
+    }
+    estimatedTokensByProfileId = estimates
+  }
+}

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/CodexModelCatalogTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/CodexModelCatalogTests.swift
@@ -54,6 +54,21 @@ struct CodexModelCatalogTests {
     #expect(options.map(\.identifier) == ["gpt-5.5"])
   }
 
+  @Test("Parses the per-model context window when present")
+  func parsesContextWindow() throws {
+    let json = Data("""
+    {"models":[
+      {"slug":"gpt-5.6-sol","display_name":"GPT-5.6 Sol","visibility":"list","priority":1,"context_window":272000},
+      {"slug":"gpt-legacy","display_name":"Legacy","visibility":"list","priority":2}
+    ]}
+    """.utf8)
+
+    let options = try CodexModelCatalog.modelOptions(fromDebugModelsJSON: json)
+
+    #expect(options.first?.contextWindowTokens == 272_000)
+    #expect(options.last?.contextWindowTokens == nil)
+  }
+
   @Test("Parses per-model reasoning levels and the default")
   func parsesReasoningLevels() throws {
     let json = Data("""

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/ContextAssemblerTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/ContextAssemblerTests.swift
@@ -1,0 +1,121 @@
+import Foundation
+import Testing
+
+@testable import AgentHubCore
+
+@Suite("Context assembler")
+struct ContextAssemblerTests {
+
+  private let assembler = ContextAssembler()
+
+  private func loadedFile(_ path: String, _ content: String) -> ContextLoadedFile {
+    ContextLoadedFile(relativePath: path, content: content)
+  }
+
+  @Test("Deterministic regardless of input order")
+  func deterministicOrdering() throws {
+    let files = [
+      loadedFile("b/second.swift", "let b = 2"),
+      loadedFile("a/first.swift", "let a = 1"),
+      loadedFile("c/third.swift", "let c = 3"),
+    ]
+    let forward = assembler.assemble(ContextAssemblyInput(files: files, instructions: "do it"))
+    let shuffled = assembler.assemble(ContextAssemblyInput(files: files.reversed(), instructions: "do it"))
+
+    #expect(forward == shuffled)
+    let aIndex = try #require(forward.block.range(of: "a/first.swift")).lowerBound
+    let bIndex = try #require(forward.block.range(of: "b/second.swift")).lowerBound
+    #expect(aIndex < bIndex)
+  }
+
+  @Test("Block structure contains map, files, and instructions sections")
+  func blockStructure() {
+    let result = assembler.assemble(ContextAssemblyInput(
+      files: [loadedFile("src/main.swift", "print(\"hi\")\nprint(\"bye\")")],
+      missingPaths: ["gone/away.swift"],
+      instructions: "Focus on main."
+    ))
+
+    #expect(result.block.hasPrefix("<context>\n"))
+    #expect(result.block.hasSuffix("\n</context>"))
+    #expect(result.block.contains("<file_map>\ngone/away.swift (missing)\nsrc/main.swift (2 lines)\n</file_map>"))
+    #expect(result.block.contains("<file path=\"src/main.swift\">\nprint(\"hi\")\nprint(\"bye\")\n</file>"))
+    #expect(result.block.contains("<instructions>\nFocus on main.\n</instructions>"))
+    #expect(result.byteCount == result.block.utf8.count)
+  }
+
+  @Test("Missing files are annotated in the map but emit no file body")
+  func missingFilesAnnotated() {
+    let result = assembler.assemble(ContextAssemblyInput(
+      files: [],
+      missingPaths: ["lost.swift"],
+      instructions: ""
+    ))
+
+    #expect(result.block.contains("lost.swift (missing)"))
+    #expect(!result.block.contains("<files>"))
+    #expect(!result.block.contains("<instructions>"))
+  }
+
+  @Test("Empty sections are omitted")
+  func emptySectionsOmitted() {
+    let instructionsOnly = assembler.assemble(ContextAssemblyInput(
+      files: [],
+      instructions: "Just instructions."
+    ))
+    #expect(!instructionsOnly.block.contains("<file_map>"))
+    #expect(!instructionsOnly.block.contains("<files>"))
+    #expect(instructionsOnly.block.contains("<instructions>\nJust instructions.\n</instructions>"))
+
+    let filesOnly = assembler.assemble(ContextAssemblyInput(
+      files: [loadedFile("a.swift", "let a = 1")]
+    ))
+    #expect(filesOnly.block.contains("<file_map>"))
+    #expect(filesOnly.block.contains("<files>"))
+    #expect(!filesOnly.block.contains("<instructions>"))
+  }
+
+  @Test("Fully empty input produces an empty block")
+  func emptyInput() {
+    let result = assembler.assemble(ContextAssemblyInput(files: [], instructions: "   \n "))
+    #expect(result.block.isEmpty)
+    #expect(result.byteCount == 0)
+  }
+
+  @Test("Text snippets render as a titled section and appear in the map")
+  func snippetsSection() {
+    let result = assembler.assemble(ContextAssemblyInput(
+      files: [],
+      textSnippets: [
+        ContextTextSnippet(id: "b", title: "Zeta", content: "second"),
+        ContextTextSnippet(id: "a", title: "Alpha", content: "first"),
+      ]
+    ))
+
+    #expect(result.block.contains("<snippets>\n<snippet title=\"Alpha\">\nfirst\n</snippet>\n<snippet title=\"Zeta\">\nsecond\n</snippet>\n</snippets>"))
+    #expect(result.block.contains("Alpha (pasted text)"))
+    #expect(result.block.contains("Zeta (pasted text)"))
+  }
+
+  @Test("Attachments are listed by path with a read-it-yourself note")
+  func attachmentsSection() {
+    let result = assembler.assemble(ContextAssemblyInput(
+      files: [loadedFile("src/a.swift", "let a = 1")],
+      attachmentPaths: ["/Users/me/books/manual.pdf"]
+    ))
+
+    #expect(result.block.contains("/Users/me/books/manual.pdf (attachment — read separately)"))
+    #expect(result.block.contains("<attachments>"))
+    #expect(result.block.contains("Read them with your file tools:"))
+    #expect(result.block.contains("/Users/me/books/manual.pdf\n</attachments>"))
+  }
+
+  @Test("Instructions are trimmed")
+  func instructionsTrimmed() {
+    let result = assembler.assemble(ContextAssemblyInput(
+      files: [],
+      instructions: "\n  Keep tests green.  \n"
+    ))
+    #expect(result.block.contains("<instructions>\nKeep tests green.\n</instructions>"))
+  }
+}

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/ContextBuilderViewModelTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/ContextBuilderViewModelTests.swift
@@ -1,0 +1,316 @@
+import Foundation
+import Testing
+
+@testable import AgentHubCore
+
+@MainActor
+@Suite("Context builder view model")
+struct ContextBuilderViewModelTests {
+
+  private func withProject(
+    _ body: (URL, ContextBuilderViewModel, MockContextProfileService) async throws -> Void
+  ) async throws {
+    let project = FileManager.default.temporaryDirectory
+      .appendingPathComponent("context-builder-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: project, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: project) }
+
+    let service = MockContextProfileService()
+    let viewModel = ContextBuilderViewModel(
+      projectPath: project.path,
+      fileLoader: ContextFileLoader(fileIndexService: FileIndexService()),
+      profileService: service,
+      fileIndexService: FileIndexService()
+    )
+    try await body(project, viewModel, service)
+  }
+
+  private func write(_ relativePath: String, _ content: String, in project: URL) throws {
+    let url = project.appendingPathComponent(relativePath)
+    try FileManager.default.createDirectory(
+      at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+    try content.write(to: url, atomically: true, encoding: .utf8)
+  }
+
+  @Test("Toggling a file updates per-file and total token estimates")
+  func toggleUpdatesTokens() async throws {
+    try await withProject { project, viewModel, _ in
+      try write("a.swift", String(repeating: "a", count: 400), in: project)
+
+      await viewModel.toggleSelection(relativePath: "a.swift")
+
+      #expect(viewModel.selectedRows.count == 1)
+      // 400 bytes / 4 × 1.15 = 115.
+      #expect(viewModel.selectedRows.first?.estimatedTokens == 115)
+      #expect(viewModel.totalEstimatedTokens == 115)
+
+      await viewModel.toggleSelection(relativePath: "a.swift")
+      #expect(viewModel.selectedRows.isEmpty)
+      #expect(viewModel.totalEstimatedTokens == 0)
+    }
+  }
+
+  @Test("Instructions contribute to the total estimate")
+  func instructionsContribute() async throws {
+    try await withProject { _, viewModel, _ in
+      viewModel.instructions = String(repeating: "b", count: 40)
+      // 40 bytes / 4 × 1.15 = 11.5 → 12.
+      #expect(viewModel.totalEstimatedTokens == 12)
+    }
+  }
+
+  @Test("Window fraction uses the configured model's resolved context window")
+  func windowFractionUsesResolvedModel() {
+    let oneMillion = ContextBuilderViewModel(
+      projectPath: "/tmp/project", modelIdentifier: "claude-sonnet-4-5[1m]")
+    #expect(oneMillion.contextWindowTokens == 1_000_000)
+
+    let standard = ContextBuilderViewModel(
+      projectPath: "/tmp/project", modelIdentifier: "claude-opus-4-8")
+    #expect(standard.contextWindowTokens == 200_000)
+
+    standard.instructions = String(repeating: "a", count: 4_000)
+    oneMillion.instructions = String(repeating: "a", count: 4_000)
+    #expect(standard.windowFraction > oneMillion.windowFraction)
+  }
+
+  @Test("Applying a profile loads its valid subset and flags missing paths")
+  func applyProfileFlagsMissing() async throws {
+    try await withProject { project, viewModel, _ in
+      try write("real.swift", "let real = 1", in: project)
+      let profile = ContextProfile(
+        name: "Mixed",
+        scope: .project,
+        projectPath: project.path,
+        selection: ContextSelection(
+          files: [
+            ContextFileSelection(relativePath: "real.swift"),
+            ContextFileSelection(relativePath: "gone.swift"),
+          ],
+          instructions: "From profile."
+        )
+      )
+
+      await viewModel.applyProfile(profile)
+
+      #expect(viewModel.instructions == "From profile.")
+      #expect(viewModel.selectedRows.count == 2)
+      #expect(viewModel.missingPaths == ["gone.swift"])
+      #expect(viewModel.selectedRows.first { $0.relativePath == "real.swift" }?.isMissing == false)
+    }
+  }
+
+  @Test("Save-as-profile persists the current selection through the service")
+  func saveAsProfilePersists() async throws {
+    try await withProject { project, viewModel, service in
+      try write("a.swift", "let a = 1", in: project)
+      await viewModel.toggleSelection(relativePath: "a.swift")
+      viewModel.instructions = "Save me."
+
+      let saved = try #require(try await viewModel.saveAsProfile(name: " Voice work ", scope: .project))
+
+      #expect(saved.name == "Voice work")
+      #expect(service.savedProfiles.count == 1)
+      #expect(service.savedProfiles.first?.selection.files.map(\.relativePath) == ["a.swift"])
+      #expect(service.savedProfiles.first?.selection.instructions == "Save me.")
+      #expect(viewModel.sourceProfile?.id == saved.id)
+    }
+  }
+
+  @Test("Save Changes is gated on actual edits to the loaded set")
+  func unsavedChangesGating() async throws {
+    try await withProject { project, viewModel, _ in
+      try write("a.swift", "let a = 1", in: project)
+      let profile = ContextProfile(
+        id: "gate",
+        name: "Gate",
+        scope: .project,
+        projectPath: project.path,
+        selection: ContextSelection(
+          files: [ContextFileSelection(relativePath: "a.swift")],
+          instructions: "original"
+        )
+      )
+      await viewModel.applyProfile(profile)
+      #expect(!viewModel.hasUnsavedChanges)
+
+      viewModel.instructions = "edited"
+      #expect(viewModel.hasUnsavedChanges)
+
+      _ = try await viewModel.saveEditedProfile()
+      #expect(!viewModel.hasUnsavedChanges)
+
+      await viewModel.toggleSelection(relativePath: "a.swift")  // remove the file
+      #expect(viewModel.hasUnsavedChanges)
+
+      // A fresh draft has no source set, so nothing to "save changes" to.
+      viewModel.startNewDraft()
+      #expect(!viewModel.hasUnsavedChanges)
+    }
+  }
+
+  @Test("Text snippets add, count toward tokens, round-trip, and gate saves")
+  func textSnippetsFlow() async throws {
+    try await withProject { _, viewModel, _ in
+      viewModel.addTextSnippet(title: "  Notes  ", content: String(repeating: "n", count: 400))
+
+      #expect(viewModel.textSnippets.count == 1)
+      #expect(viewModel.textSnippets.first?.title == "Notes")
+      // 400 bytes / 4 x 1.15 = 115.
+      #expect(viewModel.totalEstimatedTokens == 115)
+      #expect(viewModel.hasSelection)
+
+      let selection = viewModel.currentSelection()
+      #expect(selection.textSnippets.count == 1)
+
+      // Blank title or empty content are rejected.
+      viewModel.addTextSnippet(title: "   ", content: "x")
+      viewModel.addTextSnippet(title: "y", content: "")
+      #expect(viewModel.textSnippets.count == 1)
+
+      await viewModel.refreshPreview()
+      #expect(viewModel.assembledPreview.contains("<snippet title=\"Notes\">"))
+
+      viewModel.removeTextSnippet(id: viewModel.textSnippets[0].id)
+      #expect(viewModel.textSnippets.isEmpty)
+      #expect(!viewModel.hasSelection)
+    }
+  }
+
+  @Test("Deleting the loaded set removes it and resets to a fresh draft")
+  func deleteLoadedSetResets() async throws {
+    try await withProject { project, viewModel, service in
+      try write("a.swift", "let a = 1", in: project)
+      let profile = makeProfile(id: "doomed", name: "Doomed", projectPath: project.path)
+      service.storedProfiles = [profile]
+      await viewModel.loadProfiles()
+      await viewModel.applyProfile(profile)
+
+      await viewModel.deleteProfile(profile)
+
+      #expect(service.deletedIds == ["doomed"])
+      #expect(viewModel.availableProfiles.isEmpty)
+      #expect(viewModel.sourceProfile == nil)
+      #expect(viewModel.selectedRows.isEmpty)
+    }
+  }
+
+  @Test("Starting a new draft clears the loaded set and selection")
+  func startNewDraftClears() async throws {
+    try await withProject { project, viewModel, _ in
+      try write("a.swift", "let a = 1", in: project)
+      await viewModel.applyProfile(makeProfile(id: "loaded", name: "Loaded", projectPath: project.path))
+      #expect(viewModel.sourceProfile != nil)
+      #expect(!viewModel.selectedRows.isEmpty)
+
+      viewModel.startNewDraft()
+
+      #expect(viewModel.sourceProfile == nil)
+      #expect(viewModel.selectedRows.isEmpty)
+      #expect(viewModel.instructions.isEmpty)
+      #expect(viewModel.assembledPreview.isEmpty)
+    }
+  }
+
+  @Test("Saving an edited profile keeps its identity and updates the selection")
+  func saveEditedProfileKeepsIdentity() async throws {
+    try await withProject { project, viewModel, service in
+      try write("new.swift", "let new = 1", in: project)
+      let original = ContextProfile(
+        id: "stable-id",
+        name: "Editable",
+        scope: .project,
+        projectPath: project.path,
+        selection: ContextSelection(files: [ContextFileSelection(relativePath: "old.swift")])
+      )
+      await viewModel.applyProfile(original)
+      viewModel.removeSelection(relativePath: "old.swift")
+      await viewModel.toggleSelection(relativePath: "new.swift")
+
+      let saved = try #require(try await viewModel.saveEditedProfile())
+
+      #expect(saved.id == "stable-id")
+      #expect(saved.selection.files.map(\.relativePath) == ["new.swift"])
+      #expect(service.savedProfiles.first?.id == "stable-id")
+    }
+  }
+
+  @Test("The preview is the exact assembled block")
+  func previewMatchesAssembler() async throws {
+    try await withProject { project, viewModel, _ in
+      try write("a.swift", "let a = 1", in: project)
+      await viewModel.toggleSelection(relativePath: "a.swift")
+      viewModel.instructions = "Check."
+
+      await viewModel.refreshPreview()
+
+      let expected = ContextAssembler().assemble(ContextAssemblyInput(
+        files: [ContextLoadedFile(relativePath: "a.swift", content: "let a = 1")],
+        instructions: "Check."
+      ))
+      #expect(viewModel.assembledPreview == expected.block)
+    }
+  }
+
+  @Test("External files can be added, classified, and round-tripped")
+  func externalFilesFlow() async throws {
+    try await withProject { project, viewModel, _ in
+      let outside = project.deletingLastPathComponent()
+        .appendingPathComponent("outside-\(UUID().uuidString)", isDirectory: true)
+      try FileManager.default.createDirectory(at: outside, withIntermediateDirectories: true)
+      defer { try? FileManager.default.removeItem(at: outside) }
+      let notes = outside.appendingPathComponent("notes.md")
+      try String(repeating: "n", count: 400).write(to: notes, atomically: true, encoding: .utf8)
+      let pdf = outside.appendingPathComponent("book.pdf")
+      try Data([0x25, 0x50, 0x44, 0x46, 0xFF, 0xFE]).write(to: pdf)
+
+      await viewModel.addExternalFiles([notes, pdf, outside])
+
+      let externalRows = viewModel.selectedRows.filter(\.isExternal)
+      #expect(externalRows.count == 2)
+      #expect(externalRows.first { $0.relativePath == notes.path }?.estimatedTokens == 115)
+      #expect(externalRows.first { $0.relativePath == pdf.path }?.isAttachment == true)
+
+      let selection = viewModel.currentSelection()
+      #expect(Set(selection.externalPaths) == [notes.path, pdf.path])
+      #expect(selection.files.isEmpty)
+
+      await viewModel.refreshPreview()
+      #expect(viewModel.assembledPreview.contains("<attachments>"))
+      #expect(viewModel.assembledPreview.contains(String(repeating: "n", count: 50)))
+      #expect(viewModel.previewTruncatedByteCount == nil)
+    }
+  }
+
+  @Test("The preview display truncates huge blocks instead of freezing layout")
+  func previewDisplayTruncates() async throws {
+    try await withProject { project, viewModel, _ in
+      try write("huge.txt", String(repeating: "x", count: 60_000), in: project)
+      await viewModel.toggleSelection(relativePath: "huge.txt")
+
+      await viewModel.refreshPreview()
+
+      #expect(viewModel.assembledPreview.count == ContextBuilderViewModel.previewDisplayCharacterLimit)
+      let fullBytes = try #require(viewModel.previewTruncatedByteCount)
+      #expect(fullBytes > 60_000)
+    }
+  }
+
+  @Test("File fallback hint appears when selected bytes exceed the threshold")
+  func fallbackHint() async throws {
+    let project = FileManager.default.temporaryDirectory
+      .appendingPathComponent("context-builder-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: project, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: project) }
+    try write("big.txt", String(repeating: "x", count: 600), in: project)
+
+    let viewModel = ContextBuilderViewModel(
+      projectPath: project.path,
+      fileLoader: ContextFileLoader(fileIndexService: FileIndexService()),
+      payloadThreshold: 512
+    )
+    await viewModel.toggleSelection(relativePath: "big.txt")
+
+    #expect(viewModel.willUseFileFallback)
+  }
+}

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/ContextFileLoaderTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/ContextFileLoaderTests.swift
@@ -1,0 +1,175 @@
+import Foundation
+import Testing
+
+@testable import AgentHubCore
+
+@Suite("Context file loader")
+struct ContextFileLoaderTests {
+
+  private func withProject(_ body: (URL, ContextFileLoader) async throws -> Void) async throws {
+    let project = FileManager.default.temporaryDirectory
+      .appendingPathComponent("context-loader-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: project, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: project) }
+    let loader = ContextFileLoader(fileIndexService: FileIndexService(), maxConcurrentReads: 2)
+    try await body(project, loader)
+  }
+
+  private func write(_ relativePath: String, _ content: String, in project: URL) throws {
+    let url = project.appendingPathComponent(relativePath)
+    try FileManager.default.createDirectory(
+      at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+    try content.write(to: url, atomically: true, encoding: .utf8)
+  }
+
+  @Test("Loads readable files and reports missing ones, both sorted")
+  func loadsSubsetAndReportsMissing() async throws {
+    try await withProject { project, loader in
+      try write("src/b.swift", "let b = 2", in: project)
+      try write("src/a.swift", "line1\nline2", in: project)
+
+      let result = await loader.loadFiles(
+        relativePaths: ["src/b.swift", "missing/z.swift", "src/a.swift", "missing/a.swift"],
+        projectPath: project.path
+      )
+
+      #expect(result.loaded.map(\.relativePath) == ["src/a.swift", "src/b.swift"])
+      #expect(result.loaded.first?.content == "line1\nline2")
+      #expect(result.loaded.first?.metrics.lineCount == 2)
+      #expect(result.missing == ["missing/a.swift", "missing/z.swift"])
+    }
+  }
+
+  @Test("Duplicate paths are loaded once")
+  func deduplicatesPaths() async throws {
+    try await withProject { project, loader in
+      try write("one.swift", "let one = 1", in: project)
+
+      let result = await loader.loadFiles(
+        relativePaths: ["one.swift", "one.swift", "one.swift"],
+        projectPath: project.path
+      )
+
+      #expect(result.loaded.count == 1)
+      #expect(result.missing.isEmpty)
+    }
+  }
+
+  @Test("Paths escaping the project root are reported missing, not read")
+  func rejectsPathTraversal() async throws {
+    try await withProject { project, loader in
+      let outside = project.deletingLastPathComponent()
+        .appendingPathComponent("outside-\(UUID().uuidString).txt")
+      try "secret".write(to: outside, atomically: true, encoding: .utf8)
+      defer { try? FileManager.default.removeItem(at: outside) }
+
+      let result = await loader.loadFiles(
+        relativePaths: ["../\(outside.lastPathComponent)"],
+        projectPath: project.path
+      )
+
+      #expect(result.loaded.isEmpty)
+      #expect(result.missing.count == 1)
+    }
+  }
+
+  @Test("Metrics are returned per path and omit unreadable files")
+  func metricsPerPath() async throws {
+    try await withProject { project, loader in
+      try write("a.swift", "12345678", in: project)
+
+      let metrics = await loader.fileMetrics(
+        relativePaths: ["a.swift", "gone.swift"],
+        projectPath: project.path
+      )
+
+      #expect(metrics.count == 1)
+      #expect(metrics["a.swift"]?.byteCount == 8)
+    }
+  }
+
+  @Test("Metrics cache invalidates when the file changes")
+  func metricsCacheInvalidation() async throws {
+    try await withProject { project, loader in
+      try write("a.swift", "short", in: project)
+      let first = await loader.fileMetrics(relativePaths: ["a.swift"], projectPath: project.path)
+      #expect(first["a.swift"]?.byteCount == 5)
+
+      try write("a.swift", "much longer content", in: project)
+      let second = await loader.fileMetrics(relativePaths: ["a.swift"], projectPath: project.path)
+      #expect(second["a.swift"]?.byteCount == 19)
+    }
+  }
+
+  @Test("Many files load with a small concurrency bound")
+  func boundedConcurrencyLoadsAll() async throws {
+    try await withProject { project, loader in
+      for index in 0..<20 {
+        try write("file-\(index).swift", "let value = \(index)", in: project)
+      }
+
+      let result = await loader.loadFiles(
+        relativePaths: (0..<20).map { "file-\($0).swift" },
+        projectPath: project.path
+      )
+
+      #expect(result.loaded.count == 20)
+      #expect(result.missing.isEmpty)
+    }
+  }
+
+  // MARK: - External files
+
+  @Test("External files load by absolute path; binary files become attachments")
+  func externalFilesLoadAndClassify() async throws {
+    try await withProject { project, loader in
+      let outside = project.deletingLastPathComponent()
+        .appendingPathComponent("external-\(UUID().uuidString)", isDirectory: true)
+      try FileManager.default.createDirectory(at: outside, withIntermediateDirectories: true)
+      defer { try? FileManager.default.removeItem(at: outside) }
+
+      let textURL = outside.appendingPathComponent("notes.md")
+      try "external notes".write(to: textURL, atomically: true, encoding: .utf8)
+      let binaryURL = outside.appendingPathComponent("book.pdf")
+      try Data([0x25, 0x50, 0x44, 0x46, 0xFF, 0xFE, 0x00, 0x01]).write(to: binaryURL)
+
+      let result = await loader.loadExternalFiles(absolutePaths: [
+        textURL.path, binaryURL.path, outside.appendingPathComponent("gone.txt").path,
+      ])
+
+      #expect(result.loaded.map(\.relativePath) == [textURL.path])
+      #expect(result.loaded.first?.content == "external notes")
+      #expect(result.attachments == [binaryURL.path])
+      #expect(result.missing.count == 1)
+
+      let statuses = await loader.externalFileStatuses(absolutePaths: [
+        textURL.path, binaryURL.path,
+      ])
+      #expect(statuses[binaryURL.path] == .attachment)
+      if case .text(let metrics)? = statuses[textURL.path] {
+        #expect(metrics.byteCount == 14)
+      } else {
+        Issue.record("expected text status")
+      }
+    }
+  }
+
+  @Test("Picker URLs filter to existing regular files — directories are ignored")
+  func regularFilePathsFiltering() async throws {
+    let root = FileManager.default.temporaryDirectory
+      .appendingPathComponent("pick-\(UUID().uuidString)", isDirectory: true)
+    defer { try? FileManager.default.removeItem(at: root) }
+    try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+    let file = root.appendingPathComponent("notes.md")
+    try "a".write(to: file, atomically: true, encoding: .utf8)
+
+    let paths = ContextFileLoader.regularFilePaths(from: [
+      file,
+      root,  // directory — ignored
+      root.appendingPathComponent("gone.md"),  // missing — ignored
+      file,  // duplicate — deduped
+    ])
+
+    #expect(paths == [file.path])
+  }
+}

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/ContextPayloadStoreTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/ContextPayloadStoreTests.swift
@@ -1,0 +1,88 @@
+import Foundation
+import Testing
+
+@testable import AgentHubCore
+
+@Suite("Context payload store")
+struct ContextPayloadStoreTests {
+
+  private func withTempDirectory(_ body: (URL) throws -> Void) throws {
+    let directory = FileManager.default.temporaryDirectory
+      .appendingPathComponent("context-payloads-\(UUID().uuidString)", isDirectory: true)
+    defer { try? FileManager.default.removeItem(at: directory) }
+    try body(directory)
+  }
+
+  @Test("Blocks at or below the threshold stay inline")
+  func inlineBelowThreshold() throws {
+    try withTempDirectory { directory in
+      let store = ContextPayloadStore(directoryURL: directory, inlineByteThreshold: 100)
+      let block = String(repeating: "a", count: 100)
+
+      let payload = try store.materializeIfNeeded(block: block)
+
+      #expect(payload == .inline(block))
+      #expect(payload.promptText == block)
+      // Nothing written for inline payloads (directory not even created).
+      #expect(!FileManager.default.fileExists(atPath: directory.path))
+    }
+  }
+
+  @Test("Oversized blocks are written to a file and referenced by path")
+  func fileReferenceAboveThreshold() throws {
+    try withTempDirectory { directory in
+      let store = ContextPayloadStore(directoryURL: directory, inlineByteThreshold: 100)
+      let block = String(repeating: "b", count: 101)
+
+      let payload = try store.materializeIfNeeded(block: block)
+
+      guard case .fileReference(let path, let prompt) = payload else {
+        Issue.record("Expected fileReference, got \(payload)")
+        return
+      }
+      #expect(prompt.contains(path))
+      #expect(prompt.contains("Read that file before doing anything else."))
+      #expect(payload.promptText == prompt)
+      #expect(try String(contentsOfFile: path, encoding: .utf8) == block)
+      #expect(path.hasPrefix(directory.path))
+      #expect(path.hasSuffix(".md"))
+    }
+  }
+
+  @Test("Stale payloads are pruned on write; fresh ones survive")
+  func prunesStalePayloads() throws {
+    try withTempDirectory { directory in
+      try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+      let staleURL = directory.appendingPathComponent("context-stale.md")
+      let freshURL = directory.appendingPathComponent("context-fresh.md")
+      try "stale".write(to: staleURL, atomically: true, encoding: .utf8)
+      try "fresh".write(to: freshURL, atomically: true, encoding: .utf8)
+      let staleDate = Date().addingTimeInterval(-ContextPayloadStore.stalePayloadMaxAge - 3600)
+      try FileManager.default.setAttributes(
+        [.modificationDate: staleDate], ofItemAtPath: staleURL.path)
+
+      let store = ContextPayloadStore(directoryURL: directory, inlineByteThreshold: 10)
+      _ = try store.materializeIfNeeded(block: String(repeating: "c", count: 11))
+
+      #expect(!FileManager.default.fileExists(atPath: staleURL.path))
+      #expect(FileManager.default.fileExists(atPath: freshURL.path))
+    }
+  }
+
+  @Test("Threshold compares UTF-8 bytes, not characters")
+  func thresholdUsesUTF8Bytes() throws {
+    try withTempDirectory { directory in
+      let store = ContextPayloadStore(directoryURL: directory, inlineByteThreshold: 5)
+      // "éé" is 2 characters but 4 UTF-8 bytes — inline at a 5-byte threshold.
+      let inline = try store.materializeIfNeeded(block: "éé")
+      #expect(inline == .inline("éé"))
+
+      // "ééé" is 6 bytes — over the 5-byte threshold.
+      let reference = try store.materializeIfNeeded(block: "ééé")
+      guard case .fileReference = reference else {
+        Issue.record("Expected fileReference for 6-byte block")
+        return
+      }
+    }
+  }
+}

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/ContextProfileServiceTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/ContextProfileServiceTests.swift
@@ -1,0 +1,98 @@
+import AgentHubCLIKit
+import Foundation
+import Testing
+
+@testable import AgentHubCore
+
+@Suite("Context profile service")
+struct ContextProfileServiceTests {
+
+  private func withService(
+    _ body: (ContextProfileService, ContextProfileIndexStore) async throws -> Void
+  ) async throws {
+    let root = FileManager.default.temporaryDirectory
+      .appendingPathComponent("context-profile-service-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    let store = try SessionMetadataStore(
+      path: root.appendingPathComponent("db.sqlite").path)
+    let indexStore = ContextProfileIndexStore(
+      directoryURL: root.appendingPathComponent("index", isDirectory: true))
+    try await body(ContextProfileService(metadataStore: store, indexStore: indexStore), indexStore)
+  }
+
+  @Test("Profiles list project-scoped first, then personal")
+  func profilesListProjectFirst() async throws {
+    try await withService { service, _ in
+      try await service.save(makePersonalProfile(id: "pers", name: "AAA Personal"))
+      try await service.save(makeProfile(id: "proj", name: "ZZZ Project"))
+
+      let profiles = try await service.profiles(forProjectPath: "/tmp/project")
+      #expect(profiles.map(\.id) == ["proj", "pers"])
+    }
+  }
+
+  @Test("Saving republishes the project's JSON index")
+  func saveRepublishesIndex() async throws {
+    try await withService { service, indexStore in
+      try await service.save(makeProfile(id: "proj", name: "Project profile"))
+
+      let index = try #require(indexStore.read(projectPath: "/tmp/project"))
+      #expect(index.profiles.map(\.id) == ["proj"])
+      #expect(index.profiles.first?.relativeFilePaths == ["Sources/App/Main.swift", "CLAUDE.md"])
+    }
+  }
+
+  @Test("A personal save is merged into every project's index")
+  func personalSaveMergesIntoProjectIndexes() async throws {
+    try await withService { service, indexStore in
+      try await service.save(makeProfile(id: "proj", name: "Project profile"))
+      try await service.save(makePersonalProfile(id: "pers", name: "Personal profile"))
+
+      let index = try #require(indexStore.read(projectPath: "/tmp/project"))
+      #expect(Set(index.profiles.map(\.id)) == ["proj", "pers"])
+      #expect(index.profiles.first { $0.id == "pers" }?.scope == "personal")
+    }
+  }
+
+  @Test("Set-default flows through to the index and defaultProfile")
+  func setDefaultFlowsThrough() async throws {
+    try await withService { service, indexStore in
+      try await service.save(makeProfile(id: "proj", name: "Project profile"))
+      try await service.setDefault(id: "proj", forProjectPath: "/tmp/project")
+
+      #expect(try await service.defaultProfile(forProjectPath: "/tmp/project")?.id == "proj")
+      let index = try #require(indexStore.read(projectPath: "/tmp/project"))
+      #expect(index.profiles.first?.isDefault == true)
+    }
+  }
+
+  @Test("Deleting removes the profile from the store and the index")
+  func deleteRemovesEverywhere() async throws {
+    try await withService { service, indexStore in
+      try await service.save(makeProfile(id: "a", name: "A"))
+      try await service.save(makeProfile(id: "b", name: "B"))
+
+      try await service.delete(id: "a", projectPath: "/tmp/project")
+
+      #expect(try await service.profiles(forProjectPath: "/tmp/project").map(\.id) == ["b"])
+      let index = try #require(indexStore.read(projectPath: "/tmp/project"))
+      #expect(index.profiles.map(\.id) == ["b"])
+    }
+  }
+
+  @Test("Save stamps updatedAt")
+  func saveStampsUpdatedAt() async throws {
+    try await withService { service, _ in
+      let stale = Date(timeIntervalSince1970: 1_000)
+      var profile = makeProfile(id: "proj", name: "Project profile")
+      profile.updatedAt = stale
+
+      try await service.save(profile)
+
+      let saved = try #require(try await service.profiles(forProjectPath: "/tmp/project").first)
+      #expect(saved.updatedAt > stale)
+    }
+  }
+}

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/ContextProfileStoreTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/ContextProfileStoreTests.swift
@@ -1,0 +1,362 @@
+import Foundation
+import GRDB
+import Testing
+
+@testable import AgentHubCore
+
+@Suite("Context profile store")
+struct ContextProfileStoreTests {
+
+  @Test("A profile round-trips through SQLite with its selection intact")
+  func profileRoundTrips() async throws {
+    let store = try SessionMetadataStore(path: temporaryContextDatabasePath())
+    let profile = makeProfile(name: "Voice work")
+
+    try await store.saveContextProfile(ContextProfileRecord(profile: profile))
+
+    let stored = try await store.getContextProfiles(forProjectPath: "/tmp/project")
+    #expect(stored.count == 1)
+    #expect(try stored.first?.decodedProfile() == profile)
+  }
+
+  @Test("Selections saved before externalPaths existed still decode")
+  func legacySelectionPayloadDecodes() throws {
+    let legacyJSON = Data(#"{"files":[{"relativePath":"a.swift"}],"instructions":"hi"}"#.utf8)
+    let decoded = try JSONDecoder().decode(ContextSelection.self, from: legacyJSON)
+
+    #expect(decoded.files.map(\.relativePath) == ["a.swift"])
+    #expect(decoded.externalPaths.isEmpty)
+    #expect(decoded.textSnippets.isEmpty)
+    #expect(decoded.instructions == "hi")
+  }
+
+  @Test("Text snippets survive the profile round trip")
+  func textSnippetsRoundTrip() async throws {
+    let store = try SessionMetadataStore(path: temporaryContextDatabasePath())
+    var profile = makeProfile(id: "snip", name: "With snippet")
+    profile.selection.textSnippets = [
+      ContextTextSnippet(id: "s1", title: "API notes", content: "POST /v1/things returns 201")
+    ]
+
+    try await store.saveContextProfile(ContextProfileRecord(profile: profile))
+
+    let decoded = try #require(
+      try await store.getContextProfiles(forProjectPath: "/tmp/project").first?.decodedProfile())
+    #expect(decoded.selection.textSnippets.count == 1)
+    #expect(decoded.selection.textSnippets.first?.title == "API notes")
+    #expect(decoded.selection.textSnippets.first?.content == "POST /v1/things returns 201")
+  }
+
+  @Test("External paths survive the profile round trip")
+  func externalPathsRoundTrip() async throws {
+    let store = try SessionMetadataStore(path: temporaryContextDatabasePath())
+    var profile = makeProfile(id: "ext", name: "With externals")
+    profile.selection.externalPaths = ["/Users/me/books/swift-book.md"]
+
+    try await store.saveContextProfile(ContextProfileRecord(profile: profile))
+
+    let decoded = try #require(
+      try await store.getContextProfiles(forProjectPath: "/tmp/project").first?.decodedProfile())
+    #expect(decoded.selection.externalPaths == ["/Users/me/books/swift-book.md"])
+  }
+
+  @Test("Profiles list name-ordered, case-insensitively")
+  func profilesListNameOrdered() async throws {
+    let store = try SessionMetadataStore(path: temporaryContextDatabasePath())
+    for name in ["zeta", "Alpha", "beta"] {
+      try await store.saveContextProfile(
+        ContextProfileRecord(profile: makeProfile(id: name, name: name)))
+    }
+
+    #expect(
+      try await store.getContextProfiles(forProjectPath: "/tmp/project").map(\.name)
+        == ["Alpha", "beta", "zeta"])
+  }
+
+  @Test("Personal and project scopes stay separate")
+  func scopesStaySeparate() async throws {
+    let store = try SessionMetadataStore(path: temporaryContextDatabasePath())
+    try await store.saveContextProfile(
+      ContextProfileRecord(profile: makeProfile(id: "proj", name: "Project profile")))
+    try await store.saveContextProfile(
+      ContextProfileRecord(profile: makePersonalProfile(id: "pers", name: "Personal profile")))
+
+    #expect(try await store.getContextProfiles(forProjectPath: "/tmp/project").map(\.id) == ["proj"])
+    #expect(try await store.getPersonalContextProfiles().map(\.id) == ["pers"])
+    #expect(try await store.getProjectPathsWithContextProfiles() == ["/tmp/project"])
+  }
+
+  @Test("Project lookup normalizes the path")
+  func projectLookupNormalizesPath() async throws {
+    let store = try SessionMetadataStore(path: temporaryContextDatabasePath())
+    try await store.saveContextProfile(ContextProfileRecord(profile: makeProfile()))
+
+    #expect(try await store.getContextProfiles(forProjectPath: "/tmp/project/").count == 1)
+    #expect(try await store.getContextProfiles(forProjectPath: "/tmp/nested/../project").count == 1)
+  }
+
+  @Test("Setting a default swaps the previous one in a single transaction")
+  func setDefaultSwaps() async throws {
+    let store = try SessionMetadataStore(path: temporaryContextDatabasePath())
+    try await store.saveContextProfile(ContextProfileRecord(profile: makeProfile(id: "first", name: "First")))
+    try await store.saveContextProfile(ContextProfileRecord(profile: makeProfile(id: "second", name: "Second")))
+
+    try await store.setDefaultContextProfile(id: "first", forProjectPath: "/tmp/project")
+    try await store.setDefaultContextProfile(id: "second", forProjectPath: "/tmp/project")
+
+    let profiles = try await store.getContextProfiles(forProjectPath: "/tmp/project")
+    #expect(profiles.first { $0.id == "second" }?.isDefault == true)
+    #expect(profiles.first { $0.id == "first" }?.isDefault == false)
+
+    try await store.setDefaultContextProfile(id: nil, forProjectPath: "/tmp/project")
+    #expect(try await store.getContextProfiles(forProjectPath: "/tmp/project").allSatisfy { !$0.isDefault })
+  }
+
+  @Test("A personal profile cannot become a project default")
+  func personalProfileRejectedAsDefault() async throws {
+    let store = try SessionMetadataStore(path: temporaryContextDatabasePath())
+    try await store.saveContextProfile(
+      ContextProfileRecord(profile: makePersonalProfile(id: "pers", name: "Personal")))
+
+    await #expect(throws: (any Error).self) {
+      try await store.setDefaultContextProfile(id: "pers", forProjectPath: "/tmp/project")
+    }
+  }
+
+  @Test("An unknown id cannot become a default, and the old default is not lost silently")
+  func unknownIdRejectedAsDefault() async throws {
+    let store = try SessionMetadataStore(path: temporaryContextDatabasePath())
+    try await store.saveContextProfile(ContextProfileRecord(profile: makeProfile(id: "real", name: "Real")))
+    try await store.setDefaultContextProfile(id: "real", forProjectPath: "/tmp/project")
+
+    await #expect(throws: (any Error).self) {
+      try await store.setDefaultContextProfile(id: "ghost", forProjectPath: "/tmp/project")
+    }
+    // The failed transaction rolled back, so the previous default survives.
+    #expect(try await store.getContextProfiles(forProjectPath: "/tmp/project").first?.isDefault == true)
+  }
+
+  /// The partial unique index is the last line of defense: a record slipping in
+  /// with isDefault already set while another default exists must fail loudly.
+  @Test("The database rejects a second default row for one project")
+  func databaseRejectsSecondDefault() async throws {
+    let store = try SessionMetadataStore(path: temporaryContextDatabasePath())
+    try await store.saveContextProfile(ContextProfileRecord(profile: makeProfile(id: "a", name: "A")))
+    try await store.setDefaultContextProfile(id: "a", forProjectPath: "/tmp/project")
+
+    var sneaky = makeProfile(id: "b", name: "B")
+    sneaky.isDefault = true
+    await #expect(throws: (any Error).self) {
+      try await store.saveContextProfile(ContextProfileRecord(profile: sneaky))
+    }
+  }
+
+  @Test("Sync readers return the default profile and the project list")
+  func syncReaders() async throws {
+    let store = try SessionMetadataStore(path: temporaryContextDatabasePath())
+    try await store.saveContextProfile(ContextProfileRecord(profile: makeProfile(id: "a", name: "A")))
+    try await store.saveContextProfile(ContextProfileRecord(profile: makeProfile(id: "b", name: "B")))
+    try await store.setDefaultContextProfile(id: "b", forProjectPath: "/tmp/project")
+
+    #expect(store.getDefaultContextProfileSync(forProjectPath: "/tmp/project")?.id == "b")
+    #expect(store.getContextProfilesSync(forProjectPath: "/tmp/project").map(\.id) == ["a", "b"])
+    #expect(store.getDefaultContextProfileSync(forProjectPath: "/tmp/other") == nil)
+  }
+
+  @Test("Deleting a profile leaves the rest")
+  func deleteLeavesRest() async throws {
+    let store = try SessionMetadataStore(path: temporaryContextDatabasePath())
+    try await store.saveContextProfile(ContextProfileRecord(profile: makeProfile(id: "a", name: "A")))
+    try await store.saveContextProfile(ContextProfileRecord(profile: makeProfile(id: "b", name: "B")))
+
+    try await store.deleteContextProfile(id: "a")
+
+    #expect(try await store.getContextProfiles(forProjectPath: "/tmp/project").map(\.id) == ["b"])
+  }
+
+  @Test("Profiles survive reopening the database")
+  func profilesSurviveReopen() async throws {
+    let path = temporaryContextDatabasePath()
+    let store = try SessionMetadataStore(path: path)
+    try await store.saveContextProfile(ContextProfileRecord(profile: makeProfile(id: "kept", name: "Kept")))
+
+    let reopened = try SessionMetadataStore(path: path)
+    #expect(try await reopened.getContextProfiles(forProjectPath: "/tmp/project").map(\.id) == ["kept"])
+  }
+
+  /// Replicates a database that ran builds from a divergent development
+  /// branch: its ledger holds foreign migration identifiers and an abandoned
+  /// `context_profiles` table with a different schema (and zero rows). v16
+  /// must clear that leftover and succeed instead of failing on CREATE TABLE
+  /// — the failure mode that renders the whole app store-less.
+  @Test("v16 migration recovers from a divergent branch's leftover context_profiles table")
+  func v16MigrationRecoversFromForeignLeftoverTable() async throws {
+    let path = temporaryContextDatabasePath()
+    let dbQueue = try DatabaseQueue(path: path)
+
+    try await dbQueue.write { db in
+      try seedMigrationBaseline(
+        before: SessionMetadataStore.MigrationID.createContextProfiles,
+        in: db
+      )
+      try seedLegacyContextBaselineData(in: db)
+
+      // Foreign identifiers applied by another branch's builds.
+      for foreign in ["v11_create_context_profiles", "v14_create_session_findings"] {
+        try db.execute(
+          sql: "INSERT INTO grdb_migrations (identifier) VALUES (?)", arguments: [foreign])
+      }
+      // The abandoned experiment's schema — incompatible with v16's.
+      try db.execute(sql: """
+        CREATE TABLE context_profiles (
+          id TEXT PRIMARY KEY, name TEXT NOT NULL, projectPath TEXT NOT NULL,
+          schemaVersion INTEGER NOT NULL, selectionData BLOB NOT NULL,
+          createdAt DATETIME NOT NULL, updatedAt DATETIME NOT NULL)
+        """)
+      try db.execute(
+        sql: "CREATE INDEX context_profiles_on_projectPath ON context_profiles(projectPath)")
+      // The other branch's feature table must survive untouched.
+      try db.execute(sql: "CREATE TABLE session_findings (id TEXT PRIMARY KEY, payload TEXT)")
+      try db.execute(sql: "INSERT INTO session_findings (id, payload) VALUES ('f1', 'keep-me')")
+    }
+
+    let store = try SessionMetadataStore(path: path)
+
+    // Migration succeeded, existing data is intact, and the new table works.
+    #expect(try await store.getCustomName(for: "legacy-session") == "legacy-name")
+    #expect(try await store.getMeasurements(forProjectPath: "/tmp/project").map(\.id) == ["legacy-measurement"])
+    try await store.saveContextProfile(ContextProfileRecord(profile: makeProfile(id: "post", name: "Post")))
+    #expect(try await store.getContextProfiles(forProjectPath: "/tmp/project").map(\.id) == ["post"])
+
+    let findings = try await dbQueue.read { db in
+      try String.fetchAll(db, sql: "SELECT payload FROM session_findings")
+    }
+    #expect(findings == ["keep-me"])
+  }
+
+  @Test("v16 migration preserves existing metadata")
+  func v16MigrationPreservesExistingMetadata() async throws {
+    let path = temporaryContextDatabasePath()
+    let dbQueue = try DatabaseQueue(path: path)
+
+    try await dbQueue.write { db in
+      try seedMigrationBaseline(
+        before: SessionMetadataStore.MigrationID.createContextProfiles,
+        in: db
+      )
+      try seedLegacyContextBaselineData(in: db)
+    }
+
+    let store = try SessionMetadataStore(path: path)
+
+    #expect(try await store.getCustomName(for: "legacy-session") == "legacy-name")
+    #expect(try await store.getPinnedSessionIds() == ["legacy-session"])
+    #expect(try await store.getMeasurements(forProjectPath: "/tmp/project").map(\.id) == ["legacy-measurement"])
+    #expect(try await store.getContextProfiles(forProjectPath: "/tmp/project").isEmpty)
+
+    // The new table is usable immediately after migrating.
+    try await store.saveContextProfile(ContextProfileRecord(profile: makeProfile(id: "post", name: "Post")))
+    #expect(try await store.getContextProfiles(forProjectPath: "/tmp/project").map(\.id) == ["post"])
+  }
+}
+
+// MARK: - Helpers
+
+func makeProfile(
+  id: String = "profile-1",
+  name: String = "Profile",
+  projectPath: String = "/tmp/project",
+  isDefault: Bool = false
+) -> ContextProfile {
+  ContextProfile(
+    id: id,
+    name: name,
+    scope: .project,
+    projectPath: projectPath,
+    selection: ContextSelection(
+      files: [
+        ContextFileSelection(relativePath: "Sources/App/Main.swift"),
+        ContextFileSelection(relativePath: "CLAUDE.md"),
+      ],
+      instructions: "Focus on the launch flow."
+    ),
+    isDefault: isDefault,
+    createdAt: Date(timeIntervalSince1970: 1_000),
+    updatedAt: Date(timeIntervalSince1970: 2_000)
+  )
+}
+
+func makePersonalProfile(id: String = "personal-1", name: String = "Personal") -> ContextProfile {
+  ContextProfile(
+    id: id,
+    name: name,
+    scope: .personal,
+    projectPath: "",
+    selection: ContextSelection(
+      files: [ContextFileSelection(relativePath: "README.md")],
+      instructions: "Read the README first."
+    ),
+    createdAt: Date(timeIntervalSince1970: 1_000),
+    updatedAt: Date(timeIntervalSince1970: 2_000)
+  )
+}
+
+private func seedLegacyContextBaselineData(in db: Database) throws {
+  try db.create(table: "session_metadata") { t in
+    t.column("sessionId", .text).primaryKey()
+    t.column("customName", .text)
+    t.column("createdAt", .datetime).notNull()
+    t.column("updatedAt", .datetime).notNull()
+    t.column("isPinned", .boolean).notNull().defaults(to: false)
+  }
+  try db.execute(
+    sql: """
+    INSERT INTO session_metadata (sessionId, customName, createdAt, updatedAt, isPinned)
+    VALUES (?, ?, ?, ?, ?)
+    """,
+    arguments: [
+      "legacy-session",
+      "legacy-name",
+      Date(timeIntervalSince1970: 1_000),
+      Date(timeIntervalSince1970: 2_000),
+      true,
+    ]
+  )
+
+  // The v15 shape of session_measurements: projectPath column already present.
+  try db.create(table: "session_measurements") { t in
+    t.column("id", .text).primaryKey(onConflict: .replace)
+    t.column("sessionId", .text).notNull().indexed()
+    t.column("provider", .text).notNull()
+    t.column("createdAt", .datetime).notNull()
+    t.column("payloadVersion", .integer).notNull()
+    t.column("payloadData", .blob).notNull()
+    t.column("projectPath", .text).notNull().defaults(to: "")
+  }
+  try db.create(
+    index: "idx_session_measurements_project",
+    on: "session_measurements",
+    columns: ["projectPath"]
+  )
+  try db.execute(
+    sql: """
+    INSERT INTO session_measurements (id, sessionId, provider, createdAt, payloadVersion, payloadData, projectPath)
+    VALUES (?, ?, ?, ?, ?, ?, ?)
+    """,
+    arguments: [
+      "legacy-measurement",
+      "legacy-session",
+      "claude",
+      Date(timeIntervalSince1970: 1_000),
+      1,
+      Data("{}".utf8),
+      "/tmp/project",
+    ]
+  )
+}
+
+private func temporaryContextDatabasePath() -> String {
+  FileManager.default.temporaryDirectory
+    .appending(path: "context_profiles_\(UUID().uuidString).sqlite")
+    .path
+}

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/ContextTokenEstimatorTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/ContextTokenEstimatorTests.swift
@@ -1,0 +1,36 @@
+import Foundation
+import Testing
+
+@testable import AgentHubCore
+
+@Suite("Context token estimator")
+struct ContextTokenEstimatorTests {
+
+  private let estimator = ContextTokenEstimator()
+
+  @Test("Zero bytes estimates zero tokens")
+  func zeroBytes() {
+    #expect(estimator.estimatedTokens(forByteCount: 0) == 0)
+    #expect(estimator.estimatedTokens(forByteCount: -10) == 0)
+  }
+
+  @Test("bytes/4 with safety multiplier, rounded up")
+  func estimateFormula() {
+    // 4000 bytes / 4 = 1000 tokens × 1.15 = 1150.
+    #expect(estimator.estimatedTokens(forByteCount: 4000) == 1150)
+    // 1 byte → 0.2875 → rounds up to 1.
+    #expect(estimator.estimatedTokens(forByteCount: 1) == 1)
+    // 10 bytes → 2.875 → 3.
+    #expect(estimator.estimatedTokens(forByteCount: 10) == 3)
+  }
+
+  @Test("Estimate is monotonic")
+  func monotonic() {
+    var previous = 0
+    for bytes in stride(from: 0, through: 100_000, by: 7919) {
+      let estimate = estimator.estimatedTokens(forByteCount: bytes)
+      #expect(estimate >= previous)
+      previous = estimate
+    }
+  }
+}

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/MockContextProfileService.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/MockContextProfileService.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+@testable import AgentHubCore
+
+/// Shared protocol mock for context-profile consumers (launcher, builder,
+/// Project Details tab).
+final class MockContextProfileService: ContextProfileServiceProtocol, @unchecked Sendable {
+  var storedProfiles: [ContextProfile] = []
+  var defaultProfileResult: ContextProfile?
+  private(set) var savedProfiles: [ContextProfile] = []
+  private(set) var deletedIds: [String] = []
+  private(set) var defaultRequests: [String?] = []
+
+  func profiles(forProjectPath projectPath: String) async throws -> [ContextProfile] {
+    storedProfiles
+  }
+
+  func save(_ profile: ContextProfile) async throws {
+    savedProfiles.append(profile)
+    storedProfiles.removeAll { $0.id == profile.id }
+    storedProfiles.append(profile)
+  }
+
+  func delete(id: String, projectPath: String) async throws {
+    deletedIds.append(id)
+    storedProfiles.removeAll { $0.id == id }
+  }
+
+  func setDefault(id: String?, forProjectPath projectPath: String) async throws {
+    defaultRequests.append(id)
+    storedProfiles = storedProfiles.map { profile in
+      var updated = profile
+      updated.isDefault = profile.id == id
+      return updated
+    }
+  }
+
+  func defaultProfile(forProjectPath projectPath: String) async throws -> ContextProfile? {
+    defaultProfileResult ?? storedProfiles.first { $0.isDefault }
+  }
+}

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/ModelContextWindowResolverTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/ModelContextWindowResolverTests.swift
@@ -1,0 +1,57 @@
+import Foundation
+import Testing
+
+@testable import AgentHubCore
+
+@Suite("Model context window resolver")
+struct ModelContextWindowResolverTests {
+
+  private let codexWindows = ["gpt-5.6-sol": 272_000, "gpt-5.6-luna": 272_000]
+
+  @Test("No model resolves to the conservative default")
+  func nilModelUsesDefault() {
+    #expect(
+      ModelContextWindowResolver.window(forModelIdentifier: nil, codexWindows: codexWindows)
+        == ModelContextWindowResolver.conservativeDefaultTokens)
+    #expect(
+      ModelContextWindowResolver.window(forModelIdentifier: "  ", codexWindows: codexWindows)
+        == ModelContextWindowResolver.conservativeDefaultTokens)
+  }
+
+  @Test("Plain Claude ids run the standard 200K window")
+  func plainClaudeIdsUseStandardWindow() {
+    #expect(
+      ModelContextWindowResolver.window(forModelIdentifier: "claude-opus-4-8", codexWindows: [:])
+        == 200_000)
+    #expect(
+      ModelContextWindowResolver.window(forModelIdentifier: "claude-haiku-4-5-20251001", codexWindows: [:])
+        == 200_000)
+  }
+
+  @Test("The [1m] beta suffix resolves to a 1M window")
+  func oneMillionSuffix() {
+    #expect(
+      ModelContextWindowResolver.window(forModelIdentifier: "claude-sonnet-4-5[1m]", codexWindows: [:])
+        == 1_000_000)
+    #expect(
+      ModelContextWindowResolver.window(forModelIdentifier: "Claude-Opus-4-8[1M]", codexWindows: [:])
+        == 1_000_000)
+  }
+
+  @Test("Codex models resolve from the cached per-model window")
+  func codexCacheLookup() {
+    #expect(
+      ModelContextWindowResolver.window(forModelIdentifier: "gpt-5.6-sol", codexWindows: codexWindows)
+        == 272_000)
+    #expect(
+      ModelContextWindowResolver.window(forModelIdentifier: "GPT-5.6-Sol", codexWindows: codexWindows)
+        == 272_000)
+  }
+
+  @Test("Unknown models fall back conservatively")
+  func unknownModelFallsBack() {
+    #expect(
+      ModelContextWindowResolver.window(forModelIdentifier: "gpt-9-experimental", codexWindows: codexWindows)
+        == ModelContextWindowResolver.conservativeDefaultTokens)
+  }
+}

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/MultiSessionLaunchContextTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/MultiSessionLaunchContextTests.swift
@@ -1,0 +1,283 @@
+import AppKit
+import Combine
+import Foundation
+import Testing
+
+@testable import AgentHubCore
+
+// MARK: - Stubs
+
+private actor ContextStubMonitorService: SessionMonitorServiceProtocol {
+  nonisolated var repositoriesPublisher: AnyPublisher<[SelectedRepository], Never> {
+    Empty<[SelectedRepository], Never>().eraseToAnyPublisher()
+  }
+
+  func addRepository(_ path: String) async -> SelectedRepository? { nil }
+  func removeRepository(_ path: String) async {}
+  func getSelectedRepositories() async -> [SelectedRepository] { [] }
+  func setSelectedRepositories(_ repositories: [SelectedRepository]) async {}
+  func refreshSessions(skipWorktreeRedetection: Bool) async {}
+}
+
+private actor ContextStubFileWatcher: SessionFileWatcherProtocol {
+  private nonisolated let subject = PassthroughSubject<SessionFileWatcher.StateUpdate, Never>()
+
+  nonisolated var statePublisher: AnyPublisher<SessionFileWatcher.StateUpdate, Never> {
+    subject.eraseToAnyPublisher()
+  }
+
+  func startMonitoring(sessionId: String, projectPath: String, sessionFilePath: String?) async {}
+  func stopMonitoring(sessionId: String) async {}
+  func getState(sessionId: String) async -> SessionMonitorState? { nil }
+  func refreshState(sessionId: String) async {}
+  func setApprovalTimeout(_ seconds: Int) async {}
+}
+
+// MARK: - Helpers
+
+@MainActor
+private func makeSessionsViewModel() -> CLISessionsViewModel {
+  CLISessionsViewModel(
+    monitorService: ContextStubMonitorService(),
+    fileWatcher: ContextStubFileWatcher(),
+    searchService: nil,
+    cliConfiguration: CLICommandConfiguration(command: "claude", mode: .claude),
+    providerKind: .claude,
+    approvalNotificationService: NoOpApprovalNotificationService()
+  )
+}
+
+@MainActor
+private func makeLaunchViewModel(
+  profileService: MockContextProfileService? = nil,
+  payloadStore: any ContextPayloadStoring = ContextPayloadStore(),
+  repositoryPath: String? = nil
+) -> MultiSessionLaunchViewModel {
+  let viewModel = MultiSessionLaunchViewModel(
+    claudeViewModel: makeSessionsViewModel(),
+    codexViewModel: makeSessionsViewModel(),
+    contextProfileService: profileService,
+    contextPayloadStore: payloadStore
+  )
+  if let repositoryPath {
+    viewModel.selectedRepository = SelectedRepository(path: repositoryPath)
+  }
+  return viewModel
+}
+
+private func withTempProject(_ body: (URL) async throws -> Void) async throws {
+  let project = FileManager.default.temporaryDirectory
+    .appendingPathComponent("launch-context-\(UUID().uuidString)", isDirectory: true)
+  try FileManager.default.createDirectory(at: project, withIntermediateDirectories: true)
+  defer { try? FileManager.default.removeItem(at: project) }
+  try await body(project)
+}
+
+private func write(_ relativePath: String, _ content: String, in project: URL) throws {
+  let url = project.appendingPathComponent(relativePath)
+  try FileManager.default.createDirectory(
+    at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+  try content.write(to: url, atomically: true, encoding: .utf8)
+}
+
+// MARK: - Prompt merging
+
+@MainActor
+@Suite("Merged launch prompt")
+struct MergedLaunchPromptTests {
+  @Test("Nil or empty context leaves the prompt byte-identical")
+  func nilContextLeavesPromptUntouched() {
+    #expect(CLISessionsViewModel.mergedLaunchPrompt(contextBlock: nil, initialPrompt: "fix the bug") == "fix the bug")
+    #expect(CLISessionsViewModel.mergedLaunchPrompt(contextBlock: "  \n ", initialPrompt: "fix the bug") == "fix the bug")
+    #expect(CLISessionsViewModel.mergedLaunchPrompt(contextBlock: nil, initialPrompt: nil) == nil)
+  }
+
+  @Test("Context with a prompt is prepended with a blank line")
+  func contextPrepended() {
+    let merged = CLISessionsViewModel.mergedLaunchPrompt(
+      contextBlock: "<context>x</context>", initialPrompt: "fix the bug")
+    #expect(merged == "<context>x</context>\n\nfix the bug")
+  }
+
+  @Test("Context with no prompt asks the agent to load and acknowledge")
+  func contextOnlyAddsTrailer() throws {
+    let merged = try #require(CLISessionsViewModel.mergedLaunchPrompt(
+      contextBlock: "<context>x</context>", initialPrompt: nil))
+    #expect(merged.hasPrefix("<context>x</context>"))
+    #expect(merged.contains("background context"))
+  }
+}
+
+// MARK: - Launch view model context state
+
+@MainActor
+@Suite("Launch view model context")
+struct MultiSessionLaunchContextTests {
+
+  @Test("No selection resolves to no context block")
+  func noSelectionResolvesNil() async {
+    let viewModel = makeLaunchViewModel(repositoryPath: "/tmp/project")
+    #expect(await viewModel.resolveContextBlock(repoPath: "/tmp/project") == nil)
+  }
+
+  @Test("Curated selection resolves to an assembled block and records missing paths")
+  func curatedSelectionResolves() async throws {
+    try await withTempProject { project in
+      try write("src/a.swift", "let a = 1", in: project)
+      let viewModel = makeLaunchViewModel(repositoryPath: project.path)
+      viewModel.applyCuratedContext(ContextSelection(
+        files: [
+          ContextFileSelection(relativePath: "src/a.swift"),
+          ContextFileSelection(relativePath: "gone.swift"),
+        ],
+        instructions: "Careful."
+      ))
+
+      let block = try #require(await viewModel.resolveContextBlock(repoPath: project.path))
+
+      #expect(block.contains("<file path=\"src/a.swift\">\nlet a = 1\n</file>"))
+      #expect(block.contains("gone.swift (missing)"))
+      #expect(block.contains("<instructions>\nCareful.\n</instructions>"))
+      #expect(viewModel.contextMissingPaths == ["gone.swift"])
+    }
+  }
+
+  @Test("External files inline as text or ride along as attachment paths")
+  func externalFilesResolve() async throws {
+    try await withTempProject { project in
+      try write("src/a.swift", "let a = 1", in: project)
+      let outside = project.deletingLastPathComponent()
+        .appendingPathComponent("outside-\(UUID().uuidString)", isDirectory: true)
+      try FileManager.default.createDirectory(at: outside, withIntermediateDirectories: true)
+      defer { try? FileManager.default.removeItem(at: outside) }
+      let notes = outside.appendingPathComponent("notes.md")
+      try "external knowledge".write(to: notes, atomically: true, encoding: .utf8)
+      let pdf = outside.appendingPathComponent("book.pdf")
+      try Data([0x25, 0x50, 0x44, 0x46, 0xFF]).write(to: pdf)
+
+      let viewModel = makeLaunchViewModel(repositoryPath: project.path)
+      viewModel.applyCuratedContext(ContextSelection(
+        files: [ContextFileSelection(relativePath: "src/a.swift")],
+        externalPaths: [notes.path, pdf.path]
+      ))
+
+      let block = try #require(await viewModel.resolveContextBlock(repoPath: project.path))
+
+      #expect(block.contains("<file path=\"\(notes.path)\">\nexternal knowledge\n</file>"))
+      #expect(block.contains("\(pdf.path) (attachment — read separately)"))
+      #expect(block.contains("<file path=\"src/a.swift\">"))
+      #expect(viewModel.contextMissingPaths.isEmpty)
+    }
+  }
+
+  @Test("Text snippets are assembled into the launch block")
+  func textSnippetsResolve() async throws {
+    try await withTempProject { project in
+      let viewModel = makeLaunchViewModel(repositoryPath: project.path)
+      viewModel.applyCuratedContext(ContextSelection(
+        textSnippets: [ContextTextSnippet(title: "House rules", content: "Always run tests.")]
+      ))
+
+      let block = try #require(await viewModel.resolveContextBlock(repoPath: project.path))
+
+      #expect(block.contains("<snippet title=\"House rules\">\nAlways run tests.\n</snippet>"))
+      #expect(block.contains("House rules (pasted text)"))
+    }
+  }
+
+  @Test("An oversized block resolves to a temp-file reference prompt")
+  func oversizedBlockUsesFileReference() async throws {
+    try await withTempProject { project in
+      try write("big.txt", String(repeating: "x", count: 4_000), in: project)
+      let payloadDirectory = project.appendingPathComponent("payloads", isDirectory: true)
+      let viewModel = makeLaunchViewModel(
+        payloadStore: ContextPayloadStore(directoryURL: payloadDirectory, inlineByteThreshold: 512),
+        repositoryPath: project.path
+      )
+      viewModel.applyCuratedContext(ContextSelection(
+        files: [ContextFileSelection(relativePath: "big.txt")]
+      ))
+
+      let block = try #require(await viewModel.resolveContextBlock(repoPath: project.path))
+
+      #expect(block.contains("Read that file before doing anything else."))
+      #expect(!block.contains(String(repeating: "x", count: 100)))
+    }
+  }
+
+  @Test("The project default profile attaches once, and never after removal")
+  func defaultProfileAttachesOnce() async {
+    let service = MockContextProfileService()
+    service.defaultProfileResult = makeProfile(id: "default", name: "Default", isDefault: true)
+    let viewModel = makeLaunchViewModel(profileService: service, repositoryPath: "/tmp/project")
+
+    await viewModel.loadDefaultContextProfile()
+    #expect(viewModel.attachedContextProfile?.id == "default")
+
+    viewModel.removeAttachedContextProfile()
+    await viewModel.loadDefaultContextProfile()
+    #expect(viewModel.attachedContextProfile == nil)
+    #expect(viewModel.activeContextSelection == nil)
+  }
+
+  @Test("Ad-hoc curation overrides the attached profile")
+  func curationOverridesProfile() async {
+    let service = MockContextProfileService()
+    service.defaultProfileResult = makeProfile(id: "default", name: "Default", isDefault: true)
+    let viewModel = makeLaunchViewModel(profileService: service, repositoryPath: "/tmp/project")
+    await viewModel.loadDefaultContextProfile()
+
+    let curated = ContextSelection(files: [ContextFileSelection(relativePath: "only.swift")])
+    viewModel.applyCuratedContext(curated)
+
+    #expect(viewModel.activeContextSelection == curated)
+  }
+
+  @Test("Context summary estimates tokens and flags missing files without loading contents")
+  func summaryEstimatesTokens() async throws {
+    try await withTempProject { project in
+      try write("a.swift", String(repeating: "a", count: 400), in: project)
+      let viewModel = makeLaunchViewModel(repositoryPath: project.path)
+      viewModel.applyCuratedContext(ContextSelection(
+        files: [
+          ContextFileSelection(relativePath: "a.swift"),
+          ContextFileSelection(relativePath: "gone.swift"),
+        ]
+      ))
+
+      await viewModel.refreshContextSummary()
+
+      // 400 bytes / 4 × 1.15 = 115.
+      #expect(viewModel.contextSummaryTokens == 115)
+      #expect(viewModel.contextMissingPaths == ["gone.swift"])
+    }
+  }
+
+  @Test("Reset clears all context state")
+  func resetClearsContext() async {
+    let service = MockContextProfileService()
+    service.defaultProfileResult = makeProfile(id: "default", name: "Default", isDefault: true)
+    let viewModel = makeLaunchViewModel(profileService: service, repositoryPath: "/tmp/project")
+    await viewModel.loadDefaultContextProfile()
+
+    viewModel.reset()
+
+    #expect(viewModel.attachedContextProfile == nil)
+    #expect(viewModel.pendingContextSelection == nil)
+    #expect(viewModel.contextMissingPaths.isEmpty)
+  }
+}
+
+// MARK: - Terminal submit delay tiers
+
+@MainActor
+@Suite("Terminal prompt submit delay")
+struct TerminalPromptSubmitDelayTests {
+  @Test("Delay scales with payload size, topping out at one second")
+  func delayTiers() {
+    #expect(TerminalContainerView.submitDelay(forByteCount: 100) == .milliseconds(100))
+    #expect(TerminalContainerView.submitDelay(forByteCount: 1_000) == .milliseconds(250))
+    #expect(TerminalContainerView.submitDelay(forByteCount: 10_000) == .milliseconds(500))
+    #expect(TerminalContainerView.submitDelay(forByteCount: 50_000) == .seconds(1))
+  }
+}

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/ProjectContextViewModelTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/ProjectContextViewModelTests.swift
@@ -1,0 +1,92 @@
+import Foundation
+import Testing
+
+@testable import AgentHubCore
+
+@MainActor
+@Suite("Project context view model")
+struct ProjectContextViewModelTests {
+
+  private func withProject(
+    _ body: (URL, ProjectContextViewModel, MockContextProfileService) async throws -> Void
+  ) async throws {
+    let project = FileManager.default.temporaryDirectory
+      .appendingPathComponent("project-context-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: project, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: project) }
+
+    let service = MockContextProfileService()
+    let viewModel = ProjectContextViewModel(
+      projectPath: project.path,
+      service: service,
+      fileLoader: ContextFileLoader(fileIndexService: FileIndexService())
+    )
+    try await body(project, viewModel, service)
+  }
+
+  @Test("Load lists profiles and estimates tokens for resolvable files")
+  func loadListsAndEstimates() async throws {
+    try await withProject { project, viewModel, service in
+      let content = String(repeating: "a", count: 400)
+      try content.write(
+        to: project.appendingPathComponent("a.swift"), atomically: true, encoding: .utf8)
+      service.storedProfiles = [
+        ContextProfile(
+          id: "p1",
+          name: "One",
+          scope: .project,
+          projectPath: project.path,
+          selection: ContextSelection(files: [ContextFileSelection(relativePath: "a.swift")])
+        )
+      ]
+
+      await viewModel.load()
+
+      #expect(viewModel.profiles.map(\.id) == ["p1"])
+      // 400 bytes / 4 × 1.15 = 115.
+      #expect(viewModel.estimatedTokensByProfileId["p1"] == 115)
+    }
+  }
+
+  @Test("Delete removes through the service and reloads")
+  func deleteRemovesAndReloads() async throws {
+    try await withProject { project, viewModel, service in
+      service.storedProfiles = [
+        ContextProfile(id: "p1", name: "One", scope: .project, projectPath: project.path, selection: ContextSelection()),
+        ContextProfile(id: "p2", name: "Two", scope: .project, projectPath: project.path, selection: ContextSelection()),
+      ]
+      await viewModel.load()
+
+      await viewModel.delete(viewModel.profiles[0])
+
+      #expect(service.deletedIds == ["p1"])
+      #expect(viewModel.profiles.map(\.id) == ["p2"])
+    }
+  }
+
+  @Test("Set default flows through the service, and nil clears it")
+  func setDefaultFlows() async throws {
+    try await withProject { project, viewModel, service in
+      service.storedProfiles = [
+        ContextProfile(id: "p1", name: "One", scope: .project, projectPath: project.path, selection: ContextSelection())
+      ]
+      await viewModel.load()
+
+      await viewModel.setDefault(viewModel.profiles[0])
+      #expect(service.defaultRequests == ["p1"])
+      #expect(viewModel.profiles.first?.isDefault == true)
+
+      await viewModel.setDefault(nil)
+      #expect(service.defaultRequests == ["p1", nil])
+      #expect(viewModel.profiles.first?.isDefault == false)
+    }
+  }
+
+  @Test("Without a service the tab reports unavailable and stays inert")
+  func unavailableWithoutService() async {
+    let viewModel = ProjectContextViewModel(projectPath: "/tmp/project", service: nil)
+    #expect(!viewModel.isAvailable)
+    await viewModel.load()
+    #expect(viewModel.profiles.isEmpty)
+  }
+}


### PR DESCRIPTION
## Summary

First milestone of #398 — explicit, reviewable, token-aware context for launched agents, built around the new Projects concept.

- **Context Builder** (launch sheet → *Add Context…*): three-pane master–detail — a **Context Sets rail** (tap to load, hover to delete, "New Context Set" on top), a **sources pane** with labeled sections (search *this project's* files / add **external files** from anywhere / add **pasted text**), and the **selection editor** with per-item token estimates, a budget bar against the model's real context window, instructions, and a preview of the **exact assembled block** (display capped at 20K chars so CoreText layout can't freeze the main thread). *Use This Context* is the theme-tinted primary action; saves live bottom-right and are gated on actual edits.
- **Context sets**: named, reusable selections persisted in SQLite via a new append-only `v16_create_context_profiles` migration (Codable blob payload; a **partial unique index** makes "one default per project" a database guarantee), CRUD through `ContextProfileService`, and a `MeasurementIndexStore`-style **JSON mirror** for future CLI/agent tools. Scopes: **Project** and **Global** (user-level, works across repos).
- **Per-project default**: mark one set as default and it pre-attaches to every launch in that project as a removable chip with an approximate token readout — this is what makes the compact Start Session sheet context-aware.
- **Three context sources**: repo files stored as worktree-safe relative paths; external files as absolute paths (binary/oversized ones become `<attachments>` references the agent reads with its own tools — PDFs and books just work); pasted text snippets stored inside the set.
- **Launch plumbing**: `startNewSessionInHub` gains an optional `contextBlock` merged ahead of the first prompt for both Claude and Codex; blocks over 48KB are written to an app-support file and referenced by path. **Empty context is byte-identical to today's launch** (regression-tested).
- **Project Details → Context tab**: cards grid with All/Global/Project chips, create/edit/delete/set-default — the panel's first editing surface, with animated grid↔editor push.
- **Model-aware token budgeting**: `ModelContextWindowResolver` replaces the hardcoded 200K with real local data — Codex's `models_cache.json` `context_window` per slug (e.g. 272K for gpt-5.6) and Claude's `[1m]` id suffix (1M) — feeding both the live session usage bar and the builder, with an "approximate" disclaimer popover explaining the bytes÷4 estimator.

### Fixes along the way

- Claude initial-prompt delivery now uses **bracketed paste + a size-scaled submit delay** — previously a multi-line first prompt could submit at its first newline (`sendPromptIfNeeded` typed raw text).
- The v16 migration **recovers from a divergent dev branch's leftover `context_profiles` table** instead of failing and rendering the whole app store-less (empty Projects sidebar).

## Epic

Part of #398 — implements #400 (core spine), #402 (builder UI), #404 (token estimates), and #406 (reusable sets, promoted into this milestone). Deferred: #405 line slices, #407 code maps, #408 Smart-mode per-session context.

## Testing

- 90+ new/updated tests across 12 suites: assembler determinism & sections, payload-store thresholds & pruning, file loader (bounded reads, path traversal, external/binary classification), store CRUD + **v16 migration-preservation** + divergent-branch recovery, profile service + JSON mirror & alias mirroring, builder VM (tokens, dirty-gating, snippets, external flow, preview truncation), launch resolution incl. the byte-identical empty-context regression, window resolver, Codex catalog `context_window` decode, and the Context tab VM. All green via `AgentHubCore-Tests`.
- `AgentHubCLI` package fully green, including the new `ContextProfileIndexStore` suite.
- Full gate `./scripts/test.sh`: fails only in the documented parallel-load flake suites (agent workspaces, request monitors, worktree coordinator, CI notifier — all untouched by this diff); all five suites (42 tests) pass when run targeted on this tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)