### PR TITLE
Present the new-session sheet instantly; load branches behind it

### DIFF
--- a/app/AgentHub.xcodeproj/xcshareddata/xcschemes/AgentHub.xcscheme
+++ b/app/AgentHub.xcodeproj/xcshareddata/xcschemes/AgentHub.xcscheme
@@ -29,6 +29,18 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
       shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "7B03D9162F14D4E400C36AA3"
+               BuildableName = "AgentHubTests.xctest"
+               BlueprintName = "AgentHubTests"
+               ReferencedContainer = "container:AgentHub.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"

--- a/app/AgentHubTests/ForkSessionTests.swift
+++ b/app/AgentHubTests/ForkSessionTests.swift
@@ -1,3 +1,4 @@
+import AgentHubSessionGraph
 import Combine
 import Foundation
 import Testing

--- a/app/AgentHubTests/GitWorktreeServiceTests.swift
+++ b/app/AgentHubTests/GitWorktreeServiceTests.swift
@@ -1,3 +1,4 @@
+import AgentHubCLIKit
 import Foundation
 import Testing
 

--- a/app/AgentHubTests/ManagedProcessRegistryTests.swift
+++ b/app/AgentHubTests/ManagedProcessRegistryTests.swift
@@ -1,3 +1,4 @@
+import AgentHubSessionGraph
 import Foundation
 import Testing
 

--- a/app/AgentHubTests/SessionMetadataMigrationSafetyTests.swift
+++ b/app/AgentHubTests/SessionMetadataMigrationSafetyTests.swift
@@ -1,3 +1,4 @@
+import AgentHubSessionGraph
 import Foundation
 import GRDB
 import Testing

--- a/app/AgentHubTests/SessionWorkspaceStatePersistenceTests.swift
+++ b/app/AgentHubTests/SessionWorkspaceStatePersistenceTests.swift
@@ -1,3 +1,4 @@
+import AgentHubSessionGraph
 import Foundation
 import Testing
 

--- a/app/AgentHubTests/WorktreeCreationTests.swift
+++ b/app/AgentHubTests/WorktreeCreationTests.swift
@@ -1,3 +1,4 @@
+import AgentHubSessionGraph
 import Combine
 import Foundation
 import Testing
@@ -570,7 +571,7 @@ struct MultiSessionLaunchViewModelForkTests {
       sessionFilePath: "/tmp/session.jsonl"
     )
 
-    await vm.configureForFork(from: session, targetProvider: .codex)
+    vm.configureForFork(from: session, targetProvider: .codex)
 
     #expect(vm.selectedRepository?.path == "/tmp/repo")
     #expect(vm.launchMode == .manual)
@@ -604,7 +605,7 @@ struct MultiSessionLaunchViewModelForkTests {
       sessionFilePath: repo.repoPath + "/session.jsonl"
     )
 
-    await viewModel.configureForFork(from: session, targetProvider: .codex)
+    viewModel.configureForFork(from: session, targetProvider: .codex)
     await viewModel.launchSessions()
 
     let pending = try #require(codexViewModel.pendingHubSessions.first)

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/MultiProviderSessionsListView.swift
@@ -2407,14 +2407,14 @@ public struct MultiProviderSessionsListView: View {
       return
     }
 
-    Task { @MainActor in
-      let didPreselect = await launchViewModel.preselectRepository(path: preferredRepositoryPath)
-      if didPreselect {
-        startSessionSheetContext = StartSessionSheetContext(launchViewModel: launchViewModel)
-      } else if fallsBackToRepositoryPicker {
-        startSessionSheetContext = StartSessionSheetContext(launchViewModel: launchViewModel)
-        launchViewModel.selectRepository()
-      }
+    if launchViewModel.preselectRepository(path: preferredRepositoryPath) {
+      // Present immediately; branches (including the remote fetch) load
+      // behind the sheet's loading state.
+      startSessionSheetContext = StartSessionSheetContext(launchViewModel: launchViewModel)
+      launchViewModel.beginBranchLoad()
+    } else if fallsBackToRepositoryPicker {
+      startSessionSheetContext = StartSessionSheetContext(launchViewModel: launchViewModel)
+      launchViewModel.selectRepository()
     }
   }
 
@@ -2452,14 +2452,8 @@ public struct MultiProviderSessionsListView: View {
   private func triggerForkSessionFlow(session: CLISession, targetProvider: SessionProviderKind) {
     let launchViewModel = makeLaunchViewModel()
 
-    Task { @MainActor in
-      let didConfigure = await launchViewModel.configureForFork(
-        from: session,
-        targetProvider: targetProvider
-      )
-      if didConfigure {
-        startSessionSheetContext = StartSessionSheetContext(launchViewModel: launchViewModel)
-      }
+    if launchViewModel.configureForFork(from: session, targetProvider: targetProvider) {
+      startSessionSheetContext = StartSessionSheetContext(launchViewModel: launchViewModel)
     }
   }
 

--- a/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/MultiSessionLaunchViewModel.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/MultiSessionLaunchViewModel.swift
@@ -138,6 +138,9 @@ public final class MultiSessionLaunchViewModel {
   private var namingCoordinatorOperationID: String?
   private var activeLaunchTask: Task<Void, Never>?
   private var activeWorktreeOperations: [WorktreeCreationOperationID: ActiveWorktreeOperation] = [:]
+  /// Monotonic token so a superseded branch load (repository changed while the
+  /// git fetch was in flight) discards its results instead of applying them.
+  @ObservationIgnored private var branchLoadGeneration = 0
 
   // MARK: - Form State
 
@@ -455,15 +458,17 @@ public final class MultiSessionLaunchViewModel {
 
   /// Preselects a repository already tracked by either provider.
   /// Returns true when a matching repository was found and selected.
+  /// Matching is synchronous so callers can present the launch sheet
+  /// immediately; call `beginBranchLoad()` (or await `loadBranches()`)
+  /// afterwards to populate branch state — this never touches git.
   @discardableResult
-  public func preselectRepository(path: String) async -> Bool {
+  public func preselectRepository(path: String) -> Bool {
     let combined = claudeViewModel.selectedRepositories + codexViewModel.selectedRepositories
     let normalizedPath = WorktreeModuleResolver.normalizedDirectoryPath(path)
     if let repository = combined.last(where: {
       WorktreeModuleResolver.normalizedDirectoryPath($0.path) == normalizedPath
     }) {
       selectedRepository = repository
-      await loadBranches()
       return true
     }
 
@@ -481,7 +486,6 @@ public final class MultiSessionLaunchViewModel {
     } else {
       selectedRepository = match.repository
     }
-    await loadBranches()
     return true
   }
 
@@ -492,10 +496,10 @@ public final class MultiSessionLaunchViewModel {
   public func configureForFork(
     from session: CLISession,
     targetProvider: SessionProviderKind
-  ) async -> Bool {
+  ) -> Bool {
     reset()
 
-    let didPreselect = await preselectRepository(path: session.projectPath)
+    let didPreselect = preselectRepository(path: session.projectPath)
     if !didPreselect {
       selectedRepository = SelectedRepository(
         path: session.projectPath,
@@ -509,7 +513,6 @@ public final class MultiSessionLaunchViewModel {
         ],
         isExpanded: true
       )
-      await loadBranches()
     }
 
     launchMode = .manual
@@ -532,13 +535,36 @@ public final class MultiSessionLaunchViewModel {
     let branchName = Self.forkBranchName(for: session)
     manualSingleBranchName = branchName
     manualSingleDirectoryName = directoryName(for: branchName)
+
+    // Branch data loads behind the sheet. Fork deliberately bases the new
+    // worktree on the session's current HEAD (`baseBranch = nil`), so the
+    // load must not apply the remote default when it lands.
+    beginBranchLoad(applyDefaultBaseBranch: false)
     return selectedRepository != nil
+  }
+
+  /// Starts a branch load without blocking the caller, so the launch sheet can
+  /// be presented immediately while git (including a network fetch) runs behind
+  /// its loading state. The loading flags are set synchronously so the sheet's
+  /// first frame never flashes an empty branch picker.
+  public func beginBranchLoad(applyDefaultBaseBranch: Bool = true) {
+    guard selectedRepository != nil else { return }
+    isLoadingBranches = true
+    isLoadingCurrentBranch = true
+    Task { @MainActor [weak self] in
+      await self?.loadBranches(applyDefaultBaseBranch: applyDefaultBaseBranch)
+    }
   }
 
   /// Loads local branches and current branch for the selected repository.
   /// Uses a single `git branch` call to get both, reducing process spawns from 3 to 1-2.
-  public func loadBranches() async {
+  /// When `applyDefaultBaseBranch` is false, values seeded by the caller
+  /// (fork's base branch and branch name) survive the load; only the picker
+  /// options are filled in.
+  public func loadBranches(applyDefaultBaseBranch: Bool = true) async {
     guard let repo = selectedRepository else { return }
+    branchLoadGeneration &+= 1
+    let generation = branchLoadGeneration
     isLoadingBranches = true
     isLoadingCurrentBranch = true
 
@@ -547,20 +573,28 @@ public final class MultiSessionLaunchViewModel {
       async let remoteDefaultBranch = worktreeService.fetchAndGetDefaultRemoteBaseBranch(at: repo.path)
       let result = try await localBranches
       let defaultRemoteBranch = try await remoteDefaultBranch
+      guard generation == branchLoadGeneration else { return }
 
       availableBranches = RemoteBranch.worktreeBaseOptions(
         localBranches: result.branches,
         remoteDefaultBranch: defaultRemoteBranch
       )
-      currentBranchName = result.currentBranchName
-      if let defaultRemoteBranch {
-        baseBranch = defaultRemoteBranch
-      } else if let first = availableBranches.first {
-        baseBranch = first
+      if applyDefaultBaseBranch {
+        currentBranchName = result.currentBranchName
+        if let defaultRemoteBranch {
+          baseBranch = defaultRemoteBranch
+        } else if let first = availableBranches.first {
+          baseBranch = first
+        }
+      } else if currentBranchName.isEmpty {
+        currentBranchName = result.currentBranchName
       }
     } catch {
+      guard generation == branchLoadGeneration else { return }
       availableBranches = []
-      currentBranchName = ""
+      if applyDefaultBaseBranch {
+        currentBranchName = ""
+      }
     }
 
     isLoadingBranches = false

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/FocusedSessionLaunchTargetResolverTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/FocusedSessionLaunchTargetResolverTests.swift
@@ -152,7 +152,7 @@ struct MultiSessionLaunchViewModelPreselectionTests {
     await fixture.claudeMonitor.setRepositories([repository])
     try await waitUntil { fixture.claudeViewModel.selectedRepositories == [repository] }
 
-    let didPreselect = await fixture.launchViewModel.preselectRepository(path: "/tmp/Repo/app")
+    let didPreselect = fixture.launchViewModel.preselectRepository(path: "/tmp/Repo/app")
 
     #expect(didPreselect)
     #expect(fixture.launchViewModel.selectedRepository?.path == "/tmp/Repo")
@@ -166,7 +166,7 @@ struct MultiSessionLaunchViewModelPreselectionTests {
     await fixture.claudeMonitor.setRepositories([repository])
     try await waitUntil { fixture.claudeViewModel.selectedRepositories == [repository] }
 
-    let didPreselect = await fixture.launchViewModel.preselectRepository(path: "/tmp/Repo-feature/app")
+    let didPreselect = fixture.launchViewModel.preselectRepository(path: "/tmp/Repo-feature/app")
 
     #expect(didPreselect)
     #expect(fixture.launchViewModel.selectedRepository?.path == "/tmp/Repo-feature")

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/MultiSessionLaunchBranchLoadTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/MultiSessionLaunchBranchLoadTests.swift
@@ -1,0 +1,166 @@
+import Combine
+import Foundation
+import Testing
+
+@testable import AgentHubCore
+
+// Guards the non-blocking launch-sheet contract: repository selection and fork
+// configuration are synchronous so the sheet can present immediately, while
+// `loadBranches` runs behind the sheet's loading state — and a load finishing
+// late must never stomp values the flow seeded (fork's `baseBranch = nil`).
+
+@Suite("MultiSessionLaunchViewModel branch loading")
+@MainActor
+struct MultiSessionLaunchBranchLoadTests {
+
+  @Test("Fork configures synchronously and the branch load preserves the seeded base")
+  func forkConfiguresSynchronouslyAndLoadPreservesSeededBase() async throws {
+    let repo = try BranchLoadGitRepoFixture.create()
+    defer { repo.cleanup() }
+
+    let viewModel = makeBranchLoadFixtureViewModel()
+    let session = CLISession(
+      id: "abcdef1234567890",
+      projectPath: repo.repoPath,
+      branchName: "main",
+      sessionFilePath: repo.repoPath + "/session.jsonl"
+    )
+
+    let didConfigure = viewModel.configureForFork(from: session, targetProvider: .codex)
+
+    // Everything the sheet needs is seeded before any git call completes.
+    #expect(didConfigure)
+    #expect(viewModel.selectedRepository?.path == repo.repoPath)
+    #expect(viewModel.baseBranch == nil)
+    #expect(viewModel.currentBranchName == "main")
+    #expect(viewModel.isLoadingBranches)
+
+    try await waitUntil { !viewModel.isLoadingBranches }
+
+    // The load fills the picker but must not apply the remote/local default
+    // over fork's deliberate "current HEAD" base.
+    #expect(viewModel.baseBranch == nil)
+    #expect(viewModel.currentBranchName == "main")
+    #expect(viewModel.availableBranches.contains { $0.name == "main" })
+  }
+
+  @Test("Default branch load still applies a base branch when nothing was seeded")
+  func defaultBranchLoadAppliesBase() async throws {
+    let repo = try BranchLoadGitRepoFixture.create()
+    defer { repo.cleanup() }
+
+    let viewModel = makeBranchLoadFixtureViewModel()
+    viewModel.selectedRepository = SelectedRepository(path: repo.repoPath)
+
+    await viewModel.loadBranches()
+
+    #expect(viewModel.currentBranchName == "main")
+    #expect(viewModel.baseBranch != nil)
+    #expect(viewModel.isLoadingBranches == false)
+  }
+}
+
+// MARK: - Fixture
+
+@MainActor
+private func makeBranchLoadFixtureViewModel() -> MultiSessionLaunchViewModel {
+  let claudeViewModel = CLISessionsViewModel(
+    monitorService: BranchLoadMonitorService(),
+    fileWatcher: BranchLoadFileWatcher(),
+    searchService: nil,
+    cliConfiguration: .claudeDefault,
+    providerKind: .claude,
+    approvalNotificationService: NoOpApprovalNotificationService()
+  )
+  let codexViewModel = CLISessionsViewModel(
+    monitorService: BranchLoadMonitorService(),
+    fileWatcher: BranchLoadFileWatcher(),
+    searchService: nil,
+    cliConfiguration: .codexDefault,
+    providerKind: .codex,
+    approvalNotificationService: NoOpApprovalNotificationService()
+  )
+  return MultiSessionLaunchViewModel(
+    claudeViewModel: claudeViewModel,
+    codexViewModel: codexViewModel
+  )
+}
+
+@MainActor
+private func waitUntil(
+  _ condition: @escaping () -> Bool,
+  timeoutAttempts: Int = 250
+) async throws {
+  for _ in 0..<timeoutAttempts {
+    if condition() { return }
+    try await Task.sleep(for: .milliseconds(20))
+  }
+  #expect(condition())
+}
+
+private struct BranchLoadGitRepoFixture {
+  let repoPath: String
+  let parentDir: String
+
+  static func create() throws -> BranchLoadGitRepoFixture {
+    let parentDir = FileManager.default.temporaryDirectory
+      .appendingPathComponent("AgentHubBranchLoadTests-\(UUID().uuidString)", isDirectory: true)
+    let repoURL = parentDir.appendingPathComponent("repo", isDirectory: true)
+    try FileManager.default.createDirectory(at: repoURL, withIntermediateDirectories: true)
+
+    let fixture = BranchLoadGitRepoFixture(repoPath: repoURL.path, parentDir: parentDir.path)
+    try fixture.runGit("init", "-b", "main")
+    try fixture.runGit("config", "user.email", "test@test.com")
+    try fixture.runGit("config", "user.name", "Test")
+    try "initial".write(toFile: repoURL.appendingPathComponent("README.md").path, atomically: true, encoding: .utf8)
+    try fixture.runGit("add", ".")
+    try fixture.runGit("commit", "-m", "initial")
+    return fixture
+  }
+
+  private func runGit(_ args: String...) throws {
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "/usr/bin/git")
+    process.arguments = args
+    process.currentDirectoryURL = URL(fileURLWithPath: repoPath)
+    process.standardOutput = Pipe()
+    process.standardError = Pipe()
+    try process.run()
+    process.waitUntilExit()
+    guard process.terminationStatus == 0 else {
+      throw NSError(domain: "BranchLoadGitRepoFixture", code: Int(process.terminationStatus))
+    }
+  }
+
+  func cleanup() {
+    try? FileManager.default.removeItem(atPath: parentDir)
+  }
+}
+
+private final class BranchLoadMonitorService: SessionMonitorServiceProtocol, @unchecked Sendable {
+  private let subject = CurrentValueSubject<[SelectedRepository], Never>([])
+
+  var repositoriesPublisher: AnyPublisher<[SelectedRepository], Never> {
+    subject.eraseToAnyPublisher()
+  }
+
+  func addRepository(_ path: String) async -> SelectedRepository? { nil }
+  func removeRepository(_ path: String) async {}
+  func getSelectedRepositories() async -> [SelectedRepository] { [] }
+  func setSelectedRepositories(_ repositories: [SelectedRepository]) async {}
+  func refreshSessions(skipWorktreeRedetection: Bool) async {}
+}
+
+private final class BranchLoadFileWatcher: SessionFileWatcherProtocol, @unchecked Sendable {
+  private let subject = PassthroughSubject<SessionFileWatcher.StateUpdate, Never>()
+
+  var statePublisher: AnyPublisher<SessionFileWatcher.StateUpdate, Never> {
+    subject.eraseToAnyPublisher()
+  }
+
+  func startMonitoring(sessionId: String, projectPath: String, sessionFilePath: String?) async {}
+  func stopMonitoring(sessionId: String) async {}
+  func getState(sessionId: String) async -> SessionMonitorState? { nil }
+  func refreshState(sessionId: String) async {}
+  func setApprovalTimeout(_ seconds: Int) async {}
+}


### PR DESCRIPTION
## Problem

Users reported the start-thread sheet (sidebar pencil button) taking seconds to appear. Presentation was blocked on `await loadBranches()`, whose `fetchAndGetDefaultRemoteBaseBranch` runs a network **`git fetch --all`** — multi-second on slow networks and worst-case a DNS/connect timeout per unreachable remote. The Fork flow had the same await-before-present pattern.

## Fix

- `preselectRepository` is now synchronous (repository match only). The pencil flow presents the sheet immediately and calls the new `beginBranchLoad()`, which sets `isLoadingBranches`/`isLoadingCurrentBranch` synchronously (no empty-picker flash on the first frame) and runs `loadBranches()` behind the sheet's existing loading state.
- `configureForFork` is synchronous too, seeding the form first and loading branches with the new `applyDefaultBaseBranch: false` mode — the late fetch fills the picker but can no longer overwrite fork's deliberate `baseBranch = nil` (base = current HEAD) or the seeded branch name.
- `loadBranches` is generation-guarded: if the user switches repositories while a slow fetch is in flight, the superseded load discards its results instead of stomping the newer repo's state.

Note: in worktree mode, launching before the fetch settles now bases the worktree on current HEAD (the picker shows "Loading…" during that window). Previously that window was spent staring at a frozen click before the sheet appeared.

## Test-infra repairs (found while validating)

The app-target test bundle (`app/AgentHubTests`) had rotted unnoticed — nothing gates it headless:
- The shared `AgentHub` scheme had no testables, so `xcodebuild … -scheme AgentHub test` (the command in CLAUDE.md) errored. Added the `AgentHubTests` testable reference.
- Restored missing `AgentHubSessionGraph` / `AgentHubCLIKit` imports in five test files that no longer compiled.
- Heads-up: running these app-hosted tests headless additionally needs ad-hoc signing overrides (`CODE_SIGN_IDENTITY=- CODE_SIGN_STYLE=Manual DEVELOPMENT_TEAM=`) because the homebrew libgit2 dylib's Team ID doesn't match a dev-signed test host.

## Testing

- New `MultiSessionLaunchBranchLoadTests` (headless core gate) pin the contract: fork seeds synchronously, the load preserves the seeded base, and the default flow still applies a base branch. **2/2 passed.**
- Targeted package suites (preselection/resolver/context/prompt): **23/23 passed.**
- App-target suites (fork, manual naming, AI naming, reset) with the signing override: **21/21 passed.**
- Full gate `./scripts/test.sh`: all fast packages ✓; the AgentHubCore suite reported failures only in the documented timing-flaky families (DiffAvailabilityService, SessionNameRequestMonitor, WorktreeDeletionRequestMonitor, WorktreeLaunchRequestMonitor, GitHubCIFailureNotifier, workspace-attach suites — see TestQuarantine.md/#380), none intersecting this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)