### PR TITLE
Fix six context-engineering defects found in code review

### DIFF
--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/ContextAssembler.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/ContextAssembler.swift
@@ -75,14 +75,14 @@ public struct ContextAssembler: ContextAssembling {
 
     if !files.isEmpty {
       let fileBlocks = files.map { file in
-        "<file path=\"\(file.relativePath)\">\n\(file.content)\n</file>"
+        "<file path=\"\(Self.escapeAttribute(file.relativePath))\">\n\(file.content)\n</file>"
       }
       sections.append("<files>\n\(fileBlocks.joined(separator: "\n"))\n</files>")
     }
 
     if !snippets.isEmpty {
       let snippetBlocks = snippets.map { snippet in
-        "<snippet title=\"\(snippet.title)\">\n\(snippet.content)\n</snippet>"
+        "<snippet title=\"\(Self.escapeAttribute(snippet.title))\">\n\(snippet.content)\n</snippet>"
       }
       sections.append("<snippets>\n\(snippetBlocks.joined(separator: "\n"))\n</snippets>")
     }
@@ -102,5 +102,15 @@ public struct ContextAssembler: ContextAssembling {
     }
 
     return ContextAssemblyResult(block: "<context>\n\(sections.joined(separator: "\n"))\n</context>")
+  }
+
+  /// User-typed snippet titles and arbitrary paths land in attribute positions;
+  /// a stray `"` or `<` there would break the block structure for the agent.
+  private static func escapeAttribute(_ value: String) -> String {
+    value
+      .replacingOccurrences(of: "&", with: "&amp;")
+      .replacingOccurrences(of: "<", with: "&lt;")
+      .replacingOccurrences(of: ">", with: "&gt;")
+      .replacingOccurrences(of: "\"", with: "&quot;")
   }
 }

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/ContextFileLoader.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/ContextFileLoader.swift
@@ -44,8 +44,8 @@ public struct ContextFileLoadResult: Sendable {
   }
 }
 
-/// What an external (outside-the-repo) path resolves to.
-public enum ContextExternalFileStatus: Equatable, Sendable {
+/// What a selected path resolves to (project-relative or external).
+public enum ContextFileStatus: Equatable, Sendable {
   /// UTF-8 text small enough to inline.
   case text(TextFileMetrics)
   /// Exists but is referenced by path instead of inlined (binary or too large).
@@ -58,11 +58,15 @@ public protocol ContextFileLoading: Sendable {
   /// Metrics only (no contents retained) — cheap enough to refresh a token
   /// column on every selection toggle. Unreadable paths are omitted.
   func fileMetrics(relativePaths: [String], projectPath: String) async -> [String: TextFileMetrics]
+  /// Classifies project-relative paths without retaining contents: existing
+  /// text is `.text`, binary or oversized files are `.attachment` (they exist —
+  /// the agent reads them itself), unresolvable paths are `.missing`.
+  func projectFileStatuses(relativePaths: [String], projectPath: String) async -> [String: ContextFileStatus]
   /// Loads files from absolute paths outside the project root (other repos,
   /// documents, books). Binary or oversized files land in `attachments`.
   func loadExternalFiles(absolutePaths: [String]) async -> ContextFileLoadResult
   /// Classifies external paths without retaining contents.
-  func externalFileStatuses(absolutePaths: [String]) async -> [String: ContextExternalFileStatus]
+  func externalFileStatuses(absolutePaths: [String]) async -> [String: ContextFileStatus]
 }
 
 public actor ContextFileLoader: ContextFileLoading {
@@ -86,8 +90,9 @@ public actor ContextFileLoader: ContextFileLoading {
     let uniquePaths = orderedUnique(relativePaths)
     var loaded: [ContextLoadedFile] = []
     var missing: [String] = []
+    var attachments: [String] = []
 
-    await withTaskGroup(of: (String, ProjectTextFile?).self) { group in
+    await withTaskGroup(of: (String, ProjectFileRead).self) { group in
       var iterator = uniquePaths.makeIterator()
       var inFlight = 0
 
@@ -96,23 +101,26 @@ public actor ContextFileLoader: ContextFileLoading {
         inFlight += 1
         let absolutePath = Self.absolutePath(for: relativePath, projectPath: projectPath)
         group.addTask { [fileIndexService] in
-          let file = try? await fileIndexService.readTextFile(at: absolutePath, projectPath: projectPath)
-          return (relativePath, file)
+          (relativePath, await Self.readProjectFile(
+            atPath: absolutePath, projectPath: projectPath, fileIndexService: fileIndexService))
         }
       }
 
       for _ in 0..<maxConcurrentReads { addNext() }
 
-      for await (relativePath, file) in group {
+      for await (relativePath, read) in group {
         inFlight -= 1
-        if let file {
+        switch read {
+        case .text(let file):
           loaded.append(ContextLoadedFile(
             relativePath: relativePath,
             content: file.content,
             metrics: file.metrics
           ))
           cacheMetrics(file.metrics, relativePath: relativePath, projectPath: projectPath)
-        } else {
+        case .attachment:
+          attachments.append(relativePath)
+        case .missing:
           missing.append(relativePath)
         }
         addNext()
@@ -121,8 +129,34 @@ public actor ContextFileLoader: ContextFileLoading {
 
     return ContextFileLoadResult(
       loaded: loaded.sorted { $0.relativePath < $1.relativePath },
-      missing: missing.sorted()
+      missing: missing.sorted(),
+      attachments: attachments.sorted()
     )
+  }
+
+  public func projectFileStatuses(
+    relativePaths: [String], projectPath: String
+  ) async -> [String: ContextFileStatus] {
+    var statuses: [String: ContextFileStatus] = [:]
+    for relativePath in orderedUnique(relativePaths) {
+      let absolutePath = Self.absolutePath(for: relativePath, projectPath: projectPath)
+      if let entry = cachedMetricsEntry(atAbsolutePath: absolutePath) {
+        statuses[relativePath] = .text(entry.metrics)
+        continue
+      }
+      switch await Self.readProjectFile(
+        atPath: absolutePath, projectPath: projectPath, fileIndexService: fileIndexService
+      ) {
+      case .text(let file):
+        cacheMetrics(file.metrics, relativePath: relativePath, projectPath: projectPath)
+        statuses[relativePath] = .text(file.metrics)
+      case .attachment:
+        statuses[relativePath] = .attachment
+      case .missing:
+        statuses[relativePath] = .missing
+      }
+    }
+    return statuses
   }
 
   public func fileMetrics(relativePaths: [String], projectPath: String) async -> [String: TextFileMetrics] {
@@ -152,6 +186,53 @@ public actor ContextFileLoader: ContextFileLoading {
   }
 
   // MARK: - Private
+
+  private enum ProjectFileRead: Sendable {
+    case text(ProjectTextFile)
+    case attachment
+    case missing
+  }
+
+  /// Classifies and (when inlinable) reads one project file. Oversized files
+  /// are never read; binary files surface as the UTF-8 failure the read throws.
+  private static func readProjectFile(
+    atPath absolutePath: String,
+    projectPath: String,
+    fileIndexService: FileIndexService
+  ) async -> ProjectFileRead {
+    if let attributes = fileAttributes(atPath: absolutePath),
+      attributes.fileSize > maxProjectInlineBytes {
+      // Attachment paths are handed to the agent unread, so confinement must
+      // be checked here; inlined reads get the authoritative (symlink-
+      // resolving) check inside readTextFile.
+      return isWithinProject(absolutePath: absolutePath, projectPath: projectPath)
+        ? .attachment : .missing
+    }
+    do {
+      let file = try await fileIndexService.readTextFile(at: absolutePath, projectPath: projectPath)
+      return .text(file)
+    } catch let error as CocoaError where error.code == .fileReadCorruptFile {
+      // Exists inside the root but is not UTF-8 text (PDF, image, archive, …).
+      return .attachment
+    } catch {
+      return .missing
+    }
+  }
+
+  private static func isWithinProject(absolutePath: String, projectPath: String) -> Bool {
+    let root = URL(fileURLWithPath: projectPath).standardizedFileURL.path
+    let candidate = URL(fileURLWithPath: absolutePath).standardizedFileURL.path
+    return candidate == root || candidate.hasPrefix(root + "/")
+  }
+
+  private func cachedMetricsEntry(atAbsolutePath absolutePath: String) -> MetricsCacheEntry? {
+    guard let attributes = Self.fileAttributes(atPath: absolutePath),
+      let entry = metricsCache[absolutePath],
+      entry.fileSize == attributes.fileSize,
+      entry.modificationDate == attributes.modificationDate
+    else { return nil }
+    return entry
+  }
 
   private func cacheMetrics(_ metrics: TextFileMetrics, relativePath: String, projectPath: String) {
     let absolutePath = Self.absolutePath(for: relativePath, projectPath: projectPath)
@@ -185,6 +266,9 @@ public actor ContextFileLoader: ContextFileLoading {
   /// External text files above this size are referenced as attachments instead
   /// of inlined — a book-sized text would blow past any context window anyway.
   public static let maxExternalInlineBytes = 10 * 1024 * 1024
+  /// Project files share the same inline cap: oversized files exist and are
+  /// part of the context, so they are referenced, never reported missing.
+  public static let maxProjectInlineBytes = maxExternalInlineBytes
 
   public func loadExternalFiles(absolutePaths: [String]) async -> ContextFileLoadResult {
     var loaded: [ContextLoadedFile] = []
@@ -209,8 +293,8 @@ public actor ContextFileLoader: ContextFileLoading {
     )
   }
 
-  public func externalFileStatuses(absolutePaths: [String]) async -> [String: ContextExternalFileStatus] {
-    var statuses: [String: ContextExternalFileStatus] = [:]
+  public func externalFileStatuses(absolutePaths: [String]) async -> [String: ContextFileStatus] {
+    var statuses: [String: ContextFileStatus] = [:]
     for path in orderedUnique(absolutePaths) {
       switch Self.readExternalFile(atPath: path) {
       case .text(_, let metrics): statuses[path] = .text(metrics)

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/ContextPayloadStore.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/ContextPayloadStore.swift
@@ -42,11 +42,10 @@ public struct ContextPayloadStore: ContextPayloadStoring {
   public let directoryURL: URL
   public let inlineByteThreshold: Int
 
+  /// Resolves through `AgentHubApplicationSupport` so test processes and
+  /// `AGENTHUB_APP_SUPPORT_DIR` overrides never touch the user's real payloads.
   public static func defaultDirectoryURL(fileManager: FileManager = .default) -> URL {
-    let base = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
-      ?? fileManager.temporaryDirectory
-    return base
-      .appendingPathComponent("AgentHub", isDirectory: true)
+    AgentHubApplicationSupport.baseDirectoryURL
       .appendingPathComponent("context", isDirectory: true)
       .appendingPathComponent("payloads", isDirectory: true)
   }
@@ -90,6 +89,9 @@ public struct ContextPayloadStore: ContextPayloadStoring {
 
     let cutoff = Date().addingTimeInterval(-Self.stalePayloadMaxAge)
     for url in contents {
+      // Only reap files this store wrote — never other content that ends up
+      // in (or shares) the directory.
+      guard url.lastPathComponent.hasPrefix("context-"), url.pathExtension == "md" else { continue }
       let modified = (try? url.resourceValues(forKeys: [.contentModificationDateKey]))?
         .contentModificationDate
       if let modified, modified < cutoff {

--- a/app/modules/AgentHubCore/Sources/AgentHub/Services/ContextProfileService.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/Services/ContextProfileService.swift
@@ -14,7 +14,10 @@ public protocol ContextProfileServiceProtocol: Sendable {
   /// Profiles applicable to a project: its project-scoped profiles first,
   /// then personal (user-level) ones, each group name-ordered.
   func profiles(forProjectPath projectPath: String) async throws -> [ContextProfile]
-  func save(_ profile: ContextProfile) async throws
+  /// `projectPath` is the project the caller is working in — required so a
+  /// personal-scope save (whose profile stores an empty path) still republishes
+  /// that project's JSON index. Mirrors `delete(id:projectPath:)`.
+  func save(_ profile: ContextProfile, projectPath: String) async throws
   func delete(id: String, projectPath: String) async throws
   /// Marks a project-scoped profile as the project's default (nil clears it).
   func setDefault(id: String?, forProjectPath projectPath: String) async throws
@@ -40,11 +43,11 @@ public actor ContextProfileService: ContextProfileServiceProtocol {
     return (project + personal).compactMap { try? $0.decodedProfile() }
   }
 
-  public func save(_ profile: ContextProfile) async throws {
+  public func save(_ profile: ContextProfile, projectPath: String) async throws {
     var stamped = profile
     stamped.updatedAt = Date()
     try await metadataStore.saveContextProfile(ContextProfileRecord(profile: stamped))
-    await republish(afterMutationOf: stamped.scope, projectPath: stamped.projectPath)
+    await republish(afterMutationOf: stamped.scope, projectPath: projectPath)
   }
 
   public func delete(id: String, projectPath: String) async throws {
@@ -99,12 +102,14 @@ public actor ContextProfileService: ContextProfileServiceProtocol {
     case .project:
       await republishIndex(forProjectPath: projectPath)
     case .personal:
-      let projectPaths = (try? await metadataStore.getProjectPathsWithContextProfiles()) ?? []
+      var projectPaths = (try? await metadataStore.getProjectPathsWithContextProfiles()) ?? []
+      // The working project may have no project-scoped profiles yet (a user's
+      // very first save can be personal) — it still needs its index written.
+      if !projectPath.isEmpty {
+        projectPaths.insert(projectPath)
+      }
       for path in projectPaths {
         await republishIndex(forProjectPath: path)
-      }
-      if !projectPath.isEmpty {
-        await republishIndex(forProjectPath: projectPath)
       }
     }
   }

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/ContextBuilderView.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/ContextBuilderView.swift
@@ -13,8 +13,10 @@ import AppKit
 import SwiftUI
 
 public enum ContextBuilderMode {
-  /// Launcher curation: primary button applies the selection to the pending launch.
-  case launch(onApply: (ContextSelection) -> Void)
+  /// Launcher curation: primary button applies the selection to the pending
+  /// launch. The profile is non-nil when the selection is an unmodified saved
+  /// set, so the caller can keep the set's identity instead of going ad-hoc.
+  case launch(onApply: (ContextSelection, ContextProfile?) -> Void)
   /// Context-set editing: primary button saves back into the set being edited.
   case editProfile(onSave: (ContextProfile) -> Void)
   /// New context set: primary button names and saves the selection.
@@ -96,7 +98,7 @@ public struct ContextBuilderView: View {
 
       if case .launch(let onApply) = mode {
         Button("Use This Context") {
-          onApply(viewModel.currentSelection())
+          onApply(viewModel.currentSelection(), viewModel.unmodifiedSourceProfile)
           onDismiss()
         }
         .keyboardShortcut(.defaultAction)

--- a/app/modules/AgentHubCore/Sources/AgentHub/UI/ContextLaunchSection.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/UI/ContextLaunchSection.swift
@@ -144,8 +144,12 @@ struct ContextLaunchSection: View {
           estimator: viewModel.contextTokenEstimator,
           profileService: viewModel.contextProfileService
         ),
-        mode: .launch { selection in
-          viewModel.applyCuratedContext(selection)
+        mode: .launch { selection, unmodifiedProfile in
+          if let unmodifiedProfile {
+            viewModel.attachContextProfile(unmodifiedProfile)
+          } else {
+            viewModel.applyCuratedContext(selection)
+          }
           Task { await viewModel.refreshContextSummary() }
         },
         onDismiss: { showingContextBuilder = false }

--- a/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/ContextBuilderViewModel.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/ContextBuilderViewModel.swift
@@ -165,6 +165,14 @@ public final class ContextBuilderViewModel {
     selectedRows.contains { $0.relativePath == relativePath }
   }
 
+  /// The saved set the editor state still matches exactly — launch mode uses
+  /// this so applying an untouched saved set keeps its identity (name, default
+  /// badge) instead of downgrading to ad-hoc curation.
+  public var unmodifiedSourceProfile: ContextProfile? {
+    guard let sourceProfile, !hasUnsavedChanges else { return nil }
+    return sourceProfile
+  }
+
   public func currentSelection() -> ContextSelection {
     ContextSelection(
       files: selectedRows.filter { !$0.isExternal }
@@ -223,45 +231,36 @@ public final class ContextBuilderViewModel {
     guard !selectedRows.isEmpty else { return }
     let projectPaths = selectedRows.filter { !$0.isExternal }.map(\.relativePath)
     let externalPaths = selectedRows.filter(\.isExternal).map(\.relativePath)
-    let metrics = await fileLoader.fileMetrics(relativePaths: projectPaths, projectPath: projectPath)
+    let projectStatuses = await fileLoader.projectFileStatuses(
+      relativePaths: projectPaths, projectPath: projectPath)
     let externalStatuses = await fileLoader.externalFileStatuses(absolutePaths: externalPaths)
 
     selectedRows = selectedRows.map { row in
-      if row.isExternal {
-        switch externalStatuses[row.relativePath] {
-        case .text(let fileMetrics):
-          return ContextSelectedFileRow(
-            relativePath: row.relativePath,
-            byteCount: fileMetrics.byteCount,
-            estimatedTokens: estimator.estimatedTokens(forByteCount: fileMetrics.byteCount),
-            isMissing: false,
-            isExternal: true
-          )
-        case .attachment:
-          return ContextSelectedFileRow(
-            relativePath: row.relativePath,
-            byteCount: nil,
-            estimatedTokens: estimator.estimatedTokens(forByteCount: row.relativePath.utf8.count),
-            isMissing: false,
-            isExternal: true,
-            isAttachment: true
-          )
-        case .missing, nil:
-          return ContextSelectedFileRow(
-            relativePath: row.relativePath, byteCount: nil, estimatedTokens: nil,
-            isMissing: true, isExternal: true)
-        }
-      }
-      if let fileMetrics = metrics[row.relativePath] {
+      let status = row.isExternal
+        ? externalStatuses[row.relativePath] : projectStatuses[row.relativePath]
+      switch status {
+      case .text(let fileMetrics):
         return ContextSelectedFileRow(
           relativePath: row.relativePath,
           byteCount: fileMetrics.byteCount,
           estimatedTokens: estimator.estimatedTokens(forByteCount: fileMetrics.byteCount),
-          isMissing: false
+          isMissing: false,
+          isExternal: row.isExternal
         )
+      case .attachment:
+        return ContextSelectedFileRow(
+          relativePath: row.relativePath,
+          byteCount: nil,
+          estimatedTokens: estimator.estimatedTokens(forByteCount: row.relativePath.utf8.count),
+          isMissing: false,
+          isExternal: row.isExternal,
+          isAttachment: true
+        )
+      case .missing, nil:
+        return ContextSelectedFileRow(
+          relativePath: row.relativePath, byteCount: nil, estimatedTokens: nil,
+          isMissing: true, isExternal: row.isExternal)
       }
-      return ContextSelectedFileRow(
-        relativePath: row.relativePath, byteCount: nil, estimatedTokens: nil, isMissing: true)
     }
   }
 
@@ -292,6 +291,7 @@ public final class ContextBuilderViewModel {
     let selection = currentSelection()
     guard !selection.isEmpty else {
       assembledPreview = ""
+      previewTruncatedByteCount = nil
       return
     }
     let projectLoad = await fileLoader.loadFiles(
@@ -357,7 +357,7 @@ public final class ContextBuilderViewModel {
       projectPath: projectPath,
       selection: currentSelection()
     )
-    try await profileService.save(profile)
+    try await profileService.save(profile, projectPath: projectPath)
     sourceProfile = profile
     await loadProfiles()
     return profile
@@ -378,7 +378,7 @@ public final class ContextBuilderViewModel {
   public func saveEditedProfile() async throws -> ContextProfile? {
     guard let profileService, var profile = sourceProfile else { return nil }
     profile.selection = currentSelection()
-    try await profileService.save(profile)
+    try await profileService.save(profile, projectPath: projectPath)
     sourceProfile = profile
     await loadProfiles()
     return profile

--- a/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/MultiSessionLaunchViewModel.swift
+++ b/app/modules/AgentHubCore/Sources/AgentHub/ViewModels/MultiSessionLaunchViewModel.swift
@@ -164,7 +164,15 @@ public final class MultiSessionLaunchViewModel {
   public var manualCodexBranchName: String = ""
   public var manualCodexDirectoryName: String = ""
   public var baseBranch: RemoteBranch?
-  public var selectedRepository: SelectedRepository?
+  public var selectedRepository: SelectedRepository? {
+    didSet {
+      // Curated context is repo-specific: attached sets, ad-hoc curation, and
+      // the removed-chip suppression must never carry across a repo change.
+      if oldValue?.path != selectedRepository?.path {
+        resetContextState()
+      }
+    }
+  }
   public var carrySourceChangesPath: String?
 
   // MARK: - Loaded Data
@@ -346,6 +354,16 @@ public final class MultiSessionLaunchViewModel {
     contextRemovedByUser = true
   }
 
+  /// Drops all context state, including the removed-chip suppression, so the
+  /// next repository's default profile can attach.
+  private func resetContextState() {
+    attachedContextProfile = nil
+    pendingContextSelection = nil
+    contextMissingPaths = []
+    contextSummaryTokens = nil
+    contextRemovedByUser = false
+  }
+
   /// Cheap metrics pass for the chip row: approximate tokens plus which
   /// selected paths do not resolve. Never loads file contents into UI state.
   public func refreshContextSummary() async {
@@ -355,16 +373,16 @@ public final class MultiSessionLaunchViewModel {
       return
     }
     let paths = selection.files.map(\.relativePath)
-    let metrics = await contextFileLoader.fileMetrics(relativePaths: paths, projectPath: repo.path)
+    let projectStatuses = await contextFileLoader.projectFileStatuses(
+      relativePaths: paths, projectPath: repo.path
+    )
     let externalStatuses = await contextFileLoader.externalFileStatuses(
       absolutePaths: selection.externalPaths
     )
 
-    var missing = paths.filter { metrics[$0] == nil }
-    var tokens = metrics.values.reduce(0) {
-      $0 + contextTokenEstimator.estimatedTokens(forByteCount: $1.byteCount)
-    }
-    for (path, status) in externalStatuses {
+    var missing: [String] = []
+    var tokens = 0
+    for (path, status) in projectStatuses.merging(externalStatuses) { current, _ in current } {
       switch status {
       case .text(let fileMetrics):
         tokens += contextTokenEstimator.estimatedTokens(forByteCount: fileMetrics.byteCount)
@@ -1140,10 +1158,7 @@ public final class MultiSessionLaunchViewModel {
     smartProvider = .claude
     smartPlanText = ""
     smartOrchestrationPlan = nil
-    attachedContextProfile = nil
-    pendingContextSelection = nil
-    contextMissingPaths = []
-    contextRemovedByUser = false
+    resetContextState()
   }
 
   // MARK: - Private

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/ContextAssemblerTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/ContextAssemblerTests.swift
@@ -110,6 +110,22 @@ struct ContextAssemblerTests {
     #expect(result.block.contains("/Users/me/books/manual.pdf\n</attachments>"))
   }
 
+  @Test("Attribute values are escaped so user text cannot break the block")
+  func attributeValuesEscaped() {
+    let result = assembler.assemble(ContextAssemblyInput(
+      files: [loadedFile("dir/we\"ird & <odd>.swift", "let x = 1")],
+      textSnippets: [
+        ContextTextSnippet(id: "a", title: "spec\" mode=\"raw", content: "payload")
+      ]
+    ))
+
+    #expect(result.block.contains(
+      "<snippet title=\"spec&quot; mode=&quot;raw\">\npayload\n</snippet>"))
+    #expect(!result.block.contains("<snippet title=\"spec\" mode=\"raw\">"))
+    #expect(result.block.contains(
+      "<file path=\"dir/we&quot;ird &amp; &lt;odd&gt;.swift\">\nlet x = 1\n</file>"))
+  }
+
   @Test("Instructions are trimmed")
   func instructionsTrimmed() {
     let result = assembler.assemble(ContextAssemblyInput(

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/ContextBuilderViewModelTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/ContextBuilderViewModelTests.swift
@@ -296,6 +296,64 @@ struct ContextBuilderViewModelTests {
     }
   }
 
+  @Test("Clearing the selection clears the truncation banner too")
+  func emptySelectionClearsTruncationBanner() async throws {
+    try await withProject { project, viewModel, _ in
+      try write("huge.txt", String(repeating: "x", count: 60_000), in: project)
+      await viewModel.toggleSelection(relativePath: "huge.txt")
+      await viewModel.refreshPreview()
+      #expect(viewModel.previewTruncatedByteCount != nil)
+
+      viewModel.removeSelection(relativePath: "huge.txt")
+      await viewModel.refreshPreview()
+
+      #expect(viewModel.assembledPreview.isEmpty)
+      #expect(viewModel.previewTruncatedByteCount == nil)
+    }
+  }
+
+  @Test("Binary project files show as attachments in the selection rows")
+  func binaryProjectRowIsAttachment() async throws {
+    try await withProject { project, viewModel, _ in
+      let pdf = project.appendingPathComponent("spec.pdf")
+      try Data([0x25, 0x50, 0x44, 0x46, 0xFF, 0xFE]).write(to: pdf)
+
+      await viewModel.toggleSelection(relativePath: "spec.pdf")
+
+      let row = try #require(viewModel.selectedRows.first)
+      #expect(row.isAttachment)
+      #expect(!row.isMissing)
+    }
+  }
+
+  @Test("An untouched saved set keeps its identity for launch apply; edits drop it")
+  func unmodifiedSourceProfileGating() async throws {
+    try await withProject { project, viewModel, _ in
+      try write("a.swift", "let a = 1", in: project)
+      let profile = ContextProfile(
+        id: "set",
+        name: "Set",
+        scope: .project,
+        projectPath: project.path,
+        selection: ContextSelection(
+          files: [ContextFileSelection(relativePath: "a.swift")],
+          instructions: "keep"
+        )
+      )
+      await viewModel.applyProfile(profile)
+      #expect(viewModel.unmodifiedSourceProfile?.id == "set")
+
+      viewModel.instructions = "changed"
+      #expect(viewModel.unmodifiedSourceProfile == nil)
+
+      viewModel.instructions = "keep"
+      #expect(viewModel.unmodifiedSourceProfile?.id == "set")
+
+      viewModel.startNewDraft()
+      #expect(viewModel.unmodifiedSourceProfile == nil)
+    }
+  }
+
   @Test("File fallback hint appears when selected bytes exceed the threshold")
   func fallbackHint() async throws {
     let project = FileManager.default.temporaryDirectory

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/ContextFileLoaderTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/ContextFileLoaderTests.swift
@@ -118,6 +118,72 @@ struct ContextFileLoaderTests {
     }
   }
 
+  @Test("Binary project files are attachments, not missing")
+  func binaryProjectFilesAreAttachments() async throws {
+    try await withProject { project, loader in
+      let binaryURL = project.appendingPathComponent("docs/spec.pdf")
+      try FileManager.default.createDirectory(
+        at: binaryURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+      try Data([0x25, 0x50, 0x44, 0x46, 0xFF, 0xFE, 0x00, 0x01]).write(to: binaryURL)
+      try write("readme.md", "text", in: project)
+
+      let result = await loader.loadFiles(
+        relativePaths: ["docs/spec.pdf", "readme.md", "gone.md"],
+        projectPath: project.path
+      )
+
+      #expect(result.loaded.map(\.relativePath) == ["readme.md"])
+      #expect(result.attachments == ["docs/spec.pdf"])
+      #expect(result.missing == ["gone.md"])
+
+      let statuses = await loader.projectFileStatuses(
+        relativePaths: ["docs/spec.pdf", "readme.md", "gone.md"], projectPath: project.path)
+      #expect(statuses["docs/spec.pdf"] == .attachment)
+      #expect(statuses["gone.md"] == .missing)
+      if case .text(let metrics)? = statuses["readme.md"] {
+        #expect(metrics.byteCount == 4)
+      } else {
+        Issue.record("expected text status")
+      }
+    }
+  }
+
+  @Test("Oversized project files are attachments and are never inlined")
+  func oversizedProjectFilesAreAttachments() async throws {
+    try await withProject { project, loader in
+      let bigURL = project.appendingPathComponent("dump.txt")
+      try Data(count: ContextFileLoader.maxProjectInlineBytes + 1).write(to: bigURL)
+
+      let result = await loader.loadFiles(relativePaths: ["dump.txt"], projectPath: project.path)
+      #expect(result.loaded.isEmpty)
+      #expect(result.attachments == ["dump.txt"])
+      #expect(result.missing.isEmpty)
+
+      let statuses = await loader.projectFileStatuses(
+        relativePaths: ["dump.txt"], projectPath: project.path)
+      #expect(statuses["dump.txt"] == .attachment)
+    }
+  }
+
+  @Test("Oversized files outside the project root stay missing, not attachments")
+  func oversizedTraversalStaysMissing() async throws {
+    try await withProject { project, loader in
+      let outside = project.deletingLastPathComponent()
+        .appendingPathComponent("big-outside-\(UUID().uuidString).bin")
+      try Data(count: ContextFileLoader.maxProjectInlineBytes + 1).write(to: outside)
+      defer { try? FileManager.default.removeItem(at: outside) }
+
+      let result = await loader.loadFiles(
+        relativePaths: ["../\(outside.lastPathComponent)"],
+        projectPath: project.path
+      )
+
+      #expect(result.loaded.isEmpty)
+      #expect(result.attachments.isEmpty)
+      #expect(result.missing.count == 1)
+    }
+  }
+
   // MARK: - External files
 
   @Test("External files load by absolute path; binary files become attachments")

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/ContextPayloadStoreTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/ContextPayloadStoreTests.swift
@@ -69,6 +69,37 @@ struct ContextPayloadStoreTests {
     }
   }
 
+  @Test("Pruning only touches payload files the store wrote")
+  func pruneIsScopedToOwnPayloads() throws {
+    try withTempDirectory { directory in
+      try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+      let foreignURL = directory.appendingPathComponent("user-notes.md")
+      let wrongExtensionURL = directory.appendingPathComponent("context-export.json")
+      try "keep me".write(to: foreignURL, atomically: true, encoding: .utf8)
+      try "{}".write(to: wrongExtensionURL, atomically: true, encoding: .utf8)
+      let staleDate = Date().addingTimeInterval(-ContextPayloadStore.stalePayloadMaxAge - 3600)
+      for url in [foreignURL, wrongExtensionURL] {
+        try FileManager.default.setAttributes(
+          [.modificationDate: staleDate], ofItemAtPath: url.path)
+      }
+
+      let store = ContextPayloadStore(directoryURL: directory, inlineByteThreshold: 10)
+      _ = try store.materializeIfNeeded(block: String(repeating: "c", count: 11))
+
+      #expect(FileManager.default.fileExists(atPath: foreignURL.path))
+      #expect(FileManager.default.fileExists(atPath: wrongExtensionURL.path))
+    }
+  }
+
+  @Test("The default directory resolves inside the sandboxed app-support base")
+  func defaultDirectoryIsSandboxSafe() {
+    let directory = ContextPayloadStore.defaultDirectoryURL()
+    #expect(directory.path.hasPrefix(AgentHubApplicationSupport.baseDirectoryURL.path))
+    // Under the test runner the base is a per-process temp sandbox, so payload
+    // writes in tests can never land in the user's real Application Support.
+    #expect(!directory.path.contains("/Library/Application Support/AgentHub/"))
+  }
+
   @Test("Threshold compares UTF-8 bytes, not characters")
   func thresholdUsesUTF8Bytes() throws {
     try withTempDirectory { directory in

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/ContextProfileServiceTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/ContextProfileServiceTests.swift
@@ -25,8 +25,8 @@ struct ContextProfileServiceTests {
   @Test("Profiles list project-scoped first, then personal")
   func profilesListProjectFirst() async throws {
     try await withService { service, _ in
-      try await service.save(makePersonalProfile(id: "pers", name: "AAA Personal"))
-      try await service.save(makeProfile(id: "proj", name: "ZZZ Project"))
+      try await service.save(makePersonalProfile(id: "pers", name: "AAA Personal"), projectPath: "/tmp/project")
+      try await service.save(makeProfile(id: "proj", name: "ZZZ Project"), projectPath: "/tmp/project")
 
       let profiles = try await service.profiles(forProjectPath: "/tmp/project")
       #expect(profiles.map(\.id) == ["proj", "pers"])
@@ -36,7 +36,7 @@ struct ContextProfileServiceTests {
   @Test("Saving republishes the project's JSON index")
   func saveRepublishesIndex() async throws {
     try await withService { service, indexStore in
-      try await service.save(makeProfile(id: "proj", name: "Project profile"))
+      try await service.save(makeProfile(id: "proj", name: "Project profile"), projectPath: "/tmp/project")
 
       let index = try #require(indexStore.read(projectPath: "/tmp/project"))
       #expect(index.profiles.map(\.id) == ["proj"])
@@ -47,8 +47,8 @@ struct ContextProfileServiceTests {
   @Test("A personal save is merged into every project's index")
   func personalSaveMergesIntoProjectIndexes() async throws {
     try await withService { service, indexStore in
-      try await service.save(makeProfile(id: "proj", name: "Project profile"))
-      try await service.save(makePersonalProfile(id: "pers", name: "Personal profile"))
+      try await service.save(makeProfile(id: "proj", name: "Project profile"), projectPath: "/tmp/project")
+      try await service.save(makePersonalProfile(id: "pers", name: "Personal profile"), projectPath: "/tmp/project")
 
       let index = try #require(indexStore.read(projectPath: "/tmp/project"))
       #expect(Set(index.profiles.map(\.id)) == ["proj", "pers"])
@@ -56,10 +56,24 @@ struct ContextProfileServiceTests {
     }
   }
 
+  @Test("A first personal save still publishes the working project's index")
+  func firstPersonalSavePublishesWorkingProjectIndex() async throws {
+    try await withService { service, indexStore in
+      // No project-scoped profile exists yet — the regression this guards
+      // against left the index unwritten entirely in that case.
+      try await service.save(
+        makePersonalProfile(id: "pers", name: "Global set"), projectPath: "/tmp/project")
+
+      let index = try #require(indexStore.read(projectPath: "/tmp/project"))
+      #expect(index.profiles.map(\.id) == ["pers"])
+      #expect(index.profiles.first?.scope == "personal")
+    }
+  }
+
   @Test("Set-default flows through to the index and defaultProfile")
   func setDefaultFlowsThrough() async throws {
     try await withService { service, indexStore in
-      try await service.save(makeProfile(id: "proj", name: "Project profile"))
+      try await service.save(makeProfile(id: "proj", name: "Project profile"), projectPath: "/tmp/project")
       try await service.setDefault(id: "proj", forProjectPath: "/tmp/project")
 
       #expect(try await service.defaultProfile(forProjectPath: "/tmp/project")?.id == "proj")
@@ -71,8 +85,8 @@ struct ContextProfileServiceTests {
   @Test("Deleting removes the profile from the store and the index")
   func deleteRemovesEverywhere() async throws {
     try await withService { service, indexStore in
-      try await service.save(makeProfile(id: "a", name: "A"))
-      try await service.save(makeProfile(id: "b", name: "B"))
+      try await service.save(makeProfile(id: "a", name: "A"), projectPath: "/tmp/project")
+      try await service.save(makeProfile(id: "b", name: "B"), projectPath: "/tmp/project")
 
       try await service.delete(id: "a", projectPath: "/tmp/project")
 
@@ -89,7 +103,7 @@ struct ContextProfileServiceTests {
       var profile = makeProfile(id: "proj", name: "Project profile")
       profile.updatedAt = stale
 
-      try await service.save(profile)
+      try await service.save(profile, projectPath: "/tmp/project")
 
       let saved = try #require(try await service.profiles(forProjectPath: "/tmp/project").first)
       #expect(saved.updatedAt > stale)

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/MockContextProfileService.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/MockContextProfileService.swift
@@ -8,6 +8,7 @@ final class MockContextProfileService: ContextProfileServiceProtocol, @unchecked
   var storedProfiles: [ContextProfile] = []
   var defaultProfileResult: ContextProfile?
   private(set) var savedProfiles: [ContextProfile] = []
+  private(set) var savedProjectPaths: [String] = []
   private(set) var deletedIds: [String] = []
   private(set) var defaultRequests: [String?] = []
 
@@ -15,8 +16,9 @@ final class MockContextProfileService: ContextProfileServiceProtocol, @unchecked
     storedProfiles
   }
 
-  func save(_ profile: ContextProfile) async throws {
+  func save(_ profile: ContextProfile, projectPath: String) async throws {
     savedProfiles.append(profile)
+    savedProjectPaths.append(projectPath)
     storedProfiles.removeAll { $0.id == profile.id }
     storedProfiles.append(profile)
   }

--- a/app/modules/AgentHubCore/Tests/AgentHubTests/MultiSessionLaunchContextTests.swift
+++ b/app/modules/AgentHubCore/Tests/AgentHubTests/MultiSessionLaunchContextTests.swift
@@ -329,6 +329,80 @@ struct MultiSessionLaunchContextTests {
     }
   }
 
+  @Test("Switching repositories drops the previous repo's context state")
+  func repoSwitchDropsContext() async {
+    let service = MockContextProfileService()
+    service.defaultProfileResult = makeProfile(id: "default", name: "Default", isDefault: true)
+    let viewModel = makeLaunchViewModel(profileService: service, repositoryPath: "/tmp/project-a")
+    await viewModel.loadDefaultContextProfile()
+    #expect(viewModel.attachedContextProfile?.id == "default")
+
+    viewModel.selectedRepository = SelectedRepository(path: "/tmp/project-b")
+
+    #expect(viewModel.attachedContextProfile == nil)
+    #expect(viewModel.pendingContextSelection == nil)
+    #expect(viewModel.contextMissingPaths.isEmpty)
+    #expect(viewModel.contextSummaryTokens == nil)
+  }
+
+  @Test("Removing the chip in one repo does not suppress the next repo's default")
+  func chipRemovalDoesNotLeakAcrossRepos() async {
+    let service = MockContextProfileService()
+    service.defaultProfileResult = makeProfile(id: "default", name: "Default", isDefault: true)
+    let viewModel = makeLaunchViewModel(profileService: service, repositoryPath: "/tmp/project-a")
+    await viewModel.loadDefaultContextProfile()
+    viewModel.removeAttachedContextProfile()
+    #expect(viewModel.attachedContextProfile == nil)
+
+    viewModel.selectedRepository = SelectedRepository(path: "/tmp/project-b")
+    await viewModel.loadDefaultContextProfile()
+
+    #expect(viewModel.attachedContextProfile?.id == "default")
+  }
+
+  @Test("Ad-hoc curation does not survive a repository switch")
+  func adHocCurationDoesNotSurviveRepoSwitch() {
+    let viewModel = makeLaunchViewModel(repositoryPath: "/tmp/project-a")
+    viewModel.applyCuratedContext(
+      ContextSelection(files: [ContextFileSelection(relativePath: "a.swift")]))
+    #expect(viewModel.activeContextSelection != nil)
+
+    viewModel.selectedRepository = SelectedRepository(path: "/tmp/project-b")
+    #expect(viewModel.activeContextSelection == nil)
+  }
+
+  @Test("Attaching a saved set restores its identity over ad-hoc curation")
+  func attachProfileKeepsIdentity() {
+    let viewModel = makeLaunchViewModel(repositoryPath: "/tmp/project")
+    viewModel.applyCuratedContext(
+      ContextSelection(files: [ContextFileSelection(relativePath: "x.swift")]))
+    let profile = makeProfile(id: "named", name: "Named")
+
+    viewModel.attachContextProfile(profile)
+
+    #expect(viewModel.attachedContextProfile?.id == "named")
+    #expect(viewModel.pendingContextSelection == nil)
+    #expect(viewModel.activeContextSelection == profile.selection)
+  }
+
+  @Test("Binary project files summarize and resolve as attachments, not missing")
+  func binaryProjectFileIsAttachment() async throws {
+    try await withTempProject { project in
+      try Data([0x25, 0x50, 0x44, 0x46, 0xFF]).write(
+        to: project.appendingPathComponent("spec.pdf"))
+      let viewModel = makeLaunchViewModel(repositoryPath: project.path)
+      viewModel.applyCuratedContext(
+        ContextSelection(files: [ContextFileSelection(relativePath: "spec.pdf")]))
+
+      await viewModel.refreshContextSummary()
+      #expect(viewModel.contextMissingPaths.isEmpty)
+
+      let block = try #require(await viewModel.resolveContextBlock(repoPath: project.path))
+      #expect(block.contains("spec.pdf (attachment — read separately)"))
+      #expect(!block.contains("spec.pdf (missing)"))
+    }
+  }
+
   @Test("Reset clears all context state")
   func resetClearsContext() async {
     let service = MockContextProfileService()


### PR DESCRIPTION
Addresses findings from a code review of the context-engineering work in #446/#448. Seven issues were raised; six apply to this repo. **Each was reproduced against current `main` before fixing, and every new test was confirmed to fail against the pre-fix code.**

| # | Finding | Status |
|---|---|---|
| 1 | Switching repositories keeps the previous project's context attached | Fixed |
| 2 | First personal-scope save publishes no JSON index | Fixed |
| 3 | Binary project files reported as "missing" instead of attached | Fixed |
| 4 | Payload store directory choice | Not applicable here — two related issues fixed |
| 5 | Stale "Preview truncated" banner after clearing the selection | Fixed |
| 6 | Choosing a saved set in the builder downgrades it to ad-hoc | Fixed |
| 7 | No escaping of titles/paths in assembled-block attributes | Fixed |

## What was wrong, and what changed

**1 — Repo switch leaked context.** Nothing cleared `attachedContextProfile` / `pendingContextSelection` / `contextRemovedByUser` when the repository changed; only `reset()` and `removeAttachedContextProfile()` did, and neither `selectRepository()` nor `clearSelectedRepository()` called them. Repo A's set stayed attached, `refreshContextSummary()` resolved A's project-relative paths against B (chip showed every file missing), the launch prepended a `<context>` block of `(missing)` entries, and B's own default never attached. The inverse stuck too: removing the chip in A suppressed B's default for the session. Now cleared from a `didSet` on `selectedRepository`, which covers all seven assignment sites including the direct ones in `preselectRepository`.

**2 — First personal save published nothing.** `ContextProfile.init` forces `projectPath = ""` for personal scope and `getProjectPathsWithContextProfiles()` filters empty paths, so the very common first-run case (first set saved as "Global (all projects)") ran neither `republish` branch. `save` now takes the caller's real project path, mirroring the asymmetry already present in `delete(id:projectPath:)`.

**3 — Binary files reported missing.** `loadFiles` funneled every `readTextFile` failure into `missing` and never populated `attachments`, contradicting both `ContextFileLoadResult.attachments`' own doc comment and the picker UI. A repo `docs/spec.pdf` rendered struck through and the agent was told an existing file didn't exist. Non-UTF-8 and oversized project files now classify as attachments. Project files also gain the inline size cap they previously lacked entirely (`maxProjectInlineBytes`, mirroring `maxExternalInlineBytes`). Since attachment paths are handed to the agent unread, the oversized branch does its own project-root confinement check — a traversal path stays `missing` rather than becoming an attachment.

**5 — Stale truncation banner.** The empty-selection early return in `refreshPreview()` reset only `assembledPreview`, so "Preview truncated — the full block is 4.2 MB" rendered directly above "Nothing selected."

**6 — Saved set downgraded to ad-hoc.** Launch mode handed back only `currentSelection()`, so `applyCuratedContext` populated `pendingContextSelection`, which outranks `attachedContextProfile` — the chip lost the set's name and its "default" badge. `.launch` now also reports the source profile when the selection is unmodified, and `ContextLaunchSection` calls `attachContextProfile(_:)`, which previously had no production callers.

**7 — Unescaped attributes.** `&`, `<`, `>` and `"` are now escaped in `<file path=…>` and `<snippet title=…>` values.

## On finding 4

The directory relocation itself doesn't apply here (AgentHub legitimately owns `Application Support/AgentHub`), but two related problems in that code are real and fixed:

- `pruneStalePayloads()` deleted **any** file in the directory older than 7 days, not just the `context-*.md` files the store wrote.
- `ContextPayloadStore.defaultDirectoryURL` built the Application Support path directly instead of resolving through `AgentHubApplicationSupport.baseDirectoryURL`, violating the repo's own persistent-state rule. This meant payload writes escaped the test sandbox — verified concretely: against the old code the new test resolves to the real user Application Support directory while the sandbox base is a per-process temp directory. Given the prior incident where a test run overwrote real workspace state, this one mattered.

## Testing

- **84 tests across 8 context suites pass** (`ContextAssembler`, `ContextFileLoader`, `ContextPayloadStore`, `ContextProfileService`, `ContextBuilderViewModel`, `MultiSessionLaunchContext`, `ProjectContextViewModel`, `ContextProfileStore`).
- **Negative verification:** with each behavioral fix surgically reverted (APIs kept so everything still compiled), all 18 new assertions failed, reproducing the reported scenarios exactly — repo A's profile still attached after switching to B, `indexStore.read → nil`, `missing == ["docs/spec.pdf", "gone.md"]`, a non-nil `previewTruncatedByteCount` after clearing, and the unescaped `<snippet title="spec" mode="raw">`.
- **Full core suite:** 23 failures on this branch vs **18 on a stashed clean-tree baseline**. The five extra are in `WorktreeGenerationProgressCoordinatorTests` and `SimulatorHotReloadControllerTests` (announcement/debounce timing) and **all 29 of their tests pass in isolation**; one baseline failure conversely passed here, confirming the set is nondeterministic. These are the known parallel-execution flakes, unrelated to this diff.
- Production `session_metadata.sqlite` verified byte-identical before and after every run.

## Not changed

`ProjectContextViewModel.refreshEstimates` still uses `fileMetrics`, so a binary file contributes 0 tokens to the Project Details estimate rather than its path length. That surface only displays an estimate (it never renders "missing") and isn't the picker described in the review, so it's left out of scope. Separately, `republishIndex(forProjectPath:aliasPaths:)` is never called with `aliasPaths` anywhere — the documented worktree-alias mirroring is still unimplemented, and is left for a follow-up.
